### PR TITLE
docs: switch CLAUDE.md / REVIEW_POLICY.md to active-account convention (#164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,43 @@ Never push directly to `main`. All changes must go through a pull request.
 Every PR you open must follow this workflow. No exceptions unless the human
 explicitly authorizes a break-glass override in chat.
 
+## Active-account convention
+
+`gh` resolves auth differently for read paths vs write paths:
+
+- **Read paths** (`gh api user`, `gh api ...` GETs, `gh pr view`, `gh pr
+  checks`) honor `GH_TOKEN` correctly. Set the env var per command and
+  the request runs as whichever PAT you supply.
+- **Write paths** that create reviews / comments / PRs / merges /
+  label edits (`gh pr review`, `gh pr create`, `gh pr merge`,
+  `gh pr edit`, `gh api -X POST repos/.../pulls/.../reviews`) use the
+  keyring's **active** account regardless of `GH_TOKEN`. The byline is
+  whoever `gh auth status` shows as `Active: true` when the call lands.
+
+Each agent's working machine has the agent identity as the **active**
+gh account, set once per machine: `gh auth switch -u nathanpayne-claude`
+(substitute your agent identity). Both `nathanjohnpayne` (author) and
+`nathanpayne-<agent>` (reviewer) must already be in the keyring (one-
+time `gh auth login` per identity per machine). With this convention:
+
+- Reviewer-identity writes (`gh pr review --comment` from your agent
+  identity) just work — no `GH_TOKEN` switch, no `gh auth switch`.
+- Author-identity writes (`gh pr create`, `gh pr merge`, `gh pr edit`
+  for label changes) need a temporary switch-around so the byline is
+  the author identity, paired with a switch-back so the active state
+  never lingers wrong:
+
+  ```bash
+  gh auth switch -u nathanjohnpayne && \
+    gh pr merge <PR#> --squash --delete-branch && \
+    gh auth switch -u nathanpayne-claude
+  ```
+
+`git commit` does NOT go through gh auth — it uses the local git
+config (`user.name` / `user.email` set to the human author identity),
+so commits keep attributing to nathanjohnpayne even when the gh
+keyring active is your agent identity. No switch needed for commits.
+
 ## Session start (run once)
 
 0. Run credential preflight to front-load all biometric prompts:
@@ -50,12 +87,13 @@ explicitly authorizes a break-glass override in chat.
 
 ## After opening the PR
 
-4. Switch to your reviewer identity (e.g., nathanpayne-claude).
-   If preflight was run: `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"` (no biometric).
-   Otherwise: `GH_TOKEN="$(op read 'op://Private/<item-id>/token')"`.
-   See REVIEW_POLICY.md § PAT lookup table for your agent's item ID.
-5. Review the PR. Post comments on any issues found.
-6. Switch back to nathanjohnpayne. Address each comment. Push fix commits.
+4. Review the PR under your reviewer identity. With your agent identity
+   active per the convention above, just run:
+   `gh pr review <PR#> --repo owner/repo --comment --body "..."`.
+   The review is correctly attributed to the agent reviewer identity.
+5. Post comments on any issues found.
+6. Address each comment via fix commits (commits use git config, no
+   gh auth involved — byline stays nathanjohnpayne).
 7. Repeat steps 4–6 until the reviewer identity approves.
 7.5. If `.github/review-policy.yml` has `coderabbit.enabled: true`:
      a. Wait for CodeRabbit to post on the current HEAD. Prefer
@@ -134,8 +172,11 @@ explicitly authorizes a break-glass override in chat.
       the merge gate (CI green + internal reviewer approved + Codex
       cleared on current HEAD). The merge gate does NOT require an
       `APPROVED` review state from the Codex bot — the app never emits
-      one. If the gate passes, merge as nathanjohnpayne with
-      `gh pr merge --squash --delete-branch`.
+      one. If the gate passes, merge as nathanjohnpayne with the
+      switch-around per the active-account convention:
+      `gh auth switch -u nathanjohnpayne && \
+       gh pr merge <PR#> --squash --delete-branch && \
+       gh auth switch -u nathanpayne-claude`
 
    **Phase 4b — Manual CLI fallback.** Applies when Phase 4a is
    unavailable (`codex.enabled: false`, either helper script missing,
@@ -150,7 +191,9 @@ explicitly authorizes a break-glass override in chat.
    d. Wait for the external reviewer identity to post an `APPROVED` review.
    e. If the external reviewer flags observations or risks, file the
       post-merge GitHub Issues per step 11 below.
-   f. Merge as nathanjohnpayne.
+   f. Merge as nathanjohnpayne via the switch-around per the
+      active-account convention (`gh auth switch -u nathanjohnpayne &&
+      gh pr merge ... && gh auth switch -u nathanpayne-claude`).
 
 10. Never use `--admin` to merge unless the human explicitly authorizes it
     in chat as a break-glass exception. The hook will block it otherwise.

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -34,9 +34,26 @@ To add a new agent, register a GitHub account following the pattern `nathanpayne
 
 ### Reviewer PAT Quick Start
 
-When posting a PR review as a reviewer identity, always pass a PAT from 1Password
-to `gh` explicitly. Do not rely on the GitHub connector session or on the
-account shown by `gh auth status`.
+`gh` resolves auth differently for read paths vs write paths:
+
+- **Read paths** (`gh api user`, `gh api ...` GETs, `gh pr view`,
+  `gh pr checks`) honor `GH_TOKEN`. Pass it inline per command.
+- **Write paths** (`gh pr review`, `gh pr create`, `gh pr merge`,
+  `gh pr edit`, `gh api -X POST repos/.../pulls/.../reviews`) use the
+  keyring's **active** account regardless of `GH_TOKEN`. The byline is
+  whoever `gh auth status` shows as `Active: true`.
+
+Each agent's working machine has the agent identity as the **active**
+gh account, set once: `gh auth switch -u nathanpayne-<agent>`.
+Reviewer-identity writes then attribute correctly without an env var.
+Author-identity writes (`gh pr create`, `gh pr merge`, `gh pr edit`)
+need a temporary `gh auth switch -u nathanjohnpayne` around them,
+paired with a switch-back. See nathanjohnpayne/mergepath#164 for the
+empirical diagnosis (matchline PRs #181, #182).
+
+PATs are still required for read-path API calls and for the helper
+scripts (`coderabbit-wait.sh`, `codex-review-request.sh`,
+`codex-review-check.sh`) that drive the review pipeline.
 
 #### PAT lookup table
 
@@ -48,24 +65,35 @@ account shown by `gh auth status`.
 | Human | `nathanjohnpayne` | `sm5kopwk6t6p3xmu2igesndzhe` | `op://Private/sm5kopwk6t6p3xmu2igesndzhe/token` |
 
 ```bash
-# Example: verify the Claude reviewer identity before approving a PR
+# Read-path identity check — GH_TOKEN works here.
 GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
   gh api user --jq '.login'
 # expected: nathanpayne-claude
 
-GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
-  gh pr review <PR#> --repo <owner/repo> --approve --body "Review comment"
+# Write-path: with the agent identity active, GH_TOKEN is irrelevant
+# for the byline. Just run the command.
+gh pr review <PR#> --repo <owner/repo> --comment --body "Review comment"
+
+# Author-identity write: switch around the call so the byline is the
+# author identity, then switch back so the active state is correct
+# for subsequent reviewer-identity writes.
+gh auth switch -u nathanjohnpayne && \
+  gh pr create --title "..." --body "..." && \
+  gh auth switch -u nathanpayne-claude
 ```
 
 - Use the item ID from the lookup table above for your agent identity. Do not use the 1Password item title.
-- If `gh auth status` still shows `nathanjohnpayne`, that is okay.
-  `GH_TOKEN=...` overrides the ambient login for that command.
+- `gh auth status` should show your **agent identity** as `Active: true`.
+  If it shows `nathanjohnpayne` instead, reviewer-identity writes will
+  attribute to nathanjohnpayne (not the reviewer). Fix once with
+  `gh auth switch -u nathanpayne-<agent>`. The `op-preflight.sh` script
+  warns when active ≠ expected.
 - If `op whoami` says you are not signed in, still run the `op read ...`
   command in an interactive TTY. That is what triggers the 1Password biometric
   prompt on local machines.
-- If GitHub returns `Review Can not approve your own pull request`, the wrong
-  reviewer identity is still being used. Check the lookup table and verify you
-  are using your agent's item ID, not the author identity's.
+- If GitHub returns `Review Can not approve your own pull request`, you are
+  the active account on a PR you authored. Switch to a different agent's
+  reviewer identity (or skip self-approve per the no-self-approve rule).
 
 ## Workflow
 

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -305,14 +305,26 @@ log_stale_adc_guidance() {
 # diagnosis (matchline PRs #181, #182 — wrong-byline reviews when active
 # was nathanjohnpayne instead of the agent identity).
 warn_active_account_mismatch() {
-  local expected="nathanpayne-${AGENT}"
+  # Skip silently when no agent is selected (e.g. deploy-only runs that
+  # don't need a reviewer identity). The check only makes sense when
+  # we know which agent identity SHOULD be active. Codex P2 on PR #171.
+  [[ -z "$AGENT" ]] && return 0
   command -v gh >/dev/null 2>&1 || return 0
-  local actual
-  actual=$(gh auth status 2>/dev/null | awk '
+  local expected="nathanpayne-${AGENT}"
+  local actual=""
+  # Capture in a way that cannot abort the parent script under
+  # `set -eo pipefail` if `gh auth status` fails (no login, network
+  # blip) or if the awk pipeline returns no match. Codex P1 on PR
+  # #171: bare `actual=$(... | awk ... | head -1)` propagates the
+  # failure and terminates the whole script. Wrap in a subshell with
+  # pipefail disabled and `|| true` to neutralize both failure modes.
+  actual=$( ( set +o pipefail; gh auth status 2>/dev/null | awk '
     /Active account: true/ {found=1; next}
     /account / && found { print $NF; found=0; exit }
-  ' | head -1)
-  [[ -z "$actual" ]] && actual=$(gh api user --jq .login 2>/dev/null || echo "")
+  ' | head -1 ) || true )
+  if [[ -z "$actual" ]]; then
+    actual=$(gh api user --jq .login 2>/dev/null || true)
+  fi
   if [[ -n "$actual" ]] && [[ "$actual" != "$expected" ]]; then
     echo "# WARNING: gh active account is '$actual' (expected '$expected')." >&2
     echo "#   Reviewer-identity writes (gh pr review) will mis-attribute." >&2

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -295,6 +295,32 @@ log_stale_adc_guidance() {
 # incomplete codex session file look valid and causing gh to run as
 # the wrong identity. See round-5 Codex finding on the propagation
 # PRs for the multi-agent repro.
+# Active-account check (warn-only). gh's write paths use the keyring's
+# active account regardless of GH_TOKEN. Each agent's machine should
+# have its agent identity (nathanpayne-<agent>) as the active gh
+# account so reviewer-identity writes (gh pr review --comment) attribute
+# correctly without a switch. Author-identity writes (gh pr create /
+# merge / edit) still need a temporary `gh auth switch -u nathanjohnpayne`
+# around them. See nathanjohnpayne/mergepath#164 for the empirical
+# diagnosis (matchline PRs #181, #182 — wrong-byline reviews when active
+# was nathanjohnpayne instead of the agent identity).
+warn_active_account_mismatch() {
+  local expected="nathanpayne-${AGENT}"
+  command -v gh >/dev/null 2>&1 || return 0
+  local actual
+  actual=$(gh auth status 2>/dev/null | awk '
+    /Active account: true/ {found=1; next}
+    /account / && found { print $NF; found=0; exit }
+  ' | head -1)
+  [[ -z "$actual" ]] && actual=$(gh api user --jq .login 2>/dev/null || echo "")
+  if [[ -n "$actual" ]] && [[ "$actual" != "$expected" ]]; then
+    echo "# WARNING: gh active account is '$actual' (expected '$expected')." >&2
+    echo "#   Reviewer-identity writes (gh pr review) will mis-attribute." >&2
+    echo "#   Fix once: gh auth switch -u $expected" >&2
+    echo "#   See CLAUDE.md § Active-account convention for the full pattern." >&2
+  fi
+}
+
 emit_from_session_file() (
   # Subshell: the (  ... ) above means unset/source/return here do
   # not escape back to the caller. We still "return" rc codes via
@@ -427,6 +453,7 @@ if ! $REFRESH && session_is_fresh; then
       echo "#   $line" >&2
     done
     echo "# Run with --refresh to force a new biometric fetch." >&2
+    warn_active_account_mismatch
     echo "# ──────────────────────────────────────────────────────────" >&2
     exit 0
   fi
@@ -553,5 +580,6 @@ for line in "${SUMMARY[@]}"; do
 done
 echo "# Session file: $SESSION_FILE (TTL ${TTL_SECONDS}s)" >&2
 echo "# OP_PREFLIGHT_DONE=1" >&2
+warn_active_account_mismatch
 echo "# Human can step away." >&2
 echo "# ──────────────────────────────────────────────────────" >&2


### PR DESCRIPTION
Closes #164.

## What

Three changes to bring the template into alignment with the active-account convention:

1. **`CLAUDE.md`** — new "Active-account convention" section explaining the gh CLI read/write auth split. Rewrite "After opening the PR" steps 4–6 to drop the bogus `GH_TOKEN=$OP_PREFLIGHT_REVIEWER_PAT` switch-via-env. Update Phase 4a step 9.f and Phase 4b step f to use the switch-around for author-identity merges.
2. **`REVIEW_POLICY.md` § Reviewer PAT Quick Start** — clarify the read/write split. Reframe PATs as "still required for read-path API calls and helper scripts." Replace the misleading "if `gh auth status` still shows `nathanjohnpayne`, that is okay" line.
3. **`scripts/op-preflight.sh`** — warn-only check at the end of both full-fetch and cache-hit paths. If `gh auth status`'s active account doesn't match `nathanpayne-<agent>`, print a one-line fix recipe and a pointer to the CLAUDE.md section.

## Why

`GH_TOKEN` only overrides ambient gh auth on **read** paths. Write paths (`gh pr review`, `gh pr create`, `gh pr merge`, `gh pr edit`) use the keyring's active account regardless of `GH_TOKEN`. The previous template instruction silently fails on write paths whenever the keyring active is something other than the expected reviewer identity.

Verified empirically:
- matchline PRs #181/#182 — `gh api user` returned `nathanpayne-claude` (read path honored `GH_TOKEN`) while a paired `gh pr review` posted under `nathanjohnpayne` (write path used active keyring).
- This repo PR #169 (the parent branch of this PR's session) — needed the switch-around to merge as nathanjohnpayne even though preflight had exported `OP_PREFLIGHT_AUTHOR_PAT` into env.

## Verification

- `bash -n` syntax check passes on `scripts/op-preflight.sh`.
- Warn function smoke-tested with both matching (claude active, expected = claude → quiet) and mismatching (claude active, expected = codex → warns with fix recipe) inputs.
- Doc edits read end-to-end coherent; no dangling references to the old `GH_TOKEN`-as-write-switch pattern in the touched files. (Other places in the repo that mention `GH_TOKEN` reference helper scripts that consume it on read paths only — not in scope.)

## Authoring-Agent

Authoring-Agent: claude

## Self-Review

- **Correctness:** the read/write auth split is documented in [gh's environment manual](https://cli.github.com/manual/gh_help_environment) under `GH_TOKEN`, and reproduced empirically on the citations above. The convention matches `~/GitHub/CLAUDE.md` (machine-level); this PR brings the repo template into alignment.
- **Regression risk:** doc-only for CLAUDE.md / REVIEW_POLICY.md. The preflight change is warn-only and non-fatal. The active-account check uses `gh auth status` parsing with an `awk` extractor that handles both the table and per-account formats; falls back to `gh api user --jq .login` if parsing fails. Either fallback returning empty → no warn fires. No path that previously printed nothing now fails.
- **Style:** matches existing comment-block conventions in `op-preflight.sh` (banner, history reference, why-not). New `## Active-account convention` section in `CLAUDE.md` mirrors the section-header rhythm of the file.
- **Test coverage:** warn function smoke-tested with both matching and mismatching inputs.
- **Security/dependency hygiene:** no new dependencies, no new env vars exposed, no new permissions. The preflight check reads `gh auth status` (already required for any preflight callsite) and falls back to `gh api user`, both read-only.

## Propagation

After merge, propagate to the 6 downstream consumers (matchline, nathanpaynedotcom, overridebroadway, device-source-of-truth, friends-and-family-billing, device-platform-reporting, swipewatch). The doc convention should land everywhere; the `op-preflight.sh` warning is canonical and propagates automatically. #168 tracks the propagation tool.
