### PR TITLE
docs(policy): rewrite Phase 4 as 4a (Codex App) + 4b (manual CLI fallback)

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -54,12 +54,18 @@ jobs:
           # protected-paths check never fired, and draft→ready PRs touching
           # `.github/**` / `src/auth/**` / etc. merged without the
           # `needs-external-review` label on every agent-review run. See #54.
+          # `jq -c` (compact) is required here: multi-line JSON cannot be
+          # written via the `key=value` GITHUB_OUTPUT format. Before #54
+          # fixed the awk extractor, PATHS was always an empty array `[]`
+          # (single-line) so this latent bug was hidden; the first PR that
+          # exercised the pipeline after #55 merged (PR #58 / #30) blew up
+          # on load-config with "Invalid format '  \"src/auth/**\",'".
           PATHS=$(awk '
             /^external_review_paths:/ {in_block=1; next}
             in_block && /^[^[:space:]#]/ {in_block=0}
             in_block && /^ *-/ {print}
           ' "$CONFIG" | sed 's/^ *- *"//' | sed 's/"$//' \
-            | jq -R -s 'split("\n") | map(select(length > 0))')
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "paths=$PATHS" >> "$GITHUB_OUTPUT"
 
           # Extract available_reviewers as JSON array using the same
@@ -67,12 +73,13 @@ jobs:
           # fix, REVIEWERS was always an empty JSON array, which silently
           # broke the assign step's reviewer lookup and left PRs with no
           # assigned reviewer identity.
+          # `jq -c` for the same GITHUB_OUTPUT reason as PATHS above.
           REVIEWERS=$(awk '
             /^available_reviewers:/ {in_block=1; next}
             in_block && /^[^[:space:]#]/ {in_block=0}
             in_block && /^ *-/ {print}
           ' "$CONFIG" | sed 's/^ *- *//' \
-            | jq -R -s 'split("\n") | map(select(length > 0))')
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "reviewers=$REVIEWERS" >> "$GITHUB_OUTPUT"
 
           AUTHOR=$(grep 'author_identity:' "$CONFIG" | awk '{print $2}')

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -139,7 +139,7 @@ Before moving past Phase 2.5, confirm all of the following:
 
 ### Phase 3: External Review Threshold Check
 
-> **Note on automation timing:** CI workflows may apply the `needs-external-review` label automatically when a PR is opened or updated, as an early advisory based on line count and protected paths. This label blocks merge immediately. The agent's responsibility is to post the handoff message and alert the human after internal review passes—the label itself may already be present.
+> **Note on automation timing:** CI workflows may apply the `needs-external-review` label automatically when a PR is opened or updated, as an early advisory based on line count and protected paths. The label blocks merge via the label-gate until external review clears. When the label is present, the agent's responsibility after internal review passes is to proceed to [Phase 4](#phase-4-external-review) — which routes the PR to Phase 4a (automated via the Codex GitHub App) or Phase 4b (manual handoff) depending on `codex.enabled` and on whether 4a converges. The label itself does NOT imply immediate human mediation; Phase 4b only posts the handoff message when the fallback path is actually taken.
 
 8. After internal review passes, the agent evaluates whether the PR meets the external review threshold (see [Review Policy Configuration](#review-policy-configuration)).
 9. If the threshold is **not** met, the agent merges the PR as `nathanjohnpayne`. Done.
@@ -150,9 +150,9 @@ Before moving past Phase 2.5, confirm all of the following:
 Phase 4 has two sub-phases that together cover the two ways external review can run:
 
 - **Phase 4a — Automated external review** via the ChatGPT Codex Connector GitHub App. This is the default happy path. The authoring agent drives the review loop without human intervention until Codex signals clearance, then runs a merge-gate check and merges.
-- **Phase 4b — Manual CLI fallback** via a different agent's CLI session (e.g., Codex CLI as `nathanpayne-codex`, or Cursor, or Claude Code). This is the escape hatch when 4a escalates, times out twice, or is unavailable because `codex.enabled: false`. The human mediates the handoff.
+- **Phase 4b — Manual CLI fallback** via a different agent's CLI session (e.g., Codex CLI as `nathanpayne-codex`, or Cursor, or Claude Code). This is the escape hatch when 4a escalates (disagreement or runaway), times out, or is unavailable because `codex.enabled: false`. The human mediates the handoff.
 
-An agent proceeds to 4a first. If 4a escalates or is disabled, the agent falls back to 4b and surfaces the handoff to the human per [Handoff Message Format](#handoff-message-format).
+An agent proceeds to 4a first. If 4a escalates, times out, or is disabled, the agent falls back to 4b and surfaces the handoff to the human per [Handoff Message Format](#handoff-message-format).
 
 #### Phase 4a: Automated External Review (Codex GitHub App)
 
@@ -194,7 +194,7 @@ An agent proceeds to 4a first. If 4a escalates or is disabled, the agent falls b
 
 #### Phase 4b: Manual CLI Fallback (Human Handoff)
 
-Phase 4b is invoked when Phase 4a escalates to disagreement or runaway, times out twice consecutively, or when `codex.enabled: false` in the repo. It preserves the cross-agent review flow that existed before the Codex GitHub App integration and provides a human-mediated escape hatch.
+Phase 4b is invoked when Phase 4a escalates to disagreement or runaway, times out (single timeout, exit code `4` from `codex-review-request.sh`), or when `codex.enabled: false` in the repo. It preserves the cross-agent review flow that existed before the Codex GitHub App integration and provides a human-mediated escape hatch.
 
 11b. The authoring agent posts the handoff message (see [Handoff Message Format](#handoff-message-format)) as a PR comment and alerts the human.
 
@@ -261,7 +261,7 @@ Phase 4b is invoked when Phase 4a escalates to disagreement or runaway, times ou
   │  ├─ P0/P1 findings → fix or reply; round += 1; repeat   │
   │  ├─ repeat-after-rebuttal → ESCALATE (Disagreements)    │
   │  ├─ round > max_review_rounds → ESCALATE (Disagreements)│
-  │  └─ 2nd consecutive timeout → FALL BACK to Phase 4b     │
+  │  └─ timeout (exit code 4) → FALL BACK to Phase 4b       │
   └──────────────┬───────────────────────┬──────────────────┘
                  │ clearance              │ escalate / fallback
                  ▼                        ▼

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -147,14 +147,72 @@ Before moving past Phase 2.5, confirm all of the following:
 
 ### Phase 4: External Review
 
-11. The human takes the handoff message to a different agent (e.g., from Claude to Cursor, or from Cursor to Codex).
-12. The external agent's reviewer identity (e.g., `nathanpayne-codex`) reviews the PR and posts comments.
-13. The human relays the external reviewer's feedback back to the originating agent.
-14. The originating agent, as `nathanjohnpayne`, addresses the feedback and pushes fixes.
-15. The human shuttles updated code back to the external reviewer.
-16. Steps 12–15 repeat until the external reviewer approves.
-17. If the external reviewer flags **observations** or **risks** while approving, those are converted to GitHub Issues on the repo, assigned to `nathanjohnpayne` (see [Post-Merge Issue Creation](#post-merge-issue-creation)).
-18. `nathanjohnpayne` merges the PR. Done.
+Phase 4 has two sub-phases that together cover the two ways external review can run:
+
+- **Phase 4a — Automated external review** via the ChatGPT Codex Connector GitHub App. This is the default happy path. The authoring agent drives the review loop without human intervention until Codex signals clearance, then runs a merge-gate check and merges.
+- **Phase 4b — Manual CLI fallback** via a different agent's CLI session (e.g., Codex CLI as `nathanpayne-codex`, or Cursor, or Claude Code). This is the escape hatch when 4a escalates, times out twice, or is unavailable because `codex.enabled: false`. The human mediates the handoff.
+
+An agent proceeds to 4a first. If 4a escalates or is disabled, the agent falls back to 4b and surfaces the handoff to the human per [Handoff Message Format](#handoff-message-format).
+
+#### Phase 4a: Automated External Review (Codex GitHub App)
+
+> **Applies only to repos with `codex.enabled: true` in `.github/review-policy.yml`.** The ChatGPT Codex Connector GitHub App must also be installed on the repository with Code Review enabled at [chatgpt.com/codex/cloud/settings/code-review](https://chatgpt.com/codex/cloud/settings/code-review). If either condition is not met, skip directly to Phase 4b.
+
+11a. The authoring agent runs `scripts/codex-review-request.sh <PR#>` to trigger or await a Codex review. If the Codex App's "Automatic reviews" setting has already caused Codex to review the PR on open (typical latency ~2 minutes for small PRs), the script skips posting `@codex review` and goes straight to polling.
+
+12a. `codex-review-request.sh` polls the PR until one of the following:
+
+     - **Codex posts a review.** Always in `COMMENTED` state — the Codex GitHub App never uses `APPROVED` or `CHANGES_REQUESTED`. Findings appear as **inline comments on the diff** (`/pulls/{pr}/comments` endpoint), not in the top-level review body. Inline findings carry priority markers: `![P0 Badge]`, `![P1 Badge]`, `![P2 Badge]`, or `![P3 Badge]`.
+     - **Codex reacts 👍 / `+1`** on the PR issue with no review body. This is Codex's no-findings clearance signal per the ChatGPT Codex Connector documentation.
+     - **Timeout.** No review and no reaction within `codex.review_timeout_seconds` (default: 600s / 10 min). The script exits with code `4` (`FALLBACK_REQUIRED`).
+
+13a. If Codex posted inline findings, the agent addresses each P0/P1 by either:
+
+     - **Fixing the code** and pushing a new commit to the same branch, or
+     - **Replying on the finding thread** with a clear rebuttal explaining why the finding does not apply (for false positives or scope disagreements).
+
+     P2 and P3 findings are addressed at the agent's judgment — not every cosmetic or nit-level finding needs a fix or a rebuttal.
+
+14a. The agent increments its round counter and re-runs `scripts/codex-review-request.sh` to request a re-review of the new HEAD.
+
+15a. The loop continues until one of the following terminates it:
+
+     - **Clearance (happy path).** Codex posts a review with no unaddressed P0/P1 inline findings on the current HEAD, OR reacts 👍 on or after the current HEAD commit. Proceed to step 16a.
+     - **Disagreement (escalate).** Codex re-flags the same finding after the agent posted a rebuttal. This is "repeat-after-rebuttal." See [Disagreements and Tiebreaking](#disagreements-and-tiebreaking).
+     - **Runaway (escalate).** The round counter exceeds `codex.max_review_rounds` (default: 2). The 3rd round trips this guard. See [Disagreements and Tiebreaking](#disagreements-and-tiebreaking).
+     - **Second consecutive timeout (fall back).** Two rounds in a row exit with code 4. The agent falls back to Phase 4b.
+
+16a. Before merging, the agent runs `scripts/codex-review-check.sh <PR#>` to verify the merge gate. All of the following must be true:
+
+     - `gh pr checks` reports all required CI checks green
+     - A reviewer identity from `available_reviewers` has posted an `APPROVED` review (Phase 2 internal self-peer review)
+     - Codex has signaled clearance on the current HEAD via one of the two forms in step 12a
+
+     **The merge gate must never require an `APPROVED` review state from `chatgpt-codex-connector[bot]` — the app does not emit that state.** This point is load-bearing; a merge gate that looks for Codex APPROVED will never be satisfied and the Phase 4a happy path will be unreachable.
+
+17a. On a passing merge gate, `nathanjohnpayne` merges the PR with `gh pr merge <n> --squash --delete-branch`. Never `--admin` unless the human explicitly authorizes a break-glass override in chat.
+
+#### Phase 4b: Manual CLI Fallback (Human Handoff)
+
+Phase 4b is invoked when Phase 4a escalates to disagreement or runaway, times out twice consecutively, or when `codex.enabled: false` in the repo. It preserves the cross-agent review flow that existed before the Codex GitHub App integration and provides a human-mediated escape hatch.
+
+11b. The authoring agent posts the handoff message (see [Handoff Message Format](#handoff-message-format)) as a PR comment and alerts the human.
+
+12b. The human takes the handoff message to a different agent session (e.g., from Claude to Cursor, or to a Codex CLI session authenticated as `nathanpayne-codex`).
+
+13b. The external agent's reviewer identity reviews the PR and posts review comments. Unlike the Codex GitHub App, CLI-driven reviews use the standard GitHub review states (`APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`) as expected.
+
+14b. The human relays the external reviewer's feedback back to the originating agent.
+
+15b. The originating agent, as `nathanjohnpayne`, addresses the feedback and pushes fix commits to the same branch.
+
+16b. The human shuttles updated code back to the external reviewer.
+
+17b. Steps 13b–16b repeat until the external reviewer submits an `APPROVED` review.
+
+18b. If the external reviewer flags **observations** or **risks** while approving, those are converted to GitHub Issues on the repo, assigned to `nathanjohnpayne` (see [Post-Merge Issue Creation](#post-merge-issue-creation)).
+
+19b. `nathanjohnpayne` merges the PR. Done.
 
 ### Flow Diagram
 
@@ -187,21 +245,50 @@ Before moving past Phase 2.5, confirm all of the following:
   │  Lines changed ≥ threshold OR protected paths touched?   │
   │                                                          │
   │  NO ──→ nathanjohnpayne merges. Done.                    │
-  │  YES ──→ Post handoff message. Alert human.              │
+  │  YES ──→ Proceed to Phase 4                              │
   └──────────────────────────┬──────────────────────────────┘
                              │
                              ▼
   ┌─────────────────────────────────────────────────────────┐
-  │  PHASE 4: EXTERNAL REVIEW                                │
-  │  Human hands PR to different agent                       │
-  │  External nathanpayne-{agent} reviews → posts comments   │
-  │  Human relays feedback to original agent                 │
-  │  nathanjohnpayne fixes → human relays back               │
-  │  ↻ Repeat until external reviewer approves               │
-  │                                                          │
-  │  Observations/risks → GitHub Issues                      │
-  │  nathanjohnpayne merges. Done.                           │
-  └─────────────────────────────────────────────────────────┘
+  │  PHASE 4a: AUTOMATED EXTERNAL REVIEW                    │
+  │  (Codex GitHub App, default when codex.enabled: true)   │
+  │                                                         │
+  │  round ← 1                                              │
+  │  Agent runs codex-review-request.sh                     │
+  │    → Codex posts COMMENTED review OR 👍 reaction        │
+  │                                                         │
+  │  ┌─ no unaddressed P0/P1 findings → clearance           │
+  │  ├─ P0/P1 findings → fix or reply; round += 1; repeat   │
+  │  ├─ repeat-after-rebuttal → ESCALATE (Disagreements)    │
+  │  ├─ round > max_review_rounds → ESCALATE (Disagreements)│
+  │  └─ 2nd consecutive timeout → FALL BACK to Phase 4b     │
+  └──────────────┬───────────────────────┬──────────────────┘
+                 │ clearance              │ escalate / fallback
+                 ▼                        ▼
+  ┌──────────────────────────┐  ┌────────────────────────────┐
+  │  MERGE GATE:             │  │  PHASE 4b: MANUAL CLI      │
+  │  codex-review-check.sh   │  │  FALLBACK                  │
+  │                          │  │                            │
+  │  • gh pr checks = green  │  │  Post handoff message;     │
+  │  • internal reviewer     │  │  alert human.              │
+  │    identity APPROVED     │  │                            │
+  │  • Codex cleared on HEAD │  │  Human takes handoff to    │
+  │    via COMMENTED-no-P0/1 │  │  different agent CLI       │
+  │    OR 👍 reaction        │  │  (e.g. nathanpayne-codex). │
+  │                          │  │                            │
+  │  (NEVER expects APPROVED │  │  External reviewer posts   │
+  │   state from Codex bot —  │  │  comments / APPROVED /     │
+  │   the app does not emit  │  │  CHANGES_REQUESTED.         │
+  │   that state.)           │  │                            │
+  └──────────┬───────────────┘  │  Human relays feedback.    │
+             │                  │  Agent fixes. Repeat.       │
+             ▼                  │                            │
+  ┌──────────────────────────┐  │  Observations/risks →      │
+  │  nathanjohnpayne merges  │  │  GitHub Issues             │
+  │  (--squash). Done.       │  │                            │
+  └──────────────────────────┘  │  nathanjohnpayne merges.   │
+                                │  Done.                     │
+                                └────────────────────────────┘
 ```
 
 ## Handoff Message Format
@@ -248,7 +335,39 @@ These issues are tracked like any other work item. They are not blockers to the 
 
 ## Disagreements and Tiebreaking
 
-If the internal reviewer and external reviewer disagree on whether code is ready to merge, the human is the tiebreaker. The agent should surface the disagreement clearly, summarizing both positions, and wait for the human's decision.
+When the internal reviewer and external reviewer disagree on whether code is ready to merge, the human is the tiebreaker. The agent surfaces the disagreement clearly, summarizing both positions, and waits for the human's explicit decision before taking further action.
+
+### Concrete detection signals (Phase 4a)
+
+In Phase 4a, the agent escalates to the human when any one of the following fires:
+
+1. **Repeat-after-rebuttal.** The agent posted a reply to a Codex inline finding explaining why the finding does not apply. Codex's next review re-flags the same or substantively-equivalent finding. The agent treats this as a disagreement: Codex is not convinced by the rebuttal, and the agent stops trying to change Codex's mind autonomously. Continuing the loop past this point is rude to the reviewer and wastes API calls.
+
+2. **Runaway rounds.** The round counter exceeds `codex.max_review_rounds` (default: 2). The 3rd `@codex review` request trips this guard. This catches cases where Codex keeps finding new, distinct issues on each pass without the review converging. Even if each individual finding is valid, three rounds of novel issues is a signal that the PR scope is too broad and a human should weigh in.
+
+3. **Second consecutive timeout.** `codex-review-request.sh` exits with code `2` (timeout) on two consecutive rounds of the same PR. A single timeout is not a disagreement — it triggers a graceful fallback to Phase 4b per step 15a above. Two timeouts in a row indicates the Codex path is broken beyond the normal retry and warrants human attention rather than another silent fallback.
+
+Phase 4b escalation (the traditional cross-agent CLI flow) uses the human's judgment directly — there is no automated detection loop to fire, so this subsection does not apply there.
+
+### Escalation procedure
+
+When any of the three signals above fires, the agent:
+
+1. **Stops the automated loop immediately.** Does NOT push more commits, does NOT re-run `@codex review`, does NOT run the merge gate, does NOT merge.
+2. **Posts a comment on the PR** summarizing:
+   - Which signal fired and what triggered it
+   - Both positions (the agent's and Codex's) in plain language, with links to the specific review rounds and the rebuttal replies
+   - The current round counter and a link to the `scripts/codex-review-request.sh` output from the terminating round
+3. **If the trigger was a second consecutive timeout**, also posts the handoff message per [Handoff Message Format](#handoff-message-format), since the forward path is Phase 4b rather than human resolution in place.
+4. **Alerts the human via chat** and waits for an explicit decision before taking any further action on the PR.
+
+The human resolves by one of:
+
+- **Approving the existing state** — posting an `APPROVED` review as `nathanjohnpayne` or removing the `needs-external-review` label manually. This unblocks merge under the label-gate rules in [Review Policy Configuration](#review-policy-configuration).
+- **Requesting additional changes** — typing the feedback directly in chat. The agent addresses it as normal edits. No `@codex review` loop, no round counter.
+- **Taking the PR over manually** — the human merges on behalf of the agent, or closes and reopens with a different approach, or promotes the escalation to Phase 4b manually.
+
+The agent never resolves a fired escalation signal on its own.
 
 ## Review Policy Configuration
 
@@ -282,7 +401,33 @@ available_reviewers:
 # Default suggestion when the agent needs to recommend an external reviewer.
 # The agent may override this suggestion based on context.
 default_external_reviewer: nathanpayne-codex
+
+# Author identity under which all agents commit and merge.
+author_identity: nathanjohnpayne
+
+# CodeRabbit (Phase 2.5 advisory automated review).
+# Enabled on public repos only; advisory, does not block merge.
+# NOTE: This flag governs AGENT behavior only (whether agents wait for
+# CodeRabbit in Phase 2.5). It does NOT control whether the CodeRabbit
+# GitHub App itself runs — the App runs based on its own install state.
+# To fully disable CodeRabbit, uninstall the GitHub App AND set this flag.
+coderabbit:
+  enabled: false
+
+# Codex (Phase 4a automated external review) — see Phase 4a above.
+# Same semantics note as coderabbit: this flag governs agent behavior,
+# not app runtime. The ChatGPT Codex Connector App runs based on its
+# per-repo install state and its "Automatic reviews" setting.
+codex:
+  enabled: true
+  bot_login: "chatgpt-codex-connector[bot]"   # REST API form, with [bot] suffix
+  cli_login: nathanpayne-codex                # manual CLI fallback (Phase 4b)
+  max_review_rounds: 2                        # runaway guard; 3rd round escalates
+  review_timeout_seconds: 600                 # per-round poll timeout
+  require_ci_green: true                      # merge gate
 ```
+
+> **Note on `enabled` flags (both `coderabbit` and `codex`).** These flags govern **agent behavior only** — whether the authoring agent waits for the corresponding review in its phase. They do NOT control whether the underlying GitHub App runs. Both apps run based on their own install state on GitHub, independent of what this YAML says. Setting `enabled: false` alone will cause the agent to skip the corresponding phase while the app continues to post reviews silently in the background. This may be desired as a "dark launch," but can confuse readers who expect the flag to mean "off." To fully disable an integration, uninstall the GitHub App AND set the flag to false.
 
 ### Threshold Evaluation
 

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -143,7 +143,7 @@ Before moving past Phase 2.5, confirm all of the following:
 
 8. After internal review passes, the agent evaluates whether the PR meets the external review threshold (see [Review Policy Configuration](#review-policy-configuration)).
 9. If the threshold is **not** met, the agent merges the PR as `nathanjohnpayne`. Done.
-10. If the threshold **is** met, the agent posts a **handoff message** (see [Handoff Message Format](#handoff-message-format)) as a PR comment and alerts the human.
+10. If the threshold **is** met, the agent proceeds to [Phase 4: External Review](#phase-4-external-review). Phase 4 itself routes the PR to Phase 4a (automated, via the Codex GitHub App) or Phase 4b (manual handoff) based on `codex.enabled` in `.github/review-policy.yml` and on whether 4a's automated loop converges. The agent does NOT post a handoff message directly from this step — Phase 4b posts its own handoff message if and when the fallback path is taken.
 
 ### Phase 4: External Review
 
@@ -180,7 +180,7 @@ An agent proceeds to 4a first. If 4a escalates or is disabled, the agent falls b
      - **Clearance (happy path).** Codex posts a review with no unaddressed P0/P1 inline findings on the current HEAD, OR reacts 👍 on or after the current HEAD commit. Proceed to step 16a.
      - **Disagreement (escalate).** Codex re-flags the same finding after the agent posted a rebuttal. This is "repeat-after-rebuttal." See [Disagreements and Tiebreaking](#disagreements-and-tiebreaking).
      - **Runaway (escalate).** The round counter exceeds `codex.max_review_rounds` (default: 2). The 3rd round trips this guard. See [Disagreements and Tiebreaking](#disagreements-and-tiebreaking).
-     - **Second consecutive timeout (fall back).** Two rounds in a row exit with code 4. The agent falls back to Phase 4b.
+     - **Timeout (fall back).** `codex-review-request.sh` exits with code `4` (`FALLBACK_REQUIRED`) for the current round. The agent falls back to Phase 4b. There is no "second timeout" escalation — a single timeout already routes to human mediation via the 4b handoff.
 
 16a. Before merging, the agent runs `scripts/codex-review-check.sh <PR#>` to verify the merge gate. All of the following must be true:
 
@@ -339,27 +339,28 @@ When the internal reviewer and external reviewer disagree on whether code is rea
 
 ### Concrete detection signals (Phase 4a)
 
-In Phase 4a, the agent escalates to the human when any one of the following fires:
+In Phase 4a, the agent escalates to the human when either of the following fires:
 
 1. **Repeat-after-rebuttal.** The agent posted a reply to a Codex inline finding explaining why the finding does not apply. Codex's next review re-flags the same or substantively-equivalent finding. The agent treats this as a disagreement: Codex is not convinced by the rebuttal, and the agent stops trying to change Codex's mind autonomously. Continuing the loop past this point is rude to the reviewer and wastes API calls.
 
 2. **Runaway rounds.** The round counter exceeds `codex.max_review_rounds` (default: 2). The 3rd `@codex review` request trips this guard. This catches cases where Codex keeps finding new, distinct issues on each pass without the review converging. Even if each individual finding is valid, three rounds of novel issues is a signal that the PR scope is too broad and a human should weigh in.
 
-3. **Second consecutive timeout.** `codex-review-request.sh` exits with code `2` (timeout) on two consecutive rounds of the same PR. A single timeout is not a disagreement — it triggers a graceful fallback to Phase 4b per step 15a above. Two timeouts in a row indicates the Codex path is broken beyond the normal retry and warrants human attention rather than another silent fallback.
+**Timeout is NOT a disagreement signal.** A Codex response timeout (`codex-review-request.sh` exit code `4` = `FALLBACK_REQUIRED`) routes the PR directly to Phase 4b per step 15a above. It is a fallback trigger, not a tiebreaker trigger. Phase 4b itself mediates via the human through the manual handoff, so there is nothing for the disagreement detector to add on top.
 
 Phase 4b escalation (the traditional cross-agent CLI flow) uses the human's judgment directly — there is no automated detection loop to fire, so this subsection does not apply there.
 
 ### Escalation procedure
 
-When any of the three signals above fires, the agent:
+When either of the two signals above fires, the agent:
 
 1. **Stops the automated loop immediately.** Does NOT push more commits, does NOT re-run `@codex review`, does NOT run the merge gate, does NOT merge.
 2. **Posts a comment on the PR** summarizing:
    - Which signal fired and what triggered it
    - Both positions (the agent's and Codex's) in plain language, with links to the specific review rounds and the rebuttal replies
    - The current round counter and a link to the `scripts/codex-review-request.sh` output from the terminating round
-3. **If the trigger was a second consecutive timeout**, also posts the handoff message per [Handoff Message Format](#handoff-message-format), since the forward path is Phase 4b rather than human resolution in place.
-4. **Alerts the human via chat** and waits for an explicit decision before taking any further action on the PR.
+3. **Alerts the human via chat** and waits for an explicit decision before taking any further action on the PR.
+
+Note that timeout does NOT go through this escalation procedure. On a timeout (exit code `4` from `codex-review-request.sh`), the agent posts the handoff message per [Handoff Message Format](#handoff-message-format) and routes to Phase 4b directly from step 15a — no in-place tiebreaker.
 
 The human resolves by one of:
 


### PR DESCRIPTION
Authoring-Agent: claude

Closes #30. Implements Phase 2 sub-issue #30 of [Project #2 — External Review (Phase 4 Review) — Codex-in-GitHub external review automation](https://github.com/users/nathanjohnpayne/projects/2).

## Summary

Rewrites `REVIEW_POLICY.md` § Phase 4 from a single human-shuttled flow into an additive two-leg structure:

- **Phase 4a — Automated external review** via the ChatGPT Codex Connector GitHub App. Default happy path; no human in the loop.
- **Phase 4b — Manual CLI fallback** preserving the prior cross-agent flow verbatim as the escape hatch.

Existing Phase 4 semantics are preserved byte-for-byte as Phase 4b — agents that hit the fallback path see exactly the workflow they did before. No prior behavior is broken.

## Scope

Single file touched: `REVIEW_POLICY.md`. 4 edits:

1. **§ Phase 4 rewrite** (was lines 148–158): introduces the 4a/4b split with 7 automated steps (11a–17a) and 9 fallback steps (11b–19b) preserving the old narrative. New subsection headers: Phase 4a and Phase 4b.
2. **§ Flow Diagram** (was lines 161–205): updates the Phase 4 box into two parallel boxes — Phase 4a with explicit termination branches, Phase 4b as the escape hatch — plus the merge-gate box on the 4a clearance path.
3. **§ Disagreements and Tiebreaking** (was 3 lines at 249–251): expanded to include the three concrete detection signals (repeat-after-rebuttal, runaway rounds, second consecutive timeout), the escalation procedure, and the three human resolution paths.
4. **§ Review Policy Configuration** YAML example: adds the shipped `codex:` block from #31 with all six fields, adds the `coderabbit:` block, adds `author_identity`, and appends a note clarifying that both `enabled` flags govern agent behavior only — not app runtime.

Untouched: § Identities, PAT lookup table, § Phase 1, § Phase 2, § Phase 2.5 CodeRabbit, § Phase 3 Threshold Check, § Handoff Message Format, § Post-Merge Issue Creation, § Threshold Evaluation, § Git Identity Switching, § Adding a New Agent, § Template Usage.

## Correctness points baked into the rewrite

Each of these was caught by the #31 bootstrap PR cycle (Codex GitHub App auto-review, CodeRabbit review, and nathanpayne-codex external review) and is now explicitly called out:

1. **The Codex GitHub App never posts `APPROVED` state reviews.** It uses `COMMENTED` regardless of findings, and signals "no findings" via a 👍 reaction on the PR issue. The new Phase 4a explicitly states both signals and warns that a merge gate requiring `APPROVED` from the bot will be unreachable. See #29 for the observational evidence.
2. **Findings appear as inline comments on `/pulls/{pr}/comments`**, not in the top-level review body. They carry priority markers `![P0 Badge]` through `![P3 Badge]`. Consumers must poll both `/reviews` and `/comments` endpoints.
3. **REST API returns the bot login with the `[bot]` suffix.** GraphQL strips it. The config example in the rewrite uses the REST form consistently.
4. **`coderabbit.enabled: false` does not actually disable CodeRabbit** — it only tells the agent to skip Phase 2.5. The CodeRabbit GitHub App continues to run based on its install state. Same semantics for the new `codex.enabled` flag. This is now documented in a call-out note under the Review Policy Configuration section so future readers don't get tripped up.

## Line count

- 121 insertions, 20 deletions, 141 total changed lines
- Under the `external_review_threshold: 300`, so CI will NOT auto-label this PR
- No files in `external_review_paths` are touched (REVIEW_POLICY.md is at repo root)

**I will manually apply `needs-external-review` after opening.** This is a high-impact policy change that warrants a cross-agent pass even though the mechanical threshold does not fire — the whole point of Project #2 is to ensure Phase 4 review correctness, and the policy document itself is exactly where wording drift is most expensive to miss.

## Self-Review

**Correctness**

- [x] Phase 4a steps 11a–17a cover request → poll → address findings → re-request → merge-gate → merge, with explicit termination cases for clearance, disagreement, runaway, and second-consecutive-timeout
- [x] Phase 4b steps 11b–19b match the old Phase 4 narrative verbatim in meaning (not word-for-word, but same intent and ordering)
- [x] The new flow diagram shows both legs and the merge-gate decision; the two legs converge only at "nathanjohnpayne merges. Done."
- [x] The § Disagreements signals (repeat-after-rebuttal, runaway, second timeout) are phrased as "any one fires → escalate" (OR semantics)
- [x] The Review Policy Configuration YAML example matches the actual shipped `codex:` block from #31, field-for-field
- [x] Cross-references use `[anchor](#anchor)` format and point at sections that still exist post-rewrite

**Regression risk**

- [x] No pre-existing Phase 4 behavior is removed — the entire old narrative is preserved as Phase 4b
- [x] No other sections are edited; I grep'd for references to Phase 4 elsewhere in the file and found only § Phase 3 pointing forward, which is unchanged
- [x] Config example uses the REAL shipped field names, so readers copying from the doc will get a working `codex:` block

**Style / conventions**

- [x] Phase 4a step numbering uses the `11a, 12a, ...` suffix pattern to distinguish from 4b's `11b, 12b, ...` — chosen over `11, 12, ... / 20, 21, ...` to keep both legs at parallel step 11
- [x] Flow diagram uses the same box-drawing character set as the existing diagram
- [x] Code references use backticks consistently for file paths, field names, and script names
- [x] Footnote-style "see #29 / #31 / #27" references added where the observational or decision trail is non-obvious

**Test coverage**

- [x] N/A for a doc-only change — no tests to run. Integration coverage comes from the Phase 3 dry-run suite (#40–#44) once #34 and #35 ship, and from any follow-up PRs that actually execute the Phase 4a flow documented here.
- [x] Cross-checked against the #29 live observations to make sure every claim in Phase 4a matches reality (bot login, review state, reaction mechanism, finding format, timeout handling)

**Security / dependency hygiene**

- [x] No new dependencies
- [x] No tokens or secrets introduced
- [x] `bot_login` and `cli_login` in the config example are public GitHub identities, not credentials

## Related

- Closes #30
- Unblocks Phase 2 sub-issues #32 (CLAUDE.md step 8), #33 (AGENTS.md workflow summary), #34 (codex-review-request.sh), #35 (codex-review-check.sh), all of which should reference the sections I added here
- Part of [Project #2](https://github.com/users/nathanjohnpayne/projects/2)
