### PR TITLE
chore: standardize .gitignore with agent directory hygiene policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Build artifacts — regenerate through build system
 dist/
+build/
+.next/
+.out/
 
 # Environment and secrets
 .env
@@ -18,6 +21,32 @@ __pycache__/
 .DS_Store
 Thumbs.db
 
-# Claude Code local settings
+# Logs
+*.log
+logs/
+
+# Editor
+.vscode/
+!.vscode/extensions.json
+.idea/
+
+# AI / agents (local state and runtime artifacts only)
+# Shared config (settings.json, .cursor/rules/, etc.) remains committed
 .claude/settings.local.json
 .claude/launch.json
+.claude/worktrees/
+.cursor/cache/
+.cursor/state/
+.cursor/plans/
+
+# Testing
+coverage/
+playwright-report/
+test-results/
+
+# Firebase
+.firebase/
+
+# Misc
+tmp/
+.cache/


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

- Expands `.gitignore` to cover logs, editor dirs (`.vscode/` with `!.vscode/extensions.json` exception, `.idea/`), testing artifacts (`coverage/`, `playwright-report/`, `test-results/`), and Firebase `.firebase/`
- Adds `.claude/worktrees/` — critical missing rule for Claude Code runtime git worktrees
- Adds `.cursor/plans/`, `.cursor/cache/`, `.cursor/state/` — Cursor runtime artifacts
- Adds `build/`, `.next/`, `.out/` — additional build output paths
- Adds `tmp/`, `.cache/` — misc runtime dirs

Part of cross-repo gitignore standardization. Tracked in nathanjohnpayne/ai_agent_repo_template#18.

## Self-Review

- **Correctness**: Only gitignore changes. No risk of affecting application behavior. All additions are standard patterns for their categories.
- **Regression risk**: None — gitignore changes only affect untracked files. Existing tracked files are unaffected.
- **Security**: The `!.vscode/extensions.json` negation exception is safe — extensions.json contains only extension IDs, never credentials.
- **Test coverage**: N/A
- **Dependency hygiene**: N/A