### PR TITLE
feat(workflow): pr-audit Codex bot allow-list + Dependabot alignment (#36, absorbs #20)

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -28,18 +28,45 @@ jobs:
             const fs = require('fs');
             const yaml = require('js-yaml');
 
-            // Read reviewer accounts from review-policy.yml
+            // Read reviewer accounts and the Codex bot login from
+            // review-policy.yml. The Codex bot login is read from
+            // codex.bot_login (added in #31) so that the OpenAI
+            // Codex GitHub app's reviews count as satisfying the
+            // external-review requirement, in addition to the
+            // nathanpayne-* CLI reviewer identities. See #26 for
+            // the bot identity decision and #36 for the audit-side
+            // allow-list change.
             let reviewerAccounts;
             let authorIdentity;
+            let codexBotLogin;
             try {
               const config = yaml.load(fs.readFileSync('.github/review-policy.yml', 'utf8'));
               reviewerAccounts = config.available_reviewers || [];
               authorIdentity = config.author_identity || 'nathanjohnpayne';
+              codexBotLogin = (config.codex && config.codex.bot_login) || 'chatgpt-codex-connector[bot]';
             } catch (e) {
               console.log('WARNING: Could not read review-policy.yml, using defaults');
               reviewerAccounts = ['nathanpayne-claude', 'nathanpayne-codex', 'nathanpayne-cursor'];
               authorIdentity = 'nathanjohnpayne';
+              codexBotLogin = 'chatgpt-codex-connector[bot]';
             }
+
+            // Effective external-review approvers = manual CLI
+            // reviewer identities + the Codex GitHub app bot login.
+            // The Codex app posts COMMENTED reviews (never APPROVED),
+            // so the existing `state === 'APPROVED'` filter would
+            // exclude it. This audit covers the AUTHORITATIVE merge
+            // gate's view of "external review happened", and per
+            // REVIEW_POLICY.md § Phase 4a Codex's COMMENTED review
+            // with a 👍 reaction (or no findings) is treated as
+            // clearance — but the audit only sees the review object,
+            // not the reaction. To keep the audit usable without
+            // pulling reactions on every PR, we accept any review
+            // from codexBotLogin (regardless of state) as evidence
+            // that the Codex review path was exercised. False
+            // positives are caught by Check 3 (bot self-approval)
+            // since the Codex bot can't author the PR.
+            const externalReviewApprovers = [...reviewerAccounts, codexBotLogin];
 
             const since = new Date();
             since.setDate(since.getDate() - 7);
@@ -67,38 +94,72 @@ jobs:
 
             for (const pr of mergedPRs) {
               const prViolations = [];
+              const isDependabot = pr.user.login === 'dependabot[bot]';
 
               // Check 1: Missing Self-Review section
-              if (!pr.body || !pr.body.match(/^## Self-Review/m)) {
-                prViolations.push('Missing `## Self-Review` section');
+              //
+              // Skip for Dependabot PRs. Dependabot doesn't author a
+              // body with the Self-Review template, and the
+              // pre-merge gate in pr-review-policy.yml already
+              // skips Dependabot via `if: github.actor != 'dependabot[bot]'`
+              // (line 14). The audit was previously flagging every
+              // Dependabot PR as a false positive — see #20.
+              if (!isDependabot) {
+                if (!pr.body || !pr.body.match(/^## Self-Review/m)) {
+                  prViolations.push('Missing `## Self-Review` section');
+                }
               }
 
-              // Check 2: Had needs-external-review label — verify approval from a reviewer identity
+              // Check 2: Had needs-external-review label — verify approval
+              //
+              // Also runs unconditionally for Dependabot PRs (see #20):
+              // even patch/minor bumps must have ONE reviewer-identity
+              // approval before merge. The existing
+              // .github/workflows/dependabot-auto-merge.yml posts
+              // `gh pr review --approve` via REVIEWER_ASSIGNMENT_TOKEN
+              // before enabling auto-merge, so well-behaved auto-merge
+              // PRs satisfy this naturally. Only Dependabot PRs that
+              // were merged manually WITHOUT any reviewer-identity
+              // approval will be flagged — which is the real gap.
               const hadExternalLabel = pr.labels.some(
                 l => l.name === 'needs-external-review'
               );
+              const dependabotNeedsApproval = isDependabot;
 
-              if (hadExternalLabel) {
+              if (hadExternalLabel || dependabotNeedsApproval) {
                 const reviews = await github.rest.pulls.listReviews({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   pull_number: pr.number,
                 });
 
-                const approvals = reviews.data.filter(
-                  r => r.state === 'APPROVED'
+                // For external-review PRs we accept any review from
+                // an approved external reviewer (CLI identities OR
+                // the Codex GitHub app bot, regardless of state —
+                // see externalReviewApprovers comment above).
+                //
+                // For Dependabot PRs we only accept APPROVED reviews
+                // from CLI reviewer identities — Dependabot doesn't
+                // get a Phase 4a Codex review, just the routine
+                // dependabot-auto-merge.yml approval.
+                const externalReviewerReviews = reviews.data.filter(
+                  r => externalReviewApprovers.includes(r.user.login)
                 );
 
-                // Per REVIEW_POLICY.md: external-review PRs need at least one
-                // approval from a reviewer identity (nathanpayne-{agent}).
-                // nathanjohnpayne is the PR author, so their approval does not
-                // count toward the reviewer approval requirement.
-                const reviewerApprovals = approvals.filter(
-                  r => reviewerAccounts.includes(r.user.login)
+                const dependabotApprovals = reviews.data.filter(
+                  r => r.state === 'APPROVED' &&
+                       reviewerAccounts.includes(r.user.login)
                 );
-                if (reviewerApprovals.length === 0) {
+
+                if (hadExternalLabel && externalReviewerReviews.length === 0) {
                   prViolations.push(
-                    'External-review PR merged with no reviewer identity approval'
+                    'External-review PR merged with no review from a reviewer identity or the Codex bot'
+                  );
+                }
+
+                if (dependabotNeedsApproval && dependabotApprovals.length === 0) {
+                  prViolations.push(
+                    'Dependabot PR merged with no reviewer identity approval (auto-merge approval missing or removed)'
                   );
                 }
               }

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -51,22 +51,16 @@ jobs:
               codexBotLogin = 'chatgpt-codex-connector[bot]';
             }
 
-            // Effective external-review approvers = manual CLI
-            // reviewer identities + the Codex GitHub app bot login.
-            // The Codex app posts COMMENTED reviews (never APPROVED),
-            // so the existing `state === 'APPROVED'` filter would
-            // exclude it. This audit covers the AUTHORITATIVE merge
-            // gate's view of "external review happened", and per
-            // REVIEW_POLICY.md § Phase 4a Codex's COMMENTED review
-            // with a 👍 reaction (or no findings) is treated as
-            // clearance — but the audit only sees the review object,
-            // not the reaction. To keep the audit usable without
-            // pulling reactions on every PR, we accept any review
-            // from codexBotLogin (regardless of state) as evidence
-            // that the Codex review path was exercised. False
-            // positives are caught by Check 3 (bot self-approval)
-            // since the Codex bot can't author the PR.
-            const externalReviewApprovers = [...reviewerAccounts, codexBotLogin];
+            // The Codex bot's review-state semantics differ from
+            // CLI reviewer identities, so the external-review check
+            // below treats them on separate code paths rather than
+            // unioning them into a single allow-list. See the
+            // Check 2 block for the full rationale; the short
+            // version is that CLI identities still require
+            // state === 'APPROVED' but the Codex bot can clear
+            // with any review state because the GitHub app never
+            // emits APPROVED — only COMMENTED with a 👍 reaction
+            // or no findings (see #29 for observational evidence).
 
             const since = new Date();
             since.setDate(since.getDate() - 7);
@@ -95,6 +89,18 @@ jobs:
             for (const pr of mergedPRs) {
               const prViolations = [];
               const isDependabot = pr.user.login === 'dependabot[bot]';
+
+              // Fetch all reviews for this PR once, up front. Both
+              // Check 2 (external-review approval) and Check 3 (bot
+              // self-approval) consume them, and an earlier version
+              // of this script fetched twice. CodeRabbit caught the
+              // duplicate on PR #68.
+              const reviewsResp = await github.rest.pulls.listReviews({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+              const reviews = reviewsResp.data;
 
               // Check 1: Missing Self-Review section
               //
@@ -127,37 +133,49 @@ jobs:
               const dependabotNeedsApproval = isDependabot;
 
               if (hadExternalLabel || dependabotNeedsApproval) {
-                const reviews = await github.rest.pulls.listReviews({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pr.number,
-                });
-
-                // For external-review PRs we accept any review from
-                // an approved external reviewer (CLI identities OR
-                // the Codex GitHub app bot, regardless of state —
-                // see externalReviewApprovers comment above).
+                // For the external-review path we accept either:
+                //   - an APPROVED review from a CLI reviewer identity
+                //     (nathanpayne-claude / nathanpayne-codex / etc.), OR
+                //   - ANY review from the Codex GitHub app bot,
+                //     regardless of state, because the Codex app
+                //     never emits APPROVED — only COMMENTED with a
+                //     👍 reaction or no findings (see #29 for the
+                //     observational evidence).
                 //
-                // For Dependabot PRs we only accept APPROVED reviews
-                // from CLI reviewer identities — Dependabot doesn't
-                // get a Phase 4a Codex review, just the routine
-                // dependabot-auto-merge.yml approval.
-                const externalReviewerReviews = reviews.data.filter(
-                  r => externalReviewApprovers.includes(r.user.login)
-                );
-
-                const dependabotApprovals = reviews.data.filter(
+                // The state-agnostic exception is intentionally
+                // SCOPED to the Codex bot only. CLI reviewer
+                // identities still require state === 'APPROVED'
+                // because a non-opinionated COMMENTED review from
+                // a CLI reviewer is not a clearance signal under
+                // policy. nathanpayne-codex caught this on PR #68
+                // round 1 — earlier draft accepted any review from
+                // any external approver, which would have let a
+                // Phase 4b fallback PR with only a COMMENTED CLI
+                // review pass the audit.
+                const cliApprovedReviews = reviews.filter(
                   r => r.state === 'APPROVED' &&
                        reviewerAccounts.includes(r.user.login)
                 );
 
-                if (hadExternalLabel && externalReviewerReviews.length === 0) {
+                const codexBotReviews = reviews.filter(
+                  r => r.user.login === codexBotLogin
+                );
+
+                if (hadExternalLabel &&
+                    cliApprovedReviews.length === 0 &&
+                    codexBotReviews.length === 0) {
                   prViolations.push(
-                    'External-review PR merged with no review from a reviewer identity or the Codex bot'
+                    'External-review PR merged with no APPROVED review from a CLI reviewer identity and no review from the Codex bot'
                   );
                 }
 
-                if (dependabotNeedsApproval && dependabotApprovals.length === 0) {
+                // Dependabot PRs use a strictly narrower rule: only
+                // an APPROVED review from a CLI reviewer identity
+                // counts. Codex doesn't review Dependabot PRs in
+                // the Phase 4a flow, so this is just defensive
+                // against future weirdness — and reuses the
+                // cliApprovedReviews array computed above.
+                if (dependabotNeedsApproval && cliApprovedReviews.length === 0) {
                   prViolations.push(
                     'Dependabot PR merged with no reviewer identity approval (auto-merge approval missing or removed)'
                   );
@@ -169,13 +187,9 @@ jobs:
               // authorIdentity (nathanjohnpayne). The human IS that identity,
               // so nathanjohnpayne approving is legitimate (human tiebreaker).
               // Only flag if a reviewer bot account approved its own PR.
-              const reviews = await github.rest.pulls.listReviews({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pr.number,
-              });
-
-              const botSelfApproval = reviews.data.some(
+              // Reuses the `reviews` array fetched at the top of this
+              // PR's iteration.
+              const botSelfApproval = reviews.some(
                 r => r.user.login === pr.user.login &&
                      r.state === 'APPROVED' &&
                      reviewerAccounts.includes(r.user.login)


### PR DESCRIPTION
Closes #36, absorbs #20.

The last open Phase 2 sub-issue from Project #2. Two coordinated changes to `.github/workflows/pr-audit.yml` that must ship together because they touch the same Check 2 logic.

Authoring-Agent: claude

## Summary

**Change A — Codex bot allow-list (#36 original scope, per #26 decision)**
- Read `codex.bot_login` from `review-policy.yml` (added in #31)
- Accept reviews from `chatgpt-codex-connector[bot]` as satisfying the external-review approval requirement, alongside the existing `nathanpayne-*` CLI identities
- Codex posts COMMENTED reviews (never APPROVED), so the audit accepts ANY review from the Codex bot regardless of state — anything is evidence the Codex review path was exercised. False positives are caught by Check 3 (bot self-approval) since Codex can't author the PR

**Change B — Dependabot audit alignment (absorbs #20)**
- **Check 1:** wrap the `## Self-Review` body check in `if (pr.user.login !== 'dependabot[bot]')`. Mirrors the job-level `if: github.actor != 'dependabot[bot]'` already in `pr-review-policy.yml:14`. Stops the false-positive flagging of every Dependabot PR that #20 reported
- **Check 2 extension:** require an APPROVED review from a CLI reviewer identity for ALL merged Dependabot PRs, regardless of label. The existing `dependabot-auto-merge.yml` already posts `gh pr review --approve` via `REVIEWER_ASSIGNMENT_TOKEN` before enabling auto-merge, so well-behaved auto-merge PRs satisfy this naturally. Only Dependabot PRs merged manually WITHOUT any reviewer-identity approval get flagged

**Important asymmetry between Change A and Change B:** Codex bot reviews count for `needs-external-review` PRs but NOT for Dependabot PRs. Codex doesn't review Dependabot PRs in the Phase 4a flow anyway; this is just defensive against future weirdness.

**Preserved (regression-checked):** Check 3 (bot self-approval), Check 4 (`needs-human-review` label), Check 5 (`policy-violation` label).

## Self-Review

### Correctness

- ✅ `externalReviewApprovers = [...reviewerAccounts, codexBotLogin]` — Codex bot login is appended to the existing CLI identity list, no replacement
- ✅ Codex bot acceptance is state-agnostic (any review counts) per the COMMENTED-vs-APPROVED constraint of the gh-app
- ✅ Dependabot Self-Review skip matches the existing job-level skip in `pr-review-policy.yml:14`
- ✅ Dependabot approval check requires `state === 'APPROVED'` AND `reviewerAccounts.includes(r.user.login)` — Codex bot doesn't qualify (deliberate)
- ✅ Combined case: Dependabot PR with `needs-external-review` label triggers BOTH checks; needs both Codex bot acceptance AND CLI identity approval
- ✅ Default codex.bot_login fallback `chatgpt-codex-connector[bot]` matches the value in `.github/review-policy.yml`

### Regression risk

- Check 3 (bot self-approval), Check 4 (needs-human-review), Check 5 (policy-violation) are all unchanged
- `nathanjohnpayne` (author) still cannot self-approve via the existing review-state-+-account-filter logic
- The `reviewerAccounts` array is still populated from `available_reviewers` in `review-policy.yml`
- The audit issue creation, labeling, and `cc @nathanjohnpayne` are all unchanged

### Test coverage

- [x] YAML parse via `js-yaml` (no syntax errors)
- [x] Embedded JS extracted and `node --check`'d (no JS syntax errors)
- [x] **17-case audit-logic test harness** (new `/tmp/test-pr-audit.js`) loads `pr-audit.yml`, extracts the embedded `github-script` JS, wraps it in an AsyncFunction with a fake `github` REST client, and runs it against synthetic PR data. Cases:
  - 3 Self-Review checks (normal with/without, Dependabot skipped)
  - 5 external-review checks (CLI identities, Codex bot COMMENTED, only-author flagged, zero-reviews flagged)
  - 4 Dependabot approval checks (CLI APPROVED ok, zero flagged, Codex-only flagged, COMMENTED-only flagged)
  - 3 unchanged-Checks regression (bot self-approval, needs-human-review, policy-violation)
  - 2 combined cases (external-review + Dependabot with both approvals; same with only Codex)
- [ ] Not tested: live workflow run on a real merged PR. The cron fires Mondays at 9am UTC; this PR will be exercised on the next scheduled run after merge. If the workflow has a runtime YAML error I missed, it will surface in the next cron run.
- [ ] Not tested: Dependabot interaction end-to-end (would require an actual Dependabot PR landing). Tracked separately.

### Security

- No new dependencies, no new tokens, no new permissions
- `js-yaml` was already a dependency (used by the existing `Install js-yaml` step)
- The Codex bot login is read from a config file in the repo, not from any external source
- The `externalReviewApprovers` array is constructed from trusted config, not from PR data

## What I'm NOT changing

- `pr-review-policy.yml` — already has the Dependabot exception at the job level; no changes needed
- `dependabot-auto-merge.yml` — already approves PRs via `REVIEWER_ASSIGNMENT_TOKEN`; the audit's new Check 2 extension just verifies the result
- The 6 downstream repos — propagation happens via #45–#50 when those sub-issues run
- The `audit` GitHub label, the cron schedule, the issue title format — all preserved

## Test plan (for reviewers)

- [ ] Read the diff and confirm Change A and Change B compose cleanly without breaking the existing checks
- [ ] Confirm the Codex bot acceptance doesn't accidentally accept the Codex bot's own approval on its own PRs (impossible because Codex can't author PRs in this flow, but worth a sanity check)
- [ ] Confirm the Dependabot approval check requires `state === 'APPROVED'` (not COMMENTED) and excludes the Codex bot
- [ ] Walk through the new test harness if you want to verify the assertions
