### PR TITLE
feat(scripts): add codex-review-request.sh and codex-review-check.sh (#34, #35)

### DIFF
--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -164,6 +164,18 @@ die() {
   exit "$code"
 }
 
+# Fetch a paginated GitHub REST API endpoint and return the flattened JSON
+# array on stdout. See the identical helper in codex-review-request.sh for
+# the rationale; both scripts need the same fix (#64 review finding 3).
+fetch_api_array() {
+  local endpoint=$1
+  local label=$2
+  local raw
+  raw=$(gh api --paginate "$endpoint" 2>&1) || die 3 "failed to fetch $label: $raw"
+  echo "$raw" | jq -s 'add // []' 2>/dev/null \
+    || die 3 "failed to flatten $label pagination output"
+}
+
 # --- fetch PR metadata ------------------------------------------------------
 
 log "PR $REPO#$PR_NUMBER — fetching metadata"
@@ -180,6 +192,27 @@ HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.commi
   || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
 
 log "HEAD = $HEAD_SHA    author = $PR_AUTHOR    committer date = $HEAD_COMMITTER_DATE"
+
+# --- preflight: blocking labels --------------------------------------------
+#
+# `needs-human-review` is applied by the detect-disagreement job in
+# agent-review.yml when two reviewers have opposing opinionated states —
+# a human must resolve it. `policy-violation` is applied by
+# block-self-approval when a reviewer bot tries to approve its own PR.
+# Both block merge categorically and are not resolvable by Phase 4a flow.
+#
+# Note: `needs-external-review` is NOT a blocking label from this script's
+# perspective — it's the signal that this script should run, not a block.
+# Gate (c) resolves whether the external review is actually complete.
+PR_LABELS=$(echo "$PR_JSON" | jq -r '[.labels[].name] | join(",")')
+case ",$PR_LABELS," in
+  *,needs-human-review,*)
+    fail_gate "blocking label 'needs-human-review' present — human disagreement resolution required"
+    ;;
+  *,policy-violation,*)
+    fail_gate "blocking label 'policy-violation' present — policy violation must be resolved"
+    ;;
+esac
 
 # --- gate (a): CI checks green ---------------------------------------------
 
@@ -254,32 +287,49 @@ log "gate (a): CI is green (Label Gate failure, if present, is expected during P
 
 # --- gate (b): reviewer identity approval ----------------------------------
 
-log "gate (b): checking for APPROVED review from a reviewer identity"
+log "gate (b): checking for latest-state APPROVED review from a reviewer identity"
 
-REVIEWS_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate 2>&1) \
-  || die 3 "failed to fetch reviews: $REVIEWS_JSON"
+REVIEWS_JSON=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/reviews" "reviews")
 
-# Build a JSON array of reviewer logins, then filter reviews to approved
-# ones from those logins, excluding the PR author.
+# Build a JSON array of reviewer logins for the filter.
 REVIEWERS_JSON=$(echo "$REVIEWERS" | jq -R . | jq -s .)
 
+# Take each reviewer identity's LATEST OPINIONATED review state — where
+# "opinionated" means APPROVED, CHANGES_REQUESTED, or DISMISSED. COMMENTED
+# reviews are informational and do not change a reviewer's position. The
+# gate passes iff at least one reviewer identity's latest opinionated
+# state is APPROVED.
+#
+# Note (#64 review finding 1): the previous implementation matched any
+# historical APPROVED review, which meant a reviewer who approved at t=0
+# and later submitted CHANGES_REQUESTED at t=5 still cleared the gate.
+# The group_by + max_by pattern below fixes that by collapsing each
+# reviewer's review history down to their latest opinionated state.
+#
+# Multi-reviewer disagreement (one reviewer approves, another requests
+# changes) is caught by the preflight blocking-label check above: the
+# Agent Review Pipeline's detect-disagreement job applies
+# `needs-human-review`, which the preflight rejects before this gate runs.
 APPROVING_REVIEWER=$(echo "$REVIEWS_JSON" | jq -r \
   --argjson reviewers "$REVIEWERS_JSON" \
   --arg author "$PR_AUTHOR" '
     [ .[]
-      | select(.state == "APPROVED")
+      | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
       | select(.user.login as $u | $reviewers | index($u))
       | select(.user.login != $author)
-      | .user.login
     ]
-    | first // empty
+    | group_by(.user.login)
+    | map(max_by(.submitted_at))
+    | map(select(.state == "APPROVED"))
+    | first
+    | if . == null then empty else .user.login end
 ')
 
 if [ -z "$APPROVING_REVIEWER" ]; then
-  fail_gate "no APPROVED review from a reviewer identity in available_reviewers"
+  fail_gate "no reviewer identity in available_reviewers has a latest-state APPROVED review (COMMENTED reviews are ignored; later CHANGES_REQUESTED/DISMISSED overrides earlier APPROVED)"
 fi
 
-log "gate (b): APPROVED by $APPROVING_REVIEWER"
+log "gate (b): latest-state APPROVED by $APPROVING_REVIEWER"
 
 # --- gate (c): Codex cleared on current HEAD -------------------------------
 
@@ -290,29 +340,42 @@ log "gate (c): checking Codex clearance on $HEAD_SHA"
 CODEX_REVIEW=$(echo "$REVIEWS_JSON" | jq \
   --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" '
   [.[] | select(.user.login == $bot) | select(.commit_id == $sha)]
-  | sort_by(.submitted_at) | last
+  | max_by(.submitted_at) // null
 ')
 
-# Inline findings on the current HEAD. Filter for P0/P1 only — P2/P3
-# don't block clearance per REVIEW_POLICY.md § Phase 4a step 15a.
-COMMENTS_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate 2>&1) \
-  || die 3 "failed to fetch inline comments: $COMMENTS_JSON"
+# If a Codex review on HEAD exists, extract its id for filtering inline
+# comments down to THAT REVIEW ONLY. Older reviews on the same HEAD
+# (same-HEAD rebuttal flow) must not count, per #64 review finding 2:
+# if Codex posted a review with P1 findings, the agent replied with a
+# rebuttal, and Codex's next review on the same HEAD cleared the
+# finding, the earlier P1 comments are still visible in the API but
+# tied to the older review's id. Filtering by pull_request_review_id
+# scopes the findings to the latest round only.
+CODEX_REVIEW_ID=$(echo "$CODEX_REVIEW" | jq -r 'if . == null then "" else .id end')
 
-UNADDRESSED_P01=$(echo "$COMMENTS_JSON" | jq \
-  --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" '
-  [ .[]
-    | select(.user.login == $bot)
-    | select((.original_commit_id == $sha) or (.commit_id == $sha))
-    | select(.body | test("!\\[P[01] Badge\\]"))
-    | { path, line, comment_id: .id }
-  ]
-')
+COMMENTS_JSON=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "inline comments")
+
+# P0/P1 inline findings from the LATEST Codex review round on HEAD only.
+# P2/P3 don't block clearance per REVIEW_POLICY.md § Phase 4a step 15a.
+# If there's no Codex review on HEAD, UNADDRESSED_P01 is [] — the
+# reaction path is then the only way gate (c) can clear.
+if [ -n "$CODEX_REVIEW_ID" ] && [ "$CODEX_REVIEW_ID" != "null" ]; then
+  UNADDRESSED_P01=$(echo "$COMMENTS_JSON" | jq \
+    --argjson review_id "$CODEX_REVIEW_ID" '
+    [ .[]
+      | select(.pull_request_review_id == $review_id)
+      | select(.body | test("!\\[P[01] Badge\\]"))
+      | { path, line, comment_id: .id }
+    ]
+  ')
+else
+  UNADDRESSED_P01='[]'
+fi
 
 UNADDRESSED_COUNT=$(echo "$UNADDRESSED_P01" | jq 'length')
 
 # +1 reaction on the PR issue from the Codex bot, dated after HEAD commit.
-REACTIONS_JSON=$(gh api "repos/$REPO/issues/$PR_NUMBER/reactions" --paginate 2>&1) \
-  || die 3 "failed to fetch reactions: $REACTIONS_JSON"
+REACTIONS_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/reactions" "reactions")
 
 RECENT_THUMBS_UP=$(echo "$REACTIONS_JSON" | jq \
   --arg bot "$BOT_LOGIN" --arg after "$HEAD_COMMITTER_DATE" '

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# scripts/codex-review-check.sh — Phase 4a merge gate
+#
+# Verifies that a pull request is ready to merge under the Phase 4a
+# automated external review flow. Read-only. Never merges, labels, or
+# comments on the PR.
+#
+# Usage:
+#   scripts/codex-review-check.sh <PR_NUMBER> [REPO]
+#
+# Arguments:
+#   PR_NUMBER  Required. The pull request number (integer).
+#   REPO       Optional. "owner/repo". Defaults to the current repo.
+#
+# Environment:
+#   GH_TOKEN   Required. Needs pull_requests:read + checks:read.
+#
+# Merge gate (all three must pass):
+#
+#   (a) Required CI checks are green.
+#       `gh pr checks` reports no failing or pending required checks.
+#
+#   (b) At least one APPROVED review from a reviewer identity in
+#       codex.available_reviewers (e.g., nathanpayne-claude,
+#       nathanpayne-cursor, nathanpayne-codex) is present on the PR,
+#       from an account != the PR author.
+#
+#   (c) Codex has cleared on or after the current HEAD commit via one
+#       of two signals:
+#
+#         - A COMMENTED review from the Codex bot on the current HEAD
+#           with NO unaddressed P0/P1 inline findings, OR
+#         - A +1 / 👍 reaction from the Codex bot on the PR issue
+#           with created_at >= current HEAD committer date.
+#
+#       The merge gate explicitly does NOT require an APPROVED review
+#       state from the Codex bot. The ChatGPT Codex Connector GitHub
+#       App never emits APPROVED — it uses COMMENTED with inline
+#       findings, or no review at all when it reacts 👍. See #29 for
+#       live observational evidence from the PR #53 bootstrap.
+#
+# "Unaddressed" heuristic for v1:
+#   A P0/P1 finding is considered unaddressed if it exists on the
+#   current HEAD (original_commit_id == HEAD or commit_id == HEAD) in
+#   Codex's LATEST review round. Findings from earlier rounds that
+#   are not re-raised by Codex on the current HEAD are considered
+#   implicitly addressed — the agent either fixed them or Codex
+#   accepted a rebuttal. This is the simpler end of the two options
+#   discussed in the #35 refinement; see #35 comment thread for the
+#   reply-matching version if false-negatives become a problem.
+#
+# Exit codes:
+#   0   All three gate conditions pass; PR is mergeable.
+#   1   At least one gate condition fails. A one-line reason is
+#       printed to stderr.
+#   3   API / infrastructure error. Error message on stderr.
+#
+# Design notes:
+#   - Read-only. The only API calls are GETs: pulls, reviews, comments,
+#     reactions, commits, checks. No POSTs, no PATCHes, no DELETEs.
+#   - Uses jq for all JSON parsing. No ad-hoc string extraction.
+#   - The available_reviewers list is read from .github/review-policy.yml
+#     at runtime via the same state-machine awk parser used in
+#     agent-review.yml post-#54.
+#
+# References:
+#   - Project #2 — External Review (Phase 4 Review)
+#   - #35 — this script
+#   - #29 — live observations
+#   - REVIEW_POLICY.md § Phase 4a merge gate (canonical policy)
+#   - #37 — scripts/hooks/gh-pr-guard.sh extension that will call this
+#     script before allowing `gh pr merge` on a labeled PR
+
+set -euo pipefail
+
+# --- argument parsing -------------------------------------------------------
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <PR_NUMBER> [REPO]" >&2
+  exit 3
+fi
+
+PR_NUMBER=$1
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: PR_NUMBER must be an integer; got '$PR_NUMBER'" >&2
+  exit 3
+fi
+
+REPO=${2:-}
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+  if [ -z "$REPO" ]; then
+    echo "ERROR: could not detect current repo via 'gh repo view'. Pass REPO explicitly." >&2
+    exit 3
+  fi
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  exit 3
+fi
+
+# --- config readers ---------------------------------------------------------
+
+CONFIG=".github/review-policy.yml"
+
+# Read a scalar field from the codex: block. See agent-review.yml
+# post-#54 for the rationale on the state-machine awk parser.
+codex_field() {
+  local field=$1
+  [ -f "$CONFIG" ] || return 0
+  awk -v field="$field" '
+    /^codex:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block && $1 == field":" {
+      sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+      gsub(/^"/, "", $0)
+      gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      gsub(/[[:space:]]*#.*$/, "", $0)
+      sub(/[[:space:]]+$/, "", $0)
+      print
+      exit
+    }
+  ' "$CONFIG"
+}
+
+BOT_LOGIN=$(codex_field bot_login)
+BOT_LOGIN=${BOT_LOGIN:-"chatgpt-codex-connector[bot]"}
+
+# Read the available_reviewers list (one per line). Same state-machine
+# awk pattern, but collecting list items rather than matching a scalar.
+# Outputs one reviewer login per line to stdout. Handles both quoted
+# (`  - "name"`) and unquoted (`  - name`) list item formats.
+read_available_reviewers() {
+  [ -f "$CONFIG" ] || return 0
+  awk '
+    /^available_reviewers:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block && /^ *-/ {print}
+  ' "$CONFIG" | sed -E 's/^[[:space:]]*-[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/'
+}
+
+REVIEWERS=$(read_available_reviewers)
+if [ -z "$REVIEWERS" ]; then
+  echo "ERROR: no available_reviewers found in $CONFIG" >&2
+  exit 3
+fi
+
+# --- logging helpers --------------------------------------------------------
+
+log() {
+  echo "[codex-review-check] $*" >&2
+}
+
+fail_gate() {
+  echo "[codex-review-check] FAIL: $*" >&2
+  exit 1
+}
+
+die() {
+  local code=$1
+  shift
+  echo "[codex-review-check] ERROR: $*" >&2
+  exit "$code"
+}
+
+# --- fetch PR metadata ------------------------------------------------------
+
+log "PR $REPO#$PR_NUMBER — fetching metadata"
+
+PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>&1) || die 3 "failed to fetch PR metadata: $PR_JSON"
+
+HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login')
+if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+  die 3 "could not determine HEAD sha for PR #$PR_NUMBER"
+fi
+
+HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \
+  || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
+
+log "HEAD = $HEAD_SHA    author = $PR_AUTHOR    committer date = $HEAD_COMMITTER_DATE"
+
+# --- gate (a): CI checks green ---------------------------------------------
+
+log "gate (a): checking CI state"
+
+# Use the structured statusCheckRollup instead of `gh pr checks` so we can
+# filter out checks that are EXPECTED to be failing during Phase 4a flow:
+#
+#   - "Label Gate" (from the "PR Review Policy" workflow) fails by design
+#     whenever `needs-external-review`, `needs-human-review`, or
+#     `policy-violation` is present on the PR. During Phase 4a, the first
+#     of those labels is always set by pr-review-policy.yml, so Label Gate
+#     will fail. It's the enforcement mechanism for "don't merge until
+#     external review clears" — NOT a code-quality signal. We verify
+#     external review clearance separately in gate (b) below.
+#
+# All OTHER checks must be in a successful or explicitly skipped terminal
+# state. A check still running (no conclusion yet) is treated as not-green
+# — the caller should wait or retry. SKIPPED is treated as success because
+# many Agent Review Pipeline jobs skip by design when the label is set.
+ROLLUP_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json statusCheckRollup 2>&1) \
+  || die 3 "failed to fetch statusCheckRollup: $ROLLUP_JSON"
+
+# statusCheckRollup mixes two entry types:
+#   - CheckRun (GitHub Actions jobs): uses .name, .workflowName,
+#     .status, .conclusion (SUCCESS/SKIPPED/FAILURE/NEUTRAL/CANCELLED/
+#     TIMED_OUT/ACTION_REQUIRED).
+#   - StatusContext (commit statuses, e.g. CodeRabbit): uses .context
+#     (as the label) and .state (SUCCESS/FAILURE/PENDING/ERROR/EXPECTED).
+#     No .workflowName, .name, .status, or .conclusion.
+#
+# Normalize both into {label, workflow, result}, then accept only
+# SUCCESS / SKIPPED / NEUTRAL as non-blocking.
+BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq '
+  [.statusCheckRollup[]
+    | {
+        label: (.name // .context // "?"),
+        workflow: (.workflowName // ""),
+        result: (.conclusion // .state // "")
+      }
+    # Filter out the known "expected to fail during Phase 4a" check.
+    # Label Gate lives in the "PR Review Policy" workflow and fails by
+    # design whenever needs-external-review / needs-human-review /
+    # policy-violation is set. That enforcement is what Phase 4a is
+    # trying to unblock; we verify clearance separately in gate (c).
+    | select(
+        (.workflow != "PR Review Policy") or
+        (.label != "Label Gate")
+      )
+    # A check passes the gate iff its result is SUCCESS, SKIPPED, or
+    # NEUTRAL. Everything else — FAILURE, CANCELLED, TIMED_OUT,
+    # ACTION_REQUIRED, PENDING, EXPECTED, ERROR, or unknown — blocks.
+    | select(
+        (.result != "SUCCESS") and
+        (.result != "SKIPPED") and
+        (.result != "NEUTRAL")
+      )
+  ]
+')
+
+BAD_COUNT=$(echo "$BAD_CHECKS" | jq 'length')
+
+if [ "$BAD_COUNT" -gt 0 ]; then
+  SUMMARY=$(echo "$BAD_CHECKS" | jq -r '
+    [.[] | (if .workflow == "" then .label else "\(.workflow)/\(.label)" end) + "=" + .result]
+    | unique | join(", ")
+  ')
+  fail_gate "CI not green: $BAD_COUNT non-passing check(s): $SUMMARY"
+fi
+
+log "gate (a): CI is green (Label Gate failure, if present, is expected during Phase 4a)"
+
+# --- gate (b): reviewer identity approval ----------------------------------
+
+log "gate (b): checking for APPROVED review from a reviewer identity"
+
+REVIEWS_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate 2>&1) \
+  || die 3 "failed to fetch reviews: $REVIEWS_JSON"
+
+# Build a JSON array of reviewer logins, then filter reviews to approved
+# ones from those logins, excluding the PR author.
+REVIEWERS_JSON=$(echo "$REVIEWERS" | jq -R . | jq -s .)
+
+APPROVING_REVIEWER=$(echo "$REVIEWS_JSON" | jq -r \
+  --argjson reviewers "$REVIEWERS_JSON" \
+  --arg author "$PR_AUTHOR" '
+    [ .[]
+      | select(.state == "APPROVED")
+      | select(.user.login as $u | $reviewers | index($u))
+      | select(.user.login != $author)
+      | .user.login
+    ]
+    | first // empty
+')
+
+if [ -z "$APPROVING_REVIEWER" ]; then
+  fail_gate "no APPROVED review from a reviewer identity in available_reviewers"
+fi
+
+log "gate (b): APPROVED by $APPROVING_REVIEWER"
+
+# --- gate (c): Codex cleared on current HEAD -------------------------------
+
+log "gate (c): checking Codex clearance on $HEAD_SHA"
+
+# Latest Codex review on the current HEAD commit (if any). Codex always
+# uses COMMENTED state regardless of findings — do NOT filter on state.
+CODEX_REVIEW=$(echo "$REVIEWS_JSON" | jq \
+  --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" '
+  [.[] | select(.user.login == $bot) | select(.commit_id == $sha)]
+  | sort_by(.submitted_at) | last
+')
+
+# Inline findings on the current HEAD. Filter for P0/P1 only — P2/P3
+# don't block clearance per REVIEW_POLICY.md § Phase 4a step 15a.
+COMMENTS_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate 2>&1) \
+  || die 3 "failed to fetch inline comments: $COMMENTS_JSON"
+
+UNADDRESSED_P01=$(echo "$COMMENTS_JSON" | jq \
+  --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" '
+  [ .[]
+    | select(.user.login == $bot)
+    | select((.original_commit_id == $sha) or (.commit_id == $sha))
+    | select(.body | test("!\\[P[01] Badge\\]"))
+    | { path, line, comment_id: .id }
+  ]
+')
+
+UNADDRESSED_COUNT=$(echo "$UNADDRESSED_P01" | jq 'length')
+
+# +1 reaction on the PR issue from the Codex bot, dated after HEAD commit.
+REACTIONS_JSON=$(gh api "repos/$REPO/issues/$PR_NUMBER/reactions" --paginate 2>&1) \
+  || die 3 "failed to fetch reactions: $REACTIONS_JSON"
+
+RECENT_THUMBS_UP=$(echo "$REACTIONS_JSON" | jq \
+  --arg bot "$BOT_LOGIN" --arg after "$HEAD_COMMITTER_DATE" '
+  [.[]
+    | select(.user.login == $bot)
+    | select(.content == "+1")
+    | select(.created_at >= $after)
+  ] | length
+')
+
+# Decide: cleared iff (review on HEAD with zero P0/P1) OR (recent +1 reaction).
+CODEX_REVIEW_ON_HEAD=$(echo "$CODEX_REVIEW" | jq 'if . == null then false else true end')
+
+CLEARED=false
+CLEARANCE_REASON=""
+
+if [ "$RECENT_THUMBS_UP" -gt 0 ]; then
+  CLEARED=true
+  CLEARANCE_REASON="👍 reaction from $BOT_LOGIN on or after $HEAD_COMMITTER_DATE"
+elif [ "$CODEX_REVIEW_ON_HEAD" = "true" ] && [ "$UNADDRESSED_COUNT" -eq 0 ]; then
+  CLEARED=true
+  CLEARANCE_REASON="COMMENTED review from $BOT_LOGIN on $HEAD_SHA with no unaddressed P0/P1 findings"
+fi
+
+if [ "$CLEARED" != "true" ]; then
+  if [ "$CODEX_REVIEW_ON_HEAD" = "false" ] && [ "$RECENT_THUMBS_UP" -eq 0 ]; then
+    fail_gate "Codex has not cleared current HEAD (no review and no +1 reaction from $BOT_LOGIN since $HEAD_COMMITTER_DATE)"
+  else
+    PATHS=$(echo "$UNADDRESSED_P01" | jq -r '[.[] | "\(.path):\(.line)"] | join(", ")')
+    fail_gate "Codex review on HEAD has $UNADDRESSED_COUNT unaddressed P0/P1 finding(s): $PATHS"
+  fi
+fi
+
+log "gate (c): cleared — $CLEARANCE_REASON"
+
+# --- all gates pass ---------------------------------------------------------
+
+log "all merge gates pass — PR $REPO#$PR_NUMBER is mergeable under Phase 4a"
+exit 0

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -175,6 +175,22 @@ die() {
   exit "$code"
 }
 
+# Fetch a paginated GitHub REST API endpoint and return the flattened JSON
+# array on stdout. `gh api --paginate` emits one JSON value per page
+# concatenated into a single stream — `jq`'s default mode runs the filter
+# once per input (per page), which miscounts and misfilters on multi-page
+# PRs. Slurp with `-s` collects all inputs into an outer array, then `add`
+# concatenates the per-page arrays into one flat array. Defaults to `[]`
+# on empty input. Exits 3 on API or parse error.
+fetch_api_array() {
+  local endpoint=$1
+  local label=$2
+  local raw
+  raw=$(gh api --paginate "$endpoint" 2>&1) || die 3 "failed to fetch $label: $raw"
+  echo "$raw" | jq -s 'add // []' 2>/dev/null \
+    || die 3 "failed to flatten $label pagination output"
+}
+
 # --- fetch PR metadata ------------------------------------------------------
 
 log "PR $REPO#$PR_NUMBER — fetching HEAD commit metadata"
@@ -204,14 +220,9 @@ log "bot_login = $BOT_LOGIN    timeout = ${TIMEOUT_SECONDS}s"
 scan_codex_state() {
   local reviews comments reactions review findings reaction
 
-  reviews=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate 2>&1) \
-    || { echo "API_ERROR: reviews: $reviews" >&2; return 3; }
-
-  comments=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate 2>&1) \
-    || { echo "API_ERROR: comments: $comments" >&2; return 3; }
-
-  reactions=$(gh api "repos/$REPO/issues/$PR_NUMBER/reactions" --paginate 2>&1) \
-    || { echo "API_ERROR: reactions: $reactions" >&2; return 3; }
+  reviews=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/reviews" "reviews")
+  comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "inline comments")
+  reactions=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/reactions" "reactions")
 
   # Latest review from the Codex bot on the current HEAD commit, if any.
   # Codex always uses COMMENTED state regardless of findings.

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# scripts/codex-review-request.sh — Phase 4a automated external review trigger
+#
+# Triggers (or awaits) a review from the ChatGPT Codex Connector GitHub App
+# on a pull request, polls for a response against the current HEAD commit,
+# and emits a machine-parseable JSON summary of what Codex produced so a
+# caller (e.g. an authoring agent) can reason over it.
+#
+# Usage:
+#   scripts/codex-review-request.sh <PR_NUMBER> [REPO]
+#
+# Arguments:
+#   PR_NUMBER  Required. The pull request number (integer).
+#   REPO       Optional. Fully-qualified "owner/repo". Defaults to the
+#              current repository detected by `gh repo view`.
+#
+# Environment:
+#   GH_TOKEN   Required. GitHub token with pull_requests:write to post the
+#              trigger comment and read reviews/comments/reactions. In the
+#              standard template flow this is set to $OP_PREFLIGHT_AUTHOR_PAT
+#              after running `scripts/op-preflight.sh`, or via inline
+#              `op read` per REVIEW_POLICY.md § PAT lookup table.
+#
+# Behavior:
+#   1. Reads codex.review_timeout_seconds and codex.bot_login from
+#      .github/review-policy.yml (defaults: 600 / chatgpt-codex-connector[bot]).
+#   2. Fetches the PR's current HEAD commit SHA and committer date. Any
+#      Codex review/reaction is only considered "current" if it is
+#      anchored on this commit (reviews) or created after its committer
+#      date (reactions).
+#   3. Scans existing reviews, inline comments, and issue reactions for
+#      a Codex signal already present on the current HEAD. If found,
+#      skips the trigger comment and goes straight to emitting JSON —
+#      re-posting `@codex review` when Codex has already responded can
+#      cause double-processing or rate-limit pushback.
+#   4. Otherwise posts `@codex review` as a PR comment and polls every
+#      15 seconds for up to `review_timeout_seconds` for either:
+#        - a review from the Codex bot on the current HEAD, OR
+#        - a +1 reaction from the Codex bot on the PR issue dated after
+#          the current HEAD committer date.
+#   5. Emits a JSON object to stdout summarizing what Codex produced.
+#      The JSON shape is the contract with the caller; do not change
+#      field names without also updating scripts/codex-review-check.sh
+#      and the policy docs (CLAUDE.md, AGENTS.md, REVIEW_POLICY.md).
+#
+# Output JSON shape:
+#   {
+#     "pr_number": 123,
+#     "repo": "owner/repo",
+#     "head_sha": "<full sha>",
+#     "head_committer_date": "<iso-8601>",
+#     "bot_login": "chatgpt-codex-connector[bot]",
+#     "review": null | {
+#       "state": "COMMENTED",
+#       "submitted_at": "<iso-8601>",
+#       "commit_id": "<full sha>",
+#       "body": "<top-level review body>"
+#     },
+#     "findings": [
+#       { "path": "...", "line": N, "priority": "P0|P1|P2|P3",
+#         "comment_id": N, "body": "<full finding body>" }
+#     ],
+#     "reaction": null | {
+#       "content": "+1",
+#       "created_at": "<iso-8601>",
+#       "reaction_id": N
+#     },
+#     "trigger_posted": true | false,
+#     "rounds_waited_seconds": N
+#   }
+#
+# Exit codes:
+#   0   Codex signal received on current HEAD. JSON on stdout.
+#   3   API / infrastructure error. Error message on stderr.
+#   4   FALLBACK_REQUIRED — timed out waiting for a Codex signal. The
+#       caller should route to REVIEW_POLICY.md § Phase 4b. See #27 for
+#       the explicit-review-required decision that mandates this path.
+#
+# Design notes:
+#   - Read-only against the PR except for the one `@codex review` trigger
+#     comment. Does not push commits, does not modify labels, does not
+#     merge.
+#   - Idempotent. Re-running on the same PR with the same HEAD is safe:
+#     it will see the existing Codex response and skip the trigger.
+#   - JSON emission uses `jq` throughout. No ad-hoc string concatenation.
+#
+# References:
+#   - Project #2 — External Review (Phase 4 Review)
+#   - #34 — this script
+#   - #29 — live observations behind the dual-endpoint / reaction polling
+#   - REVIEW_POLICY.md § Phase 4a (canonical policy)
+
+set -euo pipefail
+
+# --- argument parsing -------------------------------------------------------
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <PR_NUMBER> [REPO]" >&2
+  echo "  PR_NUMBER  pull request number (integer)" >&2
+  echo "  REPO       owner/repo (optional; defaults to current repo)" >&2
+  exit 3
+fi
+
+PR_NUMBER=$1
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: PR_NUMBER must be an integer; got '$PR_NUMBER'" >&2
+  exit 3
+fi
+
+REPO=${2:-}
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+  if [ -z "$REPO" ]; then
+    echo "ERROR: could not detect current repo via 'gh repo view'. Pass REPO explicitly." >&2
+    exit 3
+  fi
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  exit 3
+fi
+
+# --- config readers ---------------------------------------------------------
+
+CONFIG=".github/review-policy.yml"
+
+# Extract a scalar field from the codex: block in review-policy.yml.
+# Uses the state-machine awk pattern established in #54 (stops at the next
+# top-level key, tolerates column-0 comments). Returns empty string if the
+# field is not present, which the caller should turn into a default.
+codex_field() {
+  local field=$1
+  [ -f "$CONFIG" ] || return 0
+  awk -v field="$field" '
+    /^codex:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block {
+      # Match "  field: value" or "  field: \"value\""
+      if ($1 == field":") {
+        sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+        gsub(/^"/, "", $0)
+        gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+        gsub(/[[:space:]]*#.*$/, "", $0)
+        sub(/[[:space:]]+$/, "", $0)
+        print
+        exit
+      }
+    }
+  ' "$CONFIG"
+}
+
+TIMEOUT_SECONDS=$(codex_field review_timeout_seconds)
+TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-600}
+if ! [[ "$TIMEOUT_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: codex.review_timeout_seconds must be an integer; got '$TIMEOUT_SECONDS'" >&2
+  exit 3
+fi
+
+BOT_LOGIN=$(codex_field bot_login)
+BOT_LOGIN=${BOT_LOGIN:-"chatgpt-codex-connector[bot]"}
+
+POLL_INTERVAL_SECONDS=15
+
+# --- logging helpers --------------------------------------------------------
+
+log() {
+  echo "[codex-review-request] $*" >&2
+}
+
+die() {
+  local code=$1
+  shift
+  echo "[codex-review-request] ERROR: $*" >&2
+  exit "$code"
+}
+
+# --- fetch PR metadata ------------------------------------------------------
+
+log "PR $REPO#$PR_NUMBER — fetching HEAD commit metadata"
+
+PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>&1) || die 3 "failed to fetch PR metadata: $PR_JSON"
+
+HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+  die 3 "could not determine HEAD sha for PR #$PR_NUMBER"
+fi
+
+# committer date, not author date — reactions are compared against commit
+# arrival time at GitHub, not commit authorship
+HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \
+  || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
+
+log "HEAD = $HEAD_SHA committed at $HEAD_COMMITTER_DATE"
+log "bot_login = $BOT_LOGIN    timeout = ${TIMEOUT_SECONDS}s"
+
+# --- Codex signal scan ------------------------------------------------------
+
+# Scan for (a) a review from the bot on the current HEAD commit, (b) inline
+# findings from the bot on the current HEAD, (c) a +1 reaction on the issue
+# dated after the HEAD committer date. Returns a JSON object to stdout on
+# success. Emits empty object { "review": null, "findings": [], "reaction": null }
+# if nothing matches yet.
+scan_codex_state() {
+  local reviews comments reactions review findings reaction
+
+  reviews=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate 2>&1) \
+    || { echo "API_ERROR: reviews: $reviews" >&2; return 3; }
+
+  comments=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate 2>&1) \
+    || { echo "API_ERROR: comments: $comments" >&2; return 3; }
+
+  reactions=$(gh api "repos/$REPO/issues/$PR_NUMBER/reactions" --paginate 2>&1) \
+    || { echo "API_ERROR: reactions: $reactions" >&2; return 3; }
+
+  # Latest review from the Codex bot on the current HEAD commit, if any.
+  # Codex always uses COMMENTED state regardless of findings.
+  review=$(echo "$reviews" | jq --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" '
+    [.[] | select(.user.login == $bot) | select(.commit_id == $sha)]
+    | sort_by(.submitted_at) | last
+    | if . == null then null
+      else { state, submitted_at, commit_id, body }
+      end
+  ')
+
+  # Inline findings from the bot on the current HEAD commit, with P0-P3
+  # priority extracted from the ![P{0-3} Badge] markdown shortcode.
+  findings=$(echo "$comments" | jq --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" '
+    [ .[]
+      | select(.user.login == $bot)
+      | select((.original_commit_id == $sha) or (.commit_id == $sha))
+      | { path, line, comment_id: .id, body,
+          priority: (
+            (.body | capture("!\\[P(?<n>[0-3]) Badge\\]")? // {n: null}) | .n
+            | if . == null then "P?" else "P" + . end
+          )
+        }
+    ]
+  ')
+
+  # Most recent +1 reaction from the bot on the issue with created_at
+  # strictly >= the HEAD committer date.
+  reaction=$(echo "$reactions" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_COMMITTER_DATE" '
+    [.[]
+      | select(.user.login == $bot)
+      | select(.content == "+1")
+      | select(.created_at >= $after)
+    ]
+    | sort_by(.created_at) | last
+    | if . == null then null
+      else { content, created_at, reaction_id: .id }
+      end
+  ')
+
+  jq -n --argjson review "$review" --argjson findings "$findings" --argjson reaction "$reaction" '
+    { review: $review, findings: $findings, reaction: $reaction }
+  '
+}
+
+# Returns 0 iff the scan produced a review or reaction (signal received).
+has_signal() {
+  local scan=$1
+  [ "$(echo "$scan" | jq -r '.review != null or .reaction != null')" = "true" ]
+}
+
+# --- pre-flight: is Codex already working on HEAD? --------------------------
+
+log "checking for existing Codex signal on HEAD"
+if ! INITIAL_SCAN=$(scan_codex_state); then
+  die 3 "initial Codex scan failed"
+fi
+
+TRIGGER_POSTED=false
+
+if has_signal "$INITIAL_SCAN"; then
+  log "Codex has already responded on HEAD — skipping trigger comment"
+else
+  log "posting '@codex review' trigger comment"
+  if ! gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" >/dev/null 2>&1; then
+    die 3 "failed to post '@codex review' comment"
+  fi
+  TRIGGER_POSTED=true
+fi
+
+# --- poll loop --------------------------------------------------------------
+
+START_TS=$(date +%s)
+DEADLINE=$((START_TS + TIMEOUT_SECONDS))
+ELAPSED=0
+
+FINAL_SCAN=$INITIAL_SCAN
+
+while :; do
+  if has_signal "$FINAL_SCAN"; then
+    log "Codex signal received after ${ELAPSED}s"
+    break
+  fi
+
+  NOW=$(date +%s)
+  if [ "$NOW" -ge "$DEADLINE" ]; then
+    log "TIMEOUT after ${ELAPSED}s — no Codex review or reaction on HEAD"
+    log "emitting JSON with review=null, reaction=null; exit code 4 (FALLBACK_REQUIRED)"
+    # Fall through to JSON emission so the caller still gets a structured
+    # answer (all nulls), then exit 4.
+    break
+  fi
+
+  log "polling... (${ELAPSED}s / ${TIMEOUT_SECONDS}s)"
+  sleep "$POLL_INTERVAL_SECONDS"
+  ELAPSED=$(( $(date +%s) - START_TS ))
+
+  if ! FINAL_SCAN=$(scan_codex_state); then
+    die 3 "poll scan failed"
+  fi
+done
+
+# --- emit final JSON --------------------------------------------------------
+
+jq -n \
+  --argjson pr_number "$PR_NUMBER" \
+  --arg repo "$REPO" \
+  --arg head_sha "$HEAD_SHA" \
+  --arg head_committer_date "$HEAD_COMMITTER_DATE" \
+  --arg bot_login "$BOT_LOGIN" \
+  --argjson scan "$FINAL_SCAN" \
+  --argjson trigger_posted "$TRIGGER_POSTED" \
+  --argjson elapsed "$ELAPSED" '
+  {
+    pr_number: $pr_number,
+    repo: $repo,
+    head_sha: $head_sha,
+    head_committer_date: $head_committer_date,
+    bot_login: $bot_login,
+    review: $scan.review,
+    findings: $scan.findings,
+    reaction: $scan.reaction,
+    trigger_posted: $trigger_posted,
+    rounds_waited_seconds: $elapsed
+  }
+'
+
+# Exit 0 if a signal arrived; exit 4 (FALLBACK_REQUIRED) if we timed out.
+if has_signal "$FINAL_SCAN"; then
+  exit 0
+else
+  exit 4
+fi


### PR DESCRIPTION
Authoring-Agent: claude

Closes #34. Closes #35. Combined PR because the two scripts share the same config reader, the same Codex GitHub API consumer logic, and the same mental model — and because the Phase 4a applicability condition in the policy docs explicitly requires **both** scripts on disk (shipping separately would leave every repo in a "partial rollout" state that routes to 4b until the second script lands).

## Summary

Adds the two Phase 4a helper scripts that `CLAUDE.md` / `AGENTS.md` / `REVIEW_POLICY.md` point at. Until now the policy docs described Phase 4a but no repo had the scripts on disk, so every PR fell through to Phase 4b (manual handoff) per the script-existence guard. This PR makes the automated path runnable for the first time.

- **`scripts/codex-review-request.sh` (#34, 347 lines)** — triggers and awaits a Codex review, emits JSON
- **`scripts/codex-review-check.sh` (#35, 354 lines)** — read-only merge gate

Both `100755`. 701 total insertions. Above the 300-line threshold, so CI will auto-label `needs-external-review`. I'll also apply manually as defense in depth per the feedback-memory rule (even though the #61 Layer 1 fix is now live — suspenders and belt).

## `codex-review-request.sh` — what it does

1. Reads `codex.review_timeout_seconds` and `codex.bot_login` from `.github/review-policy.yml` via the same state-machine awk parser from #54. Defaults to `600` / `chatgpt-codex-connector[bot]` if missing.
2. Fetches the PR's current HEAD commit SHA and committer date. All subsequent signal detection is anchored on this commit.
3. **Pre-flight scan.** Before posting `@codex review`, scans existing reviews, inline comments, and issue reactions for a Codex signal already present on the current HEAD. If found (e.g., the Codex App's "Automatic reviews" setting already fired on PR open), skips the trigger comment and goes straight to emitting JSON. This avoids double-processing and the rate-limit pushback I observed in #29 when sending a redundant trigger.
4. **Otherwise posts `@codex review`** as a PR comment.
5. **Polls every 15 seconds** for up to `review_timeout_seconds` until either:
   - A review from the bot on the current HEAD commit, OR
   - A `+1` reaction on the PR issue with `created_at >= head_committer_date`.
6. **Emits JSON** to stdout with the full signal structure. Contract with the caller; any schema change must land with matching changes to `codex-review-check.sh` and the policy docs.

JSON shape:

```json
{
  "pr_number": 123,
  "repo": "owner/repo",
  "head_sha": "<sha>",
  "head_committer_date": "2026-04-14T12:34:56Z",
  "bot_login": "chatgpt-codex-connector[bot]",
  "review": null | { "state": "COMMENTED", "submitted_at": "...", "commit_id": "...", "body": "..." },
  "findings": [
    { "path": "...", "line": N, "priority": "P0|P1|P2|P3", "comment_id": N, "body": "..." }
  ],
  "reaction": null | { "content": "+1", "created_at": "...", "reaction_id": N },
  "trigger_posted": true | false,
  "rounds_waited_seconds": N
}
```

Exit codes: `0` (signal received), `3` (API/infra error), `4` (FALLBACK_REQUIRED / timeout — caller should route to Phase 4b per #27).

## `codex-review-check.sh` — what it does

Read-only merge gate. Three gates must all pass:

**Gate (a) — CI checks are green.** Uses `gh pr view --json statusCheckRollup` instead of `gh pr checks` so I can normalize the two entry types (`CheckRun` uses `.conclusion`; `StatusContext` uses `.state` — CodeRabbit posts the latter). Specifically **excludes the "Label Gate" check from the "PR Review Policy" workflow** because that check fails by design while `needs-external-review` is set. Accepts `SUCCESS`/`SKIPPED`/`NEUTRAL`; rejects `FAILURE`/`CANCELLED`/`TIMED_OUT`/`ACTION_REQUIRED`/`PENDING`/`EXPECTED`/`ERROR`/unknown.

**Gate (b) — reviewer identity approval.** At least one `APPROVED` review from a login in `codex.available_reviewers` (read from YAML via the same parser), from an account `!= PR author`. The PR-author check keeps `nathanjohnpayne` from self-approving via the shared-identity model.

**Gate (c) — Codex cleared on current HEAD.** Either:
- A `COMMENTED` review from the bot on the current HEAD with **zero** unaddressed P0/P1 inline findings, where a finding is "unaddressed" if the comment's `original_commit_id` or `commit_id` matches the current HEAD AND the body matches `!\[P[01] Badge\]`. P2/P3 findings do NOT block per REVIEW_POLICY.md § Phase 4a step 15a. OR:
- A `+1` reaction from the bot on the PR issue with `created_at >= head_committer_date`.

Either signal alone is sufficient. The gate explicitly does NOT require `APPROVED` state from the Codex bot — the app never emits it. See #29 and the three policy files.

Exit codes: `0` (mergeable), `1` (gate failed, one-line reason on stderr), `3` (API/infra error).

## Local testing

### Syntax

- `bash -n scripts/codex-review-request.sh` → OK
- `bash -n scripts/codex-review-check.sh` → OK
- shellcheck not installed locally; recommend installing as part of #57 (local test harness)

### End-to-end against real data

`scripts/codex-review-check.sh 63` (merged PR #63) produces:

```
[codex-review-check] PR nathanjohnpayne/ai_agent_repo_template#63 — fetching metadata
[codex-review-check] HEAD = 15b0b5f13dd0c8d415826c8d6e0348b3e0da17e4    author = nathanjohnpayne
[codex-review-check] gate (a): checking CI state
[codex-review-check] gate (a): CI is green (Label Gate failure, if present, is expected during Phase 4a)
[codex-review-check] gate (b): checking for APPROVED review from a reviewer identity
[codex-review-check] gate (b): APPROVED by nathanpayne-claude
[codex-review-check] gate (c): checking Codex clearance on 15b0b5f13dd0c8d415826c8d6e0348b3e0da17e4
[codex-review-check] FAIL: Codex has not cleared current HEAD (no review and no +1 reaction from chatgpt-codex-connector[bot] since 2026-04-15T03:03:42Z)
exit=1
```

This is **correct behavior**: PR #63 was merged manually after an earlier Codex review on an older commit, with no Codex signal on the final HEAD. The gate correctly refuses to clear it. Gate (a) survived the Label Gate filter. Gate (b) found the nathanpayne-claude approval. Gate (c) correctly blocked.

### Error paths

- `codex-review-request.sh` (no args) → prints usage, exit 3 ✓
- `codex-review-request.sh abc` (non-numeric) → "PR_NUMBER must be an integer", exit 3 ✓
- `codex-review-request.sh 999999` (nonexistent) → "failed to fetch PR metadata: ... 404", exit 3 ✓

### Config readers

Verified against the real `.github/review-policy.yml`:

```
bot_login              → chatgpt-codex-connector[bot]
review_timeout_seconds → 600
available_reviewers    → nathanpayne-claude, nathanpayne-cursor, nathanpayne-codex
```

## Self-Review

**Correctness**

- [x] `set -euo pipefail` at the top of both scripts
- [x] Both scripts handle missing `GH_TOKEN` with exit 3 and a clear message
- [x] Both scripts validate `PR_NUMBER` is an integer with exit 3 on failure
- [x] Both scripts auto-detect the current repo via `gh repo view --json nameWithOwner` if `REPO` is omitted
- [x] All JSON parsing goes through `jq` — no ad-hoc string extraction, no regex against JSON
- [x] `codex-review-request.sh` is idempotent: the pre-flight scan skips posting the trigger if Codex has already responded on HEAD
- [x] `codex-review-check.sh` is read-only: no POST, no PATCH, no DELETE, no `gh pr merge`, no `gh pr edit`
- [x] Gate (a) correctly filters only the specific `"PR Review Policy" / "Label Gate"` check, not all checks from that workflow
- [x] Gate (a) accepts both `CheckRun` and `StatusContext` entry types (CodeRabbit posts the latter and was the bug my first version tripped on)
- [x] Gate (b) filters by reviewer login membership, not regex match, and excludes PR author
- [x] Gate (c) correctly uses `original_commit_id` OR `commit_id` for inline findings (either matches "comment written against current HEAD")
- [x] Gate (c) correctly uses `created_at >= head_committer_date` for reactions
- [x] Priority extraction uses `!\[P(?<n>[0-3]) Badge\]` regex matching the actual Codex shortcode observed in #29
- [x] Config readers use the state-machine awk parser established in #54 (handles column-0 comments)
- [x] `read_available_reviewers` handles both `- "quoted"` and `- unquoted` list item formats

**Regression risk**

- [x] New files, no existing behavior changed
- [x] Does not modify any other script or workflow file
- [x] Does not touch the `codex:` YAML block or any config
- [x] Policy docs already reference these files (`codex-review-request.sh`, `codex-review-check.sh`) by exact name from #32/#33 — no doc update needed
- [x] Executable mode `100755` set at commit time; verified via `git ls-files --stage`

**Style / conventions**

- [x] Shebang `#!/usr/bin/env bash` for portability
- [x] Long comment headers documenting arguments, environment, behavior, JSON shape, exit codes, and cross-references
- [x] `log()` / `die()` / `fail_gate()` helpers for consistent stderr output
- [x] Structured output to stdout, status to stderr — caller can pipe stdout to `jq` cleanly
- [x] References to issue numbers (#27, #29, #34, #35, #54, #57) inline with the code that was informed by them

**Test coverage**

- [x] Syntax check via `bash -n` on both
- [x] End-to-end run of `codex-review-check.sh` against real merged PR #63 (positive gate (a) and (b), negative gate (c) as expected for a PR without current-HEAD Codex signal)
- [x] Error-path tests on `codex-review-request.sh` (missing args, non-numeric, nonexistent PR)
- [x] Config reader tests against real `review-policy.yml`
- [ ] **Not yet tested: end-to-end run of `codex-review-request.sh` against a live PR that triggers Codex.** This is the Phase 2 smoke test #29 — will run as part of the verification once this PR merges and the scripts are available on `main` for the first time

**Security / dependency hygiene**

- [x] No new dependencies — relies only on `bash`, `gh`, `jq`, `awk`, `sed`
- [x] Both scripts use `$GH_TOKEN` exclusively, no hardcoded tokens
- [x] No user-controlled input reaches a shell command — `$PR_NUMBER` is validated as integer, `$REPO` is interpolated into `gh api` URLs which `gh` URL-encodes correctly
- [x] `jq` handles all JSON escaping
- [x] No new secrets introduced

## Forward-looking notes

- The `codex-review-request.sh` script makes exactly one mutation to the PR: posting the `@codex review` trigger comment (conditionally). Everything else is `GET`. This matches the design in #34's scope.
- `codex-review-check.sh` is fully read-only. It's safe to run repeatedly from a pre-merge hook or a local script without side effects.
- **The "unaddressed" heuristic for inline findings is the simpler v1** from #35's refinement note: a P0/P1 finding on the current HEAD commit is unaddressed. Stale findings from earlier commits are implicitly cleared (Codex either accepted a fix or hasn't re-flagged them). The reply-matching version (parsing author rebuttals to distinguish "still unresolved" from "rebutted") is a potential v2 if false-negatives become a problem.
- **The `codex.max_review_rounds` field is NOT consumed by these scripts.** That's by design — the round counter is the caller's state, not the script's. The scripts are stateless; the caller (CLAUDE.md step 9) tracks rounds and decides when to escalate.

## Related

- Closes #34, #35
- Depends on: #30, #31, #32, #33 (all shipped)
- Forward-references: #29 (live smoke test, unblocked by this PR), #37 (gh-pr-guard.sh extension that will call codex-review-check.sh), #38 (CI check that scripts exist and are executable)
- Part of [Project #2](https://github.com/users/nathanjohnpayne/projects/2)
