### PR TITLE
feat(preflight): detect stale 1Password ADC before exporting to downstream

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -620,3 +620,34 @@ investigation and the longer-term fix under consideration
 (detect stale configstore in `op-firebase-deploy` and print a clear message
 instead of the current cryptic "Assertion failed: resolving hosting target"
 trailer).
+
+### 1Password ADC item refresh token expired (#137 failure mode B)
+
+A closely-related but distinct failure can fire immediately after the
+reauth above. If `scripts/op-preflight.sh` materializes a 1Password ADC
+item whose underlying `refresh_token` has been revoked or expired by
+Google, `op-firebase-deploy` will refuse the credential with:
+
+```
+Error: GOOGLE_APPLICATION_CREDENTIALS points to an unusable credential file: /var/folders/.../op-preflight-adc-*
+```
+
+Starting with the #137 fix, `op-preflight.sh` now validates the
+materialized ADC against the OAuth2 `/token` endpoint before exporting
+`GOOGLE_APPLICATION_CREDENTIALS`. When the credential is stale,
+preflight prints an actionable warning and skips the export — downstream
+callers (`op-firebase-deploy`, `gcloud` wrappers) then fall back to the
+local firebase-login / ADC path that the reauth has just refreshed.
+
+**Fix permanently** by refreshing the 1Password item:
+
+```bash
+gcloud auth application-default login
+# then copy the freshly-written JSON into the 1Password item:
+op document edit 'GCP ADC' --vault=Private \
+  ~/.config/gcloud/application_default_credentials.json
+# (or `op item edit` if stored as an item field)
+```
+
+After that, the next preflight run will materialize a usable credential
+and the `GOOGLE_APPLICATION_CREDENTIALS` export resumes normally.

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -203,6 +203,88 @@ session_is_fresh() {
   [[ "$age" -lt "$TTL_SECONDS" ]]
 }
 
+# Validate that a materialized ADC file still mints a token. Mirrors the
+# source_cred_is_usable check in scripts/firebase/op-firebase-deploy so a
+# stale 1Password ADC item (refresh_token expired by Google) gets caught
+# in preflight instead of inside firebase CLI after the user has already
+# eval'd the exports. See nathanjohnpayne/mergepath#137 failure mode B
+# for the concrete repro: 1Password holds an authorized_user cred whose
+# refresh_token has expired; op read succeeds and writes the file, but
+# the OAuth2 /token round-trip fails. Without this check, preflight
+# reports "GCP ADC: loaded" and downstream callers see
+# "GOOGLE_APPLICATION_CREDENTIALS points to an unusable credential file"
+# from inside op-firebase-deploy.
+#
+# Returns 0 if the file exists and mints a token (or is a self-contained
+# service_account key). Returns 1 otherwise — including when python3 is
+# unavailable or the oauth2 endpoint is unreachable in which case the
+# safer behavior is to treat the cred as stale and let downstream
+# callers fall back to their own auth path.
+adc_is_usable() {
+  local file="${1:-}"
+  [[ -n "$file" && -f "$file" && -s "$file" ]] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 - "$file" <<'PY'
+import json, pathlib, sys, urllib.request, urllib.parse
+
+try:
+    cred = json.loads(pathlib.Path(sys.argv[1]).read_text())
+except Exception:
+    sys.exit(1)
+
+while cred.get("type") == "impersonated_service_account" and "source_credentials" in cred:
+    cred = cred["source_credentials"]
+
+if cred.get("type") == "service_account":
+    sys.exit(0)
+
+refresh_token = cred.get("refresh_token", "")
+client_id     = cred.get("client_id", "")
+client_secret = cred.get("client_secret", "")
+
+if not all([refresh_token, client_id, client_secret]):
+    sys.exit(1)
+
+data = urllib.parse.urlencode({
+    "client_id": client_id,
+    "client_secret": client_secret,
+    "refresh_token": refresh_token,
+    "grant_type": "refresh_token",
+}).encode()
+try:
+    req = urllib.request.Request("https://oauth2.googleapis.com/token", data=data)
+    urllib.request.urlopen(req, timeout=10)
+except Exception:
+    sys.exit(1)
+PY
+}
+
+# Emit the human-facing guidance for a stale 1Password ADC item. Called
+# from both the full-fetch path (after op read + adc_is_usable fails)
+# and the fast-path cache-hit path (when a cached ADC fails the same
+# check on the next invocation).
+log_stale_adc_guidance() {
+  echo "# ──────────────────────────────────────────────────────" >&2
+  echo "# WARNING: 1Password ADC item is stale (OAuth2 refresh rejected)." >&2
+  echo "#" >&2
+  echo "# The credential stored at $DEFAULT_ADC_OP_URI" >&2
+  echo "# was read successfully but Google rejected its refresh token —" >&2
+  echo "# typical causes: token revoked, expired (RAPT), or user account" >&2
+  echo "# password changed. Refresh it with:" >&2
+  echo "#" >&2
+  echo "#   gcloud auth application-default login" >&2
+  echo "#   op document edit 'GCP ADC' --vault=Private \\" >&2
+  echo "#     ~/.config/gcloud/application_default_credentials.json" >&2
+  echo "#" >&2
+  echo "# (use 'op item edit' if the ADC is stored as an item field instead)" >&2
+  echo "#" >&2
+  echo "# Preflight will NOT export GOOGLE_APPLICATION_CREDENTIALS this run" >&2
+  echo "# so downstream callers (op-firebase-deploy, gcloud wrappers) can" >&2
+  echo "# fall back to the local firebase-login / ADC path." >&2
+  echo "# See nathanjohnpayne/mergepath#137 for the failure mode this guards." >&2
+  echo "# ──────────────────────────────────────────────────────" >&2
+}
+
 # Emit the session file's export statements to stdout. Caller eval's them.
 emit_from_session_file() {
   # Source the session file and re-emit only the vars we own, so a
@@ -225,8 +307,17 @@ emit_from_session_file() {
   fi
   if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
     # Both the cached-path pointer must be set AND the file it names
-    # must still be readable (non-empty).
+    # must still be readable (non-empty) AND still mint a token. The
+    # usability check catches the case where the cached ADC was valid
+    # at write time but has since been revoked/expired by Google —
+    # without it, a fresh session file would keep re-emitting a dead
+    # GOOGLE_APPLICATION_CREDENTIALS export for up to TTL_SECONDS.
+    # See #137 failure mode B.
     if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || [[ ! -s "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+      return 2
+    fi
+    if ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
+      log_stale_adc_guidance
       return 2
     fi
   fi
@@ -319,11 +410,17 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
   chmod 600 "$ADC_TMPFILE"
 
   if op read "$DEFAULT_ADC_OP_URI" > "$ADC_TMPFILE" 2>/dev/null && [[ -s "$ADC_TMPFILE" ]]; then
-    EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
-    EXPORTS+=("export OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
-    SESSION_LINES+=("GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
-    SESSION_LINES+=("OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
-    SUMMARY+=("GCP ADC: loaded -> $ADC_TMPFILE")
+    if adc_is_usable "$ADC_TMPFILE"; then
+      EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
+      EXPORTS+=("export OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
+      SESSION_LINES+=("GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
+      SESSION_LINES+=("OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
+      SUMMARY+=("GCP ADC: loaded -> $ADC_TMPFILE")
+    else
+      rm -f "$ADC_TMPFILE"
+      log_stale_adc_guidance
+      SUMMARY+=("GCP ADC: STALE (refresh_token rejected — see warning above)")
+    fi
   else
     rm -f "$ADC_TMPFILE"
     echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2


### PR DESCRIPTION
Authoring-Agent: claude

Closes the preflight-detector half of #137 (failure mode B). The firebase-CLI-side fix (detect stale `firebase-tools` configstore inside `op-firebase-deploy`) remains open.

## Summary

Adds `adc_is_usable()` to `scripts/op-preflight.sh`, mirroring `source_cred_is_usable` in `scripts/firebase/op-firebase-deploy`. Called after materializing a fresh ADC and on cached-hit fast-path reuse. If the credential fails the OAuth2 `/token` round-trip, preflight prints an actionable multi-line warning with the exact `gcloud auth application-default login` + `op document edit 'GCP ADC' --vault=Private ...` commands to refresh the 1Password item, and skips the `GOOGLE_APPLICATION_CREDENTIALS` export so downstream callers (`op-firebase-deploy`, `gcloud` wrappers) transparently fall back to the local firebase-login / ADC path — the exact workaround the issue reporter identified.

## Why

#137 failure mode B: a 1Password ADC item whose authorized_user `refresh_token` has been revoked/expired by Google is still `op read`-able, so preflight used to materialize a file and export `GOOGLE_APPLICATION_CREDENTIALS` happily — only for the next `op-firebase-deploy` invocation to refuse the credential with:

```
Error: GOOGLE_APPLICATION_CREDENTIALS points to an unusable credential file: /var/folders/.../op-preflight-adc-*
```

The reporter's workaround was `env -u GOOGLE_APPLICATION_CREDENTIALS -u OP_PREFLIGHT_DONE op-firebase-deploy --only hosting`, which forced the script to fall through to the local firebase-login ADC that had just been refreshed by `firebase login --reauth`. Automating that fallback in preflight removes the manual step.

## Implementation

- **New helper `adc_is_usable`** wraps a Python3 snippet that unwraps `impersonated_service_account` → `authorized_user`, passes through on `service_account` keys, and for `authorized_user` hits `oauth2.googleapis.com/token` with the embedded refresh token. Returns 0 on mint success, 1 otherwise (including python3 unavailable, malformed JSON, missing fields, network failure — erring toward "treat as stale" so downstream callers aren't stuck holding a dead credential).
- **New helper `log_stale_adc_guidance`** emits a multi-line warning with the exact refresh commands. Called from both the full-fetch and cached-hit paths.
- **Full-fetch path.** After `op read > $ADC_TMPFILE` succeeds and the file is non-empty, run `adc_is_usable`. On pass: export normally. On fail: delete the tempfile, log guidance, record `STALE` in the summary, proceed with preflight-done + PATs intact so review commands keep working.
- **Cached-hit fast path.** In `emit_from_session_file`, extend the ADC validation from file-exists-and-non-empty to also require `adc_is_usable`. On fail: log guidance, return non-zero to trigger a full refresh (the refresh re-detects stale on the fresh materialization and takes the same skip path — one biometric re-prompt, accepted as the cost of catching the stale-cache case; the alternative is emitting a dead `GOOGLE_APPLICATION_CREDENTIALS` export for up to `TTL_SECONDS`).

## Self-Review

- **Correctness.** End-to-end test: seeded a deliberately-broken ADC at `$HOME/.cache/mergepath/op-preflight-claude-adc.json` with `{"type": "authorized_user", "refresh_token": "INVALID_FAKE", ...}`, ran preflight. Output: fast-path detected stale → full refresh → full fetch also stale → multi-line warning → no `export GOOGLE_APPLICATION_CREDENTIALS` line emitted. `OP_PREFLIGHT_DONE=1` still set, PATs still exported (when mode is `review` or `all`). Edge cases: non-existent file, empty file, malformed JSON, missing fields, `service_account` passthrough — all verified via inline arithmetic.
- **Regression risk.** Additive — a `--mode review` invocation is unaffected (adc_is_usable is never called). A `--mode deploy`/`all` invocation against a healthy ADC sees a small additional cost (one HTTPS round-trip to `oauth2.googleapis.com`, ~50-200ms). When python3 is unavailable, adc_is_usable returns 1 — I chose stale-by-default over skip-validation because a deploy with a bad credential fails fast downstream with a clearer message than a silently-skipped check.
- **Style.** Matches the existing helper style in the file. All Python lives in `<<'PY'` heredocs identical to the sibling check in `op-firebase-deploy`.
- **Test coverage.** End-to-end manually verified on the happy path (no ADC item available → clean "not available" path) and the stale-refresh-token path (warning + skip). A bash unit-test harness for preflight helpers is out of scope here.
- **Security / dependency hygiene.** No new dependencies — `python3` + `urllib` are already required by `op-firebase-deploy`'s sibling check. No secrets logged. `$ADC_TMPFILE` deleted on stale detection. The OAuth2 round-trip transmits the refresh token over HTTPS to Google's canonical endpoint only.

## Test plan

- [ ] CI lint passes.
- [ ] First preflight run on a healthy 1Password ADC item: normal happy-path output, `GOOGLE_APPLICATION_CREDENTIALS` exported.
- [ ] Preflight run after the 1Password ADC has been rotated/revoked: multi-line warning, no export, `OP_PREFLIGHT_DONE=1` still set, downstream `op-firebase-deploy` falls through to local auth.