### PR TITLE
fix(policy-sim): use mktemp -d so the script works on a second run

### DIFF
--- a/scripts/policy-sim.sh
+++ b/scripts/policy-sim.sh
@@ -14,7 +14,16 @@ set -euo pipefail
 LIMIT="${1:-20}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEMPLATE="$REPO_ROOT/mockups/mergepath.html"
-OUT="$(mktemp /tmp/mergepath-sim.XXXXXX.html)"
+
+# macOS mktemp only substitutes TRAILING Xs, so
+# `mktemp /tmp/name.XXXXXX.html` treats the template as literal —
+# the first run succeeds and every subsequent run fails with
+# "File exists". Use a unique temp directory and place the baked
+# file inside with its extension intact; the dir name carries
+# uniqueness, the filename carries the .html so `open` picks the
+# right handler.
+OUT_DIR="$(mktemp -d -t mergepath-sim)"
+OUT="$OUT_DIR/mergepath.html"
 
 for bin in gh jq python3; do
   command -v "$bin" >/dev/null 2>&1 || {
@@ -30,8 +39,12 @@ done
 
 echo "Fetching last $LIMIT merged PRs via gh..."
 
-PRS_FILE="$(mktemp /tmp/mergepath-prs.XXXXXX.json)"
-trap 'rm -f "$PRS_FILE"' EXIT
+# PRs payload is intermediate; same trailing-X constraint, same
+# fix. The trap only cleans up this file — OUT stays so the browser
+# can open it.
+PRS_DIR="$(mktemp -d -t mergepath-prs)"
+PRS_FILE="$PRS_DIR/prs.json"
+trap 'rm -rf "$PRS_DIR"' EXIT
 
 gh pr list \
   --state merged \

--- a/tests/test_mergepath_frontend.sh
+++ b/tests/test_mergepath_frontend.sh
@@ -9,10 +9,14 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PAGE="$ROOT/mockups/mergepath.html"
 SCRIPT="$ROOT/scripts/policy-sim.sh"
-CHECK_FILE="$(mktemp /tmp/mergepath-check.XXXXXX.js)"
+# macOS mktemp only substitutes trailing Xs — `name.XXXXXX.js`
+# would work once and then fail with "File exists". Use a temp
+# directory and place fixed-name files inside.
+TMPDIR_SAFE="$(mktemp -d -t mergepath-test)"
+CHECK_FILE="$TMPDIR_SAFE/extracted.js"
 
 cleanup() {
-  rm -f "$CHECK_FILE"
+  rm -rf "$TMPDIR_SAFE"
 }
 trap cleanup EXIT
 
@@ -45,6 +49,11 @@ grep -q "MERGEPATH_INJECT"                       "$SCRIPT" || { echo "policy-sim
 # Helper script must script-safe escape injected JSON so a </script> token in
 # a PR title can't terminate the inline <script> block.
 grep -q '\\u003c'                                "$SCRIPT" || { echo "policy-sim.sh missing <-escape in JSON payload"; exit 1; }
+# Helper script must use `mktemp -d` for output paths. macOS mktemp only
+# substitutes TRAILING Xs, so `mktemp /tmp/name.XXXXXX.html` is literal —
+# it succeeds once, then every subsequent run fails with "File exists".
+grep -q 'mktemp -d'                              "$SCRIPT" || { echo "policy-sim.sh must use mktemp -d (macOS trailing-X limitation)"; exit 1; }
+grep -qE '\$\(mktemp [^)]*\.[A-Za-z]+\)'         "$SCRIPT" && { echo "policy-sim.sh uses mktemp with non-trailing Xs; will fail on macOS second run"; exit 1; } || true
 
 # YAML preview must emit full reviewer logins (nathanpayne-*), not short aliases.
 grep -q "nathanpayne-claude"                     "$PAGE" || { echo "YAML preview missing full reviewer login nathanpayne-claude"; exit 1; }
@@ -100,8 +109,7 @@ node --check "$CHECK_FILE"
 # Injection round-trip: inject a fake PR payload, confirm marker is consumed
 # and the baked copy still parses.
 # ---------------------------------------------------------------------------
-BAKED="$(mktemp /tmp/mergepath-baked.XXXXXX.html)"
-trap 'rm -f "$CHECK_FILE" "$BAKED"' EXIT
+BAKED="$TMPDIR_SAFE/baked.html"
 
 python3 - "$PAGE" "$BAKED" <<'PY'
 import sys


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

User hit this running the script a second time:

```
$ ./scripts/policy-sim.sh 5
mktemp: mkstemp failed on /tmp/mergepath-sim.XXXXXX.html: File exists
```

Root cause: macOS `mktemp` only substitutes **trailing** Xs. The previous fix used `mktemp /tmp/PREFIX.XXXXXX.EXT`, with the `.EXT` suffix after the Xs — macOS treats the whole template as literal and creates the file `/tmp/mergepath-sim.XXXXXX.html` verbatim. First run succeeds because the file doesn't exist yet; every subsequent run trips the "already exists" guard.

The same bug was in `tests/test_mergepath_frontend.sh` (the `CHECK_FILE` and `BAKED` mktemps). It didn't surface in CI because each run starts with a clean `/tmp`, but any developer running the test twice locally would have hit it.

Fix: switch to `mktemp -d` and place the baked file inside the unique directory with its extension intact. The directory carries uniqueness; the filename keeps `.html`/`.json`/`.js` so `open` dispatches correctly and `node --check` recognizes the file type.

## Files

- `scripts/policy-sim.sh` — `OUT` and `PRS_FILE` both switch to `mktemp -d` with a fixed filename inside.
- `tests/test_mergepath_frontend.sh` — same fix for `CHECK_FILE` and `BAKED`, plus two new grep assertions that lock in the pattern:
  - Script must contain `mktemp -d`.
  - Script must NOT contain the broken `mktemp ...XXXXXX.EXT` form.

## Self-Review

### Correctness

- Verified locally by running `bash tests/test_mergepath_frontend.sh` twice in a row — passes both times (previously would fail on run #2).
- `mktemp -d -t mergepath-sim` honored on both macOS and Linux (`-t` is a prefix on macOS, a template on GNU but accepts short prefixes without Xs there too).
- Temp dir lifecycle: `PRS_DIR` is trapped for cleanup on EXIT; `OUT_DIR` is intentionally leaked because the browser needs to open the file after the script exits. A handful of small directories in `/tmp` between reboots is acceptable for a dev playground.

### Regression risk

- No behavior change to the injection contract, JSON escaping, jq query, or the `open`/`xdg-open` dispatch — all I moved is where mktemp is called and how the result is named.
- The new grep assertions only accept `mktemp -d` (the correct form) and reject the specific broken pattern `$(mktemp ...XXXXXX.EXT)`. Anyone following the existing pattern via `mktemp -d` passes cleanly.

### Style

- Comments explain *why* the form changed (macOS trailing-X limitation) with the exact error message, so the next person who reaches for `mktemp -p /tmp name.XXXXXX.ext` has the context.

### Test coverage

- `tests/test_mergepath_frontend.sh` now asserts the fix is in place. If someone reverts `mktemp -d` back to the broken form, CI fails with an actionable message.
- Verified double-run: `bash tests/test_mergepath_frontend.sh && bash tests/test_mergepath_frontend.sh` both print `OK`.

### Security / dependency hygiene

- No new dependencies, no new inputs, no new attack surface. `mktemp -d` returns a path owned by the current user with 0700 perms; placing the baked file inside keeps the same filesystem posture as before.