### PR TITLE
fix(security): use canonical mergepath slug in SECURITY.md link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,7 @@
 
 Please do **not** open a public issue for security vulnerabilities.
 
-Instead, use [GitHub's private vulnerability reporting](https://github.com/nathanjohnpayne/ai_agent_repo_template/security/advisories/new) or email security concerns directly. <!-- NOTE: slug updates to `mergepath` after the Phase 2 GitHub rename (#86); GitHub auto-redirects in the meantime. -->
-
+Instead, use [GitHub's private vulnerability reporting](https://github.com/nathanjohnpayne/mergepath/security/advisories/new) or email security concerns directly.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

Swaps `SECURITY.md` back to the canonical `mergepath` slug now that the repo rename (Phase 2, #86) has landed. Removes the tracking HTML comment that marked the temporary state.

Closes #128

## Why this is a separate PR

PR #127 (Phase 1 rebrand) originally set this link to the `mergepath` slug. CodeRabbit correctly flagged that the slug didn't resolve yet because the repo rename was scoped to Phase 2. We reverted to the old slug with an HTML comment noting the canonical target. Now that `gh repo rename` has run, the canonical slug resolves and we can switch.

## Verification

```
curl -sI https://github.com/nathanjohnpayne/mergepath/security/advisories/new
# → 200 (after GitHub login) or 302 to login (expected)
```

No CI impact — documentation-only change.

## Authoring-Agent: claude

## Self-Review

**Correctness.** Swaps the link target from `ai_agent_repo_template` to `mergepath` and removes the no-longer-needed HTML tracking comment. No other changes.

**Regression risk.** Zero. GitHub's URL auto-redirect would carry the old URL through regardless; this PR just makes the canonical form explicit.

**Style.** Matches the rest of `SECURITY.md` — single-line link, no surrounding annotations.

**Test coverage.** No tests cover `SECURITY.md` contents. Manual smoke-check confirms the link resolves to the new slug.

**Security / dependency hygiene.** No dependency changes. The link points to the canonical private-vulnerability-reporting endpoint on the renamed repo; no leak of any sensitive context in the URL.
