### PR TITLE
fix(preflight): preserve refresh fallback under set -e on stale cache

### DIFF
--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -393,8 +393,19 @@ warm_ssh_keys() {
 
 # ── Fast path: reuse session file when fresh ──────────────────────────
 if ! $REFRESH && session_is_fresh; then
-  cached_exports=$(emit_from_session_file)
-  rc=$?
+  # Use if-condition to capture exit code without tripping `set -e`.
+  # Bare `cached_exports=$(emit_from_session_file); rc=$?` would be
+  # sensitive to errexit — a non-zero exit inside `$(...)` aborts the
+  # outer script before `rc=$?` runs, so the intended refresh-fallback
+  # path below never executes (reproducible: populate a review-only
+  # cache, invoke --mode deploy; old code exits 2 with zero exports,
+  # new code falls through to the full fetch). See the propagation-
+  # round Codex review across all 6 consumer PRs.
+  if cached_exports=$(emit_from_session_file); then
+    rc=0
+  else
+    rc=$?
+  fi
   if [[ "$rc" == "0" ]]; then
     echo "$cached_exports"
     age=$(( $(date +%s) - $(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"") ))


### PR DESCRIPTION
Authoring-Agent: claude

Blocker P1 Codex finding surfaced on all 6 mergepath→consumer sync PRs (device-platform-reporting#51, device-source-of-truth#52, friends-and-family-billing#227, nathanpaynedotcom#250, overridebroadway#30, swipewatch#35). My #144 refactor introduced the regression.

## The bug

#144 moved `emit_from_session_file` into a subshell that `exit 2`s to signal stale/incomplete cache (cross-mode mismatch, missing ADC on `--mode deploy`, etc.). The caller uses:

```bash
cached_exports=$(emit_from_session_file)
rc=$?
```

Under `set -e`, bash treats a non-zero exit inside `$(...)` as a fatal error of the *outer* script, **before** `rc=$?` runs. So a fresh-but-mode-incompatible session file killed preflight with exit 2 and zero exports instead of falling through to the documented refresh path.

Reproducible: populate a review-only cache, invoke `--mode deploy`; old code dies with `exit_code=2` and no exports; new code emits `"Session file stale or incomplete — refreshing"` and reaches the full fetch.

## Fix

Wrap the assignment in an if-condition. A command in an `if` condition does NOT trigger errexit on non-zero:

```bash
if cached_exports=$(emit_from_session_file); then
  rc=0
else
  rc=$?
fi
```

Same two-branch semantics, just errexit-safe.

## Why the test I added in #144 didn't catch this

I tested the happy-path cache hit (rc=0) where errexit is a no-op. The broken path fires only when `emit_from_session_file` intentionally returns non-zero — which my test didn't exercise. Adding a repro to the manual test plan below so next time.

## Self-Review

- **Correctness.** Local repro: `--purge-all` → `--mode review --skip-ssh` (populates review-only cache) → `--mode deploy` (strictly needs ADC) now correctly prints "Session file stale or incomplete — refreshing" and falls through to the full fetch. Pre-fix: exit 2, no exports.
- **Regression risk.** None — the if-condition is the canonical way to capture an errexit-intentional command's rc without aborting. Happy path (rc=0) behavior unchanged.
- **Style.** Inline comment names the propagation-round finding for git-blame context.
- **Test coverage.** Manual repro added to the test plan; adding a bash test harness for preflight state transitions is out of scope here.
- **Security / dependency hygiene.** Pure control-flow fix; no auth or file-system surface touched.

## Propagation follow-up

Once this merges, the six consumer sync PRs get another round-trip re-sync from mergepath main.

## Test plan

- [ ] CI lint passes.
- [ ] `--purge-all` + `--mode review --skip-ssh` populates a review-only cache.
- [ ] Following `--mode deploy` correctly prints "Session file stale or incomplete — refreshing" (instead of exiting 2 with no output).
- [ ] Following `--mode all` on a review-only cache continues to emit PATs + skip ADC via the partial-hit path from #144.