### PR TITLE
Fix disagreement detection: filter COMMENTED states, auto-clear label

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -327,10 +327,14 @@ jobs:
               pull_number: context.payload.pull_request.number,
             });
 
+            // Track each reviewer's last opinionated state (APPROVED or CHANGES_REQUESTED).
+            // Ignore COMMENTED reviews — they don't change a reviewer's effective position.
             const latestByReviewer = {};
             for (const review of reviews.data) {
               if (reviewerAccounts.includes(review.user.login)) {
-                latestByReviewer[review.user.login] = review.state;
+                if (review.state === 'APPROVED' || review.state === 'CHANGES_REQUESTED') {
+                  latestByReviewer[review.user.login] = review.state;
+                }
               }
             }
 
@@ -338,20 +342,51 @@ jobs:
             const hasApproval = states.includes('APPROVED');
             const hasChangesRequested = states.includes('CHANGES_REQUESTED');
 
-            if (hasApproval && hasChangesRequested) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                labels: ['needs-human-review'],
-              });
+            // Check if the label is currently applied
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const hasLabel = labels.data.some(l => l.name === 'needs-human-review');
 
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: '**Agent disagreement detected.** One reviewer approved and another requested changes. Escalating to @nathanjohnpayne for human tiebreaker per REVIEW_POLICY.md.',
-              });
+            if (hasApproval && hasChangesRequested) {
+              // Disagreement exists — apply label if not already present
+              if (!hasLabel) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  labels: ['needs-human-review'],
+                });
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: '**Agent disagreement detected.** One reviewer approved and another requested changes. Escalating to @nathanjohnpayne for human tiebreaker per REVIEW_POLICY.md.',
+                });
+              }
+            } else if (hasLabel && !hasChangesRequested) {
+              // Disagreement resolved — all reviewers who previously requested
+              // changes have since approved. Remove the label automatically.
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  name: 'needs-human-review',
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: '**Agent disagreement resolved.** All reviewers now agree. Removing `needs-human-review` label.',
+                });
+              } catch (e) {
+                // Label may already be removed — ignore 404
+                if (e.status !== 404) throw e;
+              }
             }
 
   # ──────────────────────────────────────────────

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -254,6 +254,8 @@ REVIEWER_TOKEN=$(op read "op://Private/<item-id>/token")
 GH_TOKEN="$REVIEWER_TOKEN" gh pr review <PR#> --approve --body "Review comment"
 ```
 
+> **If `op read` fails with a sign-in or biometric error here**, follow the pause-and-prompt procedure in `docs/agents/operating-rules.md` under "1Password CLI authentication failures." Do not hardcode tokens, skip review, or retry in a loop.
+
 ### PAT requirements for reviewer identities
 
 Reviewer accounts are **collaborators** on repos owned by `nathanjohnpayne`. This constrains the PAT type:

--- a/docs/agents/deployment-process.md
+++ b/docs/agents/deployment-process.md
@@ -13,3 +13,4 @@ If the project uses Firebase or Google Cloud, prefer the canonical
   `external_account` source credential
 - Do not introduce long-lived service account keys into repo docs,
   scripts, or secret stores unless a project explicitly requires them
+- If an `op` command fails with a sign-in or biometric error during deploy, follow the pause-and-prompt procedure in [operating-rules.md](operating-rules.md#1password-cli-authentication-failures). Do not retry or work around the failure without the human present.

--- a/docs/agents/operating-rules.md
+++ b/docs/agents/operating-rules.md
@@ -19,3 +19,35 @@ Conflict resolution:
   for removal.
 - If `AGENTS.md` or its sub-files are missing required sections: flag
   the gap and do not assume behavior for missing sections.
+
+## 1Password CLI authentication failures
+
+If any `op` command (`op read`, `op inject`, `op run`, `op document get`,
+or any script that wraps them) fails with a sign-in or authentication
+error — including but not limited to:
+
+- `[ERROR] ... not currently signed in`
+- `session expired`
+- `biometric unlock ... timed out`
+- `authorization prompt dismissed`
+- `error initializing client: authorization`
+
+Then follow this procedure:
+
+1. **Stop immediately.** Do not retry the command, do not attempt
+   workarounds (manual token entry, environment variable overrides,
+   fallback credential paths, or skipping the credential step).
+2. **Prompt the human with context.** State what you were trying to do
+   and what credential you needed. Example:
+   > "1Password is timing out. Could you let me know when you are back
+   > to provide a biometric response? I need the reviewer PAT to
+   > approve PR #142."
+3. **Wait for the human to confirm** they are present and ready before
+   retrying the `op` command.
+4. After confirmation, retry **once**. If it fails again, report the
+   full error output and wait — do not loop.
+
+This rule applies only to 1Password CLI sign-in and authentication
+errors. Other `op` failures (wrong item ID, missing field, network
+errors, vault permission errors) should be diagnosed and resolved
+normally.


### PR DESCRIPTION
## Summary
- Only track opinionated review states (APPROVED / CHANGES_REQUESTED) in disagreement detection, ignoring COMMENTED reviews
- Auto-remove needs-human-review label when all reviewers agree
- Prevents false positives on the review-fix-re-review cycle

Backported from friends-and-family-billing PR #121.

Authoring-Agent: claude

## Self-Review
- **Correctness**: COMMENTED reviews no longer overwrite CHANGES_REQUESTED. Label auto-clears only when no CHANGES_REQUESTED remains.
- **Regression risk**: Low — additive logic. Existing label-add path unchanged.

⚠️ External review required — .github/** protected path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)