### PR TITLE
feat(review): coderabbit-wait.sh for rate-limit retry + HEAD-tied wait

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -86,6 +86,29 @@ author_identity: nathanjohnpayne
 coderabbit:
   enabled: true
 
+  # GitHub login of the CodeRabbit bot. Comments by this login are what
+  # `scripts/coderabbit-wait.sh` filters on when classifying PR activity.
+  bot_login: "coderabbitai[bot]"
+
+  # Maximum total seconds `scripts/coderabbit-wait.sh` will poll before
+  # timing out. Used by Phase 2.5 grace window + any downstream auto-merge
+  # workflow that wants to block merge until CodeRabbit has reviewed the
+  # current HEAD. The default of 300s (5 min) accommodates CodeRabbit's
+  # typical ~2–3 min review latency plus a short buffer. Raise it for
+  # repos where CodeRabbit consistently runs long; lower it if the
+  # auto-merge workflow would rather proceed than wait. See
+  # nathanjohnpayne/mergepath#136 for the race-with-auto-merge case.
+  max_wait_seconds: 300
+
+  # Maximum number of times `scripts/coderabbit-wait.sh` will parse a
+  # "Rate limit exceeded" comment, sleep the published window + 30s
+  # buffer, and post `@coderabbitai, try again.` to re-trigger.
+  # CodeRabbit does not auto-retry after its rate-limit window elapses;
+  # the wait helper does. Set to 0 to disable retries entirely (the
+  # caller will see exit code 5 / rate_limit_stalled on the first
+  # rate-limit comment). See nathanjohnpayne/mergepath#138.
+  max_rate_limit_retries: 2
+
 # ---------------------------------------------------------------------------
 # Codex (Automated External Review — Phase 4a)
 # ---------------------------------------------------------------------------

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -543,33 +543,48 @@ jobs:
 
       - name: Wait for CodeRabbit review
         if: steps.cr.outputs.enabled == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const maxWaitMs = 5 * 60 * 1000; // 5 minutes
-            const pollMs = 30 * 1000;         // 30 seconds
-            const start = Date.now();
-
-            while (Date.now() - start < maxWaitMs) {
-              const { data: comments } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-              });
-              const hasCR = comments.some(
-                c => c.user.login === 'coderabbitai[bot]' &&
-                     !c.body.includes('Currently processing')
-              );
-              if (hasCR) {
-                core.info('CodeRabbit review found — proceeding to merge.');
-                return;
-              }
-              core.info(`Waiting for CodeRabbit... (${Math.round((Date.now() - start) / 1000)}s)`);
-              await new Promise(r => setTimeout(r, pollMs));
-            }
-            core.warning('CodeRabbit did not post within 5 minutes — proceeding to merge.');
+        env:
+          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Delegate to scripts/coderabbit-wait.sh so auto-merge honors the
+          # same semantics the agent-driven flow uses: HEAD-anchored
+          # freshness (#136 — do not merge on a stale review from a prior
+          # HEAD), rate-limit retry (#138 — CodeRabbit does not auto-retry
+          # after its published window elapses), and the coderabbit.*
+          # knobs in .github/review-policy.yml. Exit-code translation:
+          #   0 — cleared on current HEAD, no high-severity markers.
+          #   2 — cleared but findings present (Potential issue / ⚠️).
+          #       Merge path proceeds; findings are advisory.
+          #   3 — API / infra error. Surface via set-failed.
+          #   4 — max_wait_seconds grace window elapsed without a review.
+          #       CodeRabbit is advisory; log a warning and proceed.
+          #   5 — rate-limit retry budget exhausted. Do NOT merge —
+          #       block and let the human intervene.
+          set +e
+          bash scripts/coderabbit-wait.sh "$PR_NUMBER" "$REPO"
+          rc=$?
+          set -e
+          case "$rc" in
+            0)
+              echo "CodeRabbit cleared on current HEAD — proceeding to merge."
+              ;;
+            2)
+              echo "::warning::CodeRabbit review has Potential issue / ⚠️ findings. Auto-merge proceeds (findings are advisory); address in a follow-up PR."
+              ;;
+            4)
+              echo "::warning::CodeRabbit grace window elapsed without a review. CodeRabbit is advisory — proceeding to merge."
+              ;;
+            5)
+              echo "::error::CodeRabbit rate-limit retry budget exhausted. Blocking auto-merge; human must re-trigger or merge manually."
+              exit 1
+              ;;
+            *)
+              echo "::error::coderabbit-wait.sh failed with exit code $rc. Blocking auto-merge."
+              exit 1
+              ;;
+          esac
 
       - name: Re-verify blocking labels right before merge
         env:

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -556,8 +556,16 @@ jobs:
           # knobs in .github/review-policy.yml. Exit-code translation:
           #   0 — cleared on current HEAD, no high-severity markers.
           #   2 — cleared but findings present (Potential issue / ⚠️).
-          #       Merge path proceeds; findings are advisory.
-          #   3 — API / infra error. Surface via set-failed.
+          #       Blocks auto-merge per REVIEW_POLICY.md § Phase 2.5,
+          #       which requires every Potential issue / ⚠️ finding to
+          #       be explicitly addressed (fixed or dismissed with
+          #       reasoning) before moving on. The agent-driven flow
+          #       does that in-session; the auto-merge workflow has
+          #       no way to address a finding, so it stops here and
+          #       lets the author push a fix (or post a dismissal
+          #       reply). A new approving review after the fix
+          #       re-triggers this job.
+          #   3 — API / infra error. Block and surface.
           #   4 — max_wait_seconds grace window elapsed without a review.
           #       CodeRabbit is advisory; log a warning and proceed.
           #   5 — rate-limit retry budget exhausted. Do NOT merge —
@@ -571,7 +579,8 @@ jobs:
               echo "CodeRabbit cleared on current HEAD — proceeding to merge."
               ;;
             2)
-              echo "::warning::CodeRabbit review has Potential issue / ⚠️ findings. Auto-merge proceeds (findings are advisory); address in a follow-up PR."
+              echo "::error::CodeRabbit flagged Potential issue / ⚠️ findings on the current HEAD. Per REVIEW_POLICY.md § Phase 2.5, each must be explicitly addressed (fixed or dismissed with reasoning) before merge. Blocking auto-merge; address the findings and request a new approval to re-trigger."
+              exit 1
               ;;
             4)
               echo "::warning::CodeRabbit grace window elapsed without a review. CodeRabbit is advisory — proceeding to merge."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ This repository uses a multi-identity AI agent code review system. The full poli
 3. Switch back to nathanjohnpayne. Address each comment. Push fix commits.
 4. Repeat steps 2–3 until the reviewer identity approves with no outstanding issues.
 5. If this repo has `coderabbit.enabled: true` in `.github/review-policy.yml`:
-   a. **Wait** for CodeRabbit to post its review (up to 3 minutes; ask the human if it hasn't appeared).
+   a. **Wait** for CodeRabbit to post its review on the current HEAD. Prefer `scripts/coderabbit-wait.sh <PR#>` over an ad-hoc poll — it anchors "cleared" on the HEAD committer date (closing the race that let auto-merge fire pre-CodeRabbit; see #136) and handles CodeRabbit's non-auto-retrying rate-limit state by parsing the published window and posting `@coderabbitai, try again.` itself (see #138). Exit codes: `0` cleared, `2` findings, `4` grace-window timeout (advisory — log and skip), `5` rate-limit stalled (alert the human, do not proceed).
    b. **Read both endpoints:** PR-level comments (`gh api repos/{owner}/{repo}/issues/{pr}/comments`) and inline diff comments (`gh api repos/{owner}/{repo}/pulls/{pr}/comments`).
    c. **Grep inline comments** for `Potential issue` or `⚠️` — these must each be explicitly addressed (fixed or dismissed with reasoning).
    d. Address other substantive findings. CodeRabbit review is advisory and does not block merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,13 @@ explicitly authorizes a break-glass override in chat.
 6. Switch back to nathanjohnpayne. Address each comment. Push fix commits.
 7. Repeat steps 4–6 until the reviewer identity approves.
 7.5. If `.github/review-policy.yml` has `coderabbit.enabled: true`:
-     a. Wait for CodeRabbit to post (up to 3 min; ask human if delayed).
+     a. Wait for CodeRabbit to post on the current HEAD. Prefer
+        `scripts/coderabbit-wait.sh <PR#>` over an ad-hoc poll — it
+        anchors on HEAD committer date (closes the auto-merge race
+        in #136) and handles CodeRabbit's non-auto-retrying rate-limit
+        state (#138). Exit codes: 0 cleared, 2 findings, 4 grace-window
+        timeout (log + skip, CodeRabbit is advisory), 5 rate-limit
+        stalled (alert human, do not proceed).
      b. Read PR-level comments: `gh api repos/{owner}/{repo}/issues/{pr}/comments`
      c. Read inline diff comments: `gh api repos/{owner}/{repo}/pulls/{pr}/comments`
      d. Grep inline comments for `Potential issue` or `⚠️` — address each one.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -595,3 +595,28 @@ If deploy impersonation breaks because IAM bindings or project configuration dri
 ```bash
 op-firebase-setup {project-id}
 ```
+
+### Firebase CLI "Authentication Error: credentials are no longer valid" (daily reauth)
+
+`op-firebase-deploy` (and `scripts/deploy.sh` by extension) occasionally fails
+mid-deploy with:
+
+```
+Authentication Error: Your credentials are no longer valid. Please run firebase login --reauth
+```
+
+The 1Password source-credential chain is still healthy when this fires —
+`gcloud auth application-default print-access-token` against the materialized
+ADC still mints a valid token. The failure is inside firebase CLI, which
+ignores `GOOGLE_APPLICATION_CREDENTIALS` in some hosting-deploy code paths
+and falls back to the user-login cache at
+`~/.config/configstore/firebase-tools.json`. That cache's access token
+expires roughly daily and is not refreshed by the 1Password flow.
+
+**Workaround:** run `firebase login --reauth` once, then re-run the exact
+same `scripts/deploy.sh` (or `op-firebase-deploy`) command. It will succeed
+on the next attempt. See nathanjohnpayne/mergepath#137 for the open
+investigation and the longer-term fix under consideration
+(detect stale configstore in `op-firebase-deploy` and print a clear message
+instead of the current cryptic "Assertion failed: resolving hosting target"
+trailer).

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -114,7 +114,7 @@ If any `op` command fails mid-session (rare — only if 1Password locks or the 1
 
 After internal review passes (Phase 2), CodeRabbit provides an independent automated review:
 
-1. **Wait for CodeRabbit.** CodeRabbit automatically posts a review when the PR is opened or updated. The agent must wait for CodeRabbit to finish before proceeding. If CodeRabbit has not posted after 3 minutes, ask the human whether to continue waiting or skip.
+1. **Wait for CodeRabbit.** CodeRabbit automatically posts a review when the PR is opened or updated. Prefer `scripts/coderabbit-wait.sh <PR#>` over an ad-hoc poll loop — the script anchors its "cleared" signal on the current HEAD committer date, so it will not treat a stale review from a prior HEAD as current; it also handles CodeRabbit's rate-limit state, which the platform does NOT auto-retry (see nathanjohnpayne/mergepath#138). On exit code `0` CodeRabbit has cleared with no high-severity markers; on `2` it has findings to address; on `4` the `coderabbit.max_wait_seconds` grace window elapsed (the agent may log a warning and proceed since CodeRabbit is advisory); on `5` the rate-limit retry budget was exhausted (alert the human rather than proceed). If CodeRabbit has not posted after the grace window, ask the human whether to continue waiting or skip.
 2. **Read both API endpoints.** CodeRabbit posts two types of comments that must both be checked:
    - **PR-level summary:** `gh api repos/{owner}/{repo}/issues/{pr_number}/comments` — contains the high-level walkthrough and summary.
    - **Inline review comments on the diff:** `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments` — contains line-by-line findings anchored to specific code.
@@ -131,7 +131,8 @@ The agent proceeds to Phase 3 (Threshold Check) after addressing CodeRabbit comm
 
 Before moving past Phase 2.5, confirm all of the following:
 
-- [ ] CodeRabbit has posted its review (waited up to 3 minutes, or human approved skip)
+- [ ] CodeRabbit has posted its review on the current HEAD (use `scripts/coderabbit-wait.sh <PR#>` — exit `0` or `2`; `4` is a grace-window timeout that may be logged and skipped since CodeRabbit is advisory)
+- [ ] If `scripts/coderabbit-wait.sh` exited `5` (rate-limit stalled), the human has been alerted rather than the agent proceeding
 - [ ] Read PR-level comments via `issues/{pr}/comments` endpoint
 - [ ] Read inline diff comments via `pulls/{pr}/comments` endpoint
 - [ ] Grepped inline comments for `Potential issue` and `⚠️` — all flagged findings addressed
@@ -414,6 +415,9 @@ author_identity: nathanjohnpayne
 # To fully disable CodeRabbit, uninstall the GitHub App AND set this flag.
 coderabbit:
   enabled: false
+  bot_login: "coderabbitai[bot]"
+  max_wait_seconds: 300          # grace window for scripts/coderabbit-wait.sh
+  max_rate_limit_retries: 2      # retries after CodeRabbit posts "Rate limit exceeded"
 
 # Codex (Phase 4a automated external review) — see Phase 4a above.
 # Same semantics note as coderabbit: this flag governs agent behavior,

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -364,6 +364,25 @@ emit_json_and_exit() {
   exit "$exit_code"
 }
 
+# Sleep for up to `requested` seconds, but time out and emit JSON if the
+# sleep would push total elapsed past MAX_WAIT_SECONDS. Without this
+# guard, fixed 15s polling sleeps can overshoot the configured budget
+# (caller sees `waited_seconds > max_wait_seconds` in the JSON, which is
+# surprising from a knob named "max"). See #140 round-3 CodeRabbit
+# finding (Potential issue, Major, line 380).
+sleep_or_timeout() {
+  local requested=$1
+  local now elapsed remaining
+  now=$(date +%s)
+  elapsed=$((now - START_EPOCH))
+  remaining=$((MAX_WAIT_SECONDS - elapsed))
+  if [ "$remaining" -le 0 ] || [ "$requested" -ge "$remaining" ]; then
+    log "remaining budget (${remaining}s) is below next sleep (${requested}s) — timing out"
+    emit_json_and_exit "timeout" 4 "null" 0
+  fi
+  sleep "$requested"
+}
+
 while :; do
   NOW_EPOCH=$(date +%s)
   ELAPSED=$((NOW_EPOCH - START_EPOCH))
@@ -376,7 +395,7 @@ while :; do
 
   if [ "$(echo "$LATEST" | jq 'length')" = "0" ]; then
     log "no CodeRabbit comment yet (elapsed ${ELAPSED}s); sleeping ${POLL_INTERVAL_SECONDS}s"
-    sleep "$POLL_INTERVAL_SECONDS"
+    sleep_or_timeout "$POLL_INTERVAL_SECONDS"
     continue
   fi
 
@@ -394,7 +413,7 @@ while :; do
         # Same rate-limit comment as last iteration — still sleeping/waiting
         # through our own retry window. Don't double-count retries.
         log "still inside prior rate-limit window; sleeping ${POLL_INTERVAL_SECONDS}s"
-        sleep "$POLL_INTERVAL_SECONDS"
+        sleep_or_timeout "$POLL_INTERVAL_SECONDS"
         continue
       fi
       LAST_RATE_LIMIT_COMMENT_ID=$COMMENT_ID
@@ -420,7 +439,7 @@ while :; do
       NOW_EPOCH=$(date +%s)
       ELAPSED=$((NOW_EPOCH - START_EPOCH))
       REMAINING=$((MAX_WAIT_SECONDS - ELAPSED))
-      if [ "$SLEEP_FOR" -gt "$REMAINING" ]; then
+      if [ "$SLEEP_FOR" -ge "$REMAINING" ]; then
         log "rate-limit window (${SLEEP_FOR}s) exceeds remaining budget (${REMAINING}s) — timing out"
         RATE_LIMIT_REVIEW=$(echo "$LATEST" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
         emit_json_and_exit "timeout" 4 "$RATE_LIMIT_REVIEW" 0
@@ -433,7 +452,7 @@ while :; do
       ;;
     in_progress)
       log "CodeRabbit review in progress; sleeping ${POLL_INTERVAL_SECONDS}s"
-      sleep "$POLL_INTERVAL_SECONDS"
+      sleep_or_timeout "$POLL_INTERVAL_SECONDS"
       continue
       ;;
     review)

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -167,7 +167,8 @@ if ! [[ "$MAX_RATE_LIMIT_RETRIES" =~ ^[0-9]+$ ]]; then
   exit 3
 fi
 
-BOT_LOGIN="coderabbitai[bot]"
+BOT_LOGIN=$(coderabbit_field bot_login)
+BOT_LOGIN=${BOT_LOGIN:-"coderabbitai[bot]"}
 POLL_INTERVAL_SECONDS=15
 RATE_LIMIT_BUFFER_SECONDS=30
 

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -208,7 +208,29 @@ fi
 HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \
   || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
 
+# HEAD freshness anchor. Committer date alone is unreliable — force-push of
+# an older commit, cherry-pick, or rebase with `--committer-date-is-author-date`
+# can produce a HEAD whose committer date predates prior CodeRabbit comments
+# on this PR. Filtering `comments.created_at >= HEAD_COMMITTER_DATE` would
+# then treat stale review-round comments as current and return a false
+# "cleared"/"findings" signal. Mirrors the Layer-1 anchor advance in
+# codex-review-request.sh: advance the anchor past any `head_ref_force_pushed`
+# timeline event. See nathanjohnpayne/mergepath#140 round-2 Codex finding
+# (P1, line 270) for the specific exposure this closes.
+HEAD_ANCHOR="$HEAD_COMMITTER_DATE"
+ANCHOR_SOURCE="HEAD committer date"
+TIMELINE_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/timeline" "PR timeline")
+LATEST_FORCE_PUSH_TIME=$(echo "$TIMELINE_JSON" | jq -r '
+  [ .[] | select(.event == "head_ref_force_pushed") | .created_at ]
+  | max // ""
+')
+if [ -n "$LATEST_FORCE_PUSH_TIME" ] && [[ "$LATEST_FORCE_PUSH_TIME" > "$HEAD_ANCHOR" ]]; then
+  HEAD_ANCHOR="$LATEST_FORCE_PUSH_TIME"
+  ANCHOR_SOURCE="head_ref_force_pushed @ $LATEST_FORCE_PUSH_TIME"
+fi
+
 log "HEAD = $HEAD_SHA committed at $HEAD_COMMITTER_DATE"
+log "anchor = $HEAD_ANCHOR (source: $ANCHOR_SOURCE)"
 log "max_wait = ${MAX_WAIT_SECONDS}s   max_rate_limit_retries = $MAX_RATE_LIMIT_RETRIES"
 
 # --- state machine ----------------------------------------------------------
@@ -256,14 +278,15 @@ classify_comment() {
 }
 
 # Scan both comment endpoints for the latest CodeRabbit comment on or
-# after HEAD_COMMITTER_DATE. Emits JSON to stdout. Sets LATEST_* globals.
-# Empty JSON object {} if no qualifying comment found.
+# after HEAD_ANCHOR (max of HEAD committer date and latest force-push
+# timeline event). Emits JSON to stdout. Empty object {} if nothing
+# qualifying yet.
 scan_latest_comment() {
   local issue_comments pulls_comments combined latest
   issue_comments=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/comments" "issue comments")
   pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
 
-  combined=$(jq -s --arg bot "$BOT_LOGIN" --arg after "$HEAD_COMMITTER_DATE" '
+  combined=$(jq -s --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
     ( (.[0] // []) | map(. + {endpoint: "issues"}) ) +
     ( (.[1] // []) | map(. + {endpoint: "pulls"}) )
     | map(select(.user.login == $bot))
@@ -280,12 +303,12 @@ scan_latest_comment() {
 }
 
 # Count "Potential issue" / ⚠️ markers in the pulls inline comment list
-# on or after HEAD_COMMITTER_DATE. Used for exit code 2 when a real
-# review surfaces high-severity findings.
+# on or after HEAD_ANCHOR. Used for exit code 2 when a real review
+# surfaces high-severity findings.
 count_potential_issues() {
   local pulls_comments
   pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
-  echo "$pulls_comments" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_COMMITTER_DATE" '
+  echo "$pulls_comments" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
     [ .[]
       | select(.user.login == $bot)
       | select(.created_at >= $after)
@@ -388,6 +411,20 @@ while :; do
         WINDOW_SECONDS=60
       fi
       SLEEP_FOR=$((WINDOW_SECONDS + RATE_LIMIT_BUFFER_SECONDS))
+      # Clamp against remaining budget — if the published rate-limit
+      # window exceeds max_wait_seconds anyway, there's no point
+      # burning through the entire sleep only to time out on the next
+      # iteration. Time out immediately instead so the caller sees a
+      # prompt, well-formed timeout rather than a stalled process.
+      # See #140 round-2 Codex finding (P2, line 392).
+      NOW_EPOCH=$(date +%s)
+      ELAPSED=$((NOW_EPOCH - START_EPOCH))
+      REMAINING=$((MAX_WAIT_SECONDS - ELAPSED))
+      if [ "$SLEEP_FOR" -gt "$REMAINING" ]; then
+        log "rate-limit window (${SLEEP_FOR}s) exceeds remaining budget (${REMAINING}s) — timing out"
+        RATE_LIMIT_REVIEW=$(echo "$LATEST" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
+        emit_json_and_exit "timeout" 4 "$RATE_LIMIT_REVIEW" 0
+      fi
       log "rate-limited; sleeping ${SLEEP_FOR}s (window=${WINDOW_SECONDS}s + ${RATE_LIMIT_BUFFER_SECONDS}s buffer)"
       sleep "$SLEEP_FOR"
       post_retry_trigger

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -277,29 +277,39 @@ classify_comment() {
   echo "review"
 }
 
-# Scan both comment endpoints for the latest CodeRabbit comment on or
-# after HEAD_ANCHOR (max of HEAD committer date and latest force-push
-# timeline event). Emits JSON to stdout. Empty object {} if nothing
-# qualifying yet.
+# Scan the PR-level `issues/{pr}/comments` endpoint for the latest
+# CodeRabbit comment on or after HEAD_ANCHOR. Emits JSON to stdout.
+# Empty object {} if nothing qualifying yet.
+#
+# Only the issues endpoint is the terminal-state source. CodeRabbit's
+# PR-level summary/status comments (walkthrough, "No actionable
+# comments generated", rate-limit WARNING, in-progress markers) all
+# land here. Inline `pulls/{pr}/comments` are per-line findings that
+# CodeRabbit can emit BEFORE the PR-level summary lands during a
+# single review cycle — treating an inline comment as terminal state
+# could cause a "cleared"/"findings" exit while the bot is still
+# writing more findings or still mid-walkthrough. See #140 round-3
+# Codex finding (P1, line 285). Inline findings are instead scanned
+# separately by count_potential_issues() only after this function
+# reports a PR-level terminal state.
 scan_latest_comment() {
-  local issue_comments pulls_comments combined latest
+  local issue_comments latest
   issue_comments=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/comments" "issue comments")
-  pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
 
-  combined=$(jq -s --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
-    ( (.[0] // []) | map(. + {endpoint: "issues"}) ) +
-    ( (.[1] // []) | map(. + {endpoint: "pulls"}) )
-    | map(select(.user.login == $bot))
-    | map(select(.created_at >= $after))
+  latest=$(echo "$issue_comments" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
+    [ .[]
+      | select(.user.login == $bot)
+      | select(.created_at >= $after)
+    ]
     | sort_by(.created_at)
-  ' <(echo "$issue_comments") <(echo "$pulls_comments"))
+    | last // null
+  ')
 
-  latest=$(echo "$combined" | jq 'last // null')
   if [ "$latest" = "null" ]; then
     echo '{}'
     return
   fi
-  echo "$latest" | jq '{id, created_at, endpoint, body}'
+  echo "$latest" | jq '{id, created_at, endpoint: "issues", body}'
 }
 
 # Count "Potential issue" / ⚠️ markers in the pulls inline comment list
@@ -318,8 +328,16 @@ count_potential_issues() {
 }
 
 post_retry_trigger() {
-  local body='@coderabbitai, try again.'
-  log "posting retry trigger comment to PR #$PR_NUMBER"
+  # Strip the `[bot]` suffix that GitHub REST uses for App logins —
+  # @-mentions address the user-facing handle (`@coderabbitai`), not
+  # the API login (`coderabbitai[bot]`). Using the configured
+  # BOT_LOGIN here instead of a hardcoded string means a repo that
+  # overrides `coderabbit.bot_login` (e.g., to point at a fork or a
+  # differently-named review bot) gets consistent polling and
+  # triggering identities. See #140 round-3 Codex finding (P2, line 320).
+  local mention="@${BOT_LOGIN%\[bot\]}"
+  local body="${mention}, try again."
+  log "posting retry trigger comment to PR #$PR_NUMBER as $mention"
   gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" \
     -f body="$body" >/dev/null 2>&1 \
     || die 3 "failed to post retry trigger comment"

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -382,23 +382,34 @@ emit_json_and_exit() {
   exit "$exit_code"
 }
 
-# Sleep for up to `requested` seconds, but time out and emit JSON if the
-# sleep would push total elapsed past MAX_WAIT_SECONDS. Without this
-# guard, fixed 15s polling sleeps can overshoot the configured budget
-# (caller sees `waited_seconds > max_wait_seconds` in the JSON, which is
-# surprising from a knob named "max"). See #140 round-3 CodeRabbit
-# finding (Potential issue, Major, line 380).
+# Sleep for up to `requested` seconds, clamped to the remaining
+# max_wait_seconds budget. Without this guard, fixed 15s polling
+# sleeps could overshoot the configured budget (caller sees
+# `waited_seconds > max_wait_seconds`). An earlier version of this
+# helper exited early whenever `requested >= remaining` to avoid the
+# overshoot — but that shortens the effective budget by up to one
+# poll interval (iterations at elapsed 286..299 exit immediately
+# for a 300s budget, missing a review that lands right before the
+# deadline). The right shape: sleep min(requested, remaining), then
+# let the next iteration's top-of-loop check hit the exact-elapsed
+# timeout. See #140 round-3 CodeRabbit finding (Major, line 380)
+# and #140 round-4 Codex finding (P2, line 391).
 sleep_or_timeout() {
   local requested=$1
-  local now elapsed remaining
+  local now elapsed remaining actual
   now=$(date +%s)
   elapsed=$((now - START_EPOCH))
   remaining=$((MAX_WAIT_SECONDS - elapsed))
-  if [ "$remaining" -le 0 ] || [ "$requested" -ge "$remaining" ]; then
-    log "remaining budget (${remaining}s) is below next sleep (${requested}s) — timing out"
+  if [ "$remaining" -le 0 ]; then
+    log "budget exhausted (remaining=${remaining}s) — timing out"
     emit_json_and_exit "timeout" 4 "null" 0
   fi
-  sleep "$requested"
+  actual=$requested
+  if [ "$actual" -gt "$remaining" ]; then
+    actual=$remaining
+    log "clamping sleep from ${requested}s to remaining budget ${remaining}s"
+  fi
+  sleep "$actual"
 }
 
 while :; do

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+# scripts/coderabbit-wait.sh — Phase 2.5 CodeRabbit wait + rate-limit retry
+#
+# Polls a pull request for a CodeRabbit review anchored on the current HEAD
+# commit. Handles two CodeRabbit behaviors that the naive "just wait"
+# pattern in AGENTS.md step 5 does not:
+#
+#   1. **Rate-limit state.** CodeRabbit posts a comment matching
+#      "Rate limit exceeded" with a specific retry window
+#      ("Please wait X minutes and Y seconds before requesting another
+#      review") and then does NOT auto-retry when the window elapses.
+#      This script detects that state, sleeps the window + buffer, posts
+#      `@coderabbitai, try again.` to re-trigger, and continues polling.
+#      See nathanjohnpayne/mergepath#138.
+#
+#   2. **HEAD freshness.** Auto-merge-on-approval workflows in downstream
+#      repos race CodeRabbit: an internal reviewer can post APPROVED before
+#      CodeRabbit's ~2–3 minute review lands, and the PR auto-merges
+#      pre-review. The script only returns "cleared" when CodeRabbit has
+#      posted a non-rate-limited, non-in-progress comment on or after the
+#      HEAD committer date. See nathanjohnpayne/mergepath#136.
+#
+# Usage:
+#   scripts/coderabbit-wait.sh <PR_NUMBER> [REPO]
+#
+# Arguments:
+#   PR_NUMBER  Required. The pull request number (integer).
+#   REPO       Optional. Fully-qualified "owner/repo". Defaults to the
+#              current repository detected by `gh repo view`.
+#
+# Environment:
+#   GH_TOKEN   Required. GitHub token with pull_requests:write to post the
+#              retry trigger and read comments. In the template flow this
+#              is set to $OP_PREFLIGHT_AUTHOR_PAT after running preflight,
+#              or via inline `op read` per REVIEW_POLICY.md § PAT lookup.
+#
+# Behavior:
+#   1. Reads coderabbit.max_wait_seconds (default 300) and
+#      coderabbit.max_rate_limit_retries (default 2) from
+#      .github/review-policy.yml.
+#   2. Fetches PR HEAD SHA + committer date.
+#   3. Polls issue + review comments every 15s. For each CodeRabbit
+#      comment newer than HEAD committer date, classifies as:
+#        - rate_limit  — body matches /Rate limit exceeded/i
+#        - in_progress — body matches /review in progress|currently reviewing/i
+#        - review      — anything else authored by coderabbitai[bot]
+#   4. On rate_limit: parse "X minutes and Y seconds" (or "X seconds"),
+#      sleep that duration + 30s buffer, post `@coderabbitai, try again.`,
+#      increment retry counter, continue polling.
+#   5. On review (non-rate-limit, non-in-progress): emit JSON, exit 0.
+#      Also scans inline diff comments for "Potential issue" / "⚠️"
+#      markers and surfaces them in the JSON so callers can decide.
+#   6. If total elapsed > max_wait_seconds: exit 4 (TIMEOUT), emit JSON
+#      with status=timeout.
+#   7. If rate_limit_retries > max_rate_limit_retries: exit 5 (STALLED),
+#      emit JSON with status=rate_limit_stalled.
+#
+# Output JSON shape (stdout):
+#   {
+#     "pr_number": 123,
+#     "repo": "owner/repo",
+#     "head_sha": "<full sha>",
+#     "head_committer_date": "<iso-8601>",
+#     "bot_login": "coderabbitai[bot]",
+#     "status": "cleared" | "findings" | "timeout" | "rate_limit_stalled",
+#     "review": null | {
+#       "id": N,
+#       "created_at": "<iso-8601>",
+#       "endpoint": "issues" | "pulls",
+#       "body_excerpt": "<first 200 chars>"
+#     },
+#     "potential_issue_count": N,
+#     "rate_limit_retries": N,
+#     "waited_seconds": N
+#   }
+#
+# Exit codes:
+#   0   CodeRabbit posted a real review on current HEAD with no
+#       "Potential issue"/⚠️ markers. Safe to proceed.
+#   2   CodeRabbit posted a real review with at least one P0/P1-equivalent
+#       marker. Caller should address before proceeding.
+#   3   API / infrastructure error. Error on stderr.
+#   4   Timeout — max_wait_seconds elapsed without a real review. Caller
+#       may log a warning and proceed (CodeRabbit is advisory), or block.
+#   5   Rate-limit stalled — max_rate_limit_retries exceeded. Distinct
+#       from timeout so callers can alert the human instead of proceeding.
+#
+# Design notes:
+#   - Read-only except for retry-trigger comments. Does not push commits,
+#     does not modify labels, does not merge.
+#   - Idempotent across reruns on the same HEAD. A freshly-landed review
+#     is detected on the next poll regardless of how many times the script
+#     has been run.
+#   - JSON emission uses `jq`. Pattern matching on CodeRabbit comment
+#     bodies is intentionally heuristic — the bot's output format is not
+#     versioned and may drift. See nathanjohnpayne/mergepath#138 for the
+#     observed rate-limit string.
+
+set -euo pipefail
+
+# --- argument parsing -------------------------------------------------------
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <PR_NUMBER> [REPO]" >&2
+  exit 3
+fi
+
+PR_NUMBER=$1
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: PR_NUMBER must be an integer; got '$PR_NUMBER'" >&2
+  exit 3
+fi
+
+REPO=${2:-}
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+  if [ -z "$REPO" ]; then
+    echo "ERROR: could not detect current repo via 'gh repo view'. Pass REPO explicitly." >&2
+    exit 3
+  fi
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  exit 3
+fi
+
+# --- config readers ---------------------------------------------------------
+
+CONFIG=".github/review-policy.yml"
+
+# Extract a scalar field from the coderabbit: block in review-policy.yml.
+# Mirrors the state-machine pattern used by codex-review-request.sh: stops
+# at the next top-level key, tolerates column-0 comments. Empty string if
+# field missing — caller turns into default.
+coderabbit_field() {
+  local field=$1
+  [ -f "$CONFIG" ] || return 0
+  awk -v field="$field" '
+    /^coderabbit:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block {
+      if ($1 == field":") {
+        sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+        gsub(/^"/, "", $0)
+        gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+        gsub(/[[:space:]]*#.*$/, "", $0)
+        sub(/[[:space:]]+$/, "", $0)
+        print
+        exit
+      }
+    }
+  ' "$CONFIG"
+}
+
+MAX_WAIT_SECONDS=$(coderabbit_field max_wait_seconds)
+MAX_WAIT_SECONDS=${MAX_WAIT_SECONDS:-300}
+if ! [[ "$MAX_WAIT_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: coderabbit.max_wait_seconds must be an integer; got '$MAX_WAIT_SECONDS'" >&2
+  exit 3
+fi
+
+MAX_RATE_LIMIT_RETRIES=$(coderabbit_field max_rate_limit_retries)
+MAX_RATE_LIMIT_RETRIES=${MAX_RATE_LIMIT_RETRIES:-2}
+if ! [[ "$MAX_RATE_LIMIT_RETRIES" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: coderabbit.max_rate_limit_retries must be an integer; got '$MAX_RATE_LIMIT_RETRIES'" >&2
+  exit 3
+fi
+
+BOT_LOGIN="coderabbitai[bot]"
+POLL_INTERVAL_SECONDS=15
+RATE_LIMIT_BUFFER_SECONDS=30
+
+# --- logging helpers --------------------------------------------------------
+
+log() {
+  echo "[coderabbit-wait] $*" >&2
+}
+
+die() {
+  local code=$1
+  shift
+  echo "[coderabbit-wait] ERROR: $*" >&2
+  exit "$code"
+}
+
+fetch_api_array() {
+  local endpoint=$1
+  local label=$2
+  local raw
+  raw=$(gh api --paginate "$endpoint" 2>&1) || die 3 "failed to fetch $label: $raw"
+  echo "$raw" | jq -s 'add // []' 2>/dev/null \
+    || die 3 "failed to flatten $label pagination output"
+}
+
+# --- fetch PR metadata ------------------------------------------------------
+
+log "PR $REPO#$PR_NUMBER — fetching HEAD commit metadata"
+
+PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>&1) || die 3 "failed to fetch PR metadata: $PR_JSON"
+
+HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+  die 3 "could not determine HEAD sha for PR #$PR_NUMBER"
+fi
+
+HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \
+  || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
+
+log "HEAD = $HEAD_SHA committed at $HEAD_COMMITTER_DATE"
+log "max_wait = ${MAX_WAIT_SECONDS}s   max_rate_limit_retries = $MAX_RATE_LIMIT_RETRIES"
+
+# --- state machine ----------------------------------------------------------
+
+# Parse a rate-limit wait window from a CodeRabbit comment body.
+# Emits seconds on stdout. Returns 1 if no window found.
+parse_rate_limit_window() {
+  local body=$1
+  # "Please wait X minutes and Y seconds before requesting another review"
+  local mins secs total
+  if [[ "$body" =~ [Pp]lease\ wait\ +\*?\*?([0-9]+)\*?\*?\ +minutes?\ +and\ +\*?\*?([0-9]+)\*?\*?\ +seconds? ]]; then
+    mins=${BASH_REMATCH[1]}
+    secs=${BASH_REMATCH[2]}
+    total=$((mins * 60 + secs))
+    echo "$total"
+    return 0
+  fi
+  if [[ "$body" =~ [Pp]lease\ wait\ +\*?\*?([0-9]+)\*?\*?\ +seconds? ]]; then
+    secs=${BASH_REMATCH[1]}
+    echo "$secs"
+    return 0
+  fi
+  if [[ "$body" =~ [Pp]lease\ wait\ +\*?\*?([0-9]+)\*?\*?\ +minutes? ]]; then
+    mins=${BASH_REMATCH[1]}
+    total=$((mins * 60))
+    echo "$total"
+    return 0
+  fi
+  return 1
+}
+
+# Classify a CodeRabbit comment body. Emits one of:
+#   rate_limit | in_progress | review
+classify_comment() {
+  local body=$1
+  if echo "$body" | grep -qiE 'rate[- ]limit exceeded'; then
+    echo "rate_limit"
+    return
+  fi
+  if echo "$body" | grep -qiE 'review in progress|currently reviewing|commits? under review'; then
+    echo "in_progress"
+    return
+  fi
+  echo "review"
+}
+
+# Scan both comment endpoints for the latest CodeRabbit comment on or
+# after HEAD_COMMITTER_DATE. Emits JSON to stdout. Sets LATEST_* globals.
+# Empty JSON object {} if no qualifying comment found.
+scan_latest_comment() {
+  local issue_comments pulls_comments combined latest
+  issue_comments=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/comments" "issue comments")
+  pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
+
+  combined=$(jq -s --arg bot "$BOT_LOGIN" --arg after "$HEAD_COMMITTER_DATE" '
+    ( (.[0] // []) | map(. + {endpoint: "issues"}) ) +
+    ( (.[1] // []) | map(. + {endpoint: "pulls"}) )
+    | map(select(.user.login == $bot))
+    | map(select(.created_at >= $after))
+    | sort_by(.created_at)
+  ' <(echo "$issue_comments") <(echo "$pulls_comments"))
+
+  latest=$(echo "$combined" | jq 'last // null')
+  if [ "$latest" = "null" ]; then
+    echo '{}'
+    return
+  fi
+  echo "$latest" | jq '{id, created_at, endpoint, body}'
+}
+
+# Count "Potential issue" / ⚠️ markers in the pulls inline comment list
+# on or after HEAD_COMMITTER_DATE. Used for exit code 2 when a real
+# review surfaces high-severity findings.
+count_potential_issues() {
+  local pulls_comments
+  pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
+  echo "$pulls_comments" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_COMMITTER_DATE" '
+    [ .[]
+      | select(.user.login == $bot)
+      | select(.created_at >= $after)
+      | select((.body // "") | test("Potential issue|⚠️"; "i"))
+    ] | length
+  '
+}
+
+post_retry_trigger() {
+  local body='@coderabbitai, try again.'
+  log "posting retry trigger comment to PR #$PR_NUMBER"
+  gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+    -f body="$body" >/dev/null 2>&1 \
+    || die 3 "failed to post retry trigger comment"
+}
+
+# --- poll loop --------------------------------------------------------------
+
+START_EPOCH=$(date +%s)
+RATE_LIMIT_RETRIES=0
+LAST_RATE_LIMIT_COMMENT_ID=""
+
+emit_json_and_exit() {
+  local status=$1 exit_code=$2 review_json=$3 potential_issues=$4
+  local now_epoch waited
+  now_epoch=$(date +%s)
+  waited=$((now_epoch - START_EPOCH))
+
+  jq -n \
+    --argjson pr_number "$PR_NUMBER" \
+    --arg repo "$REPO" \
+    --arg head_sha "$HEAD_SHA" \
+    --arg head_committer_date "$HEAD_COMMITTER_DATE" \
+    --arg bot_login "$BOT_LOGIN" \
+    --arg status "$status" \
+    --argjson review "$review_json" \
+    --argjson potential_issue_count "$potential_issues" \
+    --argjson rate_limit_retries "$RATE_LIMIT_RETRIES" \
+    --argjson waited_seconds "$waited" \
+    '{
+      pr_number: $pr_number,
+      repo: $repo,
+      head_sha: $head_sha,
+      head_committer_date: $head_committer_date,
+      bot_login: $bot_login,
+      status: $status,
+      review: $review,
+      potential_issue_count: $potential_issue_count,
+      rate_limit_retries: $rate_limit_retries,
+      waited_seconds: $waited_seconds
+    }'
+
+  exit "$exit_code"
+}
+
+while :; do
+  NOW_EPOCH=$(date +%s)
+  ELAPSED=$((NOW_EPOCH - START_EPOCH))
+  if [ "$ELAPSED" -ge "$MAX_WAIT_SECONDS" ]; then
+    log "max_wait_seconds ($MAX_WAIT_SECONDS) exceeded after ${ELAPSED}s — timing out"
+    emit_json_and_exit "timeout" 4 "null" 0
+  fi
+
+  LATEST=$(scan_latest_comment)
+
+  if [ "$(echo "$LATEST" | jq 'length')" = "0" ]; then
+    log "no CodeRabbit comment yet (elapsed ${ELAPSED}s); sleeping ${POLL_INTERVAL_SECONDS}s"
+    sleep "$POLL_INTERVAL_SECONDS"
+    continue
+  fi
+
+  COMMENT_ID=$(echo "$LATEST" | jq -r '.id')
+  COMMENT_BODY=$(echo "$LATEST" | jq -r '.body')
+  COMMENT_ENDPOINT=$(echo "$LATEST" | jq -r '.endpoint')
+  COMMENT_CREATED=$(echo "$LATEST" | jq -r '.created_at')
+
+  CLASS=$(classify_comment "$COMMENT_BODY")
+  log "latest CodeRabbit comment id=$COMMENT_ID endpoint=$COMMENT_ENDPOINT class=$CLASS created=$COMMENT_CREATED"
+
+  case "$CLASS" in
+    rate_limit)
+      if [ "$COMMENT_ID" = "$LAST_RATE_LIMIT_COMMENT_ID" ]; then
+        # Same rate-limit comment as last iteration — still sleeping/waiting
+        # through our own retry window. Don't double-count retries.
+        log "still inside prior rate-limit window; sleeping ${POLL_INTERVAL_SECONDS}s"
+        sleep "$POLL_INTERVAL_SECONDS"
+        continue
+      fi
+      LAST_RATE_LIMIT_COMMENT_ID=$COMMENT_ID
+
+      if [ "$RATE_LIMIT_RETRIES" -ge "$MAX_RATE_LIMIT_RETRIES" ]; then
+        log "max_rate_limit_retries ($MAX_RATE_LIMIT_RETRIES) exceeded — stalling"
+        RATE_LIMIT_REVIEW=$(echo "$LATEST" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
+        emit_json_and_exit "rate_limit_stalled" 5 "$RATE_LIMIT_REVIEW" 0
+      fi
+
+      WINDOW_SECONDS=$(parse_rate_limit_window "$COMMENT_BODY" || echo "")
+      if [ -z "$WINDOW_SECONDS" ]; then
+        log "could not parse rate-limit window from comment; falling back to 60s"
+        WINDOW_SECONDS=60
+      fi
+      SLEEP_FOR=$((WINDOW_SECONDS + RATE_LIMIT_BUFFER_SECONDS))
+      log "rate-limited; sleeping ${SLEEP_FOR}s (window=${WINDOW_SECONDS}s + ${RATE_LIMIT_BUFFER_SECONDS}s buffer)"
+      sleep "$SLEEP_FOR"
+      post_retry_trigger
+      RATE_LIMIT_RETRIES=$((RATE_LIMIT_RETRIES + 1))
+      continue
+      ;;
+    in_progress)
+      log "CodeRabbit review in progress; sleeping ${POLL_INTERVAL_SECONDS}s"
+      sleep "$POLL_INTERVAL_SECONDS"
+      continue
+      ;;
+    review)
+      POTENTIAL_ISSUES=$(count_potential_issues)
+      REVIEW_JSON=$(echo "$LATEST" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
+      if [ "$POTENTIAL_ISSUES" -gt 0 ]; then
+        log "CodeRabbit review posted with $POTENTIAL_ISSUES Potential issue/⚠️ markers"
+        emit_json_and_exit "findings" 2 "$REVIEW_JSON" "$POTENTIAL_ISSUES"
+      else
+        log "CodeRabbit review posted with no high-severity markers — cleared"
+        emit_json_and_exit "cleared" 0 "$REVIEW_JSON" 0
+      fi
+      ;;
+  esac
+done


### PR DESCRIPTION
Authoring-Agent: claude

Closes #136. Closes #138. Addresses #137 (docs only; script-side fix remains open).

## Summary

- **`scripts/coderabbit-wait.sh`** (new) — Phase 2.5 helper that polls for a CodeRabbit review anchored on the current HEAD committer date and handles the non-auto-retrying rate-limit state by parsing the published window and posting `@coderabbitai, try again.` itself.
- **`.github/review-policy.yml`** — new `coderabbit` knobs: `bot_login`, `max_wait_seconds` (default 300), `max_rate_limit_retries` (default 2).
- **AGENTS.md / CLAUDE.md / REVIEW_POLICY.md** — Phase 2.5 guidance now points at `coderabbit-wait.sh <PR#>` and documents the exit codes (0 cleared, 2 findings, 4 grace-window timeout, 5 rate-limit stalled).
- **DEPLOYMENT.md** — new `## Auth Maintenance` entry for #137: `firebase login --reauth` is the current workaround when `op-firebase-deploy` fails with `Your credentials are no longer valid`.

## Why

Both CodeRabbit-integration gaps came up during the 2026-04-18 MUX Video Integration session on `nathanpaynedotcom`:

- PR #233 auto-merged 3 minutes before CodeRabbit landed a Potential issue — the finding became orphaned on the merged branch (#136).
- PR #240 sat in a rate-limit state that never auto-retried after its 1m13s window elapsed; CodeRabbit itself confirmed that behavior in the PR thread (#138).

Template-first fix because every downstream repo that installs Mergepath inherits the Phase 2.5 flow.

## Self-Review

- **Correctness.** `parse_rate_limit_window` + `classify_comment` unit-tested against the exact `Please wait **1 minutes and 13 seconds**` string from #138, the plural/singular variants, and a non-matching case. YAML parser reads the new knobs via the same awk state-machine `codex_field` uses, and that parser was verified on the edited file. Script mirrors `codex-review-request.sh`'s `fetch_api_array | jq -s 'add // []'` pagination pattern.
- **Regression risk.** Additive only. No changes to `codex-review-*.sh`, the existing Phase 2.5 prose still describes the same end state. Existing callers that never invoke the script see no behavior change.
- **Style / conventions.** Bash script mirrors `codex-review-request.sh` conventions (die/log helpers, jq-only JSON, POLL_INTERVAL constant, HEAD-anchored filtering, config fields with defaults). Script is `chmod +x` and passes `bash -n`.
- **Test coverage.** Helper functions unit-verified inline. Full integration requires a live PR with CodeRabbit, so the real-world exercise lands on the first downstream PR that invokes the script. CI lint checks (`check_required_root_files`, `check_duplicate_docs`, `check_codex_scripts`, `check_no_forbidden_top_level_dirs`) all pass locally on this branch.
- **Security / dependency hygiene.** No new dependencies — uses `jq`, `awk`, and `gh` which are already required by `codex-review-request.sh`. No secrets read or logged. Only GitHub mutation is posting a retry-trigger comment as the authenticated identity, bounded by `coderabbit.max_rate_limit_retries` (default 2). Script will not push commits, modify labels, or merge.

## Out of scope / follow-up

- #137 long-term fix: detect stale `firebase-tools` configstore inside `op-firebase-deploy` and print a clear "run firebase login --reauth" message instead of the current cryptic `Assertion failed: resolving hosting target` trailer. The `op-firebase-deploy` script itself lives at `~/.local/bin/` (outside this repo) and needs a separate patch in the source at `scripts/firebase/op-firebase-deploy`. This PR only adds the workaround doc.
- #139 agent-aware preflight — separate PR once this lands. Approach chosen by human: Option 2 from the issue (tempfile with chmod 600, rotate on timer, cleanup on session exit).

## Test plan

- [ ] CI lint workflow passes (`repo_lint.yml`, `pr-review-policy.yml`, `pr-audit.yml`).
- [ ] First downstream PR that calls `scripts/coderabbit-wait.sh` receives a cleared signal when CodeRabbit reviews cleanly.
- [ ] Rate-limit path exercised on a PR where CodeRabbit is over quota — script should parse the window, sleep + buffer, post the retry trigger, and continue.