### PR TITLE
fix(preflight): validate PATs present on cross-mode cache hit

### DIFF
--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -211,12 +211,21 @@ emit_from_session_file() {
   # shellcheck disable=SC1090
   . "$SESSION_FILE"
 
-  # If deploy is in scope, verify the ADC file still exists on disk —
-  # the session file's path pointer is only useful if the file it
-  # names is readable. If ADC is missing, do NOT emit GOOGLE_APPLICATION_CREDENTIALS;
-  # let the caller fall through to a refresh path manually. Signal with
-  # a non-zero exit so the caller knows to --refresh.
+  # Validate the session file actually contains the credentials the
+  # CURRENT invocation's --mode is asking for. A stale cross-mode cache
+  # (e.g. a prior `--mode deploy` run wrote only ADC fields, and this
+  # run is `--mode review`) would otherwise hit the fast path and emit
+  # no PAT exports — downstream `gh` review commands then run
+  # unauthenticated. Return non-zero to trigger the refresh path in
+  # each case. See #141 round-1 Codex finding (P1, line 223).
+  if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
+    if [[ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]] || [[ -z "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]]; then
+      return 2
+    fi
+  fi
   if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
+    # Both the cached-path pointer must be set AND the file it names
+    # must still be readable (non-empty).
     if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || [[ ! -s "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
       return 2
     fi


### PR DESCRIPTION
Authoring-Agent: claude

Follow-up to #141. Addresses a [P1 Codex finding](https://github.com/nathanjohnpayne/mergepath/pull/141#discussion_r3106156681) that landed on #141 at 02:30:25 — 2.5 minutes *after* #141 auto-merged at 02:28:04.

## Summary

Per the Codex finding: the cached-session fast path in `scripts/op-preflight.sh` only verified `GOOGLE_APPLICATION_CREDENTIALS` when `--mode` was `deploy`/`all`, but never validated that the session file actually contained `OP_PREFLIGHT_REVIEWER_PAT` / `OP_PREFLIGHT_AUTHOR_PAT` when `--mode` was `review`/`all`. A prior `--mode deploy` run wrote a session file with only ADC fields; a later `--mode review` invocation hit the cache, found it fresh, and emitted no PAT exports — silently leaving downstream `gh` review commands unauthenticated until a manual `--refresh`.

The fix: in `emit_from_session_file`, when the current `--mode` requires PATs, return non-zero if they're missing from the cached session. The caller's fast-path check already treats any non-zero from `emit_from_session_file` as "stale or incomplete — refreshing," so the script falls through to the full biometric fetch and rewrites the session file with the full field set.

## Why this is a follow-up PR

#141's auto-merge fired on nathanpayne-claude's APPROVED review (02:27:42) while Codex was still analyzing, and landed at 02:28:04. Codex's P1 review posted 2.5 minutes later. I had the fix staged on the branch as `6da10e6` but it never made it into the merged set.

**Ironic note:** this is exactly the race that PR [#140](https://github.com/nathanjohnpayne/mergepath/pull/140) is designed to close — auto-merge-on-approval racing an external automated reviewer. Once #140 merges, `auto-merge-on-approval` will delegate to `scripts/coderabbit-wait.sh` instead of the 5-minute github-script poll, and the CodeRabbit-side of the race goes away. The Codex-App-side still merits separate tracking if we want auto-merge to wait on it too, but today's race was specifically CodeRabbit-rate-limited (PR #141 hit #138's rate-limit state) with Codex arriving as a side effect.

## Self-Review

- **Correctness.** Verified by test: hand-crafted a deploy-only session file with no PAT vars; invoked `--mode review`; dry-run output shows `Would read: reviewer PAT ...` (full fetch path, not cache hit). Without this patch, the same sequence emits zero `export OP_PREFLIGHT_*_PAT` lines and the caller runs unauthenticated.
- **Regression risk.** Additive — a `review`/`all` invocation against a session file that already contains PATs sees no change in behavior. The validation only affects the cross-mode hole named in the Codex finding.
- **Style.** Mirrors the existing ADC validation block right below it.
- **Test coverage.** Manual end-to-end as above. A bash unit-test harness for preflight is out of scope here and would benefit from a separate cleanup PR.
- **Security.** No new secret reads or logs. Permissions model unchanged.

## Test plan

- [ ] CI lint passes.
- [ ] A `--mode review` invocation on a pre-existing deploy-only session file triggers a fresh biometric fetch rather than a silent cache hit.