### PR TITLE
fix(workflows): use PR author login for Dependabot exemptions (#148, #162)

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -92,6 +92,7 @@ jobs:
     needs: [load-config]
     if: >
       github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       (github.event.action == 'opened' || github.event.action == 'ready_for_review')
     runs-on: ubuntu-latest
     outputs:
@@ -168,6 +169,7 @@ jobs:
     if: >
       always() &&
       github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.action == 'labeled')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   self-review-check:
     name: Self-Review Required
-    if: github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check for Self-Review section


### PR DESCRIPTION
Fixes #148 and #162. Same workflow surface, same root cause (`github.actor` vs `github.event.pull_request.user.login`), so bundled.

## What

Two workflow files updated to use the stable PR author login instead of the per-event triggering actor:

- `.github/workflows/pr-review-policy.yml` line 14 (`self-review-check` job): Dependabot exemption now uses `github.event.pull_request.user.login`. Closes #148.
- `.github/workflows/agent-review.yml` `triage` and `assign` jobs: add the same author-login guard so v9 `actions/github-script` doesn't reject the empty `github-token` input on Dependabot PRs (their isolated secrets namespace lacks `REVIEWER_ASSIGNMENT_TOKEN`). Closes #162.

## Why

`github.actor` is the actor that triggered the *current* event, not the PR author. On `pull_request: labeled` / `unlabeled` / `edited` / `synchronize` events the actor is whoever (or whatever bot) caused the re-fire. With the old guards, Dependabot-authored PRs slipped past the actor check on subsequent events and the workflows ran when they shouldn't.

#162 was already fixed downstream in [overridebroadway#42](https://github.com/nathanjohnpayne/overridebroadway/pull/42) (commit `49b405e`); this lands the same fix in the canonical template.

## Verification

After merge, the next Dependabot PR should show:
- `self-review-check`: Skipped (was: ran and failed for missing `## Self-Review`)
- `triage`, `assign`: Skipped (was: failed with "Input required and not supplied: github-token")
- `dependabot-auto-merge.yml`: unchanged behavior — still merges as before.

## Authoring-Agent

Authoring-Agent: claude

## Self-Review

- **Correctness:** `github.event.pull_request.user.login` is the PR author across all `pull_request` event types per [GitHub's webhook payload docs](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request). Verified by reading both workflow files end-to-end; no other site uses `github.actor` for Dependabot gating.
- **Regression risk:** Low. The non-Dependabot path is unchanged. For Dependabot PRs, `self-review-check` correctly skips (it was supposed to before), and `triage`/`assign` skip cleanly instead of failing on empty github-token. `dependabot-auto-merge.yml` is unaffected.
- **Style:** Matches the existing `if:` folded-scalar block formatting in both files.
- **Test coverage:** Workflow guards aren't unit-testable in Mergepath's test surface; verification is observational on the next Dependabot PR after this lands.
- **Security/dependency hygiene:** No dependency changes. No new permissions or secrets exposure — the guarded jobs already had the same permissions; this just changes WHEN they run.

## Propagation

Both fixes need to ship to the 6 downstream consumers (matchline, nathanpaynedotcom, overridebroadway already has #162 only, device-source-of-truth, friends-and-family-billing, device-platform-reporting, swipewatch). #168 tracks building the propagation tool; for now each will need a manual sync PR.
