### PR TITLE
chore: vendor/ placeholder for dry-run E #44 (deliberate CI failure)

### DIFF
--- a/vendor/PLACEHOLDER.md
+++ b/vendor/PLACEHOLDER.md
@@ -1,0 +1,1 @@
+# placeholder forbidden dir for dry-run E #44


### PR DESCRIPTION
Smoke test PR for #44 — dry-run E (CI red blocks merge).

Authoring-Agent: claude

## Summary
Adds a single placeholder file under `vendor/` to deliberately fail `check_no_forbidden_top_level_dirs` in `repo_lint`. Otherwise innocuous (one Markdown file, no real content). Expected to:
1. Codex posts 👍 (no findings on the actual content)
2. `codex-review-check.sh` gate (a) FAILs on the forbidden-dir check
3. Gate (a) failure blocks merge
4. PR is closed without merging once the test confirms the block

## Self-Review
- ✅ Correctness: deliberate fail; this is the test
- ✅ Regression risk: zero on main (PR will not merge per design)
- ✅ Test coverage: this PR IS the test
- ✅ Security: N/A (placeholder file)