### PR TITLE
fix(deploy): address CodeRabbit review on PR #132

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -73,8 +73,23 @@ EOF
 fi
 
 # Guard 2: must not be behind origin/main
+# Fail closed on fetch failure — stale origin/main metadata would
+# silently defeat the freshness check and re-open the exact class
+# of failure #77 closes.
 if ! git fetch --quiet origin main 2>/dev/null; then
-  echo "warning: git fetch failed; cannot verify branch freshness" >&2
+  if [[ "$FORCE" == "true" ]]; then
+    echo "⚠️  --force: git fetch failed; skipping freshness verification" >&2
+  else
+    cat >&2 <<EOF
+Refusing to deploy: 'git fetch origin main' failed, so freshness
+against origin/main cannot be verified.
+
+Network down? Try again once connectivity is restored.
+
+To override (break-glass only): scripts/deploy.sh --force
+EOF
+    exit 1
+  fi
 fi
 
 if git rev-parse --verify --quiet origin/main >/dev/null; then
@@ -101,8 +116,11 @@ if [[ "$BUILD_SKIP" == "true" ]]; then
 else
   BUILD_CMD="${BUILD_CMD:-npm run build}"
   echo ">> Building: $BUILD_CMD"
-  # shellcheck disable=SC2086
-  eval $BUILD_CMD
+  # Use `bash -c --` so BUILD_CMD is parsed as a shell command string
+  # in a controlled subshell rather than `eval`'d in the current
+  # shell. Cheap defense against environment injection from whatever
+  # source populated BUILD_CMD.
+  bash -c -- "$BUILD_CMD"
 fi
 
 # Step 2: Deploy
@@ -118,7 +136,10 @@ else
   echo ">> Purging Cloudflare cache"
   # The Cloudflare purge endpoint returns 200 on success with a JSON body.
   # We only care about HTTP status here.
-  purge_http_code="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+  purge_http_code="$(curl -sS -o /dev/null -w '%{http_code}' \
+    --connect-timeout 5 \
+    --max-time 30 \
+    -X POST \
     "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
     -H "Authorization: Bearer ${CF_API_TOKEN}" \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
Authoring-Agent: claude

CodeRabbit follow-up on [#132](https://github.com/nathanjohnpayne/mergepath/pull/132). Three findings (1 Critical, 2 Major) posted after the review-identity approval triggered auto-merge — this lands the fixes as a follow-up.

## Summary

1. **[Critical]** Fail closed on `git fetch origin main` failure. Previously warned and continued, which meant a silent network hiccup would let the freshness guard use stale `origin/main` metadata — the exact class of failure #77 closes. Now exits 1 unless `--force`.
2. **[Major]** Replace `eval $BUILD_CMD` with `bash -c -- "$BUILD_CMD"`. `eval` in the current shell is unsafe if BUILD_CMD ever contains shell metacharacters from its source; `bash -c --` runs it as a command string in a controlled subshell. Drops the shellcheck disable since the eval-specific concern is gone.
3. **[Major]** Add `--connect-timeout 5 --max-time 30` to the Cloudflare purge curl to prevent indefinite hangs on network stalls from blocking deploys.

## Self-Review

**Correctness.** All three fixes are one-spot edits. Script's control flow is unchanged on the happy path (branch == main, fetch succeeds, build runs cleanly, purge returns 200). The behavior changes are on the error paths: fetch failure now exits unless `--force`, eval no longer happens in the current shell, purge has a bounded wall-clock time.

**Regression risk.** Low.
- Fail-closed on fetch is stricter than before; the `--force` escape covers intentional offline deploys.
- `bash -c --` accepts the same command strings `eval` did (single-line shell commands, pipes, `&&`, etc.) because it's a shell invocation. Multi-line commands still work.
- Curl timeouts are generous enough for the Cloudflare API (30s against a purge endpoint that typically returns in <1s).

**Style.** Comments at each changed block say *why*.

**Test coverage.** Manual smoke: `--help` and branch-guard refusal both verified post-change. Full deploy path was intentionally not executed (sandbox correctly blocks it).

**Security / dependency hygiene.** Closes a command-injection vector on BUILD_CMD and bounds network exposure on the purge call. No new dependencies. No protected-path hits — under Phase 4a threshold.