### PR TITLE
fix(preflight+coderabbit-wait): address Codex findings from propagation PRs

### DIFF
--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -312,16 +312,39 @@ scan_latest_comment() {
   echo "$latest" | jq '{id, created_at, endpoint: "issues", body}'
 }
 
-# Count "Potential issue" / ⚠️ markers in the pulls inline comment list
-# on or after HEAD_ANCHOR. Used for exit code 2 when a real review
-# surfaces high-severity findings.
+# Count "Potential issue" / ⚠️ markers in the pulls inline comment list,
+# scoped to the LATEST CodeRabbit review on the current HEAD. The
+# naive "all bot comments after HEAD_ANCHOR" shape would keep stale
+# findings from an earlier review round (same HEAD, pre-retry) in the
+# count forever, so a PR could stay permanently in the `findings`
+# state even after the next review comes back clean. Mirror the
+# latest-review-scoping pattern codex-review-request.sh uses via
+# `pull_request_review_id`. See propagation-round Codex finding
+# (P1) on device-platform-reporting#51.
 count_potential_issues() {
-  local pulls_comments
-  pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
-  echo "$pulls_comments" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
+  local reviews pulls_comments latest_review_id
+  reviews=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/reviews" "reviews")
+  latest_review_id=$(echo "$reviews" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
     [ .[]
       | select(.user.login == $bot)
-      | select(.created_at >= $after)
+      | select(.submitted_at >= $after)
+    ]
+    | sort_by(.submitted_at) | last
+    | if . == null then null else .id end
+  ')
+
+  if [ -z "$latest_review_id" ] || [ "$latest_review_id" = "null" ]; then
+    echo "0"
+    return
+  fi
+
+  pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
+  echo "$pulls_comments" | jq \
+    --arg bot "$BOT_LOGIN" \
+    --argjson review_id "$latest_review_id" '
+    [ .[]
+      | select(.user.login == $bot)
+      | select(.pull_request_review_id == $review_id)
       | select((.body // "") | test("Potential issue|⚠️"; "i"))
     ] | length
   '

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -286,10 +286,31 @@ log_stale_adc_guidance() {
 }
 
 # Emit the session file's export statements to stdout. Caller eval's them.
-emit_from_session_file() {
+#
+# Runs in a subshell with the relevant variables pre-unset so the
+# sourced file's definitions are NOT aliased to whatever the parent
+# shell happened to have in scope. Without this isolation a prior
+# `--agent claude` invocation could leak its PATs into an
+# `--agent codex --mode review` fast-path check, making an
+# incomplete codex session file look valid and causing gh to run as
+# the wrong identity. See round-5 Codex finding on the propagation
+# PRs for the multi-agent repro.
+emit_from_session_file() (
+  # Subshell: the (  ... ) above means unset/source/return here do
+  # not escape back to the caller. We still "return" rc codes via
+  # stdout+exit; parent stays clean.
+  unset OP_PREFLIGHT_REVIEWER_PAT OP_PREFLIGHT_AUTHOR_PAT
+  unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+  unset OP_PREFLIGHT_DONE OP_PREFLIGHT_AGENT OP_PREFLIGHT_MODE
+  unset OP_PREFLIGHT_CREATED_AT_EPOCH OP_PREFLIGHT_TTL_SECONDS
+
   # Source the session file and re-emit only the vars we own, so a
   # hand-edited file with arbitrary content cannot inject exports.
-  # Also drop CREATED_AT from the exported set; it's bookkeeping.
+  # Permissions are 0600 in a 0700 cache dir (enforced at write time
+  # and re-checked here via stat), so the source boundary is "file
+  # owner writes the file; we trust them." Rebuttal to the P2
+  # safe-parse finding on the propagation PRs — a reader that also
+  # writes the file cannot protect themselves from themselves.
   # shellcheck disable=SC1090
   . "$SESSION_FILE"
 
@@ -302,23 +323,34 @@ emit_from_session_file() {
   # each case. See #141 round-1 Codex finding (P1, line 223).
   if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
     if [[ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]] || [[ -z "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]]; then
-      return 2
+      exit 2
     fi
   fi
   if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
-    # Both the cached-path pointer must be set AND the file it names
-    # must still be readable (non-empty) AND still mint a token. The
-    # usability check catches the case where the cached ADC was valid
-    # at write time but has since been revoked/expired by Google —
-    # without it, a fresh session file would keep re-emitting a dead
-    # GOOGLE_APPLICATION_CREDENTIALS export for up to TTL_SECONDS.
-    # See #137 failure mode B.
+    # Partial-cache allowance: if the caller asked for `--mode all`
+    # and the prior run captured PATs but could not read ADC (e.g.
+    # 1Password offline for the deploy vault), the session file has
+    # review-side fields only. Don't re-prompt biometric for PATs
+    # the file already has just because ADC is absent — treat it as
+    # "PATs cached, deploy credentials not available, downstream
+    # callers fall back" same as the full-fetch stale-ADC path. A
+    # literal `--mode deploy` still requires an ADC.
+    #
+    # The ADC-missing-and-mode-is-all case was surfaced by
+    # device-source-of-truth#52 round-5 Codex review (P2).
     if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || [[ ! -s "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
-      return 2
-    fi
-    if ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
+      if [[ "$MODE" == "deploy" ]]; then
+        exit 2
+      fi
+      # MODE=all with no ADC → emit PATs, skip ADC, continue.
+    elif ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
+      # File exists but refresh token is rejected. Same behavior:
+      # warn, skip the export, let downstream fall back.
       log_stale_adc_guidance
-      return 2
+      unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+      if [[ "$MODE" == "deploy" ]]; then
+        exit 2
+      fi
     fi
   fi
 
@@ -332,16 +364,54 @@ emit_from_session_file() {
     printf 'export OP_PREFLIGHT_ADC_TMPFILE=%q\n' "$OP_PREFLIGHT_ADC_TMPFILE"
   printf 'export OP_PREFLIGHT_DONE=1\n'
   printf 'export OP_PREFLIGHT_AGENT=%q\n' "$AGENT"
-  return 0
+  exit 0
+)
+
+# Warm author + reviewer SSH keys. Idempotent — each `ssh -T` exits
+# immediately with "You've successfully authenticated" when the agent
+# has the key, otherwise triggers the 1Password SSH-agent biometric
+# prompt for the underlying key. Called from both the full-fetch path
+# and the cache-hit fast path: skipping SSH warming on the fast path
+# means subsequent git/gh SSH operations can still block on auth even
+# after preflight reports success (friends-and-family-billing#227
+# round-5 Codex P2). Output goes to stderr so it's not eval'd.
+warm_ssh_keys() {
+  echo "# Preflight: warming SSH keys..." >&2
+  if ssh -T "git@${SSH_AUTHOR_HOST}" 2>&1 | grep -qi "successfully authenticated"; then
+    SUMMARY+=("SSH key ($SSH_AUTHOR_HOST): authorized")
+  else
+    SUMMARY+=("SSH key ($SSH_AUTHOR_HOST): warming attempted")
+  fi
+  local reviewer_host
+  reviewer_host="$(ssh_host_for "$AGENT")"
+  if ssh -T "git@${reviewer_host}" 2>&1 | grep -qi "successfully authenticated"; then
+    SUMMARY+=("SSH key ($reviewer_host): authorized")
+  else
+    SUMMARY+=("SSH key ($reviewer_host): warming attempted")
+  fi
 }
 
 # ── Fast path: reuse session file when fresh ──────────────────────────
 if ! $REFRESH && session_is_fresh; then
-  if emit_from_session_file; then
+  cached_exports=$(emit_from_session_file)
+  rc=$?
+  if [[ "$rc" == "0" ]]; then
+    echo "$cached_exports"
     age=$(( $(date +%s) - $(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"") ))
+    # Warm SSH keys on the cache-hit path too. The cached PATs are
+    # worthless for git push/pull if SSH auth isn't also primed, and
+    # the prior implementation skipped this step entirely on cache
+    # hit — a repro surfaced on the consumer-repo propagation PRs.
+    SUMMARY=()
+    if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH; then
+      warm_ssh_keys
+    fi
     echo "" >&2
     echo "# ── Preflight cached hit (age ${age}s / TTL ${TTL_SECONDS}s) ──" >&2
     echo "# Session file: $SESSION_FILE" >&2
+    for line in "${SUMMARY[@]}"; do
+      echo "#   $line" >&2
+    done
     echo "# Run with --refresh to force a new biometric fetch." >&2
     echo "# ──────────────────────────────────────────────────────────" >&2
     exit 0
@@ -430,22 +500,7 @@ fi
 
 # ── Phase 2: SSH key warming ──────────────────────────────────────────
 if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH; then
-  echo "# Preflight: warming SSH keys..." >&2
-
-  # Author key
-  if ssh -T "git@${SSH_AUTHOR_HOST}" 2>&1 | grep -qi "successfully authenticated"; then
-    SUMMARY+=("SSH key ($SSH_AUTHOR_HOST): authorized")
-  else
-    SUMMARY+=("SSH key ($SSH_AUTHOR_HOST): warming attempted")
-  fi
-
-  # Reviewer key
-  reviewer_host="$(ssh_host_for "$AGENT")"
-  if ssh -T "git@${reviewer_host}" 2>&1 | grep -qi "successfully authenticated"; then
-    SUMMARY+=("SSH key ($reviewer_host): authorized")
-  else
-    SUMMARY+=("SSH key ($reviewer_host): warming attempted")
-  fi
+  warm_ssh_keys
 fi
 
 # ── Persist session file ──────────────────────────────────────────────


### PR DESCRIPTION
Authoring-Agent: claude

Upstream fix for Codex findings surfaced during the mergepath→consumer propagation PRs (device-platform-reporting#51, device-source-of-truth#52, friends-and-family-billing#227, nathanpaynedotcom#250, overridebroadway#30, swipewatch#35). Addressing here so the consumer PRs can re-sync from corrected mergepath main rather than each landing the same patch in-repo.

## Findings addressed

- **P1 env-leak in `emit_from_session_file`** (nathanpaynedotcom#250). The helper read `OP_PREFLIGHT_REVIEWER_PAT` / `OP_PREFLIGHT_AUTHOR_PAT` / ADC vars directly from the current process environment, so a prior run's exports could make an incomplete cache file look valid for a different agent/mode combination. Fix: wrap the helper in an isolated subshell and explicitly `unset` the `OP_PREFLIGHT_*` + ADC vars before sourcing, so only values actually present in the file survive. **Verified**: pre-setting `OP_PREFLIGHT_REVIEWER_PAT=FAKE_INJECTED` in the caller env and invoking the cache-hit path now emits the 40-char cached PAT from the file, not the fake.
- **P2 partial-hit on `--mode all` with missing ADC** (device-source-of-truth#52). When a prior `--mode all` run couldn't read ADC, the session file captured PATs only; the next `--mode all` cache-hit check returned 2 because `GOOGLE_APPLICATION_CREDENTIALS` was missing, forcing a biometric re-prompt every invocation. Fix: treat missing-ADC on `--mode all` as a partial hit (emit PATs, skip ADC, continue). Literal `--mode deploy` still requires an ADC.
- **P2 SSH warming skipped on cache hit** (friends-and-family-billing#227). The cache-hit fast path exited without warming SSH keys, so subsequent git/gh SSH operations could still prompt. Fix: extract SSH warming into a `warm_ssh_keys` helper and call it on both the full-fetch and cache-hit paths.
- **P1 `count_potential_issues` not scoped to latest review** (device-platform-reporting#51). The count included every bot inline comment after `HEAD_ANCHOR`, so old Potential issue comments from an earlier review round on the same HEAD kept exit code 2 firing even when the latest review was clean. Fix: scope to the latest CodeRabbit review via `pull_request_review_id` — mirrors the latest-review-scoping in `codex-review-request.sh`'s findings filter.

## Findings not addressed (with rationale)

- **P2 parse-vs-source session file** (device-platform-reporting#51). The session file is 0600 inside a 0700 cache dir, owned by the same user that writes it. Shell injection through that file requires already having owner privileges over the user's process — the read-side boundary is "same user, their own chmod-600 file." Adding a strict parser would harden against a nonexistent threat model.
- **P1 CodeRabbit freshness vs. non-force-push committer-date rewrites** (overridebroadway#30, friends-and-family-billing#227). HEAD_ANCHOR currently advances past `head_ref_force_pushed` events but does not floor on wallclock, so a cherry-pick with a preserved old committer date could accept a stale CodeRabbit comment. Low-probability in our workflow (PRs don't normally preserve old committer dates on push). Tracking as a separate follow-up — the fix mirrors `codex-review-request.sh`'s `reaction_freshness_window_seconds` floor and is worth adding but out of scope here.
- **P1 repo-namespace cache** (swipewatch#35). The cache is intentionally user+agent-scoped, not repo-scoped, because the same PAT works across all repos for a given agent identity. This is the design target named in mergepath #139 ("one biometric prompt per agent per session, shared across repos"). Rebuttal.
- **P2 mode-contract in cache-hit exports** (overridebroadway#30). The session file is a superset capture; re-emitting its full content on any cache hit is the documented shape. Callers that want mode isolation use `--mode review` vs `--mode deploy` on the ORIGINAL fetch, not on lookup. Rebuttal.

## Self-Review

- **Correctness.** Subshell isolation in `emit_from_session_file` ensures the sourced file's definitions don't alias the parent environment. Manual repro: with `OP_PREFLIGHT_REVIEWER_PAT=FAKE_INJECTED` in the caller env, a cache-hit invocation now emits the real 40-char PAT from the file (verified). The `count_potential_issues` latest-review scoping matches the pattern `codex-review-request.sh` already uses. SSH warming now runs on both paths via a shared helper.
- **Regression risk.** Public interface unchanged — `eval "$(scripts/op-preflight.sh ...)"` consumers see the same export lines. The subshell refactor is source-compatible because the helper was already output-only (caller `eval`s stdout). `warm_ssh_keys` is a straightforward extraction.
- **Style / conventions.** Follows existing script conventions. All rationale is in inline comments pointing at the specific propagation-PR finding.
- **Test coverage.** Manual end-to-end: purge cache → fetch → cache-hit → env-leak test → all pass. A bash unit-test harness for preflight/wait is out of scope here.
- **Security / dependency hygiene.** No new deps. Fixes strictly tighten the cache model (env isolation, ADC fallback, SSH reliability). Plaintext-PAT-on-disk tradeoff unchanged.

## Propagation follow-up

Once this merges, the six consumer sync PRs (listed above) will be re-synced from the new mergepath main so they carry the corrected scripts. Consumers do not ship their own copies of these findings.

## Test plan

- [ ] CI lint passes.
- [ ] `bash -n` on both scripts clean (verified locally).
- [ ] Env-leak: `OP_PREFLIGHT_REVIEWER_PAT=FAKE <preflight> --agent claude --mode review --skip-ssh` on a warm cache still emits the real cached PAT.
- [ ] Partial-hit: a `--mode all` session file with PATs only no longer triggers a refresh for every invocation.
- [ ] Cache-hit SSH: after a cache hit, subsequent `git push` / `gh` SSH operations do not prompt for auth.
- [ ] Latest-review scope: `count_potential_issues` returns 0 when the latest CodeRabbit review has no findings even if earlier reviews on the same HEAD had findings.