### PR TITLE
Add PR template with Authoring-Agent line

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+Authoring-Agent: <!-- claude | codex | cursor -->
+
+## Summary
+- Describe the change.
+- Call out any user-visible behavior or deployment notes.
+
+## Testing
+- [ ] Tests pass
+- [ ] Build succeeds
+- [ ] Manual verification completed when needed
+
+## Self-Review
+- [ ] Correctness: changes match stated requirements
+- [ ] Regression risk: no unintended impact on existing behavior
+- [ ] Style and conventions: follows repository standards
+- [ ] Test coverage: new paths tested, existing tests passing
+- [ ] Security and dependency hygiene: no new vulnerabilities or unnecessary deps


### PR DESCRIPTION
Adds `.github/pull_request_template.md` with the `Authoring-Agent:` field and 5-point self-review checklist per REVIEW_POLICY.md.