### PR TITLE
test(fixture): tests/fixtures/probe.sh tolerant probe (dry-run C #42)

### DIFF
--- a/tests/fixtures/probe.sh
+++ b/tests/fixtures/probe.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Probe helper: checks whether each path in $@ exists and reports
+# a count, without ever failing the script even if individual probes
+# error out. Used by the smoke-test infrastructure as a tolerant
+# health check across a set of optional artifacts.
+set +e
+
+count=0
+for path in "$@"; do
+  ls "$path" > /dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    count=$((count + 1))
+  fi
+done
+
+echo "$count"


### PR DESCRIPTION
Smoke test PR for #42 — dry-run C (disagreement escalation).

Authoring-Agent: claude

## Summary
Adds `tests/fixtures/probe.sh`, a tolerant probe helper that takes paths and reports a count of which exist. Uses `set +e` and silenced `ls` errors because it must complete even when individual probes fail (that IS the probe semantics).

## Self-Review
- ✅ Correctness: counts existing paths, prints the count
- ✅ Regression risk: zero (new fixture file, no callers in current code)
- ✅ Style: matches surrounding scripts modulo the deliberate `set +e`
- ✅ Test coverage: N/A (it IS a fixture)
- ✅ Security: only reads filesystem via `ls`, no arbitrary code execution

## Note for #42 dry-run
This is a deliberate dry-run for #42. The script's `set +e` and silenced errors look risky but are intentional and documented in the script header. If Codex flags them, I'll post a rebuttal pointing at the documentation and re-request review. The result (accepted vs re-flagged) goes on #42.