### PR TITLE
feat(mockups): sync-scroll the rail and workspace columns

### DIFF
--- a/mockups/mergepath.html
+++ b/mockups/mergepath.html
@@ -172,32 +172,37 @@
     border: 1px solid var(--line);
   }
 
-  /* Layout */
+  /* Layout
+   *
+   * Both columns are their own scroll containers so the rail and the
+   * workspace can sync (see initSyncScroll in the script). The layout
+   * grid owns the height; each column fills it and scrolls internally.
+   * Page-level scroll is intentionally disabled below the hero so the
+   * two panes move in lockstep rather than fighting each other. */
   .layout {
     display: grid;
     grid-template-columns: minmax(320px, 380px) minmax(0, 1fr);
     gap: 18px;
     margin-top: 18px;
+    height: calc(100vh - 140px);
+    min-height: 480px;
   }
 
-  .rail {
+  .rail, .workspace {
     display: grid;
     gap: 16px;
     align-content: start;
-    position: sticky;
-    top: 18px;
-    max-height: calc(100vh - 40px);
-    overflow: auto;
+    overflow-y: auto;
     padding-right: 4px;
+    /* Firefox */
+    scrollbar-width: thin;
+    scrollbar-color: var(--line) transparent;
   }
-  .rail::-webkit-scrollbar { width: 6px; }
-  .rail::-webkit-scrollbar-thumb { background: var(--line); border-radius: 999px; }
-
-  .workspace {
-    display: grid;
-    gap: 18px;
-    align-content: start;
-  }
+  .workspace { gap: 18px; }
+  .rail::-webkit-scrollbar,
+  .workspace::-webkit-scrollbar { width: 6px; }
+  .rail::-webkit-scrollbar-thumb,
+  .workspace::-webkit-scrollbar-thumb { background: var(--line); border-radius: 999px; }
 
   .panel {
     padding: 22px 24px;
@@ -1436,9 +1441,41 @@
   });
 
   // ---------------------------------------------------------------------
+  // Sync scroll between the rail and the workspace
+  //
+  // Columns have independent heights (reviewers list + automation ≠ a
+  // 30-PR routing log), so pixel-for-pixel sync would either overshoot
+  // or leave the shorter pane stuck. Mirror by ratio instead:
+  // scrollTop / (scrollHeight - clientHeight) maps to [0,1] on the
+  // source and we rescale to the target's own range. A re-entry flag
+  // prevents the mirrored assignment from re-firing the opposite
+  // handler into an infinite loop.
+  // ---------------------------------------------------------------------
+  function initSyncScroll() {
+    const rail = document.querySelector('.rail');
+    const workspace = document.querySelector('.workspace');
+    if (!rail || !workspace) return;
+    let syncing = false;
+    function mirror(source, target) {
+      return () => {
+        if (syncing) return;
+        const sMax = source.scrollHeight - source.clientHeight;
+        const tMax = target.scrollHeight - target.clientHeight;
+        if (sMax <= 0 || tMax <= 0) return;
+        syncing = true;
+        target.scrollTop = (source.scrollTop / sMax) * tMax;
+        requestAnimationFrame(() => { syncing = false; });
+      };
+    }
+    rail.addEventListener('scroll', mirror(rail, workspace), { passive: true });
+    workspace.addEventListener('scroll', mirror(workspace, rail), { passive: true });
+  }
+
+  // ---------------------------------------------------------------------
   // Go
   // ---------------------------------------------------------------------
   renderAll();
+  initSyncScroll();
 </script>
 </body>
 </html>

--- a/specs/mergepath_policy_configurator.md
+++ b/specs/mergepath_policy_configurator.md
@@ -25,6 +25,10 @@ repo. Product name **Mergepath**.
   exposes.
 - Changing any knob updates stats, flows, and YAML without a full
   reload.
+- The control rail and workspace are their own scroll containers and
+  scroll in sync: scrolling one advances the other proportionally so
+  a long PR list and a short control stack stay aligned without the
+  shorter pane getting stranded.
 - The page carries an HTML comment injection marker
   `<!-- MERGEPATH_INJECT -->` that `scripts/policy-sim.sh` rewrites
   to `<script>window.__PRS = [...]</script>`. The legacy marker

--- a/tests/test_mergepath_frontend.sh
+++ b/tests/test_mergepath_frontend.sh
@@ -82,7 +82,7 @@ required = [
     'compileGlob', 'matchGlob', 'simulate', 'normalizePR',
     'validatePath', 'copyText', 'openModal', 'closeModal',
     'renderChips', 'renderPRs', 'renderYaml', 'applyPreset',
-    'announce',
+    'announce', 'initSyncScroll',
 ]
 missing = [name for name in required if name not in body]
 if missing:


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Pins the rail and workspace columns together so scrolling one advances the other. Previously the left rail was `position: sticky` with its own scroll container and the right workspace scrolled with the page — the two panes fought each other (rail would scroll to Reviewers while stats stayed pinned at the top; PR list would march past a frozen rail).

Both columns now share a single height (`calc(100vh - 140px)` for the grid, each column `overflow-y: auto`), and a small `initSyncScroll` wires them with a proportional mirror.

## Files

- `mockups/mergepath.html` — CSS: drop sticky rail, give both panes `overflow-y: auto` under a shared-height grid. JS: add `initSyncScroll` that mirrors scroll position by ratio with a re-entry flag.
- `specs/mergepath_policy_configurator.md` — document the sync-scroll behavior as an acceptance criterion.
- `tests/test_mergepath_frontend.sh` — add `initSyncScroll` to the required-symbols list.

## Self-Review

### Correctness

- Ratio sync (not pixel-for-pixel). The rail's content height differs from the routing log's, so pixel sync would either let one pane overshoot or leave the shorter pane stranded at 0. Mapping `scrollTop / (scrollHeight - clientHeight)` to `[0, 1]` and rescaling to the target's range keeps them visually aligned.
- Re-entry guard. `syncing = true` before writing `target.scrollTop`, cleared in a `requestAnimationFrame` — the target's scroll event fires synchronously, and without the flag it would immediately call back into the source handler.
- Degenerate cases handled: `sMax <= 0 || tMax <= 0` early-returns so a pane that fits without scrolling never drags the other one to 0.
- Small-viewport safety: `min-height: 480px` on `.layout` so the shared-height grid doesn't collapse into unusable strips on short screens.

### Regression risk

- Everything outside these three files is untouched. No shared CSS tokens changed, no global layout primitives edited.
- The YAML preview, chip input, modal, presets, and clipboard paths all live inside `.workspace` and are unaffected by the new overflow container (they were already in a scrollable context).
- Header pill, controls, and event wiring are unchanged.

### Style

- New CSS keeps the existing kebab-case conventions and shares the scrollbar styling between the two panes via a selector list instead of duplicating rules.
- `initSyncScroll` follows the same IIFE-free top-level-function convention as `renderYaml` / `applyPreset` / etc.
- One block comment explaining *why* (different heights → ratio, not pixel) and *why the flag* (re-entry prevention). No inline commentary on obvious lines.

### Test coverage

- `tests/test_mergepath_frontend.sh` green locally. The `initSyncScroll` symbol is now in the required-symbols list, so accidental removal fails the test.
- Structural anchors unchanged. `node --check` still passes on the extracted script.
- Manual browser test: scrolled the routing log, the rail tracked down to Reviewers; scrolled the rail, the workspace advanced through the PR list.

### Security / dependency hygiene

- No new runtime dependencies, no new DOM injection sites.
- No data flows through the new code — `initSyncScroll` reads `scrollTop` / `scrollHeight` / `clientHeight` and writes `scrollTop`, all numeric. Nothing user-supplied reaches an attribute or a node's text.
- `{ passive: true }` on the scroll listeners — we never call `preventDefault`, so the browser can still optimize scroll.