### PR TITLE
docs: add no-direct-push-to-main rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ If any of these files are missing, flag the gap before proceeding.
 
 # Code Review — Mandatory Checklist
 
+Never push directly to `main`. All changes must go through a pull request.
+
 Every PR you open must follow this workflow. No exceptions unless the human
 explicitly authorizes a break-glass override in chat.
 

--- a/rules/repo_rules.md
+++ b/rules/repo_rules.md
@@ -19,6 +19,10 @@ flag the conflict before proceeding.
 
 ## Forbidden Patterns
 
+- Never push directly to `main`. All changes must go through a
+  pull request—even single-line fixes and documentation updates.
+  The only exception is if the human explicitly authorizes a
+  direct push in chat as a break-glass override.
 - Instructions must not be duplicated between root files and
   tool folders.
 - `dist/` must not be edited manually. Regenerate through the


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Add explicit "never push directly to main" rule to `rules/repo_rules.md` Forbidden Patterns
- Add prominent reminder line to `CLAUDE.md` Code Review section
- Template change—propagates to all repos created from this template

## Self-Review
- **Correctness:** Rule text is clear and matches existing break-glass override pattern
- **Regression risk:** None—documentation only
- **Style:** Consistent with existing forbidden pattern entries
- **Test coverage:** N/A (docs only)
- **Security/dependency hygiene:** No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)