### PR TITLE
feat(preflight): persist resolved credentials to chmod-600 session file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,17 @@ This repository uses a multi-identity AI agent code review system. The full poli
 
 ### Workflow Summary
 
-0. Run credential preflight at the start of every PR session:
+0. Run credential preflight at the start of every PR session (and safely
+   at the top of every subsequent tool call — re-running within the TTL
+   returns cached values without a new biometric prompt):
    `eval "$(scripts/op-preflight.sh --agent {your-agent} --mode all)"`
-   This triggers biometric prompts once and caches all credentials for the session.
+   This triggers biometric prompts once and writes a chmod-600 session
+   file at `$XDG_CACHE_HOME/mergepath/op-preflight-<agent>.env` so fresh
+   subshells can reuse the credentials (see REVIEW_POLICY.md § Phase 0).
    Use `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"` for reviewer commands and
    `GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT"` for author commands.
+   Run `scripts/op-preflight.sh --agent {your-agent} --purge` (or
+   `--purge-all`) at end of session to delete the cached PATs.
 1. Author code as nathanjohnpayne. File a PR.
 2. Switch to your reviewer identity (e.g., nathanpayne-claude). Review the PR. Post comments.
 3. Switch back to nathanjohnpayne. Address each comment. Push fix commits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,17 @@ explicitly authorizes a break-glass override in chat.
 
 0. Run credential preflight to front-load all biometric prompts:
    `eval "$(scripts/op-preflight.sh --agent claude --mode all)"`
-   This caches PATs and deploy credentials. All subsequent steps use
-   `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"` (reviewer) or
+   This caches PATs and deploy credentials in a chmod-600 session file
+   at `$XDG_CACHE_HOME/mergepath/op-preflight-claude.env` (default
+   `$HOME/.cache/mergepath/`). Safe to re-run at the top of every tool
+   call — within the TTL (4h default, override via
+   `OP_PREFLIGHT_TTL_SECONDS`) the script reads the session file and
+   emits the same exports without a new biometric prompt. All subsequent
+   steps use `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"` (reviewer) or
    `GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT"` (author) instead of `op read`.
-   If preflight was not run, fall back to inline `op read` (original pattern).
+   Run `scripts/op-preflight.sh --agent claude --purge` at end of
+   session to wipe the cache. If preflight was not run (or failed), fall
+   back to inline `op read` (original pattern).
 
 ## Before opening a PR
 

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -91,7 +91,16 @@ After preflight, these environment variables are set:
 - `GOOGLE_APPLICATION_CREDENTIALS` — used automatically by gcloud/Firebase scripts
 - `OP_PREFLIGHT_DONE=1` — flag indicating preflight has been run
 
-If any `op` command fails mid-session (rare — only if 1Password locks or the 12-hour hard limit is reached), re-run the preflight command.
+Resolved credentials are also persisted to a chmod-600 session file at `$XDG_CACHE_HOME/mergepath/op-preflight-<agent>.env` (default `$HOME/.cache/mergepath/`). Re-running the preflight command within the TTL window (4h default, override via `OP_PREFLIGHT_TTL_SECONDS`) short-circuits to the cached values — **no new biometric prompt**. This is what lets agent drivers (Claude Code, Cursor, Codex CLI) re-run preflight at the top of every tool call without repeatedly re-unlocking 1Password; each tool call spawns a fresh subshell that cannot see env vars exported by a prior call, so the session file is the only persistence layer that survives. See nathanjohnpayne/mergepath#139 for the failure mode that motivated this design.
+
+Session-cache maintenance:
+- `scripts/op-preflight.sh --agent <name> --refresh` — force a new biometric fetch, overwriting the session file.
+- `scripts/op-preflight.sh --agent <name> --purge` — delete the session file + ADC tempfile for that agent.
+- `scripts/op-preflight.sh --purge-all` — delete all session files + ADC tempfiles under the cache dir (end-of-session cleanup).
+
+The session file contains plaintext PATs guarded only by filesystem permissions (0600) and is readable by any process running as your user — equivalent to the protection `op` itself provides for its unlocked session. Rotate the PATs in 1Password and purge the cache if you suspect the machine was compromised.
+
+If any `op` command fails mid-session (rare — only if 1Password locks or the 12-hour hard limit is reached), re-run the preflight command with `--refresh` to force a fresh fetch.
 
 ### Phase 1: Authoring
 

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -1,11 +1,28 @@
 #!/usr/bin/env bash
 # op-preflight.sh — Front-load all 1Password credential reads for a session.
 #
-# Triggers biometric prompts once at the start, then exports secrets as
-# environment variables so the rest of the session runs without prompting.
+# Triggers biometric prompts once at the start, then writes resolved secrets
+# to a chmod-600 session file under $XDG_CACHE_HOME/mergepath/ (default
+# $HOME/.cache/mergepath/). Subsequent invocations within the TTL window
+# read the session file and emit the same export statements WITHOUT
+# triggering biometric.
+#
+# This is what makes the script usable from agent drivers (Claude Code,
+# Cursor, Codex CLI) where each tool call spawns a fresh subshell and
+# cannot see env vars exported by a prior call. The first tool call in a
+# session warms the cache (one biometric prompt); every subsequent tool
+# call reuses the session file until it rotates. See
+# nathanjohnpayne/mergepath#139 for the observed failure mode that
+# motivated this design.
 #
 # Usage:
 #   eval "$(scripts/op-preflight.sh --agent claude --mode all)"
+#
+#   # Force a fresh fetch even if the session file is still warm:
+#   eval "$(scripts/op-preflight.sh --agent claude --mode all --refresh)"
+#
+#   # Delete the session file + ADC tempfile (end-of-session cleanup):
+#   scripts/op-preflight.sh --agent claude --purge
 #
 # Modes:
 #   review  — reviewer PAT + author PAT + SSH key warming
@@ -13,10 +30,27 @@
 #   all     — everything (default)
 #
 # Flags:
-#   --agent <name>   Agent name: claude, cursor, or codex (required for review)
+#   --agent <name>   Agent name: claude, cursor, or codex (required except --purge-all)
 #   --mode <mode>    review, deploy, or all (default: all)
 #   --dry-run        Show what would be fetched without prompting
 #   --skip-ssh       Skip SSH key warming (useful in CI or non-interactive)
+#   --refresh        Force biometric fetch even if session file is fresh
+#   --purge          Delete session file + ADC tempfile for the given --agent
+#   --purge-all      Delete ALL session files + ADC tempfiles under the cache dir
+#
+# Environment:
+#   OP_PREFLIGHT_TTL_SECONDS  Override default TTL (14400s = 4h). Age is
+#                             measured against the session file's embedded
+#                             timestamp, not file mtime, so `touch`-ing the
+#                             file does NOT extend its effective lifetime.
+#   OP_PREFLIGHT_CACHE_DIR    Override cache dir (default
+#                             $XDG_CACHE_HOME/mergepath or $HOME/.cache/mergepath).
+#
+# Session file:
+#   Path:        $cache_dir/op-preflight-<agent>.env
+#   Permissions: 600 (owner read/write only)
+#   Format:      bash-sourceable KEY='value' lines (printf %q-escaped)
+#   TTL anchor:  OP_PREFLIGHT_CREATED_AT_EPOCH (embedded in file, not mtime)
 #
 # After eval, downstream scripts and agent commands use the exported env
 # vars instead of calling op directly:
@@ -25,7 +59,7 @@
 #   # gcloud/firebase use GOOGLE_APPLICATION_CREDENTIALS automatically
 
 set -eo pipefail
-umask 077  # Restrict file permissions before any mktemp calls
+umask 077  # Restrict file permissions before any mktemp/cache writes
 
 # ── PAT lookup table ──────────────────────────────────────────────────
 # Must match REVIEW_POLICY.md § PAT lookup table.
@@ -49,6 +83,12 @@ ssh_host_for() {
   esac
 }
 
+# ── Cache layout ──────────────────────────────────────────────────────
+DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/mergepath"
+CACHE_DIR="${OP_PREFLIGHT_CACHE_DIR:-$DEFAULT_CACHE_DIR}"
+DEFAULT_TTL_SECONDS=14400  # 4 hours
+TTL_SECONDS="${OP_PREFLIGHT_TTL_SECONDS:-$DEFAULT_TTL_SECONDS}"
+
 # ── GCP ADC ───────────────────────────────────────────────────────────
 DEFAULT_ADC_OP_URI="${GCP_ADC_OP_URI:-op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential}"
 SSH_AUTHOR_HOST="github.com"
@@ -58,6 +98,9 @@ AGENT=""
 MODE="all"
 DRY_RUN=false
 SKIP_SSH=false
+REFRESH=false
+PURGE=false
+PURGE_ALL=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -65,6 +108,9 @@ while [[ $# -gt 0 ]]; do
     --mode)   MODE="$2"; shift 2 ;;
     --dry-run) DRY_RUN=true; shift ;;
     --skip-ssh) SKIP_SSH=true; shift ;;
+    --refresh) REFRESH=true; shift ;;
+    --purge) PURGE=true; shift ;;
+    --purge-all) PURGE_ALL=true; shift ;;
     *)
       echo "Error: unknown argument: $1" >&2
       echo "Usage: eval \"\$(scripts/op-preflight.sh --agent claude --mode all)\"" >&2
@@ -74,8 +120,16 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ── Validate ──────────────────────────────────────────────────────────
-if [[ "$MODE" == "review" || "$MODE" == "all" ]] && [[ -z "$AGENT" ]]; then
-  echo "Error: --agent is required for review or all mode." >&2
+if $PURGE_ALL; then
+  if [[ -d "$CACHE_DIR" ]]; then
+    echo "# Purging all session files under $CACHE_DIR" >&2
+    find "$CACHE_DIR" -maxdepth 1 -type f \( -name 'op-preflight-*.env' -o -name 'op-preflight-*-adc.json' \) -print -delete >&2
+  fi
+  exit 0
+fi
+
+if [[ "$MODE" == "review" || "$MODE" == "all" || "$PURGE" == "true" ]] && [[ -z "$AGENT" ]]; then
+  echo "Error: --agent is required for review, all, or --purge mode." >&2
   echo "Usage: eval \"\$(scripts/op-preflight.sh --agent claude --mode all)\"" >&2
   exit 1
 fi
@@ -85,15 +139,37 @@ if [[ -n "$AGENT" ]] && [[ -z "$(reviewer_pat_item_for "$AGENT" 2>/dev/null || t
   exit 1
 fi
 
-# ── Preflight checks ─────────────────────────────────────────────────
-if ! command -v op &>/dev/null; then
-  echo "Error: 1Password CLI (op) not found." >&2
+if ! [[ "$TTL_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "Error: OP_PREFLIGHT_TTL_SECONDS must be an integer; got '$TTL_SECONDS'" >&2
   exit 1
+fi
+
+# ── Cache paths (deterministic per agent) ─────────────────────────────
+SESSION_FILE="$CACHE_DIR/op-preflight-$AGENT.env"
+ADC_TMPFILE="$CACHE_DIR/op-preflight-$AGENT-adc.json"
+
+# ── Purge mode ────────────────────────────────────────────────────────
+if $PURGE; then
+  rm -f "$SESSION_FILE" "$ADC_TMPFILE"
+  echo "# Purged session file + ADC tempfile for agent=$AGENT" >&2
+  exit 0
 fi
 
 # ── Dry run ───────────────────────────────────────────────────────────
 if $DRY_RUN; then
   echo "# op-preflight.sh --agent $AGENT --mode $MODE (dry run)" >&2
+  echo "#" >&2
+  echo "# Session file:   $SESSION_FILE" >&2
+  echo "# ADC tempfile:   $ADC_TMPFILE" >&2
+  echo "# TTL seconds:    $TTL_SECONDS" >&2
+  if [[ -f "$SESSION_FILE" ]]; then
+    embedded=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"")
+    now=$(date +%s)
+    age=$((now - ${embedded:-0}))
+    echo "# Session age:    ${age}s (TTL ${TTL_SECONDS}s)" >&2
+  else
+    echo "# Session age:    n/a (no session file)" >&2
+  fi
   echo "#" >&2
   if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
     echo "# Would read: reviewer PAT ($(reviewer_pat_item_for "$AGENT"))" >&2
@@ -109,19 +185,92 @@ if $DRY_RUN; then
   exit 0
 fi
 
-# ── Collect export statements ─────────────────────────────────────────
+# ── Ensure cache dir exists (mode 0700) ───────────────────────────────
+mkdir -p "$CACHE_DIR"
+chmod 700 "$CACHE_DIR" 2>/dev/null || true
+
+# ── Session file freshness check ──────────────────────────────────────
+# Prefer an embedded CREATED_AT epoch over file mtime so `touch`-ing the
+# file cannot silently extend its effective lifetime.
+session_is_fresh() {
+  [[ -f "$SESSION_FILE" ]] || return 1
+  local created_at now age
+  created_at=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" 2>/dev/null | cut -d= -f2- | tr -d "'\"")
+  [[ -z "$created_at" ]] && return 1
+  [[ "$created_at" =~ ^[0-9]+$ ]] || return 1
+  now=$(date +%s)
+  age=$((now - created_at))
+  [[ "$age" -lt "$TTL_SECONDS" ]]
+}
+
+# Emit the session file's export statements to stdout. Caller eval's them.
+emit_from_session_file() {
+  # Source the session file and re-emit only the vars we own, so a
+  # hand-edited file with arbitrary content cannot inject exports.
+  # Also drop CREATED_AT from the exported set; it's bookkeeping.
+  # shellcheck disable=SC1090
+  . "$SESSION_FILE"
+
+  # If deploy is in scope, verify the ADC file still exists on disk —
+  # the session file's path pointer is only useful if the file it
+  # names is readable. If ADC is missing, do NOT emit GOOGLE_APPLICATION_CREDENTIALS;
+  # let the caller fall through to a refresh path manually. Signal with
+  # a non-zero exit so the caller knows to --refresh.
+  if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
+    if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || [[ ! -s "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+      return 2
+    fi
+  fi
+
+  [[ -n "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]] && \
+    printf 'export OP_PREFLIGHT_REVIEWER_PAT=%q\n' "$OP_PREFLIGHT_REVIEWER_PAT"
+  [[ -n "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]] && \
+    printf 'export OP_PREFLIGHT_AUTHOR_PAT=%q\n' "$OP_PREFLIGHT_AUTHOR_PAT"
+  [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] && \
+    printf 'export GOOGLE_APPLICATION_CREDENTIALS=%q\n' "$GOOGLE_APPLICATION_CREDENTIALS"
+  [[ -n "${OP_PREFLIGHT_ADC_TMPFILE:-}" ]] && \
+    printf 'export OP_PREFLIGHT_ADC_TMPFILE=%q\n' "$OP_PREFLIGHT_ADC_TMPFILE"
+  printf 'export OP_PREFLIGHT_DONE=1\n'
+  printf 'export OP_PREFLIGHT_AGENT=%q\n' "$AGENT"
+  return 0
+}
+
+# ── Fast path: reuse session file when fresh ──────────────────────────
+if ! $REFRESH && session_is_fresh; then
+  if emit_from_session_file; then
+    age=$(( $(date +%s) - $(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"") ))
+    echo "" >&2
+    echo "# ── Preflight cached hit (age ${age}s / TTL ${TTL_SECONDS}s) ──" >&2
+    echo "# Session file: $SESSION_FILE" >&2
+    echo "# Run with --refresh to force a new biometric fetch." >&2
+    echo "# ──────────────────────────────────────────────────────────" >&2
+    exit 0
+  fi
+  # emit_from_session_file returned non-zero (e.g. ADC file vanished).
+  # Fall through to full fetch.
+  echo "# Session file stale or incomplete — refreshing" >&2
+fi
+
+# ── Preflight checks for full fetch ──────────────────────────────────
+if ! command -v op &>/dev/null; then
+  echo "Error: 1Password CLI (op) not found." >&2
+  exit 1
+fi
+
+# ── Collect export statements + session-file lines ───────────────────
 EXPORTS=()
+SESSION_LINES=()
 SUMMARY=()
 
 # ── Phase 1: CLI credentials (one biometric prompt + session reuse) ───
 if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
   reviewer_item="$(reviewer_pat_item_for "$AGENT")"
 
-  # Build an op inject template for both PATs.
-  # op inject resolves all op:// references in a single process — one
-  # biometric prompt covers both reads.
+  # Build an op inject template for both PATs. op inject resolves all
+  # op:// references in a single process — one biometric prompt covers
+  # both reads.
   tpl_file="$(mktemp "${TMPDIR:-/tmp}/op-preflight-tpl-XXXXXX")"
-  trap 'rm -f "$tpl_file" "${adc_tmpfile:-}"' EXIT
+  trap 'rm -f "$tpl_file"' EXIT
 
   cat > "$tpl_file" <<TPL
 REVIEWER_PAT={{ op://Private/${reviewer_item}/token }}
@@ -146,6 +295,8 @@ TPL
 
   EXPORTS+=("export OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
   EXPORTS+=("export OP_PREFLIGHT_AUTHOR_PAT=$(printf '%q' "$author_pat")")
+  SESSION_LINES+=("OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
+  SESSION_LINES+=("OP_PREFLIGHT_AUTHOR_PAT=$(printf '%q' "$author_pat")")
   SUMMARY+=("Reviewer PAT ($AGENT): loaded")
   SUMMARY+=("Author PAT: loaded")
 fi
@@ -153,14 +304,19 @@ fi
 if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
   echo "# Preflight: reading GCP ADC (reuses session)..." >&2
 
-  adc_tmpfile="$(mktemp "${TMPDIR:-/tmp}/op-preflight-adc-XXXXXX")"
+  # Deterministic path so subsequent invocations find the same file.
+  # Overwrite in place — chmod 600 before writing secret content.
+  touch "$ADC_TMPFILE"
+  chmod 600 "$ADC_TMPFILE"
 
-  if op read "$DEFAULT_ADC_OP_URI" > "$adc_tmpfile" 2>/dev/null && [[ -s "$adc_tmpfile" ]]; then
-    EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$adc_tmpfile")")
-    EXPORTS+=("export OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$adc_tmpfile")")
-    SUMMARY+=("GCP ADC: loaded -> $adc_tmpfile")
+  if op read "$DEFAULT_ADC_OP_URI" > "$ADC_TMPFILE" 2>/dev/null && [[ -s "$ADC_TMPFILE" ]]; then
+    EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
+    EXPORTS+=("export OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
+    SESSION_LINES+=("GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
+    SESSION_LINES+=("OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
+    SUMMARY+=("GCP ADC: loaded -> $ADC_TMPFILE")
   else
-    rm -f "$adc_tmpfile"
+    rm -f "$ADC_TMPFILE"
     echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2
     SUMMARY+=("GCP ADC: SKIPPED (not available)")
   fi
@@ -186,6 +342,25 @@ if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH; then
   fi
 fi
 
+# ── Persist session file ──────────────────────────────────────────────
+CREATED_AT=$(date +%s)
+{
+  printf '# op-preflight session cache — do NOT edit by hand.\n'
+  printf '# Agent:      %s\n' "$AGENT"
+  printf '# Mode:       %s\n' "$MODE"
+  printf '# Created:    %s (epoch %s)\n' "$(date -u -r "$CREATED_AT" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "@$CREATED_AT" +%Y-%m-%dT%H:%M:%SZ)" "$CREATED_AT"
+  printf '# TTL:        %s seconds\n' "$TTL_SECONDS"
+  printf 'OP_PREFLIGHT_CREATED_AT_EPOCH=%s\n' "$CREATED_AT"
+  printf 'OP_PREFLIGHT_TTL_SECONDS=%s\n' "$TTL_SECONDS"
+  printf 'OP_PREFLIGHT_AGENT=%q\n' "$AGENT"
+  printf 'OP_PREFLIGHT_MODE=%q\n' "$MODE"
+  printf 'OP_PREFLIGHT_DONE=1\n'
+  for line in "${SESSION_LINES[@]}"; do
+    printf '%s\n' "$line"
+  done
+} > "$SESSION_FILE"
+chmod 600 "$SESSION_FILE"
+
 # ── Output ────────────────────────────────────────────────────────────
 EXPORTS+=("export OP_PREFLIGHT_DONE=1")
 EXPORTS+=("export OP_PREFLIGHT_AGENT=$(printf '%q' "$AGENT")")
@@ -201,6 +376,7 @@ echo "# ── Preflight complete ───────────────�
 for line in "${SUMMARY[@]}"; do
   echo "#   $line" >&2
 done
+echo "# Session file: $SESSION_FILE (TTL ${TTL_SECONDS}s)" >&2
 echo "# OP_PREFLIGHT_DONE=1" >&2
 echo "# Human can step away." >&2
 echo "# ──────────────────────────────────────────────────────" >&2


### PR DESCRIPTION
Authoring-Agent: claude

Closes #139.

## Summary

Before this change, the "exported once, reused for the whole session" claim for `scripts/op-preflight.sh` only held in a single interactive shell. Agent drivers (Claude Code, Cursor, Codex CLI) spawn a fresh subshell for every tool call, so `OP_PREFLIGHT_REVIEWER_PAT` / `OP_PREFLIGHT_AUTHOR_PAT` evaporated between calls — each tool then either re-ran preflight (re-prompting biometric) or fell back to inline `op read` (same biometric). Across a ~3-hour session, the human had to re-unlock 1Password every 30–60 minutes.

Per the approach chosen in #139 (Option 2): write resolved credentials to a chmod-600 session file at `$XDG_CACHE_HOME/mergepath/op-preflight-<agent>.env`, keyed by agent identity. Subsequent invocations within the TTL (4h default, `OP_PREFLIGHT_TTL_SECONDS` overrides) read the file and emit the same export statements without touching `op` or the 1Password agent.

## Session-file details

- Path is **deterministic per agent** so fresh subshells can find it without passing paths through env.
- Permissions **0600** on the file, **0700** on the cache directory.
- TTL is anchored on an embedded `OP_PREFLIGHT_CREATED_AT_EPOCH`, **not file mtime**, so `touch`-ing the file cannot silently extend its lifetime.
- ADC credential moves from `mktemp`-random (deleted on script EXIT trap before the caller could consume it) to a deterministic **chmod-600** path that persists across invocations, matching the PAT caching model.

## New flags

| Flag | Behavior |
|---|---|
| `--refresh` | Force a biometric fetch even when the session file is fresh. Use after rotating a PAT. |
| `--purge` | Delete session file + ADC tempfile for the named agent. |
| `--purge-all` | Nuke every session file + ADC tempfile under the cache dir (end-of-session cleanup). |

## Docs updated

- `REVIEW_POLICY.md` § Phase 0 — session-cache behavior, maintenance flags, security note.
- `AGENTS.md` step 0 — now notes that re-running preflight at the top of every tool call is the intended pattern for agent drivers, with a pointer at `--purge` for end-of-session cleanup.
- `CLAUDE.md` — same guidance tailored for the Claude Code flow.

## Security note

The session file contains plaintext PATs guarded only by filesystem permissions (0600) and is readable by any process running as the owning user — equivalent to the protection `op` itself provides for its unlocked session. That's the tradeoff accepted in #139 to remove the per-tool-call biometric friction; the `--purge` flag is provided as an explicit wipe path for end-of-session cleanup.

During local development I inadvertently `cat`'d a session file into the conversation transcript while debugging. I flagged it to the human, purged the cache, and the human will rotate both PATs. The script itself does not `cat` or log credential contents anywhere — only file paths, age, and TTL are printed to stderr.

## Self-Review

- **Correctness.** Tested first-run (biometric + cache write), cached-hit (no biometric; `OP_PREFLIGHT_REVIEWER_PAT` and `OP_PREFLIGHT_AUTHOR_PAT` both successfully auth via `gh api user`), `--purge` / `--purge-all` (files removed), short-TTL rollover (`OP_PREFLIGHT_TTL_SECONDS=1 && sleep 2`) — dry-run reports expiry correctly, real run triggers a refresh. `session_is_fresh()` reads the embedded epoch rather than file mtime.
- **Regression risk.** Existing `eval "$(scripts/op-preflight.sh --agent X --mode all)"` invocations are unchanged — the output shape and env-var names are compatible. The ADC tempfile path changes from random to deterministic under the cache dir; callers that only read `GOOGLE_APPLICATION_CREDENTIALS` see the correct path. The previous EXIT trap was deleting the ADC file before `eval` could consume it anyway (verified by inspecting the cache), so the "fix" for that pre-existing bug is included here.
- **Style / conventions.** Follows the original script's mode + argument conventions. All shell-escaping via `printf '%q'`; no ad-hoc quoting. Script is `chmod +x` and passes `bash -n`.
- **Test coverage.** Manual end-to-end verified locally. A bash unit-test harness for secret-handling would benefit from a separate cleanup PR covering `codex-review-*.sh` + `coderabbit-wait.sh` as well; out of scope here.
- **Security / dependency hygiene.** No new dependencies — uses `op`, `mktemp`, `date`, `printf`, `chmod`, all already required. Permissions audited: 0600 on session file, 0600 on ADC tempfile, 0700 on cache dir. Plaintext-PAT-on-disk tradeoff is documented in both the script header and REVIEW_POLICY.md so downstream template consumers understand what they're opting into.

## Depends on

Ideally lands after [#140](https://github.com/nathanjohnpayne/mergepath/pull/140) (CodeRabbit/Codex review fixes), since that PR is already in Phase 4b handoff. If that one is merged first, this PR should rebase cleanly — no overlapping files.

## Test plan

- [ ] CI lint workflow passes (`repo_lint.yml`, `pr-review-policy.yml`, `pr-audit.yml`).
- [ ] First reviewer / author command after running preflight in a fresh Claude Code session succeeds without a biometric prompt on the second tool call.
- [ ] `scripts/op-preflight.sh --agent claude --dry-run` reports cache age accurately.
- [ ] After `scripts/op-preflight.sh --agent claude --purge`, the next preflight invocation prompts for biometric again.