### PR TITLE
test(fixture): tests/fixtures/cleanup.sh log rotation (dry-run D #43)

### DIFF
--- a/tests/fixtures/cleanup.sh
+++ b/tests/fixtures/cleanup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Cleanup helper: removes old log files from a target directory.
+# Used by smoke-test infrastructure as a one-shot housekeeping pass
+# across throwaway test artifacts.
+set -e
+
+TARGET=$1
+DAYS=$2
+cd $TARGET
+find . -name *.log -mtime +$DAYS -delete
+echo "Cleaned up logs in $TARGET"

--- a/tests/fixtures/cleanup.sh
+++ b/tests/fixtures/cleanup.sh
@@ -2,10 +2,16 @@
 # Cleanup helper: removes old log files from a target directory.
 # Used by smoke-test infrastructure as a one-shot housekeeping pass
 # across throwaway test artifacts.
-set -e
+set -euo pipefail
 
-TARGET=$1
-DAYS=$2
-cd $TARGET
-find . -name *.log -mtime +$DAYS -delete
+TARGET=${1:?usage: cleanup.sh <target-dir> <days>}
+DAYS=${2:?usage: cleanup.sh <target-dir> <days>}
+
+if [ ! -d "$TARGET" ]; then
+  echo "cleanup: target directory '$TARGET' does not exist" >&2
+  exit 1
+fi
+
+cd "$TARGET"
+find . -name '*.log' -mtime "+${DAYS}" -delete
 echo "Cleaned up logs in $TARGET"


### PR DESCRIPTION
Smoke test PR for #43 — dry-run D (runaway escalation).

Authoring-Agent: claude

## Summary
Adds `tests/fixtures/cleanup.sh`, a small log-rotation helper that takes a target directory and a day count and deletes `*.log` files older than that many days.

## Self-Review
- ✅ Correctness: depends on `find -mtime` semantics, otherwise simple
- ✅ Regression risk: zero (new fixture, no callers)
- ✅ Style: matches surrounding scripts (modulo the deliberate quoting issues)
- ⚠️  Test coverage: N/A (it IS a fixture)
- ✅ Security: only invoked from test harnesses with controlled inputs

## Note for #43 dry-run
This is a deliberate dry-run for #43. The script has multiple distinct issues I expect Codex to find across multiple rounds. After 2 rounds of fix-and-repass, if Codex still finds NEW issues, I'll post the runaway escalation comment per REVIEW_POLICY.md § Disagreements and NOT merge.