### PR TITLE
feat(packaging): scaffold mergepath placeholder packages (npm + PyPI)

### DIFF
--- a/.repo-template.yml
+++ b/.repo-template.yml
@@ -22,4 +22,4 @@ test_globs:
 # in this repo. Silences `check_no_forbidden_top_level_dirs` warnings.
 # Uses inline-array form because the parser in that script only
 # recognizes `key: [a, b]`, not indented list items.
-extra_top_level_dirs: [mergepath]
+extra_top_level_dirs: [mergepath, packaging]

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,37 @@
+# packaging/
+
+Placeholder package scaffolds reserving the `mergepath` name on public
+registries. See issues
+[#92](https://github.com/nathanjohnpayne/mergepath/issues/92) (npm) and
+[#93](https://github.com/nathanjohnpayne/mergepath/issues/93) (PyPI) for the
+squatting-prevention rationale.
+
+Both packages publish at version `0.0.0` and carry nothing but a README. They
+will be replaced with real artifacts when the project cuts a first release.
+
+## Publish — npm (`packaging/npm/`)
+
+```bash
+cd packaging/npm
+npm login                    # as nathanjohnpayne
+npm publish --access public
+npm view mergepath           # verify: owner = nathanjohnpayne, version = 0.0.0
+```
+
+## Publish — PyPI (`packaging/pypi/`)
+
+```bash
+cd packaging/pypi
+python3 -m pip install --upgrade build twine
+python3 -m build             # produces dist/mergepath-0.0.0.tar.gz + .whl
+python3 -m twine upload dist/*   # auth as nathanjohnpayne
+```
+
+Verify at https://pypi.org/project/mergepath/ or `pip show mergepath` after
+install.
+
+## Re-publishing
+
+Registries forbid overwriting an existing version. To update the placeholder
+README, bump to `0.0.1` (or whatever's next) in `package.json` /
+`pyproject.toml` before re-publishing.

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -1,0 +1,15 @@
+# mergepath
+
+Name reservation for the **Mergepath** umbrella project.
+
+This npm package contains no runtime code. It exists only to prevent the name
+`mergepath` from being squatted on the public registry while the project is
+under development.
+
+- **Source:** https://github.com/nathanjohnpayne/mergepath
+- **Project site:** https://mergepath.nathanpayne.com
+- **Maintainer:** [nathanjohnpayne](https://github.com/nathanjohnpayne)
+
+Do not depend on this package. It will remain at `0.0.0` with no exported
+modules until the project publishes a first real release, at which point this
+README will be replaced with real documentation.

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mergepath",
+  "version": "0.0.0",
+  "description": "Name reservation for the Mergepath umbrella project. No runtime code. See https://github.com/nathanjohnpayne/mergepath.",
+  "keywords": ["mergepath", "placeholder"],
+  "homepage": "https://github.com/nathanjohnpayne/mergepath",
+  "bugs": {
+    "url": "https://github.com/nathanjohnpayne/mergepath/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nathanjohnpayne/mergepath.git"
+  },
+  "author": "Nathan Payne (https://nathanpayne.com)",
+  "license": "UNLICENSED",
+  "files": [
+    "README.md"
+  ],
+  "private": false
+}

--- a/packaging/pypi/README.md
+++ b/packaging/pypi/README.md
@@ -1,0 +1,15 @@
+# mergepath
+
+Name reservation for the **Mergepath** umbrella project.
+
+This PyPI distribution contains no runtime code. It exists only to prevent the
+name `mergepath` from being squatted on the public index while the project is
+under development.
+
+- **Source:** https://github.com/nathanjohnpayne/mergepath
+- **Project site:** https://mergepath.nathanpayne.com
+- **Maintainer:** [nathanjohnpayne](https://github.com/nathanjohnpayne)
+
+Do not depend on this package. It will remain at `0.0.0` with no importable
+modules until the project publishes a first real release, at which point this
+README will be replaced with real documentation.

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mergepath"
+version = "0.0.0"
+description = "Name reservation for the Mergepath umbrella project. No runtime code."
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "Proprietary" }
+authors = [
+  { name = "Nathan Payne", email = "anthropic@nathanpayne.com" },
+]
+keywords = ["mergepath", "placeholder"]
+classifiers = [
+  "Development Status :: 1 - Planning",
+  "License :: Other/Proprietary License",
+  "Intended Audience :: Developers",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+]
+
+[project.urls]
+Homepage = "https://github.com/nathanjohnpayne/mergepath"
+Issues = "https://github.com/nathanjohnpayne/mergepath/issues"
+Source = "https://github.com/nathanjohnpayne/mergepath"
+
+[tool.setuptools]
+packages = []


### PR DESCRIPTION
Authoring-Agent: claude

Addresses Phase 0 pre-flight: reserves the `mergepath` name on npm ([#92](https://github.com/nathanjohnpayne/mergepath/issues/92)) and PyPI ([#93](https://github.com/nathanjohnpayne/mergepath/issues/93)) by landing README-only placeholder scaffolds under a new `packaging/` directory. The human runs the actual `npm publish` / `twine upload` commands from this tree once creds are set up — this PR only lands the scaffolds and the publish runbook.

## Summary

- `packaging/npm/package.json`: `name: mergepath`, `version: 0.0.0`, `private: false`, `license: UNLICENSED`, `files: ["README.md"]`. The repo declares no open-source license, so UNLICENSED is accurate; `private: false` is required because npm blocks publish on `private: true`.
- `packaging/pypi/pyproject.toml`: PEP 621 metadata, `setuptools` build backend with `packages = []` so the sdist ships only the README, `License :: Other/Proprietary License` classifier.
- Both package READMEs point at the GitHub repo, mark the package as squatting-prevention only, and tell consumers not to depend on it.
- `packaging/README.md`: runbook with the exact `npm login` / `npm publish --access public` and `python3 -m build` / `twine upload dist/*` commands, plus a re-publish note (registries forbid overwriting existing versions — bump to `0.0.1` to refresh).
- `.repo-template.yml`: add `packaging` to `extra_top_level_dirs` so `scripts/ci/check_no_forbidden_top_level_dirs` stops warning.

Not in scope: running the publishes. Those require `npm login` and PyPI API token auth, which only the human can do. Issue closure belongs to the commit that happens after publish succeeds and `npm view mergepath` / `pip show mergepath` return the placeholder.

## Self-Review

**Correctness.** Manifests are minimal and standards-compliant. `package.json` passes `npm pkg fix` round-trip (single author string, standard repository shape). `pyproject.toml` uses PEP 621 `[project]` with `setuptools.build_meta` backend and `tool.setuptools.packages = []` — the canonical way to ship a README-only sdist without a src layout. All seven local `scripts/ci/check_*` checks exit 0 on this branch; only the pre-existing `bugs/` WARN remains (unrelated).

**Regression risk.** Near-zero. The only file outside `packaging/` that changed is `.repo-template.yml`, and the change is purely additive (appending `packaging` to an inline array read by a single lint script). No runtime code, no workflow, no scripts. The `packaging/` tree is not referenced from any build or CI path — nothing in the repo imports or reads from it.

**Style.** Follows the repo's existing minimalism: no tests, no abstractions, no `LICENSE` file (repo has none at root). Package READMEs deliberately mirror each other so the maintainer can update both in lockstep. No comments in the JSON/TOML beyond what the fields carry themselves.

**Test coverage.** None added. The packages have no runtime behavior to test. The publish runbook will be exercised by the human during actual publish; any bug there surfaces as an `npm publish` / `twine upload` failure before anything reaches the registry, which is acceptable for a one-shot reservation.

**Security / dependency hygiene.** No dependencies added to either manifest — `package.json` has no `dependencies` or `devDependencies`; `pyproject.toml` requires only `setuptools>=68` as a build-system requirement. `.repo-template.yml` is not on any protected path in `.github/review-policy.yml`, so this PR should stay under the external-review threshold once CI computes line count.

> Per REVIEW_POLICY.md, the label gate on merge still requires CodeRabbit / internal-reviewer clearance.