### PR TITLE
refactor: rebrand as Mergepath (umbrella brand)

### DIFF
--- a/.repo-template.yml
+++ b/.repo-template.yml
@@ -10,8 +10,8 @@
 # Used by check_spec_test_alignment when the default filename search
 # wouldn't find the test.
 spec_test_map:
-  mergepath_policy_configurator:
-    - tests/test_mergepath_frontend.sh
+  mergepath_playground:
+    - tests/test_mergepath_playground.sh
 
 # Glob patterns that identify test files. Supplements the default
 # ("tests/**/*.test.*") which doesn't cover shell-based tests.

--- a/BRAND.md
+++ b/BRAND.md
@@ -1,0 +1,31 @@
+# Mergepath — brand vocabulary
+
+**Mergepath** is the reference implementation of the AI Agent Tooling
+Standard. The Standard is methodology-neutral; Mergepath is one concrete
+implementation of it. The Standard lives in
+[`ai_agent_tooling_standard.md`](ai_agent_tooling_standard.md) and keeps
+its neutral framing; Mergepath is this repo.
+
+## Surfaces
+
+- **Mergepath Playground** — interactive review-policy prototyping UI.
+  Lives at [`mergepath/playground/`](mergepath/playground/). Tune the
+  policy knobs, replay recent PRs, copy the resulting YAML. Current.
+- **Mergepath Cockpit** *(reserved)* — operator console for in-progress
+  reviews. Future.
+- **Mergepath Tiebreaker** *(reserved)* — disagreement and escalation
+  resolver per [`REVIEW_POLICY.md`](REVIEW_POLICY.md) § Disagreements
+  and Tiebreaking. Future.
+- **Mergepath Checks** *(reserved)* — CI-surface integrations. Future.
+
+Reserved names exist so a future agent doesn't pick "Cockpit" for the
+wrong surface. Don't scaffold files for these names until the surface is
+actually designed.
+
+## Naming history
+
+This project was originally `ai_agent_repo_template`. It was renamed to
+Mergepath when the umbrella scope (Playground, Cockpit, Tiebreaker,
+Checks) became clearer than "a template repo for agents." The underlying
+Standard kept its original name — Mergepath is the reference
+implementation of the Standard, not the Standard itself.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -40,13 +40,13 @@ gh auth login
 
 ```bash
 # Clone the template repo if not already present
-git clone https://github.com/nathanjohnpayne/ai_agent_repo_template.git ~/Documents/GitHub/ai_agent_repo_template
+git clone https://github.com/nathanjohnpayne/mergepath.git ~/Documents/GitHub/mergepath
 
 # Install canonical helper scripts
 mkdir -p ~/.local/bin
-cp ~/Documents/GitHub/ai_agent_repo_template/scripts/gcloud/gcloud ~/.local/bin/
-cp ~/Documents/GitHub/ai_agent_repo_template/scripts/firebase/op-firebase-deploy ~/.local/bin/
-cp ~/Documents/GitHub/ai_agent_repo_template/scripts/firebase/op-firebase-setup ~/.local/bin/
+cp ~/Documents/GitHub/mergepath/scripts/gcloud/gcloud ~/.local/bin/
+cp ~/Documents/GitHub/mergepath/scripts/firebase/op-firebase-deploy ~/.local/bin/
+cp ~/Documents/GitHub/mergepath/scripts/firebase/op-firebase-setup ~/.local/bin/
 chmod +x ~/.local/bin/gcloud ~/.local/bin/op-firebase-deploy ~/.local/bin/op-firebase-setup
 
 # Ensure PATH includes ~/.local/bin
@@ -142,7 +142,7 @@ If both machines modified the same 1Password item:
 The canonical helper scripts live in this template repo. Install them once per machine:
 
 ```bash
-# From the ai_agent_repo_template directory:
+# From the mergepath directory:
 mkdir -p ~/.local/bin
 cp scripts/gcloud/gcloud ~/.local/bin/gcloud
 cp scripts/firebase/op-firebase-deploy ~/.local/bin/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# Project Template
+# Mergepath
 
-This repository follows the **AI Agent Tooling Standard**.
+**Reference implementation of the AI Agent Tooling Standard.**
 
 The goal is to allow multiple AI coding agents and development tools to operate
-consistently without configuration drift.
+consistently without configuration drift. See [`BRAND.md`](BRAND.md) for
+the umbrella vocabulary (Playground, Cockpit, Tiebreaker, Checks) and
+naming history.
 
 ## For AI Agents
 
@@ -30,8 +32,9 @@ fallback (Phase 4b).
 | `DEPLOYMENT.md` | Build and deployment |
 | `CONTRIBUTING.md` | Development workflow |
 | `.ai_context.md` | High-level system context |
-| `mergepath/index.html` | Mergepath dashboard — tune the review policy and replay recent PRs against the draft |
-| `scripts/policy-sim.sh` | Bakes real `gh` PR data into a temp copy of the Mergepath dashboard for local replay |
+| `BRAND.md` | Mergepath umbrella vocabulary (surfaces, reserved names, naming history) |
+| `mergepath/playground/index.html` | Mergepath Playground — tune the review policy and replay recent PRs against the draft |
+| `scripts/policy-sim.sh` | Bakes real `gh` PR data into a temp copy of the Mergepath Playground for local replay |
 | `ai_agent_tooling_standard.md` | Full repository standard (reference) |
 
 ## Firebase Auth Template
@@ -55,7 +58,7 @@ See `DEPLOYMENT.md` for the full bootstrap and deploy flow.
 | `rules/` | Binding repository constraints |
 | `specs/` | Intended system behavior |
 | `plans/` | Execution and migration plans |
-| `mergepath/` | Static prototypes and interactive policy/playground mockups |
+| `mergepath/` | Mergepath Playground and reserved slots for future Mergepath surfaces (see `BRAND.md`) |
 | `tests/` | Automated validation |
 | `src/` | Application code |
 | `functions/` | Backend handlers |

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -557,7 +557,7 @@ ssh -T git@github-claude        # → Hi nathanpayne-claude!
 ### Switching all repos to SSH remotes
 
 ```bash
-for repo in ai_agent_repo_template swipewatch nathanpaynedotcom \
+for repo in mergepath swipewatch nathanpaynedotcom \
             device-platform-reporting device-source-of-truth \
             overridebroadway friends-and-family-billing docs; do
   cd ~/Documents/GitHub/$repo

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Please do **not** open a public issue for security vulnerabilities.
 
-Instead, use [GitHub's private vulnerability reporting](https://github.com/nathanjohnpayne/ai_agent_repo_template/security/advisories/new) or email security concerns directly.
+Instead, use [GitHub's private vulnerability reporting](https://github.com/nathanjohnpayne/mergepath/security/advisories/new) or email security concerns directly.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 Please do **not** open a public issue for security vulnerabilities.
 
-Instead, use [GitHub's private vulnerability reporting](https://github.com/nathanjohnpayne/mergepath/security/advisories/new) or email security concerns directly.
+Instead, use [GitHub's private vulnerability reporting](https://github.com/nathanjohnpayne/ai_agent_repo_template/security/advisories/new) or email security concerns directly. <!-- NOTE: slug updates to `mergepath` after the Phase 2 GitHub rename (#86); GitHub auto-redirects in the meantime. -->
+
 
 ## Scope
 

--- a/ai_agent_tooling_standard.md
+++ b/ai_agent_tooling_standard.md
@@ -7,7 +7,7 @@ coding agents and human developers. It governs structure, documentation
 placement, and agent behavior to prevent configuration drift and
 cross-tool inconsistency.
 
-The reference implementation is **ai_agent_repo_template**.
+The reference implementation is **Mergepath** (`mergepath`).
 When in doubt about structure or file placement, that repository is
 canonical.
 
@@ -392,13 +392,13 @@ To bring an existing repository into compliance:
 7. Verify `AGENTS.md` contains all required sections; add any missing.
 8. Add or update `.ai_context.md` if supplemental AI context is useful.
 9. Implement CI checks in `scripts/ci/`.
-10. Validate the result against **ai_agent_repo_template**.
+10. Validate the result against **Mergepath** (`mergepath`).
 
 ---
 
 ## Reference Implementation
 
-**`ai_agent_repo_template`** provides:
+**`mergepath`** (Mergepath) provides:
 - Example canonical documentation
 - Example directory structure
 - Example tool folder configuration

--- a/docs/agents/repository-overview.md
+++ b/docs/agents/repository-overview.md
@@ -1,11 +1,14 @@
 # Repository Overview
 
-This is a template repository following the AI Agent Tooling Standard.
-It provides a canonical starting structure for projects that require
-consistent behavior across multiple AI coding agents and development tools.
+This repository is **Mergepath**, the reference implementation of the AI
+Agent Tooling Standard. It provides a canonical starting structure for
+projects that require consistent behavior across multiple AI coding
+agents and development tools.
 
-Primary stack: Markdown documentation, shell automation, YAML review-policy
-configuration, and static HTML mockups.
-Agent role: maintain the template's structure and the review-policy/playground
-tooling plus supporting developer workflows, ensuring the documentation and
-tooling behavior do not drift over time.
+Primary stack: Markdown documentation, shell automation, YAML
+review-policy configuration, and the Mergepath Playground (static
+HTML + JS at `mergepath/playground/`).
+Agent role: maintain Mergepath's structure, the review-policy tooling
+and Playground, and the supporting developer workflows — ensuring
+documentation and tooling behavior do not drift over time. See
+[`BRAND.md`](../../BRAND.md) at repo root for the umbrella vocabulary.

--- a/mergepath/README.md
+++ b/mergepath/README.md
@@ -1,14 +1,16 @@
-# Mergepath
+# Mergepath — surfaces
 
-Static, single-file UI prototypes that illustrate how this template's
-review-policy tooling is meant to be used. Nothing here is wired to a
+This directory holds Mergepath's static, single-file surfaces.
+Currently only the **Playground** lives here; Cockpit, Tiebreaker, and
+Checks are reserved names for future surfaces — see
+[`BRAND.md`](../BRAND.md) at repo root. Nothing here is wired to a
 backend or a build system. Open the HTML in a browser and it works.
 
-## Dashboard
+## Mergepath Playground
 
-`index.html` is the current dashboard. It lets you tune the policy
-knobs from `.github/review-policy.yml` and replay recent PRs against
-the draft policy so you can feel the shape of the change before
+`playground/index.html` is the current Playground. It lets you tune the
+policy knobs from `.github/review-policy.yml` and replay recent PRs
+against the draft policy so you can feel the shape of the change before
 committing the YAML.
 
 ### What you can change
@@ -27,9 +29,9 @@ committing the YAML.
 
 ```bash
 # From the repo root, open directly in your default browser:
-open mergepath/index.html             # macOS
-xdg-open mergepath/index.html         # Linux
-start mergepath\index.html            # Windows
+open mergepath/playground/index.html             # macOS
+xdg-open mergepath/playground/index.html         # Linux
+start mergepath\playground\index.html            # Windows
 ```
 
 It opens with a synthetic set of sample PRs so the page demos without
@@ -44,7 +46,7 @@ any setup. The header badge reads **synthetic · 8**.
 
 The helper runs `gh pr list --state merged`, shapes the JSON into the
 `window.__PRS` format, injects it into a temporary copy of
-`index.html`, and opens that copy in a new tab. The header badge
+`playground/index.html`, and opens that copy in a new tab. The header badge
 flips to **live · N** and the routing simulation replays each PR
 against whichever policy draft you have loaded.
 
@@ -70,8 +72,8 @@ Each entry in the array must be `{ id, title, author, lines, paths }`.
 The page tolerates missing fields but expects those keys.
 
 The legacy marker `<!-- RUBRIC_INJECT -->` is still recognized for
-scripts carried over from earlier versions of this mockup; new tooling
-should target `MERGEPATH_INJECT`.
+scripts carried over from earlier versions of this Playground; new
+tooling should target `MERGEPATH_INJECT`.
 
 ### What this isn't
 
@@ -82,5 +84,5 @@ should target `MERGEPATH_INJECT`.
   knob configuration would look like as `.github/review-policy.yml`.
   It does not write to disk. Copy it yourself if you want to apply.
 - **Not canonical.** The spec for this page is
-  `specs/mergepath_policy_configurator.md`. If the spec and the page
-  disagree, the spec wins.
+  `specs/mergepath_playground.md`. If the spec and the page disagree,
+  the spec wins.

--- a/mergepath/playground/index.html
+++ b/mergepath/playground/index.html
@@ -758,7 +758,7 @@
     <div>
       <p class="eyebrow">Mergepath Playground</p>
       <h1>Tune your review policy and see how every PR would route.</h1>
-      <p class="lede">Adjust the threshold, protected paths, and automation toggles. Mergepath replays your recent PRs against the policy so you can feel the shape of the change before committing the YAML.</p>
+      <p class="lede">Adjust the threshold, protected paths, and automation toggles. Mergepath Playground replays your recent PRs against the policy so you can feel the shape of the change before committing the YAML.</p>
     </div>
     <div class="hero-meta">
       <button id="refreshBtn" class="pull-btn" type="button"

--- a/mergepath/playground/index.html
+++ b/mergepath/playground/index.html
@@ -756,7 +756,7 @@
 
   <section class="hero">
     <div>
-      <p class="eyebrow">Mergepath</p>
+      <p class="eyebrow">Mergepath Playground</p>
       <h1>Tune your review policy and see how every PR would route.</h1>
       <p class="lede">Adjust the threshold, protected paths, and automation toggles. Mergepath replays your recent PRs against the policy so you can feel the shape of the change before committing the YAML.</p>
     </div>
@@ -767,7 +767,7 @@
         <span class="icon" aria-hidden="true">↻</span> Pull live PRs
       </button>
       <span id="livePill" class="live-pill synthetic">synthetic</span>
-      <span>ai_agent_repo_template · mockup</span>
+      <span>mergepath · playground</span>
     </div>
   </section>
 
@@ -899,7 +899,7 @@
   </div>
 
   <footer>
-    <span>Mergepath · static mockup · no network, no auth</span>
+    <span>Mergepath Playground · static · no network, no auth</span>
     <span class="mono">v0.2</span>
   </footer>
 </div>

--- a/plans/mergepath-playground.md
+++ b/plans/mergepath-playground.md
@@ -10,28 +10,31 @@ application framework.
 
 ## Scope
 
-1. Ship a single dashboard at `mergepath/index.html`. Product name
-   is **Mergepath**. The file is self-contained — no build step, no
-   network, no auth.
+1. Ship a single dashboard at `mergepath/playground/index.html`. Product
+   name is **Mergepath Playground** — one surface of the Mergepath
+   umbrella (see [`BRAND.md`](../BRAND.md)). The file is self-contained —
+   no build step, no network, no auth.
 2. Ship a helper `scripts/policy-sim.sh` that uses `gh` to pull the
    repo's recent merged PRs and bakes them into a temp copy of the
    dashboard via an HTML comment injection marker.
 3. Document the dashboard in `mergepath/README.md` and formalize its
    intended behavior and hardening requirements in
-   `specs/mergepath_policy_configurator.md`.
+   `specs/mergepath_playground.md`.
 4. Exercise the dashboard and helper from
-   `tests/test_mergepath_frontend.sh` — verify structure, injection
+   `tests/test_mergepath_playground.sh` — verify structure, injection
    contract, XSS-safe rendering, and JavaScript syntactic validity.
 
 ## Deliberate cuts
 
-Earlier iterations of this plan aimed for a configurator that loaded
-and wrote back `.github/review-policy.yml`, surfaced an identities
-panel, and exposed advanced Codex knobs (bot login, reaction
-freshness, CI-green gate, timeouts). Those were cut. The dashboard is
-now a playground for the frequently-tuned subset: threshold, protected
-paths, automation toggles, max rounds, reviewer roster, and presets.
+Earlier iterations of this plan aimed for a full policy editor that
+loaded and wrote back `.github/review-policy.yml`, surfaced an
+identities panel, and exposed advanced Codex knobs (bot login,
+reaction freshness, CI-green gate, timeouts). Those were cut. The
+dashboard is now a playground for the frequently-tuned subset:
+threshold, protected paths, automation toggles, max rounds, reviewer
+roster, and presets.
 
 If a future iteration needs the full schema or read/write behavior, it
-should ship as a separate page in `mergepath/` and keep `index.html`
-simple.
+should ship as a separate page (likely `mergepath/cockpit/` — see the
+reserved brand vocabulary in [`BRAND.md`](../BRAND.md)) and keep the
+Playground simple.

--- a/scripts/policy-sim.sh
+++ b/scripts/policy-sim.sh
@@ -2,8 +2,8 @@
 # scripts/policy-sim.sh
 #
 # Replay the current repo's recent merged PRs through the Mergepath
-# dashboard. Runs `gh pr list`, inlines the result into a copy of the
-# mockup HTML, and opens it in the default browser.
+# Playground. Runs `gh pr list`, inlines the result into a copy of the
+# Playground HTML, and opens it in the default browser.
 #
 # Usage:   ./scripts/policy-sim.sh [limit]   (default 20)
 #
@@ -13,7 +13,7 @@ set -euo pipefail
 
 LIMIT="${1:-20}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-TEMPLATE="$REPO_ROOT/mergepath/index.html"
+TEMPLATE="$REPO_ROOT/mergepath/playground/index.html"
 
 # macOS mktemp only substitutes TRAILING Xs, so
 # `mktemp /tmp/name.XXXXXX.html` treats the template as literal —

--- a/specs/mergepath_playground.md
+++ b/specs/mergepath_playground.md
@@ -1,11 +1,12 @@
-# Mergepath Policy Configurator
+# Mergepath Playground
 
-Feature: static, single-file review-policy playground for the template
-repo. Product name **Mergepath**.
+Feature: static, single-file review-policy playground. One surface of the
+Mergepath system — future surfaces (Cockpit, Tiebreaker, Checks) are
+reserved, see [`BRAND.md`](../BRAND.md).
 
 ## Acceptance criteria
 
-- The dashboard lives at `mergepath/index.html` and is a single
+- The dashboard lives at `mergepath/playground/index.html` and is a single
   self-contained HTML file with no network, build, or runtime
   dependencies.
 - The page opens directly from the filesystem and renders a synthetic

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,8 +2,8 @@
 
 Automated tests live here.
 
-- `tests/test_mergepath_frontend.sh` validates `mergepath/index.html`
-  against `specs/mergepath_policy_configurator.md`. It checks for the
+- `tests/test_mergepath_playground.sh` validates `mergepath/playground/index.html`
+  against `specs/mergepath_playground.md`. It checks for the
   required structural anchors (title, injection markers, control IDs,
   preset buttons, modal ARIA attributes, reduced-motion CSS), asserts
   the embedded script block contains no data-bearing `innerHTML`

--- a/tests/test_mergepath_playground.sh
+++ b/tests/test_mergepath_playground.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# tests/test_mergepath_frontend.sh
+# tests/test_mergepath_playground.sh
 #
-# Validates mergepath/index.html against specs/mergepath_policy_configurator.md.
+# Validates mergepath/playground/index.html against specs/mergepath_playground.md.
 # Run manually or from CI. Requires: python3, node.
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PAGE="$ROOT/mergepath/index.html"
+PAGE="$ROOT/mergepath/playground/index.html"
 SCRIPT="$ROOT/scripts/policy-sim.sh"
 # macOS mktemp only substitutes trailing Xs — `name.XXXXXX.js`
 # would work once and then fail with "File exists". Use a temp
@@ -139,4 +139,4 @@ sys.stdout.write('\n'.join(scripts))
 PY
 node --check "$CHECK_FILE"
 
-echo "OK: mergepath frontend checks passed"
+echo "OK: Mergepath Playground checks passed"


### PR DESCRIPTION
## Summary

Promotes **Mergepath** from the name of one sub-artifact (the review-policy playground) to the umbrella brand for the whole reference implementation of the AI Agent Tooling Standard. The Standard itself stays methodology-neutral.

Closes #85
Closes #95
Closes #96
Closes #97
Closes #98
Closes #99
Closes #100
Closes #101
Closes #102
Closes #103
**Tracks:** #85 (Phase 1 parent) — part of the [Mergepath Rebrand project](https://github.com/users/nathanjohnpayne/projects/4/views/1)

## Changes at a glance

| Change | Path(s) |
|---|---|
| Move Playground to its sub-path; reserve `index.html` for a future umbrella landing | `mergepath/index.html` → `mergepath/playground/index.html` |
| Rename spec (purge "configurator") | `specs/mergepath_policy_configurator.md` → `specs/mergepath_playground.md` |
| Rename test to match spec | `tests/test_mergepath_frontend.sh` → `tests/test_mergepath_playground.sh` |
| Re-map `spec_test_map` so `check_spec_test_alignment` stays green | `.repo-template.yml` |
| Point policy-sim at new path + update comment | `scripts/policy-sim.sh` |
| Document umbrella vocabulary + reserved surfaces | `BRAND.md` (new) |
| Rebrand umbrella references | `README.md`, `SECURITY.md`, `DEPLOYMENT.md`, `REVIEW_POLICY.md`, `ai_agent_tooling_standard.md`, `docs/agents/repository-overview.md`, `mergepath/README.md` |
| Purge "mockup" from Playground UI strings + docs | `mergepath/playground/index.html` (eyebrow/header/footer), `mergepath/README.md`, `plans/mergepath-playground.md` |

### What is NOT in this PR

- **GitHub repo rename** (`gh repo rename mergepath`) — Phase 2 parent #86. Human-initiated after this PR merges.
- **Local clone move** — Phase 3 parent #87. Human task.
- **Peer-repo cleanup** (6 repos) — Phase 4 parent #88. Parallel follow-ups.
- **Portfolio site + external PRD + shared docs** — Phases 5, 6.
- **Scaffolding Cockpit / Tiebreaker / Checks surfaces** — names reserved in `BRAND.md` only.

## Verification

All run locally before this PR opened.

**1. Repo-wide legacy-name sweep** (required zero hits except the intentional BRAND.md naming-history line)
```bash
{ git ls-files; git ls-files --others --exclude-standard | grep -v '^mergepath-rename-feedback.md$'; } | \
  xargs grep -il -E '(ai[_-]agent[_-]repo[_-]template|AI Agent Repo|AI Agent Repository Template|mockup|configurator)'
```
Result: `BRAND.md` only (intentional — "This project was originally `ai_agent_repo_template`...").

**2. Playground test**
```bash
bash tests/test_mergepath_playground.sh
# → OK: Mergepath Playground checks passed
```

**3. Full CI suite**
```
check_codex_scripts:                     PASS
check_dist_not_modified:                 PASS
check_duplicate_docs:                    PASS
check_no_forbidden_top_level_dirs:       PASS
check_no_tool_folder_instructions:       PASS
check_required_root_files:               PASS
check_spec_test_alignment:               PASS
```

**4. Playground smoke-check (DOM)** — eyebrow now reads "Mergepath Playground", footer reads "Mergepath Playground · static · no network, no auth", no "mockup" token anywhere.

## Risk notes

- `htmlpreview.github.io` links and anything that pinned `mergepath/index.html` in the old repo URL will break once Phase 2 renames the repo and the Playground moves to `mergepath/playground/`. The portfolio site `liveUrl` update is explicitly scoped to Phase 5.
- `.github/review-policy.yml` line 3 comment still reads "AI Agent Code Review Policy Configuration" — intentionally left alone; that's the policy's own name, not the repo's.

## Authoring-Agent: claude

## Self-Review

**Correctness.**
- Playground path move: `scripts/policy-sim.sh` and `tests/test_mergepath_playground.sh` both read from the new `mergepath/playground/index.html`. Spec + test rename + `.repo-template.yml` spec_test_map updated together, so `check_spec_test_alignment` still pairs them. No orphan references to the old paths.
- BRAND.md defines Playground at `mergepath/playground/`, matching the new file location.

**Regression risk.**
- Branch protection and the `MERGEPATH_INJECT` / `RUBRIC_INJECT` contract are unchanged. `policy-sim.sh` still emits the same script-safe JSON payload.
- `.repo-template.yml` `extra_top_level_dirs: [mergepath]` unchanged; `check_no_forbidden_top_level_dirs` passes.
- No workflow file changes — the test filename change doesn't affect CI invocation because CI uses glob patterns under `tests/`, not explicit names.

**Style.**
- New BRAND.md follows the tone of existing root docs (REVIEW_POLICY, DEPLOYMENT).
- Commit message follows conventional-commits style matching recent history (`refactor: ...`, `feat: ...`).
- Markdown link targets verified against actual file paths.

**Test coverage.**
- `tests/test_mergepath_playground.sh` re-verified against renamed spec path; still exercises the injection round-trip and `node --check` on the extracted script block.
- Full CI suite (7 checks) passes locally.

**Security / dependency hygiene.**
- No dependency changes, no new scripts with secrets, no network calls added.
- Playground retains its XSS-safe stance (no `innerHTML`, script-safe JSON escaping in `policy-sim.sh`).
- `SECURITY.md` advisory URL updated to `nathanjohnpayne/mergepath` — becomes live once Phase 2 renames the repo on GitHub; prior URL 301-redirects until then.

