### PR TITLE
fix(coderabbit-wait): wallclock freshness floor for HEAD_ANCHOR

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -109,6 +109,27 @@ coderabbit:
   # rate-limit comment). See nathanjohnpayne/mergepath#138.
   max_rate_limit_retries: 2
 
+  # Wallclock freshness floor for the HEAD_ANCHOR in
+  # `scripts/coderabbit-wait.sh`. Stacked with the `head_ref_force_pushed`
+  # anchor advance — `HEAD_ANCHOR = max(HEAD_COMMITTER_DATE,
+  # latest_force_push, NOW - wallclock_freshness_window_seconds)`.
+  #
+  # Without this floor, an ordinary push of a commit with an old
+  # committer date (cherry-pick, rebase with
+  # `--committer-date-is-author-date`, or rewritten metadata) lets
+  # prior-round CodeRabbit comments pass the `created_at >= HEAD_ANCHOR`
+  # filter and the script can exit cleared/findings without waiting
+  # for a review on the actual current HEAD. The floor bounds that
+  # exposure to this many seconds.
+  #
+  # Mirrors codex-review-request.sh's `reaction_freshness_window_seconds`.
+  # Default 1800s (30min): long enough for a typical Phase 2.5 cycle
+  # (push → CodeRabbit → merge) to complete without forcing extra
+  # waits, short enough that cross-cycle staleness is caught. Raise
+  # for repos where PRs commonly take longer than 30min of wall time
+  # between consecutive CodeRabbit reviews.
+  wallclock_freshness_window_seconds: 1800
+
 # ---------------------------------------------------------------------------
 # Codex (Automated External Review — Phase 4a)
 # ---------------------------------------------------------------------------

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -425,8 +425,9 @@ author_identity: nathanjohnpayne
 coderabbit:
   enabled: false
   bot_login: "coderabbitai[bot]"
-  max_wait_seconds: 300          # grace window for scripts/coderabbit-wait.sh
-  max_rate_limit_retries: 2      # retries after CodeRabbit posts "Rate limit exceeded"
+  max_wait_seconds: 300                    # grace window for scripts/coderabbit-wait.sh
+  max_rate_limit_retries: 2                # retries after CodeRabbit posts "Rate limit exceeded"
+  wallclock_freshness_window_seconds: 1800 # HEAD_ANCHOR floor; closes cherry-pick false-clear
 
 # Codex (Phase 4a automated external review) — see Phase 4a above.
 # Same semantics note as coderabbit: this flag governs agent behavior,

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -167,6 +167,13 @@ if ! [[ "$MAX_RATE_LIMIT_RETRIES" =~ ^[0-9]+$ ]]; then
   exit 3
 fi
 
+WALLCLOCK_FRESHNESS_WINDOW_SECONDS=$(coderabbit_field wallclock_freshness_window_seconds)
+WALLCLOCK_FRESHNESS_WINDOW_SECONDS=${WALLCLOCK_FRESHNESS_WINDOW_SECONDS:-1800}
+if ! [[ "$WALLCLOCK_FRESHNESS_WINDOW_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: coderabbit.wallclock_freshness_window_seconds must be an integer; got '$WALLCLOCK_FRESHNESS_WINDOW_SECONDS'" >&2
+  exit 3
+fi
+
 BOT_LOGIN=$(coderabbit_field bot_login)
 BOT_LOGIN=${BOT_LOGIN:-"coderabbitai[bot]"}
 POLL_INTERVAL_SECONDS=15
@@ -208,15 +215,36 @@ fi
 HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \
   || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
 
-# HEAD freshness anchor. Committer date alone is unreliable — force-push of
-# an older commit, cherry-pick, or rebase with `--committer-date-is-author-date`
-# can produce a HEAD whose committer date predates prior CodeRabbit comments
-# on this PR. Filtering `comments.created_at >= HEAD_COMMITTER_DATE` would
-# then treat stale review-round comments as current and return a false
-# "cleared"/"findings" signal. Mirrors the Layer-1 anchor advance in
-# codex-review-request.sh: advance the anchor past any `head_ref_force_pushed`
-# timeline event. See nathanjohnpayne/mergepath#140 round-2 Codex finding
-# (P1, line 270) for the specific exposure this closes.
+# HEAD freshness anchor. Two stacked guards — committer date alone is
+# unreliable:
+#
+#   Layer 1 (force-push): advance the anchor past any
+#     `head_ref_force_pushed` event on this PR's timeline. Closes the
+#     force-push-with-old-commit false-clear. See #140 round-2 Codex
+#     finding (P1, line 270).
+#
+#   Layer 2 (wallclock floor): max the anchor with NOW - window.
+#     Without this, an ordinary push of a commit with an old committer
+#     date (cherry-pick, rebase with `--committer-date-is-author-date`,
+#     or a commit whose metadata was rewritten) lets CodeRabbit comments
+#     from a prior review round pass the filter and the script exits
+#     cleared/findings without waiting for a real review on the new
+#     HEAD. See #51/#52/#30/#35 round-3 Codex findings ("Anchor
+#     CodeRabbit freshness to push time", "Gate reviews against a
+#     fresh poll anchor", "Tie CodeRabbit freshness to push time",
+#     "Filter CodeRabbit state by current HEAD SHA", "Gate on review
+#     commit rather than comment timestamp").
+#
+# The two layers compose: force-push events get exact timestamps when
+# available, and the wallclock floor bounds residual exposure for the
+# ordinary-push path where the GitHub API does not expose a reliable
+# per-push time for non-force pushes.
+#
+# Mirrors the REACTION_THRESHOLD computation in codex-review-request.sh,
+# which uses `reaction_freshness_window_seconds` as its floor. Here the
+# knob is `coderabbit.wallclock_freshness_window_seconds` (default
+# 1800s / 30min — long enough for a typical Phase 2.5 cycle to land,
+# short enough that cross-cycle staleness is caught).
 HEAD_ANCHOR="$HEAD_COMMITTER_DATE"
 ANCHOR_SOURCE="HEAD committer date"
 TIMELINE_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/timeline" "PR timeline")
@@ -229,9 +257,23 @@ if [ -n "$LATEST_FORCE_PUSH_TIME" ] && [[ "$LATEST_FORCE_PUSH_TIME" > "$HEAD_ANC
   ANCHOR_SOURCE="head_ref_force_pushed @ $LATEST_FORCE_PUSH_TIME"
 fi
 
+# Layer 2 — wallclock freshness floor.
+EPOCH_NOW=$(date +%s)
+EPOCH_FLOOR=$((EPOCH_NOW - WALLCLOCK_FRESHNESS_WINDOW_SECONDS))
+if FLOOR_ISO=$(date -u -r "$EPOCH_FLOOR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null); then
+  :
+else
+  FLOOR_ISO=$(date -u -d "@$EPOCH_FLOOR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+    || die 3 "could not compute wallclock freshness floor from epoch $EPOCH_FLOOR"
+fi
+if [[ "$FLOOR_ISO" > "$HEAD_ANCHOR" ]]; then
+  HEAD_ANCHOR="$FLOOR_ISO"
+  ANCHOR_SOURCE="wallclock floor (NOW - ${WALLCLOCK_FRESHNESS_WINDOW_SECONDS}s)"
+fi
+
 log "HEAD = $HEAD_SHA committed at $HEAD_COMMITTER_DATE"
 log "anchor = $HEAD_ANCHOR (source: $ANCHOR_SOURCE)"
-log "max_wait = ${MAX_WAIT_SECONDS}s   max_rate_limit_retries = $MAX_RATE_LIMIT_RETRIES"
+log "max_wait = ${MAX_WAIT_SECONDS}s   max_rate_limit_retries = $MAX_RATE_LIMIT_RETRIES   freshness_window = ${WALLCLOCK_FRESHNESS_WINDOW_SECONDS}s"
 
 # --- state machine ----------------------------------------------------------
 


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Closes the ordinary-push-of-old-committer-date hole that round-3 Codex flagged across 4 of the 6 propagation PRs ([#51](https://github.com/nathanjohnpayne/device-platform-reporting/pull/51), [#52](https://github.com/nathanjohnpayne/device-source-of-truth/pull/52), [#30](https://github.com/nathanjohnpayne/overridebroadway/pull/30), [#35](https://github.com/nathanjohnpayne/swipewatch/pull/35)) via six different phrasings of the same finding ("Anchor CodeRabbit freshness to current push", "Gate reviews against a fresh poll anchor", "Tie CodeRabbit freshness to push time", "Filter CodeRabbit state by current HEAD SHA", "Gate on review commit rather than comment timestamp", "Anchor CodeRabbit freshness to push time, not committer date").

`HEAD_ANCHOR` now stacks two guards:
- **Layer 1 (force-push):** already shipped — advances past any `head_ref_force_pushed` timeline event.
- **Layer 2 (wallclock floor):** NEW — `HEAD_ANCHOR = max(..., NOW - coderabbit.wallclock_freshness_window_seconds)`.

New knob `coderabbit.wallclock_freshness_window_seconds` (default 1800s / 30min) mirrors `codex-review-request.sh`'s existing `reaction_freshness_window_seconds` pattern.

## Verified

Simulated a committer date of `2025-01-01T00:00:00Z`:
- Anchor correctly floors to `NOW - 1800s`.
- Stale `2025-06-01` CodeRabbit comment → blocked.
- Fresh `NOW - 60s` CodeRabbit comment → passes.

## Why 30min

Long enough that typical Phase 2.5 cycles (push → CodeRabbit ~2-3min → merge) don't run into false timeouts from the floor, short enough that cross-cycle staleness from a prior PR session is caught. Configurable per repo.

## Self-Review

- **Correctness.** Unit-tested inline (see Verified above). The two layers compose: force-push events give exact timestamps when available, floor bounds residual exposure otherwise.
- **Regression risk.** Additive — a PR whose HEAD committer date is recent (the common case) sees no change; the floor only kicks in when committer date is older than `NOW - window`. Callers see no interface change.
- **Style / conventions.** Mirrors the anchor-computation shape in `codex-review-request.sh` almost line-for-line. The config knob follows the existing `coderabbit.*` naming convention.
- **Test coverage.** Manual simulation verified. Adding a bash unit-test harness is out of scope here.
- **Security / dependency hygiene.** No new deps. `date -u -r` / `date -u -d` fallback for macOS vs. GNU date matches the existing pattern in codex-review-request.sh.

## Touches `.github/`

`.github/review-policy.yml` picks up the new `coderabbit.wallclock_freshness_window_seconds` field. That triggers the protected-path rule in `external_review_paths`, so this PR goes through Phase 4.

## Propagation follow-up

Once this merges, the 4 affected consumer PRs get a final resync and the committer-date P1 re-flags should go away. The 5th persistent P1 (swipewatch#35's "Namespace preflight cache to this repository") remains as a rebutted design dispute — that one stays a human tiebreaker call.

## Test plan

- [ ] CI lint passes.
- [ ] `scripts/coderabbit-wait.sh` parses the new knob (dry-run or direct invocation).
- [ ] A PR whose HEAD has a fresh committer date still takes the same path as before (committer date becomes the anchor).
- [ ] A PR whose HEAD has a committer date older than `NOW - window` gets anchored to the wallclock floor.