### PR TITLE
fix(scripts): latest-signal-wins in gate (c) + HEAD pushed-at anchor (#64 follow-up)

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -156,3 +156,36 @@ codex:
   # report green before allowing merge. Strongly recommended; do not disable
   # without explicit human authorization.
   require_ci_green: true
+
+  # Maximum age, in seconds, of a `+1` / 👍 reaction from the Codex bot that
+  # can clear gate (c) in codex-review-check.sh and be treated as a current
+  # signal by the pre-flight scan in codex-review-request.sh.
+  #
+  # Background: GitHub's REST and GraphQL APIs do not expose a per-PR push
+  # timestamp for ordinary (non-force) pushes. The timeline endpoint has a
+  # `committed` event for each commit, but its `created_at` field is null
+  # (verified against PR #63 on 2026-04-15). For force-push, the
+  # `head_ref_force_pushed` event provides a tight per-PR arrival time;
+  # for ordinary push, the best anchor we can derive is the commit's
+  # committer date, which is commit metadata and can be arbitrarily old
+  # (cherry-pick, rebase with `--committer-date-is-author-date`, or any
+  # commit amended from a previously-authored SHA).
+  #
+  # Consequence: without a freshness constraint, a stale 👍 reaction from
+  # a prior HEAD would pass `reaction.created_at >= HEAD_COMMITTER_DATE`
+  # when the new HEAD's committer date is older than the prior 👍 — a
+  # false clear.
+  #
+  # Mitigation: require the 👍 reaction to be created within this many
+  # seconds of the scan time. A stale 👍 from a prior HEAD is filtered
+  # out once it ages past the window, closing the exposure in practice.
+  # The window must be long enough for a typical Phase 4a cycle (push →
+  # `@codex review` trigger → Codex response → gate check) to complete
+  # without forcing a re-trigger, and short enough that cross-cycle
+  # staleness is caught.
+  #
+  # Default 1800 seconds (30 min) is conservative for the agent flow;
+  # typical cycles complete in 1–5 minutes. Applies to both
+  # codex-review-check.sh gate (c) and codex-review-request.sh pre-flight
+  # and poll scans.
+  reaction_freshness_window_seconds: 1800

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -191,7 +191,32 @@ fi
 HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \
   || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
 
-log "HEAD = $HEAD_SHA    author = $PR_AUTHOR    committer date = $HEAD_COMMITTER_DATE"
+# HEAD_PUSHED_AT: the timestamp to use as the "when did this commit
+# become current on the PR" anchor for reaction freshness. committer
+# date is commit metadata and can be ARBITRARILY OLD if someone force-
+# pushes a previously-authored commit — a stale Codex 👍 from a prior
+# HEAD could then still satisfy `reaction.created_at >= committer_date`
+# even though the reaction predates the current HEAD's existence on
+# this PR. See #64 Codex P1 finding ("Anchor reaction freshness to PR
+# head update time").
+#
+# The best proxy available from the API: the earliest check-run start
+# time on the current HEAD. A CheckRun is created only AFTER a commit
+# exists on a PR and GitHub dispatches a workflow for it, so this time
+# is strictly after the commit became the PR's HEAD. If the repo has
+# no CI at all (no check-runs exist), fall back to committer date —
+# there's no force-push concern in that case because there's also no
+# stale CI signal to worry about.
+HEAD_CHECK_RUNS_MIN=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
+  --jq '[.check_runs[].started_at] | min // ""' 2>/dev/null || echo "")
+if [ -n "$HEAD_CHECK_RUNS_MIN" ] && [ "$HEAD_CHECK_RUNS_MIN" != "null" ]; then
+  HEAD_PUSHED_AT="$HEAD_CHECK_RUNS_MIN"
+else
+  HEAD_PUSHED_AT="$HEAD_COMMITTER_DATE"
+fi
+
+log "HEAD = $HEAD_SHA    author = $PR_AUTHOR"
+log "committer_date = $HEAD_COMMITTER_DATE    pushed_at_proxy = $HEAD_PUSHED_AT"
 
 # --- preflight: blocking labels --------------------------------------------
 #
@@ -374,38 +399,78 @@ fi
 
 UNADDRESSED_COUNT=$(echo "$UNADDRESSED_P01" | jq 'length')
 
-# +1 reaction on the PR issue from the Codex bot, dated after HEAD commit.
+# Latest +1 reaction on the PR issue from the Codex bot, filtered to
+# reactions dated on or after HEAD_PUSHED_AT (see the anchor fetch
+# earlier in the script for the force-push rationale).
 REACTIONS_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/reactions" "reactions")
 
-RECENT_THUMBS_UP=$(echo "$REACTIONS_JSON" | jq \
-  --arg bot "$BOT_LOGIN" --arg after "$HEAD_COMMITTER_DATE" '
-  [.[]
+LATEST_THUMBS_UP_TIME=$(echo "$REACTIONS_JSON" | jq -r \
+  --arg bot "$BOT_LOGIN" --arg after "$HEAD_PUSHED_AT" '
+  [ .[]
     | select(.user.login == $bot)
     | select(.content == "+1")
     | select(.created_at >= $after)
-  ] | length
+    | .created_at
+  ]
+  | max // ""
 ')
 
-# Decide: cleared iff (review on HEAD with zero P0/P1) OR (recent +1 reaction).
-CODEX_REVIEW_ON_HEAD=$(echo "$CODEX_REVIEW" | jq 'if . == null then false else true end')
+# Latest Codex review submission time on HEAD (empty if none).
+CODEX_REVIEW_TIME=$(echo "$CODEX_REVIEW" | jq -r 'if . == null then "" else .submitted_at end')
+
+# Decide clearance using the LATEST Codex signal, not whichever signal
+# the script happens to check first. See #64 Codex P1 finding ("Reject
+# stale thumbs-up when newer Codex findings exist").
+#
+# Semantics: Codex sends either a review OR a 👍 reaction per pass, but
+# on a PR with multiple rounds on the same HEAD it can end up with both
+# historical review comments AND a reaction. The LATEST one wins:
+#
+#   - If Codex's most recent signal is a review, inspect its P0/P1
+#     findings. Zero findings → clear. Any findings → block.
+#   - If Codex's most recent signal is a 👍 reaction, clear. Codex only
+#     reacts 👍 when it has no suggestions, so a newer 👍 overrides any
+#     earlier review's findings.
+#   - If both timestamps exist, use max() to pick the latest.
+#   - If neither exists, block.
+#
+# All review-side analysis still uses the latest review's
+# pull_request_review_id to scope findings (addressed in round 1's
+# finding 2), so an older review's stale comments are never counted.
 
 CLEARED=false
 CLEARANCE_REASON=""
 
-if [ "$RECENT_THUMBS_UP" -gt 0 ]; then
+if [ -n "$LATEST_THUMBS_UP_TIME" ] && [ -n "$CODEX_REVIEW_TIME" ]; then
+  # Both signals present on HEAD — compare timestamps. ISO 8601 sorts
+  # chronologically under lexicographic string comparison.
+  if [[ "$LATEST_THUMBS_UP_TIME" > "$CODEX_REVIEW_TIME" ]]; then
+    CLEARED=true
+    CLEARANCE_REASON="latest signal is 👍 reaction @ $LATEST_THUMBS_UP_TIME (newer than review @ $CODEX_REVIEW_TIME)"
+  else
+    if [ "$UNADDRESSED_COUNT" -eq 0 ]; then
+      CLEARED=true
+      CLEARANCE_REASON="latest signal is COMMENTED review @ $CODEX_REVIEW_TIME on $HEAD_SHA with no unaddressed P0/P1 findings (newer than 👍 @ $LATEST_THUMBS_UP_TIME)"
+    fi
+  fi
+elif [ -n "$LATEST_THUMBS_UP_TIME" ]; then
+  # Only a qualifying reaction, no review on HEAD.
   CLEARED=true
-  CLEARANCE_REASON="👍 reaction from $BOT_LOGIN on or after $HEAD_COMMITTER_DATE"
-elif [ "$CODEX_REVIEW_ON_HEAD" = "true" ] && [ "$UNADDRESSED_COUNT" -eq 0 ]; then
-  CLEARED=true
-  CLEARANCE_REASON="COMMENTED review from $BOT_LOGIN on $HEAD_SHA with no unaddressed P0/P1 findings"
+  CLEARANCE_REASON="👍 reaction from $BOT_LOGIN @ $LATEST_THUMBS_UP_TIME (on or after HEAD push time $HEAD_PUSHED_AT)"
+elif [ -n "$CODEX_REVIEW_TIME" ]; then
+  # Only a review on HEAD, no qualifying reaction.
+  if [ "$UNADDRESSED_COUNT" -eq 0 ]; then
+    CLEARED=true
+    CLEARANCE_REASON="COMMENTED review from $BOT_LOGIN @ $CODEX_REVIEW_TIME on $HEAD_SHA with no unaddressed P0/P1 findings"
+  fi
 fi
 
 if [ "$CLEARED" != "true" ]; then
-  if [ "$CODEX_REVIEW_ON_HEAD" = "false" ] && [ "$RECENT_THUMBS_UP" -eq 0 ]; then
-    fail_gate "Codex has not cleared current HEAD (no review and no +1 reaction from $BOT_LOGIN since $HEAD_COMMITTER_DATE)"
+  if [ -z "$LATEST_THUMBS_UP_TIME" ] && [ -z "$CODEX_REVIEW_TIME" ]; then
+    fail_gate "Codex has not cleared current HEAD (no review on $HEAD_SHA and no +1 reaction from $BOT_LOGIN since HEAD push time $HEAD_PUSHED_AT)"
   else
     PATHS=$(echo "$UNADDRESSED_P01" | jq -r '[.[] | "\(.path):\(.line)"] | join(", ")')
-    fail_gate "Codex review on HEAD has $UNADDRESSED_COUNT unaddressed P0/P1 finding(s): $PATHS"
+    fail_gate "latest Codex signal is a review on HEAD with $UNADDRESSED_COUNT unaddressed P0/P1 finding(s): $PATHS"
   fi
 fi
 

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -192,31 +192,62 @@ HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.commi
   || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
 
 # HEAD_PUSHED_AT: the timestamp to use as the "when did this commit
-# become current on the PR" anchor for reaction freshness. committer
+# become current on THIS PR" anchor for reaction freshness. Committer
 # date is commit metadata and can be ARBITRARILY OLD if someone force-
 # pushes a previously-authored commit — a stale Codex 👍 from a prior
-# HEAD could then still satisfy `reaction.created_at >= committer_date`
-# even though the reaction predates the current HEAD's existence on
-# this PR. See #64 Codex P1 finding ("Anchor reaction freshness to PR
-# head update time").
+# HEAD would then satisfy `reaction.created_at >= committer_date` even
+# though the reaction predates the current HEAD's existence on this
+# PR. See #64 Codex P1 finding ("Anchor reaction freshness to PR head
+# update time") and #65 follow-up findings.
 #
-# The best proxy available from the API: the earliest check-run start
-# time on the current HEAD. A CheckRun is created only AFTER a commit
-# exists on a PR and GitHub dispatches a workflow for it, so this time
-# is strictly after the commit became the PR's HEAD. If the repo has
-# no CI at all (no check-runs exist), fall back to committer date —
-# there's no force-push concern in that case because there's also no
-# stale CI signal to worry about.
-HEAD_CHECK_RUNS_MIN=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
-  --jq '[.check_runs[].started_at] | min // ""' 2>/dev/null || echo "")
-if [ -n "$HEAD_CHECK_RUNS_MIN" ] && [ "$HEAD_CHECK_RUNS_MIN" != "null" ]; then
-  HEAD_PUSHED_AT="$HEAD_CHECK_RUNS_MIN"
+# Earlier iterations tried `repos/{repo}/commits/{sha}/check-runs` as
+# the anchor source, but that endpoint is COMMIT-scoped, not PR-scoped:
+# if the same SHA ran in an earlier context (a different branch, a
+# previous PR, a direct push to main), the earliest check-run's
+# started_at comes from THAT context and is much earlier than when
+# the commit became the current PR's HEAD. nathanpayne-codex caught
+# this on PR #65 round 1 — thanks.
+#
+# New approach: use the PR's TIMELINE events, which are strictly
+# PR-scoped. Algorithm:
+#
+#   1. Start with HEAD_COMMITTER_DATE as the base. It's correct for
+#      the common case (normal push, or force-push of a new commit
+#      authored at or after the push time). It's also strictly earlier
+#      than any CI-dispatch anchor, so a valid Codex 👍 posted in the
+#      gap between push and CI start is NOT filtered out (#65 round 1
+#      finding 3: "started_at is later than the actual head update").
+#
+#   2. If there's a `head_ref_force_pushed` event on this PR with
+#      `created_at > HEAD_COMMITTER_DATE`, override the base. This
+#      catches the force-push-with-old-commit case where committer
+#      date is arbitrarily old. `max()` across all force-push events
+#      picks the most recent force-push, which is the one that
+#      established the CURRENT head state.
+#
+#   3. fetch_api_array fails closed with exit 3 on API error — no
+#      silent fallback to the weaker anchor. If the timeline endpoint
+#      is unreachable, we fail, consistent with the rest of the
+#      script's fetch logic.
+HEAD_PUSHED_AT="$HEAD_COMMITTER_DATE"
+
+TIMELINE_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/timeline" "PR timeline")
+
+LATEST_FORCE_PUSH_TIME=$(echo "$TIMELINE_JSON" | jq -r '
+  [ .[] | select(.event == "head_ref_force_pushed") | .created_at ]
+  | max // ""
+')
+
+if [ -n "$LATEST_FORCE_PUSH_TIME" ] && [[ "$LATEST_FORCE_PUSH_TIME" > "$HEAD_PUSHED_AT" ]]; then
+  HEAD_PUSHED_AT="$LATEST_FORCE_PUSH_TIME"
+  ANCHOR_SOURCE="head_ref_force_pushed @ $LATEST_FORCE_PUSH_TIME"
 else
-  HEAD_PUSHED_AT="$HEAD_COMMITTER_DATE"
+  ANCHOR_SOURCE="HEAD committer date"
 fi
 
 log "HEAD = $HEAD_SHA    author = $PR_AUTHOR"
-log "committer_date = $HEAD_COMMITTER_DATE    pushed_at_proxy = $HEAD_PUSHED_AT"
+log "committer_date = $HEAD_COMMITTER_DATE"
+log "anchor = $HEAD_PUSHED_AT (source: $ANCHOR_SOURCE)"
 
 # --- preflight: blocking labels --------------------------------------------
 #

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -127,6 +127,13 @@ codex_field() {
 BOT_LOGIN=$(codex_field bot_login)
 BOT_LOGIN=${BOT_LOGIN:-"chatgpt-codex-connector[bot]"}
 
+REACTION_FRESHNESS_SECONDS=$(codex_field reaction_freshness_window_seconds)
+REACTION_FRESHNESS_SECONDS=${REACTION_FRESHNESS_SECONDS:-1800}
+if ! [[ "$REACTION_FRESHNESS_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: codex.reaction_freshness_window_seconds must be an integer; got '$REACTION_FRESHNESS_SECONDS'" >&2
+  exit 3
+fi
+
 # Read the available_reviewers list (one per line). Same state-machine
 # awk pattern, but collecting list items rather than matching a scalar.
 # Outputs one reviewer login per line to stdout. Handles both quoted
@@ -198,37 +205,61 @@ HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.commi
 # HEAD would then satisfy `reaction.created_at >= committer_date` even
 # though the reaction predates the current HEAD's existence on this
 # PR. See #64 Codex P1 finding ("Anchor reaction freshness to PR head
-# update time") and #65 follow-up findings.
+# update time") and the #65 round-1/2/3 follow-up findings.
 #
-# Earlier iterations tried `repos/{repo}/commits/{sha}/check-runs` as
-# the anchor source, but that endpoint is COMMIT-scoped, not PR-scoped:
-# if the same SHA ran in an earlier context (a different branch, a
-# previous PR, a direct push to main), the earliest check-run's
-# started_at comes from THAT context and is much earlier than when
-# the commit became the current PR's HEAD. nathanpayne-codex caught
-# this on PR #65 round 1 — thanks.
+# Iteration history and why the obvious fixes don't work:
 #
-# New approach: use the PR's TIMELINE events, which are strictly
-# PR-scoped. Algorithm:
+#   Round 1 tried `repos/{repo}/commits/{sha}/check-runs`. Rejected:
+#   that endpoint is COMMIT-scoped, not PR-scoped — if the same SHA
+#   ran in an earlier context (different branch, previous PR, direct
+#   push to main), the earliest check-run's started_at comes from
+#   THAT context and leaks across PRs.
 #
-#   1. Start with HEAD_COMMITTER_DATE as the base. It's correct for
-#      the common case (normal push, or force-push of a new commit
-#      authored at or after the push time). It's also strictly earlier
-#      than any CI-dispatch anchor, so a valid Codex 👍 posted in the
-#      gap between push and CI start is NOT filtered out (#65 round 1
-#      finding 3: "started_at is later than the actual head update").
+#   Round 2 tried `repos/{repo}/issues/{pr}/timeline` with a
+#   `head_ref_force_pushed` event selector. Better: that endpoint is
+#   strictly PR-scoped. BUT it only covers force-push. For ORDINARY
+#   push / fast-forward to a descendant commit, the timeline emits a
+#   `committed` event whose `created_at` is `null` — verified against
+#   PR #63's raw timeline payload on 2026-04-15. There is no per-PR
+#   push timestamp for non-force pushes in the GitHub API.
 #
-#   2. If there's a `head_ref_force_pushed` event on this PR with
-#      `created_at > HEAD_COMMITTER_DATE`, override the base. This
-#      catches the force-push-with-old-commit case where committer
-#      date is arbitrarily old. `max()` across all force-push events
-#      picks the most recent force-push, which is the one that
-#      established the CURRENT head state.
+# The ordinary-push hole:
 #
-#   3. fetch_api_array fails closed with exit 3 on API error — no
-#      silent fallback to the weaker anchor. If the timeline endpoint
-#      is unreachable, we fail, consistent with the rest of the
-#      script's fetch logic.
+#   Scenario — PR HEAD is at commit A, Codex reacts 👍 on the PR at
+#   time T1, then the PR is advanced via ordinary push (fast-forward)
+#   to descendant commit B whose committer date is OLDER than T1
+#   (e.g., cherry-pick of a pre-existing SHA, or a commit authored
+#   weeks ago and just now pushed). The stale 👍 from HEAD A would
+#   pass `reaction.created_at >= HEAD_COMMITTER_DATE` on HEAD B and
+#   false-clear gate (c) because the anchor can only be advanced by a
+#   signal we don't have access to.
+#
+# Two-layer mitigation applied below:
+#
+#   Layer 1 — per-PR push anchor via force-push events. For the cases
+#   where a per-PR push time IS observable (force-push), use it.
+#   Start with HEAD_COMMITTER_DATE as the base (correct for the
+#   common case where committer date ≈ push time), then override to
+#   `head_ref_force_pushed.created_at` if later. This closes the
+#   force-push-of-old-commit variant identified in the #64 review.
+#
+#   Layer 2 — reaction freshness floor. Bound the exposure window of
+#   the residual ordinary-push-old-committer-date hole by requiring a
+#   👍 reaction to be within `codex.reaction_freshness_window_seconds`
+#   of the gate-check time. A stale 👍 from a prior HEAD that outlives
+#   the window is automatically filtered out, regardless of how old
+#   the new HEAD's committer date is. Default 1800s (30 min) is
+#   generous for the typical Phase 4a cycle (1–5 min push → clearance)
+#   while catching cross-cycle stale 👍s. See review-policy.yml
+#   `codex.reaction_freshness_window_seconds` for the full rationale.
+#
+# Residual hole: if the stale 👍 is within the freshness window AND
+# the new HEAD was pushed via ordinary push AND the new HEAD has an
+# old committer date, a false clear is still mechanically possible.
+# That combination is narrow — it requires a rebased/cherry-picked
+# old commit pushed within the freshness window after a prior-HEAD
+# 👍. Closing it fully would require a per-PR push timestamp that
+# GitHub does not currently expose.
 HEAD_PUSHED_AT="$HEAD_COMMITTER_DATE"
 
 TIMELINE_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/timeline" "PR timeline")
@@ -245,9 +276,34 @@ else
   ANCHOR_SOURCE="HEAD committer date"
 fi
 
+# Compute freshness floor = NOW - reaction_freshness_window_seconds.
+# ISO 8601 UTC so it sorts lexicographically against reaction
+# created_at values. Cross-platform epoch→ISO conversion: try BSD
+# `date -r` first (macOS), fall back to GNU `date -d @...` (Linux).
+EPOCH_NOW=$(date +%s)
+EPOCH_FLOOR=$((EPOCH_NOW - REACTION_FRESHNESS_SECONDS))
+if REACTION_FLOOR_ISO=$(date -u -r "$EPOCH_FLOOR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null); then
+  :
+else
+  REACTION_FLOOR_ISO=$(date -u -d "@$EPOCH_FLOOR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+    || die 3 "could not compute reaction freshness floor from epoch $EPOCH_FLOOR"
+fi
+
+# Effective threshold a 👍 reaction must satisfy = max(HEAD_PUSHED_AT,
+# REACTION_FLOOR_ISO). Both are ISO 8601 UTC; lexicographic comparison
+# is chronological.
+if [[ "$REACTION_FLOOR_ISO" > "$HEAD_PUSHED_AT" ]]; then
+  REACTION_THRESHOLD="$REACTION_FLOOR_ISO"
+  REACTION_THRESHOLD_SOURCE="freshness floor (NOW - ${REACTION_FRESHNESS_SECONDS}s = $REACTION_FLOOR_ISO)"
+else
+  REACTION_THRESHOLD="$HEAD_PUSHED_AT"
+  REACTION_THRESHOLD_SOURCE="HEAD pushed-at anchor ($HEAD_PUSHED_AT, source: $ANCHOR_SOURCE)"
+fi
+
 log "HEAD = $HEAD_SHA    author = $PR_AUTHOR"
 log "committer_date = $HEAD_COMMITTER_DATE"
 log "anchor = $HEAD_PUSHED_AT (source: $ANCHOR_SOURCE)"
+log "reaction_threshold = $REACTION_THRESHOLD (source: $REACTION_THRESHOLD_SOURCE)"
 
 # --- preflight: blocking labels --------------------------------------------
 #
@@ -430,13 +486,16 @@ fi
 
 UNADDRESSED_COUNT=$(echo "$UNADDRESSED_P01" | jq 'length')
 
-# Latest +1 reaction on the PR issue from the Codex bot, filtered to
-# reactions dated on or after HEAD_PUSHED_AT (see the anchor fetch
-# earlier in the script for the force-push rationale).
+# Latest +1 reaction on the PR issue from the Codex bot, filtered by
+# REACTION_THRESHOLD. REACTION_THRESHOLD = max(HEAD_PUSHED_AT,
+# freshness_floor), where the freshness floor is NOW minus
+# reaction_freshness_window_seconds. See the anchor computation
+# earlier in the script for why both bounds are required and the
+# residual hole the freshness floor mitigates.
 REACTIONS_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/reactions" "reactions")
 
 LATEST_THUMBS_UP_TIME=$(echo "$REACTIONS_JSON" | jq -r \
-  --arg bot "$BOT_LOGIN" --arg after "$HEAD_PUSHED_AT" '
+  --arg bot "$BOT_LOGIN" --arg after "$REACTION_THRESHOLD" '
   [ .[]
     | select(.user.login == $bot)
     | select(.content == "+1")
@@ -487,7 +546,7 @@ if [ -n "$LATEST_THUMBS_UP_TIME" ] && [ -n "$CODEX_REVIEW_TIME" ]; then
 elif [ -n "$LATEST_THUMBS_UP_TIME" ]; then
   # Only a qualifying reaction, no review on HEAD.
   CLEARED=true
-  CLEARANCE_REASON="👍 reaction from $BOT_LOGIN @ $LATEST_THUMBS_UP_TIME (on or after HEAD push time $HEAD_PUSHED_AT)"
+  CLEARANCE_REASON="👍 reaction from $BOT_LOGIN @ $LATEST_THUMBS_UP_TIME (on or after reaction threshold $REACTION_THRESHOLD: $REACTION_THRESHOLD_SOURCE)"
 elif [ -n "$CODEX_REVIEW_TIME" ]; then
   # Only a review on HEAD, no qualifying reaction.
   if [ "$UNADDRESSED_COUNT" -eq 0 ]; then
@@ -498,7 +557,7 @@ fi
 
 if [ "$CLEARED" != "true" ]; then
   if [ -z "$LATEST_THUMBS_UP_TIME" ] && [ -z "$CODEX_REVIEW_TIME" ]; then
-    fail_gate "Codex has not cleared current HEAD (no review on $HEAD_SHA and no +1 reaction from $BOT_LOGIN since HEAD push time $HEAD_PUSHED_AT)"
+    fail_gate "Codex has not cleared current HEAD (no review on $HEAD_SHA and no +1 reaction from $BOT_LOGIN on or after reaction threshold $REACTION_THRESHOLD: $REACTION_THRESHOLD_SOURCE)"
   else
     PATHS=$(echo "$UNADDRESSED_P01" | jq -r '[.[] | "\(.path):\(.line)"] | join(", ")')
     fail_gate "latest Codex signal is a review on HEAD with $UNADDRESSED_COUNT unaddressed P0/P1 finding(s): $PATHS"

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -287,9 +287,13 @@ if has_signal "$INITIAL_SCAN"; then
   log "Codex has already responded on HEAD — skipping trigger comment"
 else
   log "posting '@codex review' trigger comment"
-  if ! gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" >/dev/null 2>&1; then
-    die 3 "failed to post '@codex review' comment"
-  fi
+  # Capture stderr (and stdout) into a diagnostic variable so a failure
+  # here surfaces the actual gh error — e.g. "404" from a nonexistent
+  # PR, "403" from a token without comment scope, or "422" from a closed
+  # PR — rather than a bare "failed to post". CodeRabbit non-blocking
+  # note on PR #64.
+  POST_OUTPUT=$(gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
+    || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
   TRIGGER_POSTED=true
 fi
 

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -25,9 +25,21 @@
 #   1. Reads codex.review_timeout_seconds and codex.bot_login from
 #      .github/review-policy.yml (defaults: 600 / chatgpt-codex-connector[bot]).
 #   2. Fetches the PR's current HEAD commit SHA and committer date. Any
-#      Codex review/reaction is only considered "current" if it is
-#      anchored on this commit (reviews) or created after its committer
-#      date (reactions).
+#      Codex review is only considered "current" if it is anchored on
+#      this commit (commit_id == HEAD_SHA). Any Codex +1 reaction is
+#      only considered "current" if created_at >= REACTION_THRESHOLD,
+#      where REACTION_THRESHOLD = max(HEAD_PUSHED_AT, freshness floor):
+#        - HEAD_PUSHED_AT is HEAD_COMMITTER_DATE advanced past any
+#          `head_ref_force_pushed` event on this PR's timeline, which
+#          is strictly PR-scoped. This closes the force-push-with-
+#          old-commit false-clear path.
+#        - freshness floor = NOW minus
+#          `codex.reaction_freshness_window_seconds` (default 1800).
+#          This closes the ordinary-push-with-old-committer-date
+#          false-clear path by ensuring a stale 👍 from a prior HEAD
+#          ages out of the window.
+#      See codex-review-check.sh for the iteration history behind this
+#      design and the residual hole it does NOT fully close.
 #   3. Scans existing reviews, inline comments, and issue reactions for
 #      a Codex signal already present on the current HEAD. If found,
 #      skips the trigger comment and goes straight to emitting JSON —
@@ -160,6 +172,13 @@ fi
 BOT_LOGIN=$(codex_field bot_login)
 BOT_LOGIN=${BOT_LOGIN:-"chatgpt-codex-connector[bot]"}
 
+REACTION_FRESHNESS_SECONDS=$(codex_field reaction_freshness_window_seconds)
+REACTION_FRESHNESS_SECONDS=${REACTION_FRESHNESS_SECONDS:-1800}
+if ! [[ "$REACTION_FRESHNESS_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: codex.reaction_freshness_window_seconds must be an integer; got '$REACTION_FRESHNESS_SECONDS'" >&2
+  exit 3
+fi
+
 POLL_INTERVAL_SECONDS=15
 
 # --- logging helpers --------------------------------------------------------
@@ -207,7 +226,50 @@ fi
 HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \
   || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
 
+# HEAD_PUSHED_AT + REACTION_THRESHOLD: mirrors codex-review-check.sh so
+# that the pre-flight scan below does NOT treat a stale 👍 from a prior
+# HEAD as a current signal (which would cause the trigger comment to be
+# skipped and the caller to re-run gate (c) against the same stale
+# reaction). See codex-review-check.sh for the full rationale; the short
+# version: committer date is unreliable for force-push-of-old-commit
+# and ordinary-push-of-old-committer-date. Layer 1 advances the anchor
+# via `head_ref_force_pushed` events from the PR-scoped timeline; Layer
+# 2 bounds residual exposure with a freshness floor.
+HEAD_PUSHED_AT="$HEAD_COMMITTER_DATE"
+ANCHOR_SOURCE="HEAD committer date"
+
+TIMELINE_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/timeline" "PR timeline")
+
+LATEST_FORCE_PUSH_TIME=$(echo "$TIMELINE_JSON" | jq -r '
+  [ .[] | select(.event == "head_ref_force_pushed") | .created_at ]
+  | max // ""
+')
+
+if [ -n "$LATEST_FORCE_PUSH_TIME" ] && [[ "$LATEST_FORCE_PUSH_TIME" > "$HEAD_PUSHED_AT" ]]; then
+  HEAD_PUSHED_AT="$LATEST_FORCE_PUSH_TIME"
+  ANCHOR_SOURCE="head_ref_force_pushed @ $LATEST_FORCE_PUSH_TIME"
+fi
+
+EPOCH_NOW=$(date +%s)
+EPOCH_FLOOR=$((EPOCH_NOW - REACTION_FRESHNESS_SECONDS))
+if REACTION_FLOOR_ISO=$(date -u -r "$EPOCH_FLOOR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null); then
+  :
+else
+  REACTION_FLOOR_ISO=$(date -u -d "@$EPOCH_FLOOR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+    || die 3 "could not compute reaction freshness floor from epoch $EPOCH_FLOOR"
+fi
+
+if [[ "$REACTION_FLOOR_ISO" > "$HEAD_PUSHED_AT" ]]; then
+  REACTION_THRESHOLD="$REACTION_FLOOR_ISO"
+  REACTION_THRESHOLD_SOURCE="freshness floor (NOW - ${REACTION_FRESHNESS_SECONDS}s)"
+else
+  REACTION_THRESHOLD="$HEAD_PUSHED_AT"
+  REACTION_THRESHOLD_SOURCE="HEAD pushed-at anchor ($ANCHOR_SOURCE)"
+fi
+
 log "HEAD = $HEAD_SHA committed at $HEAD_COMMITTER_DATE"
+log "anchor = $HEAD_PUSHED_AT (source: $ANCHOR_SOURCE)"
+log "reaction_threshold = $REACTION_THRESHOLD (source: $REACTION_THRESHOLD_SOURCE)"
 log "bot_login = $BOT_LOGIN    timeout = ${TIMEOUT_SECONDS}s"
 
 # --- Codex signal scan ------------------------------------------------------
@@ -250,8 +312,15 @@ scan_codex_state() {
   ')
 
   # Most recent +1 reaction from the bot on the issue with created_at
-  # strictly >= the HEAD committer date.
-  reaction=$(echo "$reactions" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_COMMITTER_DATE" '
+  # strictly >= REACTION_THRESHOLD. Threshold = max(HEAD_PUSHED_AT,
+  # freshness floor). See the anchor computation above and
+  # codex-review-check.sh for the full rationale. Without the
+  # freshness floor, a stale 👍 from a prior HEAD (where the new HEAD
+  # is a normal push with an old committer date) would read as a
+  # "current" signal here and cause the pre-flight scan to skip the
+  # trigger comment, leaving the caller to re-evaluate gate (c)
+  # against the same stale reaction.
+  reaction=$(echo "$reactions" | jq --arg bot "$BOT_LOGIN" --arg after "$REACTION_THRESHOLD" '
     [.[]
       | select(.user.login == $bot)
       | select(.content == "+1")


### PR DESCRIPTION
Authoring-Agent: claude

Follow-up to merged PR #64. Addresses two Codex non-blocking P1 findings that I missed when executing the round-2 fixes — `chatgpt-codex-connector[bot]` posted five inline findings on PR #64, but the user-summary I worked from only covered three of them (with overlap on one), so two P1 items slipped through into the merged PR.

Catching these now is important because they're both real correctness bugs in `codex-review-check.sh` gate (c) that would let the merge gate clear a PR whose LATEST Codex signal is actually blocking. And the fixes need to land before any real Phase 4a PR exercises the new code path.

## Finding a — "Reject stale thumbs-up when newer Codex findings exist"

**Bug.** Previous gate (c) clearance logic ran the reaction branch unconditionally before the review branch:

```bash
if [ "$RECENT_THUMBS_UP" -gt 0 ]; then
  CLEARED=true  # 👍 wins, no matter what
elif [ "$CODEX_REVIEW_ON_HEAD" = "true" ] && [ "$UNADDRESSED_COUNT" -eq 0 ]; then
  CLEARED=true
fi
```

Failing scenario:
- Codex posts 👍 @ t=10 (clean pass)
- Codex posts a COMMENTED review @ t=20 with P1 findings (same HEAD, e.g., re-evaluated after the agent pushed something)
- Gate hits the reaction branch first, sees the qualifying 👍, clears. The P1 findings are never consulted.

**Fix.** Compare the two latest-signal timestamps and use whichever is newer as the authoritative decision. ISO 8601 sorts chronologically under bash `[[ "$a" > "$b" ]]`, so the comparison is direct.

```bash
if [ -n "$LATEST_THUMBS_UP_TIME" ] && [ -n "$CODEX_REVIEW_TIME" ]; then
  # Both present — later one wins
  if [[ "$LATEST_THUMBS_UP_TIME" > "$CODEX_REVIEW_TIME" ]]; then
    CLEARED=true  # reaction is newer
    CLEARANCE_REASON="latest signal is 👍 @ $LATEST_THUMBS_UP_TIME (newer than review @ $CODEX_REVIEW_TIME)"
  else
    if [ "$UNADDRESSED_COUNT" -eq 0 ]; then
      CLEARED=true  # review is newer, check findings
    fi
  fi
elif ...
```

Four cases enumerated explicitly: both present, reaction-only, review-only, neither. The `UNADDRESSED_COUNT` is still computed from the latest review's `pull_request_review_id` (from round 2's fix), so older stale comments are never counted.

## Finding c — "Anchor reaction freshness to PR head update time"

**Bug.** Previous reaction filter used `HEAD_COMMITTER_DATE`:

```bash
RECENT_THUMBS_UP=$(echo "$REACTIONS_JSON" | jq \
  --arg after "$HEAD_COMMITTER_DATE" '
  [.[] | select(.content == "+1") | select(.created_at >= $after)] | length
')
```

Committer date is commit metadata and can be arbitrarily old. Failing scenario:
- PR has commit C1 with committer date t=20
- Codex 👍s the PR @ t=25
- Someone force-pushes commit C2 with committer date t=5 (earlier authored) to the same branch
- Current HEAD is now C2 with committer date t=5
- Gate computes `25 >= 5` → true → clears via the stale 👍 from before the force-push

**Fix.** Compute `HEAD_PUSHED_AT` from the earliest check-run start time on the current HEAD, via `gh api repos/{owner}/{repo}/commits/{sha}/check-runs`. A CheckRun is created only after a commit exists on a PR and GitHub dispatches a workflow for it, so this time is strictly AFTER the commit became the PR's HEAD.

```bash
HEAD_CHECK_RUNS_MIN=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
  --jq '[.check_runs[].started_at] | min // ""' 2>/dev/null || echo "")
if [ -n "$HEAD_CHECK_RUNS_MIN" ] && [ "$HEAD_CHECK_RUNS_MIN" != "null" ]; then
  HEAD_PUSHED_AT="$HEAD_CHECK_RUNS_MIN"
else
  HEAD_PUSHED_AT="$HEAD_COMMITTER_DATE"
fi
```

Fall back to committer date when no check-runs exist (repo with no CI at all). In that case there's also no stale CI signal to worry about.

Verified against PR #63: `HEAD_COMMITTER_DATE = 03:03:42Z`, `HEAD_PUSHED_AT = 03:03:48Z` — 6 seconds later, matching when the first CheckRun started. The 6-second gap is typical GitHub Actions dispatch latency and is enough to catch the force-push window described above.

## Verification

`scripts/codex-review-check.sh 63` still produces the correct negative result (the PR doesn't have a current-HEAD Codex signal, so gate (c) refuses):

```
[codex-review-check] committer_date = 2026-04-15T03:03:42Z    pushed_at_proxy = 2026-04-15T03:03:48Z
[codex-review-check] gate (a): CI green ✓
[codex-review-check] gate (b): latest-state APPROVED by nathanpayne-claude ✓
[codex-review-check] FAIL: Codex has not cleared current HEAD (no review on ... and no +1 reaction from chatgpt-codex-connector[bot] since HEAD push time 2026-04-15T03:03:48Z)
```

Error message now surfaces `HEAD push time` rather than `committer date`, which reflects the actual semantics.

## Self-Review

**Correctness**

- [x] Timestamp comparison uses ISO 8601 lexicographic ordering, which is chronologically correct
- [x] Four-case decision tree (both / reaction only / review only / neither) is exhaustive
- [x] `UNADDRESSED_P01` still filtered by `pull_request_review_id` — stale comments from earlier rounds on same HEAD are still ignored
- [x] `HEAD_PUSHED_AT` fallback to `HEAD_COMMITTER_DATE` when `check-runs` returns empty — handles fresh repos without CI
- [x] Log messages updated to show both `committer_date` and `pushed_at_proxy` so the anchor choice is visible
- [x] Error messages mention `HEAD push time` rather than `committer date`
- [x] `CODEX_REVIEW_ON_HEAD` variable removed (was redundant with `CODEX_REVIEW != null`)

**Regression risk**

- [x] Only touches the clearance decision and the anchor computation in `codex-review-check.sh`
- [x] Gate (a), gate (b), and the preflight are unchanged
- [x] `codex-review-request.sh` is unchanged
- [x] Local re-test against merged PR #63 still produces the expected negative result (gate (c) correctly refuses) — no new false positives
- [x] `fetch_api_array` helper, `read_available_reviewers`, and the config readers are all unchanged

**Style / conventions**

- [x] Comment block above the clearance decision explicitly documents the four cases, the "latest wins" rule, and the force-push anchor
- [x] Comment above `HEAD_PUSHED_AT` computation explains the committer-date failure mode with a concrete example
- [x] References to issue #64 and the relevant Codex findings baked into the code comments

**Test coverage**

- [x] End-to-end smoke test against real merged PR #63 passes as expected
- [x] No unit tests for the clearance decision tree yet — same gap as before, will land with #57

**Security**

- [x] No new dependencies, no new tokens, no new scopes
- [x] `gh api ... /check-runs` is a read-only call

## Process note

Applied `needs-external-review` label immediately after `gh pr create` per the label-first ordering rule in feedback memory. This PR touches `scripts/codex-review-check.sh` which is not in `external_review_paths` and is below the 300-line threshold (81 insertions, 16 deletions), so CI would not auto-label. Manual application is the only mechanism here.

## Related

- Follow-up to merged PR #64 (#34, #35 were closed there; this is strictly a correctness patch on top)
- Addresses Codex inline findings 3083765704 and 3083765710 on PR #64, both of which I missed in round 2
- Part of [Project #2](https://github.com/users/nathanjohnpayne/projects/2)

## Meta

Third instance of the same "use latest, not any historical" class in the #64 review cycle — enough to codify the rule in the project feedback memory. The `feedback_live_smoke_test_first.md` memory now has an explicit sub-rule about reading historical records with a latest-wins discipline, plus the specific jq patterns (`group_by + max_by`, `max_by // null`, timestamp comparison) that implement it correctly. I should have internalized the rule after round 2 caught two of these; I didn't, and the third slipped through because I was working from the user's summary instead of Codex's raw review. Lesson for myself: **always fetch the raw review comments from the bot directly, not just the human's relayed summary**, because the two may not match.
