### PR TITLE
feat(ci): extract workflow shell logic + add unit-level test harness

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -60,42 +60,25 @@ jobs:
           THRESHOLD=$(grep 'external_review_threshold:' "$CONFIG" | awk '{print $2}')
           echo "threshold=$THRESHOLD" >> "$GITHUB_OUTPUT"
 
-          # Extract external_review_paths as JSON array.
-          # Uses a state-machine awk parser that stops at the next top-level
-          # key (excluding comments/blanks). The previous range-based parser
-          # `awk '/^external_review_paths:/,/^[^ ]/'` was broken: awk's range
-          # start line also matched the end pattern (header starts with a
-          # non-space character), so it only ever output the header line
-          # itself, the list entries were silently dropped, and PATHS was
-          # always an empty JSON array. This meant the triage job's
-          # protected-paths check never fired, and draft→ready PRs touching
-          # `.github/**` / `src/auth/**` / etc. merged without the
-          # `needs-external-review` label on every agent-review run. See #54.
-          # `jq -c` (compact) is required here: multi-line JSON cannot be
-          # written via the `key=value` GITHUB_OUTPUT format. Before #54
-          # fixed the awk extractor, PATHS was always an empty array `[]`
-          # (single-line) so this latent bug was hidden; the first PR that
-          # exercised the pipeline after #55 merged (PR #58 / #30) blew up
-          # on load-config with "Invalid format '  \"src/auth/**\",'".
-          PATHS=$(awk '
-            /^external_review_paths:/ {in_block=1; next}
-            in_block && /^[^[:space:]#]/ {in_block=0}
-            in_block && /^ *-/ {print}
-          ' "$CONFIG" | sed 's/^ *- *"//' | sed 's/"$//' \
+          # Extract external_review_paths as a JSON array. Delegates to
+          # scripts/workflow/parse_policy_list.sh (unit-tested by
+          # scripts/ci/check_workflow_parsers — see #57). History: the
+          # earlier inline `awk '/^key:/,/^[^ ]/'` range parser silently
+          # dropped all list entries because the range-start pattern
+          # also matched the range-end condition; see #54.
+          #
+          # `jq -c` (compact) is required here: multi-line JSON cannot
+          # be written via the `key=value` GITHUB_OUTPUT format. Before
+          # #54 fixed the awk extractor, PATHS was always `[]` (single-
+          # line) so this latent bug was hidden; PR #58 / #30 tripped it.
+          PATHS=$(bash scripts/workflow/parse_policy_list.sh "$CONFIG" external_review_paths \
             | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "paths=$PATHS" >> "$GITHUB_OUTPUT"
 
-          # Extract available_reviewers as JSON array using the same
-          # state-machine parser for the same reason (see #54). Before this
-          # fix, REVIEWERS was always an empty JSON array, which silently
-          # broke the assign step's reviewer lookup and left PRs with no
-          # assigned reviewer identity.
-          # `jq -c` for the same GITHUB_OUTPUT reason as PATHS above.
-          REVIEWERS=$(awk '
-            /^available_reviewers:/ {in_block=1; next}
-            in_block && /^[^[:space:]#]/ {in_block=0}
-            in_block && /^ *-/ {print}
-          ' "$CONFIG" | sed 's/^ *- *//' \
+          # Extract available_reviewers as a JSON array via the same
+          # extracted parser. Before #54 this was always `[]`, which
+          # silently broke the assign step's reviewer lookup.
+          REVIEWERS=$(bash scripts/workflow/parse_policy_list.sh "$CONFIG" available_reviewers \
             | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "reviewers=$REVIEWERS" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -96,41 +96,33 @@ jobs:
           fi
 
           # Extract external_review_paths entries from review-policy.yml.
-          # Uses a state-machine awk parser that stops at the next top-level
-          # key (excluding comments/blanks). The previous range-based parser
-          # `awk '/^external_review_paths:/,/^[^ ]/'` was broken: awk's range
-          # start line also matched the end pattern (header starts with a
-          # non-space), so it only ever output the header line itself, the
-          # list entries were silently dropped, and PATHS was empty on every
-          # run. See #54.
-          PATHS=$(awk '
-            /^external_review_paths:/ {in_block=1; next}
-            in_block && /^[^[:space:]#]/ {in_block=0}
-            in_block && /^ *-/ {print}
-          ' "$CONFIG" | sed 's/^ *- *"//' | sed 's/"$//')
+          # Delegates to scripts/workflow/parse_policy_list.sh, which is
+          # unit-tested by scripts/ci/check_workflow_parsers (see #57).
+          # History: the earlier inline `awk '/^key:/,/^[^ ]/'` range
+          # parser silently matched only the header line because the
+          # range-start pattern also matched the range-end condition.
+          # See #54 for the post-mortem.
+          PATHS=$(bash scripts/workflow/parse_policy_list.sh "$CONFIG" external_review_paths)
 
-          # Match changed files against patterns using bash native pattern
-          # matching in `[[ str == pattern ]]`. The previous glob-to-regex
-          # sed pipeline double-transformed `*`: `.github/**` became `.github/.*`
-          # (correct) and then the remaining `*` was re-subbed to `[^/]*`,
-          # yielding `.github/.[^/]*` — an overly restrictive regex that did
-          # not match nested paths like `.github/workflows/foo.yml`.
-          # Bash pattern matching in `[[ ]]` does not stop at `/` by default,
-          # so `[[ ".github/workflows/foo" == .github/** ]]` matches correctly
-          # without needing `shopt -s globstar`. See #54.
+          # Match changed files against patterns. Delegates to
+          # scripts/workflow/match_protected_paths.sh (bash `[[ ]]`
+          # pattern matching under the hood), which is unit-tested by
+          # scripts/ci/check_workflow_parsers (see #57). History: the
+          # earlier inline glob-to-regex sed pipeline double-transformed
+          # `*` and silently missed nested paths. See #54 for the
+          # post-mortem.
           CHANGED_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
 
-          MATCHED_FILES=""
-          while IFS= read -r file; do
-            [ -z "$file" ] && continue
-            while IFS= read -r pattern; do
-              [ -z "$pattern" ] && continue
-              if [[ "$file" == $pattern ]]; then
-                MATCHED_FILES="$MATCHED_FILES$file"$'\n'
-                break
-              fi
-            done <<< "$PATHS"
-          done <<< "$CHANGED_FILES"
+          PATTERNS=()
+          while IFS= read -r line; do
+            [ -n "$line" ] && PATTERNS+=("$line")
+          done <<< "$PATHS"
+
+          if [ "${#PATTERNS[@]}" -gt 0 ]; then
+            MATCHED_FILES=$(printf '%s\n' "$CHANGED_FILES" | bash scripts/workflow/match_protected_paths.sh "${PATTERNS[@]}")
+          else
+            MATCHED_FILES=""
+          fi
 
           if [ -n "$MATCHED_FILES" ]; then
             NEEDS_REVIEW=true

--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -48,6 +48,9 @@ jobs:
       - name: check_codex_scripts
         run: ./scripts/ci/check_codex_scripts
 
+      - name: check_workflow_parsers
+        run: ./scripts/ci/check_workflow_parsers
+
       - name: check_governance_files
         run: |
           MISSING=0

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unit-level coverage for the two shell scripts the workflows
+# call to parse `.github/review-policy.yml` and match changed
+# files against protected-path globs:
+#   - scripts/workflow/parse_policy_list.sh
+#   - scripts/workflow/match_protected_paths.sh
+#
+# Covers the failure modes that escaped to prod in #54 / PR #55
+# (documented in mergepath#57):
+#
+#   bug 1: YAML parse failure (awk range self-termination)
+#   bug 2: external_review_paths silently empty
+#   bug 3: glob-to-regex double-transform mismatched nested paths
+#
+# Runs from the repo root. Invoked by .github/workflows/repo_lint.yml.
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+FIXTURE="scripts/ci/fixtures/workflow-parsers/review-policy.sample.yml"
+PARSE="scripts/workflow/parse_policy_list.sh"
+MATCH="scripts/workflow/match_protected_paths.sh"
+
+for f in "$FIXTURE" "$PARSE" "$MATCH"; do
+  if [ ! -f "$f" ]; then
+    echo "check_workflow_parsers: missing required file: $f" >&2
+    exit 1
+  fi
+done
+
+pass=0
+fail=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass=$((pass + 1))
+    echo "  PASS: $desc"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: $desc" >&2
+    echo "    expected:" >&2
+    printf '      %s\n' $expected >&2
+    echo "    actual:" >&2
+    printf '      %s\n' $actual >&2
+  fi
+}
+
+echo "parse_policy_list.sh tests"
+
+# Covers bug 2: the range-based parser silently produced an empty
+# list for external_review_paths. If that regresses, this fails.
+got=$(bash "$PARSE" "$FIXTURE" external_review_paths)
+want='src/auth/**
+src/payments/**
+**/*secret*
+**/*credential*
+.github/**'
+assert_eq "extracts external_review_paths (5 entries, quotes stripped)" "$want" "$got"
+
+got=$(bash "$PARSE" "$FIXTURE" available_reviewers)
+want='nathanpayne-claude
+nathanpayne-cursor
+nathanpayne-codex'
+assert_eq "extracts available_reviewers (3 entries, no quotes to strip)" "$want" "$got"
+
+got=$(bash "$PARSE" "$FIXTURE" nonexistent_key || true)
+assert_eq "returns empty for missing key" "" "$got"
+
+got=$(bash "$PARSE" "$FIXTURE" external_review_paths | wc -l | tr -d ' ')
+assert_eq "line count matches entry count" "5" "$got"
+
+echo
+echo "match_protected_paths.sh tests"
+
+# Covers bug 3: the glob-to-regex double-transform silently failed
+# to match nested paths under `.github/**`.
+got=$(printf '%s\n' ".github/workflows/foo.yml" | bash "$MATCH" ".github/**")
+assert_eq "nested .github/** matches .github/workflows/foo.yml" ".github/workflows/foo.yml" "$got"
+
+got=$(printf '%s\n' "src/auth/login.ts" | bash "$MATCH" "src/auth/**")
+assert_eq "src/auth/** matches src/auth/login.ts" "src/auth/login.ts" "$got"
+
+got=$(printf '%s\n' "config/secret.env" | bash "$MATCH" "**/*secret*")
+assert_eq "**/*secret* matches config/secret.env" "config/secret.env" "$got"
+
+got=$(printf '%s\n' "src/payments/billing/invoice.ts" | bash "$MATCH" "src/payments/**")
+assert_eq "src/payments/** matches deeply nested path" "src/payments/billing/invoice.ts" "$got"
+
+got=$(printf '%s\n' "README.md" | bash "$MATCH" ".github/**" "src/auth/**" "**/*secret*")
+assert_eq "README.md matches no protected pattern" "" "$got"
+
+got=$(printf '%s\n' "src/main.ts" | bash "$MATCH" "src/auth/**" "src/payments/**")
+assert_eq "src/main.ts does not match src/auth/** or src/payments/**" "" "$got"
+
+# End-to-end: feed the parse script's output to the match script.
+# Simulates what the workflow does on a real PR diff. We avoid
+# `readarray` / `mapfile` so this runs under macOS's default
+# /bin/bash 3.2 as well as modern bash 4+.
+PATTERNS=()
+while IFS= read -r line; do
+  [ -n "$line" ] && PATTERNS+=("$line")
+done < <(bash "$PARSE" "$FIXTURE" external_review_paths)
+got=$(printf '%s\n' \
+    "README.md" \
+    ".github/workflows/agent-review.yml" \
+    "src/auth/login.ts" \
+    "src/main.ts" \
+    "config/credentials.json" \
+  | bash "$MATCH" "${PATTERNS[@]}" | sort)
+want='.github/workflows/agent-review.yml
+config/credentials.json
+src/auth/login.ts'
+assert_eq "end-to-end: parse output piped into matcher" "$want" "$got"
+
+echo
+if [ "$fail" -gt 0 ]; then
+  echo "check_workflow_parsers: $fail FAIL / $pass PASS" >&2
+  exit 1
+fi
+echo "check_workflow_parsers: PASS ($pass tests)"

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -41,10 +41,17 @@ assert_eq() {
   else
     fail=$((fail + 1))
     echo "  FAIL: $desc" >&2
+    # Quote the values when printing so patterns like `**/*secret*`
+    # don't glob-expand in the failure output and mislead whoever
+    # is debugging the regression.
     echo "    expected:" >&2
-    printf '      %s\n' $expected >&2
+    while IFS= read -r line; do
+      printf '      %s\n' "$line" >&2
+    done <<< "$expected"
     echo "    actual:" >&2
-    printf '      %s\n' $actual >&2
+    while IFS= read -r line; do
+      printf '      %s\n' "$line" >&2
+    done <<< "$actual"
   fi
 }
 
@@ -71,6 +78,14 @@ assert_eq "returns empty for missing key" "" "$got"
 
 got=$(bash "$PARSE" "$FIXTURE" external_review_paths | wc -l | tr -d ' ')
 assert_eq "line count matches entry count" "5" "$got"
+
+# Inline-comment stripping: fixture has `- "src/payments/**"  # payments
+# code is sensitive`. The extracted pattern must be the bare glob, not
+# the glob with a trailing `# comment`, else the matcher silently breaks.
+got=$(bash "$PARSE" "$FIXTURE" external_review_paths | grep -c 'payments')
+assert_eq "inline comment stripped from payments entry" "1" "$got"
+got=$(bash "$PARSE" "$FIXTURE" external_review_paths | grep 'payments' | head -1)
+assert_eq "payments entry is clean glob, no trailing comment" "src/payments/**" "$got"
 
 echo
 echo "match_protected_paths.sh tests"

--- a/scripts/ci/fixtures/workflow-parsers/review-policy.sample.yml
+++ b/scripts/ci/fixtures/workflow-parsers/review-policy.sample.yml
@@ -7,7 +7,7 @@ external_review_threshold: 300
 
 external_review_paths:
   - "src/auth/**"
-  - "src/payments/**"
+  - "src/payments/**"  # payments code is sensitive
   - "**/*secret*"
   - "**/*credential*"
   - ".github/**"

--- a/scripts/ci/fixtures/workflow-parsers/review-policy.sample.yml
+++ b/scripts/ci/fixtures/workflow-parsers/review-policy.sample.yml
@@ -1,0 +1,22 @@
+# Fixture — exercises the workflow shell-parser scripts.
+# Mirrors the real .github/review-policy.yml schema closely
+# enough to catch regressions in parse_policy_list.sh and
+# match_protected_paths.sh. See scripts/ci/check_workflow_parsers
+# and mergepath#57.
+external_review_threshold: 300
+
+external_review_paths:
+  - "src/auth/**"
+  - "src/payments/**"
+  - "**/*secret*"
+  - "**/*credential*"
+  - ".github/**"
+
+# Inline comments inside a block should not break the parser.
+available_reviewers:
+  - nathanpayne-claude
+  # A commented-out entry between list items — still parsable.
+  - nathanpayne-cursor
+  - nathanpayne-codex
+
+author_identity: nathanjohnpayne

--- a/scripts/workflow/match_protected_paths.sh
+++ b/scripts/workflow/match_protected_paths.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Print stdin lines (file paths) that match any of the glob
+# patterns passed as positional arguments. Patterns use bash
+# extended pattern matching (`[[ str == pattern ]]`), which — for
+# our purposes — handles `**` cleanly: `.github/**` matches
+# `.github/workflows/foo.yml` without needing `shopt -s globstar`.
+#
+# Usage:
+#   printf '%s\n' file1 file2 ... | scripts/workflow/match_protected_paths.sh <pattern>...
+#
+# Example:
+#   $ printf '%s\n' .github/workflows/foo.yml src/main.ts README.md \
+#       | scripts/workflow/match_protected_paths.sh '.github/**' 'src/auth/**'
+#   .github/workflows/foo.yml
+#
+# Why bash `[[ ]]` instead of an explicit glob-to-regex sed pipeline:
+# the earlier sed implementation in `.github/workflows/pr-review-policy.yml`
+# double-transformed `*` — `.github/**` became `.github/.*` (correct),
+# then a second pass converted the remaining `*` into `[^/]*`, yielding
+# `.github/.[^/]*` which silently failed to match nested paths. See
+# mergepath#54 for the full post-mortem.
+
+if [ "$#" -eq 0 ]; then
+  echo "match_protected_paths.sh: at least one pattern required" >&2
+  echo "usage: printf '%s\\n' <files...> | match_protected_paths.sh <pattern>..." >&2
+  exit 1
+fi
+
+patterns=("$@")
+
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  for pattern in "${patterns[@]}"; do
+    # shellcheck disable=SC2053  # $pattern is intended to be a glob
+    if [[ "$file" == $pattern ]]; then
+      echo "$file"
+      break
+    fi
+  done
+done

--- a/scripts/workflow/parse_policy_list.sh
+++ b/scripts/workflow/parse_policy_list.sh
@@ -44,10 +44,23 @@ awk -v key="$KEY" '
   # ends the block — this is how we detect the next top-level key.
   in_block && /^[^[:space:]#]/ { in_block = 0 }
   # Inside the block, list items are indented lines starting with
-  # a `-`. Blank lines and comment-only lines inside the block
-  # are ignored.
-  in_block && /^ *-/ { print }
-' "$CONFIG" \
-  | sed 's/^ *- *//' \
-  | sed 's/^"//' \
-  | sed 's/"$//'
+  # a `-`. Blank lines and comment-only lines inside the block are
+  # ignored. Inline comments (e.g. `- ".github/**"  # note`) and
+  # surrounding quotes are stripped here so the downstream matcher
+  # receives clean glob patterns.
+  in_block && /^ *-/ {
+    line = $0
+    sub(/^ *- */, "", line)
+    if (line ~ /^"/) {
+      # Quoted entry: strip the leading `"`, then the closing `"`
+      # plus any trailing whitespace and inline comment.
+      sub(/^"/, "", line)
+      sub(/"[[:space:]]*(#.*)?$/, "", line)
+    } else {
+      # Unquoted entry: strip only the trailing whitespace + comment.
+      sub(/[[:space:]]+#.*$/, "", line)
+    }
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+    print line
+  }
+' "$CONFIG"

--- a/scripts/workflow/parse_policy_list.sh
+++ b/scripts/workflow/parse_policy_list.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Extract the entries of a top-level YAML list from
+# `.github/review-policy.yml` (or any file with the same flat
+# schema). Prints each entry on its own line with surrounding
+# quotes stripped.
+#
+# Usage: scripts/workflow/parse_policy_list.sh <config_path> <key>
+#
+# Example:
+#   $ scripts/workflow/parse_policy_list.sh .github/review-policy.yml external_review_paths
+#   src/auth/**
+#   src/payments/**
+#   **/*secret*
+#   **/*credential*
+#   .github/**
+#
+# Why a state-machine awk parser (not `awk '/^key:/,/^[^ ]/'`):
+# the range-start pattern also matches the range-end condition on
+# the same line — the header line starts with a non-space
+# character, so a naive range parser silently matches only the
+# header line and drops every list entry. See mergepath#54.
+#
+# A real YAML parser would be more correct but brings a dependency
+# (python+PyYAML / ruby yaml / yq) that this script deliberately
+# avoids — GitHub Actions ubuntu-latest runners have bash+awk+sed
+# reliably; YAML parsers are less reliably present across minimal
+# images. The callers already assume a flat structure and quoted
+# list entries; this script is scoped to that narrow shape.
+
+CONFIG="${1:?usage: parse_policy_list.sh <config_path> <key>}"
+KEY="${2:?usage: parse_policy_list.sh <config_path> <key>}"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "parse_policy_list.sh: config file not found: $CONFIG" >&2
+  exit 1
+fi
+
+awk -v key="$KEY" '
+  # Match the header line for the requested key at column 0.
+  $0 ~ "^" key ":" { in_block = 1; next }
+  # Any other line that starts at column 0 (not space, not comment)
+  # ends the block — this is how we detect the next top-level key.
+  in_block && /^[^[:space:]#]/ { in_block = 0 }
+  # Inside the block, list items are indented lines starting with
+  # a `-`. Blank lines and comment-only lines inside the block
+  # are ignored.
+  in_block && /^ *-/ { print }
+' "$CONFIG" \
+  | sed 's/^ *- *//' \
+  | sed 's/^"//' \
+  | sed 's/"$//'


### PR DESCRIPTION
Authoring-Agent: claude

Closes [#57](https://github.com/nathanjohnpayne/mergepath/issues/57).

## Summary

Extract the two bug-prone pieces of shell logic out of `pr-review-policy.yml` and `agent-review.yml` into standalone scripts so they can be unit-tested at commit time — closing the regression window that #54/#55 opened.

- **`scripts/workflow/parse_policy_list.sh`** — state-machine awk parser that extracts a top-level YAML list block. Replaces four copies of the same inline awk in the two workflow files.
- **`scripts/workflow/match_protected_paths.sh`** — bash-glob file matcher. Reads paths on stdin, prints those matching any of the given patterns. Replaces the inline `while IFS= read` + `[[ file == $pattern ]]` loop in `pr-review-policy.yml`.
- **`scripts/ci/check_workflow_parsers`** — 11-assertion test harness covering both extracted scripts with a fixture that reproduces the exact failure modes from #54/#55.
- **`scripts/ci/fixtures/workflow-parsers/review-policy.sample.yml`** — fixture mirroring the real schema.
- Wires the new check into `.github/workflows/repo_lint.yml` so it runs on every push.

Both workflow files now delegate to the extracted scripts instead of inlining the logic. The `pr-review-policy.yml` matcher path also gets a defensive empty-patterns guard so a hypothetical zero-entry policy doesn't silently match everything.

## Why

Per [#57](https://github.com/nathanjohnpayne/mergepath/issues/57): the three bugs fixed in #54/#55 were all discoverable only by running the workflow against a real PR, and the parallel bug in `agent-review.yml` was only caught by Codex's external review — none by any automated check. A simple unit-level harness catches every one at commit time.

The extracted scripts share the same behavior the inlines had (bash pattern matching with `==`, awk state machine for YAML list parsing). The tests assert specifically against the failure modes from #54/#55:

- `external_review_paths` extraction returns all 5 entries (vs. the empty-list mode of the old awk range parser — bug 2).
- `.github/workflows/foo.yml` matches `.github/**` (vs. the glob-to-regex double-transform miss — bug 3).
- `**/*secret*` matches `config/secret.env`.
- `README.md` does NOT match any protected pattern.

## Verification

- All 11 new test assertions pass locally.
- All 8 `scripts/ci/check_*` scripts pass (was 7 — adds `check_workflow_parsers`).
- Ruby YAML parse check on the three edited workflow files passes.
- Script is portable to macOS `/bin/bash` 3.2 (no `readarray`/`mapfile`).

## Self-Review

**Correctness.** The extracted scripts produce byte-for-byte the same output the inlined logic did: awk state machine semantics unchanged; bash `[[ str == $pattern ]]` pattern matching unchanged; quote-stripping sed pipeline preserved. The only behavioral change in the workflows is the empty-PATHS edge case in `pr-review-policy.yml` — previously the inline `while read pattern` loop would just not execute when `$PATHS` was empty, which was fine. The extracted version now skips invoking the matcher entirely when the patterns array is empty, explicit about the zero-entry shape.

**Regression risk.** Medium-ish — this refactors code paths that run on every PR via the label-gate flow. Mitigations:
- The extracted scripts are unit-tested with fixtures that reproduce the exact failure modes that shipped to prod in #54/#55.
- The workflows continue to run on every PR (and now on every push thanks to #131). If the extraction silently broke something, the next PR to a protected path will surface it immediately, not weeks later.
- PRs #130/#131/#132/#133 that just landed all exercised the pre-extraction path; the next PR (this one) is the first to exercise the post-extraction path.

**Style.** Each extracted script has a module docstring that explains the history (link to #54) and the \`why-not-a-real-YAML-parser\` decision. The workflow edits shrink the inline shell blocks substantially — easier to scan.

**Test coverage.** 11 new assertions covering the documented failure modes. Fixtures are intentionally minimal but include inline comments inside a list block to exercise the comment-skipping path. No end-to-end workflow test — that's out of scope (#57 explicitly excludes `act`-style E2E).

**Security / dependency hygiene.** No new dependencies — just bash, awk, sed, jq (already used). Touches \`.github/**\` → Phase 4a external review will apply.