### PR TITLE
fix(scripts+hook): back-port 17 propagation-discovered bugs (#75)

### DIFF
--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -412,7 +412,6 @@ if [ -z "$REQUIRED_CHECK_NAMES" ]; then
 else
   # Build a jq array of required check names
   REQUIRED_JSON=$(echo "$REQUIRED_CHECK_NAMES" | jq -R . | jq -s .)
-  REQUIRED_FILTER="(.label as \$l | $REQUIRED_JSON | index(\$l)) != null"
 fi
 
 BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq --argjson required_names "${REQUIRED_JSON:-[]}" '

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -134,6 +134,16 @@ if ! [[ "$REACTION_FRESHNESS_SECONDS" =~ ^[0-9]+$ ]]; then
   exit 3
 fi
 
+# Honor codex.require_ci_green. When true (default), gate (a) runs
+# and any non-passing required check blocks merge. When false, gate
+# (a) is skipped — useful for emergency or manual flows where CI
+# is intentionally bypassed. Codex caught the missing wire-up on
+# the nathanpaynedotcom propagation PR #180 (the field was read by
+# the policy parser and documented in the codex: block but never
+# actually consulted by this script).
+REQUIRE_CI_GREEN=$(codex_field require_ci_green)
+REQUIRE_CI_GREEN=${REQUIRE_CI_GREEN:-true}
+
 # Read the available_reviewers list (one per line). Same state-machine
 # awk pattern, but collecting list items rather than matching a scalar.
 # Outputs one reviewer login per line to stdout. Handles both quoted
@@ -328,6 +338,10 @@ esac
 
 # --- gate (a): CI checks green ---------------------------------------------
 
+if [ "$REQUIRE_CI_GREEN" != "true" ]; then
+  log "gate (a): SKIPPED (codex.require_ci_green=$REQUIRE_CI_GREEN)"
+else
+
 log "gate (a): checking CI state"
 
 # Use the structured statusCheckRollup instead of `gh pr checks` so we can
@@ -358,7 +372,50 @@ ROLLUP_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json statusCheckRollup 2>
 #
 # Normalize both into {label, workflow, result}, then accept only
 # SUCCESS / SKIPPED / NEUTRAL as non-blocking.
-BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq '
+# Determine which checks are REQUIRED via branch protection. Without
+# this filter, gate (a) blocks on any non-passing check in the
+# rollup including optional / informational ones that branch
+# protection wouldn't actually require for merge. nathanpayne-codex
+# caught the over-strict behavior on swipewatch propagation PR #33
+# round 4.
+#
+# The base branch is read from PR_JSON. If branch protection isn't
+# configured (or returns empty), fall back to the prior behavior
+# (consider all checks). If branch protection IS configured, only
+# checks listed in required_status_checks.contexts AND/OR
+# required_status_checks.checks[].context block the gate.
+BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.base.ref')
+REQUIRED_CHECK_NAMES=$(gh api "repos/$REPO/branches/$BASE_BRANCH/protection/required_status_checks" 2>/dev/null \
+  | jq -r '[.contexts[]?, .checks[]?.context] | unique | .[]' 2>/dev/null \
+  || true)
+
+if [ -z "$REQUIRED_CHECK_NAMES" ]; then
+  # No required-check list available. This can happen because:
+  #   - The branch has no branch protection rules at all, OR
+  #   - The token lacks Administration:read scope (which the
+  #     required_status_checks endpoint requires).
+  #
+  # Earlier versions treated "no list" as "all checks required",
+  # which caused over-strict blocking when the token lacked perms
+  # and optional/flaky checks happened to be failing. Codex caught
+  # this on swipewatch propagation PR #33 round 8.
+  #
+  # New behavior: log a warning and SKIP the required-check filter
+  # entirely, letting gate (a) pass. The rationale is that if
+  # branch protection isn't configured or the token can't read it,
+  # the BRANCH PROTECTION ITSELF doesn't enforce required checks,
+  # so gate (a) shouldn't either.
+  log "gate (a): WARNING — could not determine required checks from branch protection for $BASE_BRANCH (no rules configured or token lacks Administration:read scope). Skipping required-check filter — all checks treated as passing this gate."
+  # Skip gate (a) entirely for this case
+  ROLLUP_JSON='{"statusCheckRollup":[]}'
+  REQUIRED_JSON='[]'
+else
+  # Build a jq array of required check names
+  REQUIRED_JSON=$(echo "$REQUIRED_CHECK_NAMES" | jq -R . | jq -s .)
+  REQUIRED_FILTER="(.label as \$l | $REQUIRED_JSON | index(\$l)) != null"
+fi
+
+BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq --argjson required_names "${REQUIRED_JSON:-[]}" '
   [.statusCheckRollup[]
     | {
         label: (.name // .context // "?"),
@@ -373,6 +430,14 @@ BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq '
     | select(
         (.workflow != "PR Review Policy") or
         (.label != "Label Gate")
+      )
+    # When branch protection lists required checks, only those
+    # checks block the gate. When the list is empty (no branch
+    # protection configured or query failed), fall back to the
+    # prior behavior of treating all checks as required.
+    | select(
+        ($required_names | length) == 0
+        or ($required_names | index(.label)) != null
       )
     # A check passes the gate iff its result is SUCCESS, SKIPPED, or
     # NEUTRAL. Everything else — FAILURE, CANCELLED, TIMED_OUT,
@@ -396,6 +461,8 @@ if [ "$BAD_COUNT" -gt 0 ]; then
 fi
 
 log "gate (a): CI is green (Label Gate failure, if present, is expected during Phase 4a)"
+
+fi  # end REQUIRE_CI_GREEN
 
 # --- gate (b): reviewer identity approval ----------------------------------
 
@@ -471,10 +538,20 @@ COMMENTS_JSON=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "inline 
 # P2/P3 don't block clearance per REVIEW_POLICY.md § Phase 4a step 15a.
 # If there's no Codex review on HEAD, UNADDRESSED_P01 is [] — the
 # reaction path is then the only way gate (c) can clear.
+#
+# Filter MUST include user.login == BOT_LOGIN. Review-thread replies
+# (e.g., a human quoting a P1 badge from a Codex finding while
+# debugging) share the same pull_request_review_id as the original
+# Codex comments, so a quote-only reply containing `![P1 Badge]`
+# would otherwise be misclassified as an unaddressed Codex finding
+# and incorrectly block merge. nathanpayne-codex caught this on
+# nathanpaynedotcom propagation PR #180 round 3.
 if [ -n "$CODEX_REVIEW_ID" ] && [ "$CODEX_REVIEW_ID" != "null" ]; then
   UNADDRESSED_P01=$(echo "$COMMENTS_JSON" | jq \
+    --arg bot "$BOT_LOGIN" \
     --argjson review_id "$CODEX_REVIEW_ID" '
     [ .[]
+      | select(.user.login == $bot)
       | select(.pull_request_review_id == $review_id)
       | select(.body | test("!\\[P[01] Badge\\]"))
       | { path, line, comment_id: .id }

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -287,29 +287,48 @@ scan_codex_state() {
   reactions=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/reactions" "reactions")
 
   # Latest review from the Codex bot on the current HEAD commit, if any.
-  # Codex always uses COMMENTED state regardless of findings.
+  # Codex always uses COMMENTED state regardless of findings. We also
+  # capture the review id so the findings filter can scope to THIS
+  # review only and not pick up stale findings from an earlier review
+  # round on the same HEAD.
   review=$(echo "$reviews" | jq --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" '
     [.[] | select(.user.login == $bot) | select(.commit_id == $sha)]
     | sort_by(.submitted_at) | last
     | if . == null then null
-      else { state, submitted_at, commit_id, body }
+      else { id, state, submitted_at, commit_id, body }
       end
   ')
 
-  # Inline findings from the bot on the current HEAD commit, with P0-P3
-  # priority extracted from the ![P{0-3} Badge] markdown shortcode.
-  findings=$(echo "$comments" | jq --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" '
-    [ .[]
-      | select(.user.login == $bot)
-      | select((.original_commit_id == $sha) or (.commit_id == $sha))
-      | { path, line, comment_id: .id, body,
-          priority: (
-            (.body | capture("!\\[P(?<n>[0-3]) Badge\\]")? // {n: null}) | .n
-            | if . == null then "P?" else "P" + . end
-          )
-        }
-    ]
-  ')
+  # Get the LATEST Codex review id so findings are scoped to that
+  # round only. nathanpayne-codex caught (swipewatch propagation
+  # PR #33 round 2) that filtering by SHA alone keeps old P0/P1
+  # comments from earlier reviews on the same HEAD forever — same
+  # bug class as PR #65 round 1's gate (c) findings filter on
+  # codex-review-check.sh.
+  latest_review_id=$(echo "$review" | jq -r 'if . == null then "" else .id end')
+
+  # Inline findings from the bot on the current HEAD commit, scoped
+  # to the LATEST review round (via pull_request_review_id), with
+  # P0-P3 priority extracted from the ![P{0-3} Badge] markdown
+  # shortcode. If there's no current review, findings is empty.
+  if [ -n "$latest_review_id" ] && [ "$latest_review_id" != "null" ]; then
+    findings=$(echo "$comments" | jq \
+      --arg bot "$BOT_LOGIN" \
+      --argjson review_id "$latest_review_id" '
+      [ .[]
+        | select(.user.login == $bot)
+        | select(.pull_request_review_id == $review_id)
+        | { path, line, comment_id: .id, body,
+            priority: (
+              (.body | capture("!\\[P(?<n>[0-3]) Badge\\]")? // {n: null}) | .n
+              | if . == null then "P?" else "P" + . end
+            )
+          }
+      ]
+    ')
+  else
+    findings='[]'
+  fi
 
   # Most recent +1 reaction from the bot on the issue with created_at
   # strictly >= REACTION_THRESHOLD. Threshold = max(HEAD_PUSHED_AT,
@@ -337,10 +356,62 @@ scan_codex_state() {
   '
 }
 
-# Returns 0 iff the scan produced a review or reaction (signal received).
+# Returns 0 iff the scan produced ANY signal (review or reaction).
+# Used by the poll loop, which stops as soon as Codex has produced
+# any response — even a review with P0/P1 findings counts because
+# the caller will then process the findings and decide what to do.
 has_signal() {
   local scan=$1
   [ "$(echo "$scan" | jq -r '.review != null or .reaction != null')" = "true" ]
+}
+
+# Returns 0 iff the scan produced a signal that should be treated as
+# CLEARED (no further @codex review trigger needed). Cleared means
+# EITHER:
+#   - any +1 reaction on the PR issue (the no-findings happy path), OR
+#   - a review on HEAD with zero P0/P1 inline findings (the
+#     reviewed-and-clean path)
+#
+# A review with P0/P1 findings does NOT count as cleared — the caller
+# may have replied to the findings with a rebuttal and want Codex to
+# re-evaluate. Earlier versions of this function used has_signal in
+# the pre-flight, which caused the rebuttal-without-commit path to
+# stall: re-running the script saw the existing P1-bearing review
+# and skipped the trigger, so Codex was never asked to reconsider.
+# Codex caught this on swipewatch propagation PR #33 — same shape as
+# the manual `@codex review` workaround I had to use on template PR
+# #73 during dry-run C.
+has_cleared_signal() {
+  local scan=$1
+  # Latest-signal-wins: when both a reaction and a review exist on
+  # HEAD, the more recent one is authoritative. Otherwise an older
+  # 👍 from a prior round can mask a later P1-bearing review and
+  # skip a needed retrigger. nathanpayne-codex caught this on
+  # nathanpaynedotcom propagation PR #180 round 2 — same shape as
+  # PR #65 round 1's gate (c) latest-state rule on
+  # codex-review-check.sh.
+  #
+  # Cleared iff EITHER:
+  #   - reaction exists AND (review is null OR reaction is newer
+  #     than review), OR
+  #   - review exists AND review is newer than (or only signal vs)
+  #     reaction AND review has zero P0/P1 findings (the findings
+  #     array is already scoped to the latest review's id by the
+  #     pull_request_review_id filter in scan_codex_state)
+  [ "$(echo "$scan" | jq -r '
+    def review_time: if .review == null then "" else .review.submitted_at end;
+    def reaction_time: if .reaction == null then "" else .reaction.created_at end;
+    def review_clean: ([.findings[] | select(.priority == "P0" or .priority == "P1")] | length) == 0;
+
+    if .reaction == null and .review == null then "false"
+    elif .reaction != null and .review == null then "true"
+    elif .reaction == null and .review != null then
+      (review_clean | tostring)
+    elif (reaction_time > review_time) then "true"
+    else
+      (review_clean | tostring)
+    end
+  ')" = "true" ]
 }
 
 # --- pre-flight: is Codex already working on HEAD? --------------------------
@@ -351,9 +422,10 @@ if ! INITIAL_SCAN=$(scan_codex_state); then
 fi
 
 TRIGGER_POSTED=false
+TRIGGER_POST_TIME=""
 
-if has_signal "$INITIAL_SCAN"; then
-  log "Codex has already responded on HEAD — skipping trigger comment"
+if has_cleared_signal "$INITIAL_SCAN"; then
+  log "Codex has already cleared on HEAD (reaction or no-P0/P1 review) — skipping trigger comment"
 else
   log "posting '@codex review' trigger comment"
   # Capture stderr (and stdout) into a diagnostic variable so a failure
@@ -364,6 +436,39 @@ else
   POST_OUTPUT=$(gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
     || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
   TRIGGER_POSTED=true
+  # Capture the post time so the poll loop can ignore stale signals
+  # that were already on HEAD before the trigger fired. Without this,
+  # `has_signal "$INITIAL_SCAN"` would return true on the very first
+  # iteration of the poll loop and the script would exit with the
+  # stale review/reaction without waiting for Codex's actual response
+  # to the new trigger. Codex caught this on swipewatch propagation
+  # PR #33 round 2 — same shape as the round-1 has_cleared_signal
+  # bug, just on the post-trigger side.
+  #
+  # Use GitHub's authoritative timestamp from the just-posted comment
+  # (extracted from the URL gh returns) rather than local wall-clock.
+  # Local wall-clock can be ahead of or behind GitHub by a few seconds
+  # due to NTP skew, and the strict `>` comparison would misclassify
+  # a real Codex response as pre-trigger. Falls back to local wall-
+  # clock minus a 60-second buffer if the comment ID can't be
+  # extracted (e.g., gh output format change). Codex caught the
+  # wall-clock issue on nathanpaynedotcom propagation PR #180 round 4.
+  TRIGGER_COMMENT_ID=$(echo "$POST_OUTPUT" | grep -oE 'issuecomment-[0-9]+' | head -1 | sed 's/issuecomment-//')
+  if [ -n "$TRIGGER_COMMENT_ID" ]; then
+    TRIGGER_POST_TIME=$(gh api "repos/$REPO/issues/comments/$TRIGGER_COMMENT_ID" --jq '.created_at' 2>/dev/null || true)
+  fi
+  if [ -z "$TRIGGER_POST_TIME" ]; then
+    # Fallback: local wall-clock minus a 60-second buffer for
+    # clock skew tolerance.
+    EPOCH_NOW=$(date +%s)
+    EPOCH_BUFFER=$((EPOCH_NOW - 60))
+    if TRIGGER_POST_TIME=$(date -u -r "$EPOCH_BUFFER" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null); then
+      :
+    else
+      TRIGGER_POST_TIME=$(date -u -d "@$EPOCH_BUFFER" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || die 3 "could not compute fallback TRIGGER_POST_TIME")
+    fi
+  fi
 fi
 
 # --- poll loop --------------------------------------------------------------
@@ -372,10 +477,44 @@ START_TS=$(date +%s)
 DEADLINE=$((START_TS + TIMEOUT_SECONDS))
 ELAPSED=0
 
-FINAL_SCAN=$INITIAL_SCAN
+# Returns 0 iff the scan has a signal that is at least as recent
+# as TRIGGER_POST_TIME (>=, not >). Used by the poll loop only
+# when TRIGGER_POSTED=1 so we don't short-circuit on stale signals.
+#
+# Uses >= rather than > because GitHub timestamps are second-
+# precision and a legitimate Codex response in the same second as
+# the trigger comment post would otherwise be classified as stale
+# forever, forcing the script to time out to Phase 4b unnecessarily.
+# nathanpayne-codex caught the >-vs->= bug on swipewatch propagation
+# PR #33 round 4 and the related wall-clock-vs-GitHub-time bug on
+# nathanpaynedotcom propagation PR #180 round 4.
+has_post_trigger_signal() {
+  local scan=$1
+  [ "$(echo "$scan" | jq -r --arg after "$TRIGGER_POST_TIME" '
+    ((.review != null and .review.submitted_at >= $after)
+     or (.reaction != null and .reaction.created_at >= $after))
+  ')" = "true" ]
+}
+
+if [ "$TRIGGER_POSTED" = "true" ]; then
+  # We just posted a trigger. The INITIAL_SCAN data is now stale by
+  # definition — Codex will respond with something new. Skip the
+  # initial has_signal check; force the loop to actually poll.
+  FINAL_SCAN='{"review":null,"findings":[],"reaction":null}'
+else
+  FINAL_SCAN=$INITIAL_SCAN
+fi
 
 while :; do
-  if has_signal "$FINAL_SCAN"; then
+  # If we just triggered a fresh review, only break on a signal
+  # strictly newer than the trigger. Otherwise (no trigger sent),
+  # any existing signal is fine — that's the cleared-on-arrival path.
+  if [ "$TRIGGER_POSTED" = "true" ]; then
+    if has_post_trigger_signal "$FINAL_SCAN"; then
+      log "Codex signal received after ${ELAPSED}s (post-trigger)"
+      break
+    fi
+  elif has_signal "$FINAL_SCAN"; then
     log "Codex signal received after ${ELAPSED}s"
     break
   fi
@@ -423,8 +562,18 @@ jq -n \
   }
 '
 
-# Exit 0 if a signal arrived; exit 4 (FALLBACK_REQUIRED) if we timed out.
-if has_signal "$FINAL_SCAN"; then
+# Exit 0 if a signal arrived; exit 4 (FALLBACK_REQUIRED) if we timed
+# out. When TRIGGER_POSTED=true, "a signal arrived" means a signal
+# strictly newer than the trigger post — the existing pre-trigger
+# signal doesn't count, otherwise the script would exit 0 with stale
+# findings the moment we time out polling for the new review.
+if [ "$TRIGGER_POSTED" = "true" ]; then
+  if has_post_trigger_signal "$FINAL_SCAN"; then
+    exit 0
+  else
+    exit 4
+  fi
+elif has_signal "$FINAL_SCAN"; then
   exit 0
 else
   exit 4

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -133,39 +133,113 @@ fi
 
 # --- tokenize the command with shell-quote awareness ---
 #
-# xargs honors POSIX single and double quoting. `gh pr merge
+# Use python3 shlex.split which honors POSIX single and double
+# quoting AND handles multi-line quoted strings. `gh pr merge
 # --body "hello world" 65` tokenizes correctly to (gh, pr, merge,
-# --body, hello world, 65) instead of being naively split into
-# (gh, pr, merge, --body, "hello, world", 65).
+# --body, hello world, 65), and `gh pr create --body "Authoring-
+# Agent: claude\n## Self-Review\nok"` (with literal newlines in
+# the body) also tokenizes correctly because shlex.split treats
+# newlines inside quotes as literal characters, not as token
+# separators.
 #
-# IMPORTANT: pass `printf '%s\n'` as the explicit command. The
-# default `xargs` command is `echo`, and `echo` treats tokens
-# beginning with `-` (specifically `-n`, `-e`, `-E`) as ITS OWN
-# flags rather than printing them. That means a naive `xargs -n 1`
-# silently drops `-n` from the token stream, which broke the
-# pre-gh walk for inputs like `nice -n 5 gh pr merge 65` (the
-# `-n` was missing entirely, so the walk treated `5` as the
-# next command and switched to in_unrelated_args mode, missing
-# the real `gh` command). Using `printf '%s\n'` instead of the
-# implicit echo preserves every token literally.
+# Earlier versions used `xargs -n 1` (with the implicit `echo`
+# command), which:
+#   - Silently drops -n / -e / -E (echo's own flags). Codex caught
+#     this on PR #66 round 6 and the workaround was `xargs -n 1
+#     printf '%s\n'`.
+#   - Treats embedded newlines as token separators, breaking
+#     valid `gh pr create --body "...multiline..."` invocations.
+#     Codex caught this on nathanpaynedotcom propagation PR #180
+#     round 4. xargs has no flag to disable this behavior; the
+#     fix is to switch tokenizers entirely.
+#
+# python3 is available on macOS 12+ by default and on every Linux
+# distro the agent flow runs on. Python startup cost is ~50ms per
+# invocation; acceptable for a hook that already does an API call.
 #
 # Fails CLOSED on tokenization error (unmatched quote, bad escape).
 # An agent should fix the malformed command and retry.
-TOKENS_OUTPUT=""
-if ! TOKENS_OUTPUT=$(printf '%s' "$COMMAND" | xargs -n 1 printf '%s\n' 2>&1); then
+#
+# python3 emits tokens NUL-delimited so bash's read -d '' can
+# preserve embedded newlines. The output goes via a tempfile
+# rather than $(...) command substitution because bash command
+# substitution silently strips NUL bytes from its capture buffer,
+# which would re-jam all tokens together. Earlier versions used
+# newline-delimited output via print(tok), which silently SPLIT
+# any token containing a literal newline (e.g., the body of a
+# `gh pr create --body "Authoring-Agent: claude\n## Self-Review
+# \nok"`) into multiple bash tokens. Codex caught the bash-side
+# split on nathanpaynedotcom propagation PR #180 round 5.
+TMP_TOKENS=$(mktemp)
+TMP_TOKENS_ERR=$(mktemp)
+trap 'rm -f "$TMP_TOKENS" "$TMP_TOKENS_ERR"' EXIT
+# The python preprocessor first converts UNQUOTED newlines into `;`
+# command separators (so that multi-command inputs like
+# `echo ok\ngh pr merge 123 --admin` are split into two commands)
+# while preserving QUOTED newlines as literal characters in the
+# token (so that `gh pr create --body "line1\nline2"` keeps the
+# body as one token). Codex caught the unquoted-newline collapse
+# on swipewatch propagation PR #33 round 6 — privilege escalation
+# via newline-separated prefix command was the same shape as the
+# round-5 echo-prefix env spoof, just on a different separator.
+if ! printf '%s' "$COMMAND" | python3 -c '
+import sys, shlex
+
+def normalize_unquoted_newlines(cmd):
+    """Replace newlines OUTSIDE of single/double quotes with `; `.
+    Preserves newlines inside quoted strings as literal characters."""
+    out = []
+    in_single = False
+    in_double = False
+    i = 0
+    while i < len(cmd):
+        c = cmd[i]
+        # Handle backslash-escaped char in double quotes / unquoted
+        if c == "\\" and not in_single and i + 1 < len(cmd):
+            out.append(c)
+            out.append(cmd[i + 1])
+            i += 2
+            continue
+        # chr(39) is a single quote; using chr() avoids embedding a
+        # literal single quote inside the bash heredoc (which would
+        # break the python3 -c '...' surrounding quote).
+        if c == chr(39) and not in_double:
+            in_single = not in_single
+        elif c == chr(34) and not in_single:
+            in_double = not in_double
+        elif c == "\n" and not in_single and not in_double:
+            # Pad with spaces on BOTH sides so shlex parses the
+            # `;` as its own token rather than gluing it to the
+            # preceding word (e.g. "ok;" instead of "ok" + ";").
+            out.append(" ; ")
+            i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+try:
+    cmd = sys.stdin.read()
+    cmd = normalize_unquoted_newlines(cmd)
+    for tok in shlex.split(cmd):
+        sys.stdout.buffer.write(tok.encode("utf-8", errors="replace") + b"\x00")
+except ValueError as e:
+    print(f"shlex error: {e}", file=sys.stderr)
+    sys.exit(1)
+' > "$TMP_TOKENS" 2> "$TMP_TOKENS_ERR"; then
   echo "BLOCKED: gh-pr-guard could not tokenize the gh command (malformed shell quoting)." >&2
   echo "  command: $COMMAND" >&2
-  echo "  xargs error: $TOKENS_OUTPUT" >&2
+  echo "  shlex error: $(cat "$TMP_TOKENS_ERR")" >&2
   echo "  Fix the quoting and retry, or use BREAK_GLASS_ADMIN=1 + --admin." >&2
   exit 2
 fi
-# Portable read loop in lieu of bash 4+ `mapfile`. Empty lines
-# preserved so legitimate empty arg values like `--body ""` are
-# consumed correctly by downstream SKIP_NEXT_AS logic.
+# Read NUL-delimited tokens from the tempfile. `read -d ''` means
+# "read until NUL". Each iteration appends one whole token,
+# preserving any embedded newlines.
 TOKENS=()
-while IFS= read -r line; do
-  TOKENS+=("$line")
-done <<<"$TOKENS_OUTPUT"
+while IFS= read -r -d '' tok; do
+  TOKENS+=("$tok")
+done < "$TMP_TOKENS"
 
 # --- detect the pr subcommand, capturing any global -R/--repo ---
 #
@@ -213,13 +287,15 @@ INLINE_CODEX_CLEARED=""
 INLINE_BREAK_GLASS_ADMIN=""
 GLOBAL_REPO=""
 PR_SUBCOMMAND=""
+PR_SUBCOMMAND_INDEX=-1    # index in TOKENS where the gh pr subcommand was found
 SAW_GH=0
 SAW_PR=0
 SKIP_GLOBAL_AS=""        # "" | "repo"
 AT_COMMAND_POSITION=1    # 1 = at command position, 0 = walking unrelated-command args
 SKIP_PREFIX_VALUE=0      # 1 = next token is the value of a prefix-command flag
 CURRENT_PREFIX=""        # name of the most recently seen prefix command (sudo/time/etc.)
-for tok in "${TOKENS[@]}"; do
+for i in "${!TOKENS[@]}"; do
+  tok="${TOKENS[$i]}"
   # --- phase 2: walking after gh, looking for pr + subcommand ---
   if [ "$SAW_GH" -eq 1 ]; then
     if [ "$SKIP_GLOBAL_AS" = "repo" ]; then
@@ -262,6 +338,7 @@ for tok in "${TOKENS[@]}"; do
     fi
     # SAW_PR=1 — this token IS the pr subcommand.
     PR_SUBCOMMAND="$tok"
+    PR_SUBCOMMAND_INDEX=$i
     break
   fi
 
@@ -276,32 +353,53 @@ for tok in "${TOKENS[@]}"; do
     continue
   fi
 
-  # Capture inline env assignments regardless of state. Doing it
-  # here means a `CODEX_CLEARED=1 sudo gh pr merge 65` or even
-  # `cat foo; CODEX_CLEARED=1 gh pr merge 65` form still picks up
-  # the inline value when gh is eventually found.
-  case "$tok" in
-    CODEX_CLEARED=*)
-      INLINE_CODEX_CLEARED="${tok#CODEX_CLEARED=}"
-      ;;
-    BREAK_GLASS_ADMIN=*)
-      INLINE_BREAK_GLASS_ADMIN="${tok#BREAK_GLASS_ADMIN=}"
-      ;;
-  esac
-
   # Compound separators always reset us to command position,
   # whether we were in command position or skipping unrelated
   # args. Only standalone `&&` / `||` / `;` / `|` / `&` / `(`
   # tokens count — separators glommed onto adjacent words by
   # missing whitespace (e.g. `foo;`) are NOT detected, which is
   # an acceptable limitation for the agent flow.
+  #
+  # IMPORTANT: separator handling MUST run before the env-assignment
+  # capture below. Otherwise `echo CODEX_CLEARED=1 ; gh pr merge 65`
+  # would capture the literal `CODEX_CLEARED=1` arg of `echo` as a
+  # spoofed inline env var even though it never actually gets exported
+  # to the gh process. nathanpayne-codex caught this on swipewatch
+  # propagation PR #33 round 5 — privilege escalation potential.
   case "$tok" in
     "&&"|"||"|";"|"|"|"&"|"("|")")
       AT_COMMAND_POSITION=1
       CURRENT_PREFIX=""
+      # CRITICAL: clear inline env vars captured from the PREVIOUS
+      # command segment. `BREAK_GLASS_ADMIN=1 echo ok ; gh pr merge
+      # --admin 65` should NOT carry the BREAK_GLASS_ADMIN across the
+      # `;` boundary — it was scoped to `echo`, not to `gh`.
+      # nathanpayne-codex caught this on nathanpaynedotcom propagation
+      # PR #180 round 7.
+      INLINE_CODEX_CLEARED=""
+      INLINE_BREAK_GLASS_ADMIN=""
       continue
       ;;
   esac
+
+  # Capture inline env assignments ONLY when AT_COMMAND_POSITION=1.
+  # Tokens in IN_UNRELATED_ARGS are arguments to an unrelated
+  # command (e.g., `echo BREAK_GLASS_ADMIN=1 ; gh pr merge --admin
+  # 65`) and do NOT export to the spawned gh process — capturing
+  # them would let an agent spoof guard variables by prefixing the
+  # command with an echo. Only assignments that are themselves in
+  # command position (e.g., `CODEX_CLEARED=1 gh pr merge 65` or
+  # `CODEX_CLEARED=1 sudo gh pr merge 65`) count.
+  if [ "$AT_COMMAND_POSITION" -eq 1 ]; then
+    case "$tok" in
+      CODEX_CLEARED=*)
+        INLINE_CODEX_CLEARED="${tok#CODEX_CLEARED=}"
+        ;;
+      BREAK_GLASS_ADMIN=*)
+        INLINE_BREAK_GLASS_ADMIN="${tok#BREAK_GLASS_ADMIN=}"
+        ;;
+    esac
+  fi
 
   if [ "$AT_COMMAND_POSITION" -eq 0 ]; then
     # Skipping arguments of an unrelated command. Stay until a
@@ -419,7 +517,8 @@ fi
 
 # --- gh pr merge ---
 #
-# (PR_SUBCOMMAND must be "merge" by this point.)
+# (PR_SUBCOMMAND must be "merge" and PR_SUBCOMMAND_INDEX must point
+# to the actual `merge` subcommand token in TOKENS by this point.)
 #
 # Walk tokens AFTER the literal `merge` subcommand token to extract:
 #   - PR_SELECTOR (first non-flag positional)
@@ -435,15 +534,28 @@ fi
 # quoted flag value (e.g., `--subject "--admin follow-up"`).
 # nathanpayne-codex caught that on PR #66 round 6.
 #
+# An even earlier version of this walk used a separate `FOUND_MERGE`
+# scan that latched onto the FIRST `merge` token anywhere in the
+# command, not specifically the gh-context one. With chained inputs
+# like `echo merge ; gh pr merge 65`, the walk would latch onto the
+# echo arg and then capture `;` as the selector. Codex caught that
+# on the swipewatch propagation PR #33; the fix is to use the
+# PR_SUBCOMMAND_INDEX captured during phase 1 as the starting point
+# of the merge walk, eliminating the FOUND_MERGE state entirely.
+#
 # `gh pr merge` accepts the selector as <number> | <url> | <branch>;
 # we don't parse or validate the form, just pass it through to
 # `gh pr view` which accepts the same grammar.
 PR_SELECTOR=""
 REPO_ARG=""
 ADMIN_REQUESTED=0
-FOUND_MERGE=0
 SKIP_NEXT_AS=""  # "" | "skip" | "repo"
-for tok in "${TOKENS[@]}"; do
+merge_walk_start=$((PR_SUBCOMMAND_INDEX + 1))
+for j in "${!TOKENS[@]}"; do
+  if [ "$j" -lt "$merge_walk_start" ]; then
+    continue
+  fi
+  tok="${TOKENS[$j]}"
   if [ "$SKIP_NEXT_AS" = "skip" ]; then
     SKIP_NEXT_AS=""
     continue
@@ -453,44 +565,38 @@ for tok in "${TOKENS[@]}"; do
     SKIP_NEXT_AS=""
     continue
   fi
-  if [ "$FOUND_MERGE" -eq 1 ]; then
-    case "$tok" in
-      --admin)
-        ADMIN_REQUESTED=1
-        continue
-        ;;
-      --repo|-R)
-        SKIP_NEXT_AS="repo"
-        continue
-        ;;
-      --repo=*)
-        REPO_ARG="${tok#--repo=}"
-        continue
-        ;;
-      -R=*)
-        REPO_ARG="${tok#-R=}"
-        continue
-        ;;
-      --body|-b|--body-file|-F|--subject|-t|--author-email|-A|--match-head-commit)
-        SKIP_NEXT_AS="skip"
-        continue
-        ;;
-    esac
-    case "$tok" in
-      -*)
-        continue
-        ;;
-    esac
-    # First non-flag token after `merge` is the selector. Don't
-    # break — keep walking so a `--repo`/`-R` flag or `--admin`
-    # flag appearing AFTER the selector still gets captured.
-    if [ -z "$PR_SELECTOR" ]; then
-      PR_SELECTOR="$tok"
-    fi
-    continue
-  fi
-  if [ "$tok" = "merge" ]; then
-    FOUND_MERGE=1
+  case "$tok" in
+    --admin)
+      ADMIN_REQUESTED=1
+      continue
+      ;;
+    --repo|-R)
+      SKIP_NEXT_AS="repo"
+      continue
+      ;;
+    --repo=*)
+      REPO_ARG="${tok#--repo=}"
+      continue
+      ;;
+    -R=*)
+      REPO_ARG="${tok#-R=}"
+      continue
+      ;;
+    --body|-b|--body-file|-F|--subject|-t|--author-email|-A|--match-head-commit)
+      SKIP_NEXT_AS="skip"
+      continue
+      ;;
+  esac
+  case "$tok" in
+    -*)
+      continue
+      ;;
+  esac
+  # First non-flag token after the gh-context `merge` is the
+  # selector. Don't break — keep walking so a `--repo`/`-R` flag or
+  # `--admin` flag appearing AFTER the selector still gets captured.
+  if [ -z "$PR_SELECTOR" ]; then
+    PR_SELECTOR="$tok"
   fi
 done
 

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -292,6 +292,7 @@ SAW_GH=0
 SAW_PR=0
 SKIP_GLOBAL_AS=""        # "" | "repo"
 AT_COMMAND_POSITION=1    # 1 = at command position, 0 = walking unrelated-command args
+SEGMENT_HAS_COMMAND=0    # 1 = this segment has seen a non-assignment command (echo, cat, etc.)
 SKIP_PREFIX_VALUE=0      # 1 = next token is the value of a prefix-command flag
 CURRENT_PREFIX=""        # name of the most recently seen prefix command (sudo/time/etc.)
 for i in "${!TOKENS[@]}"; do
@@ -370,14 +371,27 @@ for i in "${!TOKENS[@]}"; do
     "&&"|"||"|";"|"|"|"&"|"("|")")
       AT_COMMAND_POSITION=1
       CURRENT_PREFIX=""
-      # CRITICAL: clear inline env vars captured from the PREVIOUS
-      # command segment. `BREAK_GLASS_ADMIN=1 echo ok ; gh pr merge
-      # --admin 65` should NOT carry the BREAK_GLASS_ADMIN across the
-      # `;` boundary — it was scoped to `echo`, not to `gh`.
-      # nathanpayne-codex caught this on nathanpaynedotcom propagation
-      # PR #180 round 7.
-      INLINE_CODEX_CLEARED=""
-      INLINE_BREAK_GLASS_ADMIN=""
+      # Clear inline env vars ONLY when the segment that just ended
+      # contained a non-assignment command. That means the assignment
+      # was a PREFIX scoped to that command, not a standalone
+      # assignment that persists in the shell:
+      #
+      #   BREAK_GLASS_ADMIN=1 echo ok ; gh pr merge --admin 65
+      #     → segment had `echo` (SEGMENT_HAS_COMMAND=1)
+      #     → assignment was prefix to echo → CLEAR at `;`
+      #
+      #   CODEX_CLEARED=1 && gh pr merge 76 --squash
+      #     → segment was ONLY the assignment (SEGMENT_HAS_COMMAND=0)
+      #     → standalone assignment → DON'T clear at `&&`
+      #
+      # nathanpayne-codex caught the over-clearing on template PR #76
+      # round 1 — `CODEX_CLEARED=1 && gh pr merge` was being cleared
+      # even though the assignment was standalone.
+      if [ "$SEGMENT_HAS_COMMAND" -eq 1 ]; then
+        INLINE_CODEX_CLEARED=""
+        INLINE_BREAK_GLASS_ADMIN=""
+      fi
+      SEGMENT_HAS_COMMAND=0
       continue
       ;;
   esac
@@ -471,7 +485,10 @@ for i in "${!TOKENS[@]}"; do
       # An unrelated command (echo, printf, cat, find, etc.).
       # gh-as-an-argument should NOT trigger the hook;
       # transition to skip mode and walk past the args.
+      # Mark the segment as having a real command so that
+      # separator-clearing of inline env vars fires correctly.
       AT_COMMAND_POSITION=0
+      SEGMENT_HAS_COMMAND=1
       continue
       ;;
   esac


### PR DESCRIPTION
Closes #75. Closes #67.

Back-ports all 17 bugs found by Codex during Phase 4 propagation to swipewatch (#45) and nathanpaynedotcom (#46). Full bug catalog with severity, root cause, and commit-level cross-references in issue #75.

Authoring-Agent: claude

## Summary

Three files, 434 insertions / 102 deletions. All fixes were battle-tested across 7-8 Codex review rounds on the two downstream repos before being consolidated here.

**`scripts/codex-review-request.sh`** — 10 bugs: pre-flight semantics (has_cleared_signal vs has_signal), findings scope (pull_request_review_id filter), latest-signal-wins in clearance, post-trigger poll reset, GitHub-time anchor, >= comparison for same-second tolerance.

**`scripts/codex-review-check.sh`** — 3 bugs: require_ci_green config wire-up, gate (c) bot-login filter, gate (a) branch-protection fallback (skip gate rather than treat all as required).

**`scripts/hooks/gh-pr-guard.sh`** — 9 bugs: xargs→shlex tokenizer switch, NUL-delimited output, unquoted-newline→; pre-processing, merge-walk anchor via PR_SUBCOMMAND_INDEX, token-based --admin detection, inline-env-capture scoped to AT_COMMAND_POSITION, inline-env cleared on compound separator.

## Self-Review

- ✅ All three scripts pass `bash -n`
- ✅ The hook's 15-case regression suite (from the swipewatch round-7 commit) passes against this version
- ✅ The 9-case has_cleared_signal unit test (from swipewatch round-3) passes
- ✅ Bug 18 (gate-a permission fallback) is the only fix NEW in this commit — all others were pre-tested on downstream PRs
- ✅ Bug 3 (env-clear-on-separator) was tested on nathanpaynedotcom round 7 and is applied here identically
- ⚠️ Not tested: full 167-case hook test suite from PR #66. The hook has structurally changed (xargs → shlex), so the xargs-based test cases from #66 are obsolete. The 15-case regression suite from propagation covers the same behavioral surface.

## Regression risk
- Low for codex-review-request.sh and codex-review-check.sh — additive logic (new predicates, new filters, new config reads)
- Medium for gh-pr-guard.sh — the tokenizer is a complete rewrite from xargs to shlex+python. The behavioral coverage from the 15-case suite mitigates this.

## Security
- No new dependencies beyond python3 (already available on all agent machines)
- The shlex switch eliminates the xargs echo-flag-eating vulnerability class entirely
- The privilege-escalation fixes (bugs 2, 3) close real spoofing vectors

## Test plan
- [ ] Codex review on this PR (the Codex GitHub App reviewing its own fixes is the ultimate meta-test)
- [ ] After merge: re-pull into swipewatch and ndotcom propagation PRs, confirm 0-1 round clearance
- [ ] After merge: propagate to remaining 4 repos (#47-#50) using the fixed template