### PR TITLE
feat: label-removal hook + helper, thread-resolution helper, doctrine (#165, #166)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/hooks/gh-pr-guard.sh\"",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/hooks/label-removal-guard.sh\"",
+            "timeout": 10
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,31 @@ explicitly authorizes a break-glass override in chat.
      e. Fix real issues; dismiss false positives with a brief reply.
      CodeRabbit is advisory and does not block merge.
 
+7.6. Resolve all open review threads on the current HEAD:
+
+     ```bash
+     scripts/resolve-pr-threads.sh <PR#>                       # list unresolved
+     scripts/resolve-pr-threads.sh <PR#> --auto-resolve-bots   # resolve bots
+     ```
+
+     Branch protection on `main` typically requires
+     `required_conversation_resolution: true`, which means **every
+     review thread must be resolved before merge** — including
+     CodeRabbit `🧹 Nitpick` / `🔵 Trivial` comments that don't block
+     merge in CodeRabbit's own model. Without this step,
+     `mergeStateStatus` stays `BLOCKED` even when all required CI
+     checks are green and Codex has cleared. The blocker is invisible
+     in `gh pr checks` output — only the GitHub UI surfaces it.
+
+     For each unresolved bot-authored thread where you have already
+     addressed the finding (fix on this HEAD, or rebuttal posted),
+     `--auto-resolve-bots` clears it via the GraphQL
+     `resolveReviewThread` mutation. Per
+     `REVIEW_POLICY.md § Implementation notes for branch protection
+     gates`, this is a clean-up mechanism, NOT a policy override —
+     human-authored threads must be resolved via the GitHub UI or by
+     asking the human; the helper refuses to touch them.
+
 ## Before merging
 
 8. Check `.github/review-policy.yml` for the external review threshold.
@@ -154,6 +179,20 @@ explicitly authorizes a break-glass override in chat.
 
 10. Never use `--admin` to merge unless the human explicitly authorizes it
     in chat as a break-glass exception. The hook will block it otherwise.
+
+10.5. Before merging, verify `mergeStateStatus === "CLEAN"` (not
+     `BLOCKED` or `UNSTABLE`). `BLOCKED` with an empty
+     `gh pr checks` failure list almost always means an unresolved
+     review thread — re-run step 7.6.
+
+10.6. Never use `gh pr edit ... --remove-label` (or `--add-label`) for
+     `needs-external-review`, `needs-human-review`, or
+     `policy-violation`. These are human-action labels; the
+     `scripts/hooks/label-removal-guard.sh` PreToolUse hook blocks
+     such calls regardless of chat authorization. To request removal,
+     run: `scripts/request-label-removal.sh <PR#> <label>` — the
+     human clears it from any device and auto-merge fires
+     immediately. See REVIEW_POLICY.md § Agent prohibitions.
 
 ## After merging
 

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -380,6 +380,19 @@ The human resolves by one of:
 
 The agent never resolves a fired escalation signal on its own.
 
+## Agent prohibitions
+
+Agents must never modify the `needs-external-review`, `needs-human-review`, or `policy-violation` labels on any PR — these are human-action labels. The `scripts/hooks/label-removal-guard.sh` PreToolUse hook enforces this at the mechanism layer; chat authorization does not bypass it. To request a label removal, run `scripts/request-label-removal.sh <PR#> <label>` — this posts a structured ask on the PR and (if `MERGEPATH_NOTIFY_IMESSAGE_TO` is set) pings the human via iMessage. The human clears the label from any device; auto-merge fires immediately.
+
+## Implementation notes for branch protection gates
+
+The GitHub GraphQL `resolveReviewThread` mutation may be used by agents **only** when both:
+
+- The agent has demonstrably addressed the inline finding (a fix is on the current HEAD, or a rebuttal is posted on the thread), AND
+- The bot author of the thread has not auto-resolved within a reasonable window.
+
+It is a clean-up mechanism for the `required_conversation_resolution: true` branch-protection gate, NOT a policy override. It does not authorize removing blocking labels, bypassing required reviews, or merging past unaddressed findings. **If the thread author is a human (not a bot), agents must not call this mutation regardless of state.**
+
 ## Review Policy Configuration
 
 Each repository contains a `.github/review-policy.yml` file that governs review behavior. This file is read by the agent at the start of every review cycle.

--- a/scripts/hooks/label-removal-guard.sh
+++ b/scripts/hooks/label-removal-guard.sh
@@ -40,6 +40,8 @@ set -eo pipefail
 # use that; otherwise treat stdin as the raw command.
 INPUT=$(cat)
 COMMAND=""
+TMP_CMD=$(mktemp)
+trap 'rm -f "$TMP_CMD" "${TMP_TOKENS:-}"' EXIT
 if echo "$INPUT" | python3 -c '
 import sys, json
 try:
@@ -48,9 +50,8 @@ try:
     sys.stdout.write(cmd)
 except Exception:
     sys.exit(1)
-' > /tmp/lrg-cmd.$$ 2>/dev/null; then
-  COMMAND=$(cat /tmp/lrg-cmd.$$)
-  rm -f /tmp/lrg-cmd.$$
+' > "$TMP_CMD" 2>/dev/null; then
+  COMMAND=$(cat "$TMP_CMD")
 else
   COMMAND="$INPUT"
 fi
@@ -70,7 +71,7 @@ case "$COMMAND" in
 esac
 
 TMP_TOKENS=$(mktemp)
-trap 'rm -f "$TMP_TOKENS"' EXIT
+trap 'rm -f "$TMP_CMD" "$TMP_TOKENS"' EXIT
 if ! printf '%s' "$COMMAND" | python3 -c '
 import sys, shlex
 try:

--- a/scripts/hooks/label-removal-guard.sh
+++ b/scripts/hooks/label-removal-guard.sh
@@ -59,12 +59,19 @@ fi
 # Empty command → allow (nothing to gate).
 if [ -z "$COMMAND" ]; then exit 0; fi
 
-# Cheap pre-check: if the command doesn't mention any prohibited label,
-# skip the tokenize work entirely.
-case "$COMMAND" in
-  *needs-external-review*|*needs-human-review*|*policy-violation*) ;;
-  *) exit 0 ;;
-esac
+# Cheap pre-check: if the command isn't `gh pr edit`, skip the tokenize
+# work entirely. We deliberately do NOT pre-check for the prohibited
+# label name as a substring — Codex P1 on PR #172 caught that the
+# substring gate is bypassable when the label value is supplied via
+# shell expansion (`--remove-label "$VAR"`) or ANSI-C quoting
+# (`--remove-label $'needs-human-review'`). The token-walk below sees
+# the EXPANDED value (because the harness passes the literal command
+# string the agent intends to run) — which means the post-tokenize
+# regex check is the source of truth, and any pre-check on label name
+# would either let bypasses through (bug) or false-positive on
+# unrelated commands. The `gh pr edit` form check is structural (the
+# binary name + subcommand must be literal for the command to do
+# anything), so it remains safe.
 case "$COMMAND" in
   *gh*pr*edit*|*gh*-R*pr*edit*|*gh*--repo*pr*edit*) ;;
   *) exit 0 ;;
@@ -114,21 +121,31 @@ for i in "${!TOKENS[@]}"; do
 done
 [ "$saw_edit" -eq 1 ] || exit 0
 
-# Scan tokens AFTER `edit` for --remove-label or --add-label values that
-# match the prohibited set. Both forms are blocked: removing a label
-# bypasses human gating; adding one (e.g. spuriously re-applying
-# policy-violation) is also a human action.
+# Scan tokens AFTER `edit` for --remove-label or --add-label values.
+# Both forms are blocked: removing a label bypasses human gating;
+# adding one (e.g. spuriously re-applying policy-violation) is also a
+# human action.
+#
+# Two block triggers:
+#   1. Literal value matches the prohibited set.
+#   2. Value undergoes shell expansion (contains $, backtick, or starts
+#      with $') — Codex P1 on PR #172. The hook receives the literal
+#      command string before bash expands variables, so a value like
+#      `--remove-label "$VAR"` would tokenize as the literal `$VAR`
+#      and slip past a value-only regex check, even though the bash
+#      that actually runs the command would expand it to a prohibited
+#      label. Block any expansion-bearing value with a message
+#      directing the agent to use a literal label name (so the hook
+#      can see what's being modified) or scripts/request-label-removal.sh.
 PROHIBITED_RE='^(needs-external-review|needs-human-review|policy-violation)$'
+EXPANSION_RE='[$`]'
 walk_start=$((edit_index + 1))
 SKIP_AS=""  # "" | "label-flag-value"
-for j in "${!TOKENS[@]}"; do
-  if [ "$j" -lt "$walk_start" ]; then continue; fi
-  tok="${TOKENS[$j]}"
-  if [ "$SKIP_AS" = "label-flag-value" ]; then
-    SKIP_AS=""
-    if [[ "$tok" =~ $PROHIBITED_RE ]]; then
-      cat <<EOF >&2
-BLOCKED: agents must not modify the '$tok' label on PRs.
+
+block_prohibited() {
+  local label="$1"
+  cat <<EOF >&2
+BLOCKED: agents must not modify the '$label' label on PRs.
 
 Per REVIEW_POLICY.md § Agent prohibitions, the labels:
   - needs-external-review
@@ -138,14 +155,40 @@ are HUMAN-ACTION labels. One-time chat authorization does not extend to
 agent action on these labels.
 
 If the PR is otherwise green and only this label is blocking merge:
-  scripts/request-label-removal.sh <PR#> $tok
+  scripts/request-label-removal.sh <PR#> $label
 
 That helper posts a templated ask on the PR (and optionally iMessages
 the human). The human clears the label from any device; auto-merge
 fires immediately.
 EOF
-      exit 2
-    fi
+  exit 2
+}
+
+block_expansion() {
+  local val="$1"
+  cat <<EOF >&2
+BLOCKED: --add-label / --remove-label value '$val' contains shell
+expansion (\$, backtick, or \$'…' quoting). The hook can't see what
+this expands to until bash runs the command — so it cannot verify the
+label isn't one of the prohibited set (needs-external-review,
+needs-human-review, policy-violation).
+
+Use a literal label name so the guard can verify it, OR — if you
+intended to remove a prohibited label — run:
+  scripts/request-label-removal.sh <PR#> <label>
+
+See REVIEW_POLICY.md § Agent prohibitions.
+EOF
+  exit 2
+}
+
+for j in "${!TOKENS[@]}"; do
+  if [ "$j" -lt "$walk_start" ]; then continue; fi
+  tok="${TOKENS[$j]}"
+  if [ "$SKIP_AS" = "label-flag-value" ]; then
+    SKIP_AS=""
+    if [[ "$tok" =~ $PROHIBITED_RE ]]; then block_prohibited "$tok"; fi
+    if [[ "$tok" =~ $EXPANSION_RE ]]; then block_expansion "$tok"; fi
     continue
   fi
   case "$tok" in
@@ -155,15 +198,8 @@ EOF
       ;;
     --remove-label=*|--add-label=*)
       val="${tok#*=}"
-      if [[ "$val" =~ $PROHIBITED_RE ]]; then
-        cat <<EOF >&2
-BLOCKED: agents must not modify the '$val' label on PRs.
-
-Use: scripts/request-label-removal.sh <PR#> $val
-See REVIEW_POLICY.md § Agent prohibitions.
-EOF
-        exit 2
-      fi
+      if [[ "$val" =~ $PROHIBITED_RE ]]; then block_prohibited "$val"; fi
+      if [[ "$val" =~ $EXPANSION_RE ]]; then block_expansion "$val"; fi
       continue
       ;;
   esac

--- a/scripts/hooks/label-removal-guard.sh
+++ b/scripts/hooks/label-removal-guard.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# label-removal-guard.sh — PreToolUse hook for Claude Code.
+#
+# Blocks `gh pr edit ... --remove-label <label>` calls (and the
+# add-label inverse for the same labels) for the human-action labels
+# defined in REVIEW_POLICY.md § Agent prohibitions:
+#
+#   - needs-external-review
+#   - needs-human-review
+#   - policy-violation
+#
+# Rationale: agents must never remove these labels, even when a human
+# authorizes it in chat. One-time chat authorization does not extrapolate
+# into standing permission. The sanctioned path is
+# `scripts/request-label-removal.sh <PR#> <label>`, which posts a
+# templated ask + optional iMessage ping, after which the human clears
+# the label from any device.
+#
+# This hook is mechanism enforcement — it makes the doctrinal rule
+# unbreakable regardless of whether the agent read the policy doc.
+#
+# Architecture: same shape as scripts/hooks/gh-pr-guard.sh — read the
+# Bash command from stdin (Claude Code passes JSON via stdin to
+# PreToolUse hooks), tokenize with shlex (quote-aware), walk to find
+# `gh ... pr edit`, then scan the edit subcommand's flags for
+# --remove-label / --add-label whose value matches the prohibited set.
+#
+# A break-glass override is intentionally NOT provided. If a human
+# genuinely needs the agent to act on the label, they remove it
+# themselves; the agent can re-trigger merge after.
+#
+# Exit codes:
+#   0 = allow
+#   2 = block (hard stop)
+
+set -eo pipefail
+
+# Read stdin payload (Claude Code passes JSON; older harness passes raw
+# command). Be permissive: if stdin parses as JSON with .tool_input.command,
+# use that; otherwise treat stdin as the raw command.
+INPUT=$(cat)
+COMMAND=""
+if echo "$INPUT" | python3 -c '
+import sys, json
+try:
+    d = json.loads(sys.stdin.read())
+    cmd = d.get("tool_input", {}).get("command", "")
+    sys.stdout.write(cmd)
+except Exception:
+    sys.exit(1)
+' > /tmp/lrg-cmd.$$ 2>/dev/null; then
+  COMMAND=$(cat /tmp/lrg-cmd.$$)
+  rm -f /tmp/lrg-cmd.$$
+else
+  COMMAND="$INPUT"
+fi
+
+# Empty command → allow (nothing to gate).
+if [ -z "$COMMAND" ]; then exit 0; fi
+
+# Cheap pre-check: if the command doesn't mention any prohibited label,
+# skip the tokenize work entirely.
+case "$COMMAND" in
+  *needs-external-review*|*needs-human-review*|*policy-violation*) ;;
+  *) exit 0 ;;
+esac
+case "$COMMAND" in
+  *gh*pr*edit*|*gh*-R*pr*edit*|*gh*--repo*pr*edit*) ;;
+  *) exit 0 ;;
+esac
+
+TMP_TOKENS=$(mktemp)
+trap 'rm -f "$TMP_TOKENS"' EXIT
+if ! printf '%s' "$COMMAND" | python3 -c '
+import sys, shlex
+try:
+    for tok in shlex.split(sys.stdin.read()):
+        sys.stdout.buffer.write(tok.encode("utf-8", errors="replace") + b"\x00")
+except ValueError:
+    sys.exit(1)
+' > "$TMP_TOKENS" 2>/dev/null; then
+  exit 0
+fi
+
+TOKENS=()
+while IFS= read -r -d '' tok; do TOKENS+=("$tok"); done < "$TMP_TOKENS"
+
+# Walk to find `gh ... pr edit`. We only need to know IF the command is
+# `gh pr edit`; we don't need the full state machine that gh-pr-guard.sh
+# uses for its merge-gate logic. A simple scan suffices because the
+# label-value scan below operates on the entire token list anyway.
+saw_gh=0
+saw_pr=0
+saw_edit=0
+edit_index=-1
+for i in "${!TOKENS[@]}"; do
+  tok="${TOKENS[$i]}"
+  if [ "$saw_gh" -eq 0 ]; then
+    [ "$tok" = "gh" ] && saw_gh=1
+    continue
+  fi
+  if [ "$saw_pr" -eq 0 ]; then
+    if [ "$tok" = "pr" ]; then saw_pr=1; fi
+    continue
+  fi
+  if [ "$saw_edit" -eq 0 ]; then
+    if [ "$tok" = "edit" ]; then
+      saw_edit=1
+      edit_index=$i
+    fi
+    continue
+  fi
+done
+[ "$saw_edit" -eq 1 ] || exit 0
+
+# Scan tokens AFTER `edit` for --remove-label or --add-label values that
+# match the prohibited set. Both forms are blocked: removing a label
+# bypasses human gating; adding one (e.g. spuriously re-applying
+# policy-violation) is also a human action.
+PROHIBITED_RE='^(needs-external-review|needs-human-review|policy-violation)$'
+walk_start=$((edit_index + 1))
+SKIP_AS=""  # "" | "label-flag-value"
+for j in "${!TOKENS[@]}"; do
+  if [ "$j" -lt "$walk_start" ]; then continue; fi
+  tok="${TOKENS[$j]}"
+  if [ "$SKIP_AS" = "label-flag-value" ]; then
+    SKIP_AS=""
+    if [[ "$tok" =~ $PROHIBITED_RE ]]; then
+      cat <<EOF >&2
+BLOCKED: agents must not modify the '$tok' label on PRs.
+
+Per REVIEW_POLICY.md § Agent prohibitions, the labels:
+  - needs-external-review
+  - needs-human-review
+  - policy-violation
+are HUMAN-ACTION labels. One-time chat authorization does not extend to
+agent action on these labels.
+
+If the PR is otherwise green and only this label is blocking merge:
+  scripts/request-label-removal.sh <PR#> $tok
+
+That helper posts a templated ask on the PR (and optionally iMessages
+the human). The human clears the label from any device; auto-merge
+fires immediately.
+EOF
+      exit 2
+    fi
+    continue
+  fi
+  case "$tok" in
+    --remove-label|--add-label)
+      SKIP_AS="label-flag-value"
+      continue
+      ;;
+    --remove-label=*|--add-label=*)
+      val="${tok#*=}"
+      if [[ "$val" =~ $PROHIBITED_RE ]]; then
+        cat <<EOF >&2
+BLOCKED: agents must not modify the '$val' label on PRs.
+
+Use: scripts/request-label-removal.sh <PR#> $val
+See REVIEW_POLICY.md § Agent prohibitions.
+EOF
+        exit 2
+      fi
+      continue
+      ;;
+  esac
+done
+
+exit 0

--- a/scripts/hooks/label-removal-guard.sh
+++ b/scripts/hooks/label-removal-guard.sh
@@ -142,6 +142,23 @@ EXPANSION_RE='[$`]'
 walk_start=$((edit_index + 1))
 SKIP_AS=""  # "" | "label-flag-value"
 
+# Codex r1 on PR #172 caught: gh accepts `--remove-label A,B` as a
+# comma-separated list, but the regex above only matches the entire
+# token. So `--remove-label needs-external-review,foo` would slip
+# past — the joined value doesn't match `^needs-external-review$`,
+# but bash splits and removes both labels. Check each comma-split
+# segment instead of the whole value.
+check_label_value() {
+  local raw="$1"
+  if [[ "$raw" =~ $EXPANSION_RE ]]; then block_expansion "$raw"; fi
+  local IFS=','
+  for sub in $raw; do
+    sub="${sub# }"; sub="${sub% }"   # trim incidental whitespace
+    [[ -z "$sub" ]] && continue
+    if [[ "$sub" =~ $PROHIBITED_RE ]]; then block_prohibited "$sub"; fi
+  done
+}
+
 block_prohibited() {
   local label="$1"
   cat <<EOF >&2
@@ -187,8 +204,7 @@ for j in "${!TOKENS[@]}"; do
   tok="${TOKENS[$j]}"
   if [ "$SKIP_AS" = "label-flag-value" ]; then
     SKIP_AS=""
-    if [[ "$tok" =~ $PROHIBITED_RE ]]; then block_prohibited "$tok"; fi
-    if [[ "$tok" =~ $EXPANSION_RE ]]; then block_expansion "$tok"; fi
+    check_label_value "$tok"
     continue
   fi
   case "$tok" in
@@ -197,9 +213,7 @@ for j in "${!TOKENS[@]}"; do
       continue
       ;;
     --remove-label=*|--add-label=*)
-      val="${tok#*=}"
-      if [[ "$val" =~ $PROHIBITED_RE ]]; then block_prohibited "$val"; fi
-      if [[ "$val" =~ $EXPANSION_RE ]]; then block_expansion "$val"; fi
+      check_label_value "${tok#*=}"
       continue
       ;;
   esac

--- a/scripts/request-label-removal.sh
+++ b/scripts/request-label-removal.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# request-label-removal.sh — post a structured label-removal ask on a PR.
+#
+# Background: REVIEW_POLICY.md prohibits agents from removing the
+# `needs-external-review`, `needs-human-review`, and `policy-violation`
+# labels — even when authorized in chat. Label removal is a human action.
+# This helper turns the prohibition into a one-command ask: the agent
+# posts a templated PR comment and (optionally) pings the human via
+# iMessage so they can clear the label without opening a chat window.
+#
+# Usage:
+#   scripts/request-label-removal.sh <PR#> <label>
+#   scripts/request-label-removal.sh <PR#> <label> --reason "<short reason>"
+#   scripts/request-label-removal.sh <PR#> <label> --repo owner/name
+#
+# Notification: if MERGEPATH_NOTIFY_IMESSAGE_TO is set to a phone number
+# or contact name resolvable by Messages.app, this script also fires an
+# iMessage with the PR URL. Otherwise it skips silently.
+#
+# Examples:
+#   scripts/request-label-removal.sh 182 needs-external-review
+#   scripts/request-label-removal.sh 182 needs-human-review \
+#     --reason "Codex cleared r3; CI green; only blocker is this label"
+#   MERGEPATH_NOTIFY_IMESSAGE_TO="+15551234567" \
+#     scripts/request-label-removal.sh 182 needs-external-review
+#
+# Exit codes:
+#   0 = comment posted (and iMessage sent if configured)
+#   1 = bad arguments / unsupported label
+#   2 = gh failure (auth, missing PR, network)
+
+set -eo pipefail
+
+ALLOWED_LABELS=(needs-external-review needs-human-review policy-violation)
+
+usage() {
+  cat <<'EOF' >&2
+Usage: scripts/request-label-removal.sh <PR#> <label> [--reason <text>] [--repo owner/name]
+
+Allowed labels: needs-external-review | needs-human-review | policy-violation
+
+Posts a templated PR comment asking the human to remove the label.
+Sends an iMessage to MERGEPATH_NOTIFY_IMESSAGE_TO if set.
+EOF
+  exit 1
+}
+
+PR_NUM=""
+LABEL=""
+REASON=""
+REPO=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --reason) REASON="$2"; shift 2 ;;
+    --repo)   REPO="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    -*) echo "Unknown flag: $1" >&2; usage ;;
+    *)
+      if [ -z "$PR_NUM" ]; then PR_NUM="$1"
+      elif [ -z "$LABEL" ]; then LABEL="$1"
+      else echo "Unexpected positional: $1" >&2; usage
+      fi
+      shift
+      ;;
+  esac
+done
+
+[ -z "$PR_NUM" ] && usage
+[ -z "$LABEL" ] && usage
+
+allowed=0
+for ok in "${ALLOWED_LABELS[@]}"; do
+  if [ "$LABEL" = "$ok" ]; then allowed=1; break; fi
+done
+if [ "$allowed" -ne 1 ]; then
+  echo "Refusing: '$LABEL' is not a human-action label." >&2
+  echo "Allowed: ${ALLOWED_LABELS[*]}" >&2
+  echo "If this label is genuinely a no-op blocker, just remove it directly." >&2
+  exit 1
+fi
+
+REPO_FLAG=()
+if [ -n "$REPO" ]; then REPO_FLAG=(--repo "$REPO"); fi
+
+PR_URL=$(gh pr view "$PR_NUM" "${REPO_FLAG[@]}" --json url --jq .url 2>/dev/null) || {
+  echo "Could not resolve PR #$PR_NUM. Check --repo and gh auth." >&2
+  exit 2
+}
+
+REASON_BLOCK=""
+if [ -n "$REASON" ]; then
+  REASON_BLOCK=$'\n\n**Context:** '"$REASON"
+fi
+
+BODY="@nathanjohnpayne — this PR is blocked only on the \`$LABEL\` label.
+
+Per [REVIEW_POLICY.md § Agent prohibitions](https://github.com/nathanjohnpayne/mergepath/blob/main/REVIEW_POLICY.md), agents do not remove this label. When you're ready, clear it from any device:
+
+- GitHub UI: Labels sidebar → click \`x\` on \`$LABEL\`
+- CLI: \`gh pr edit $PR_NUM --remove-label $LABEL\` $([ -n "$REPO" ] && echo "--repo $REPO")
+
+Auto-merge will fire as soon as the label is gone.${REASON_BLOCK}
+
+— posted by \`scripts/request-label-removal.sh\`"
+
+if ! gh pr comment "$PR_NUM" "${REPO_FLAG[@]}" --body "$BODY" >/dev/null; then
+  echo "Failed to post comment on PR #$PR_NUM" >&2
+  exit 2
+fi
+echo "Posted label-removal request on $PR_URL"
+
+if [ -n "${MERGEPATH_NOTIFY_IMESSAGE_TO:-}" ]; then
+  IMSG_BODY="Mergepath: PR #$PR_NUM blocked on '$LABEL' label. Clear when ready: $PR_URL"
+  IMSG_BODY_ESC=${IMSG_BODY//\"/\\\"}
+  TARGET_ESC=${MERGEPATH_NOTIFY_IMESSAGE_TO//\"/\\\"}
+  if osascript -e "tell application \"Messages\" to send \"$IMSG_BODY_ESC\" to buddy \"$TARGET_ESC\" of (service 1 whose service type is iMessage)" >/dev/null 2>&1; then
+    echo "Notified $MERGEPATH_NOTIFY_IMESSAGE_TO via iMessage"
+  else
+    echo "iMessage notify failed (non-fatal); comment is the source of truth" >&2
+  fi
+fi

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -72,7 +72,16 @@ BOT_LOGINS_RE='^(coderabbitai\[bot\]|chatgpt-codex-connector\[bot\]|dependabot\[
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --repo) REPO="$2"; shift 2 ;;
+    --repo)
+      # Codex r2 on PR #172: bare `shift 2` silently consumed nothing
+      # when --repo was the last arg, leaving REPO empty and falling
+      # through to gh-repo-view auto-detect. Validate the value is
+      # present and non-empty so the user gets a clear error instead.
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        echo "Error: --repo requires a non-empty value (owner/name)" >&2
+        usage
+      fi
+      REPO="$2"; shift 2 ;;
     --list) MODE="list"; shift ;;
     --auto-resolve-bots) MODE="auto-resolve-bots"; shift ;;
     --dry-run) DRY_RUN=true; shift ;;
@@ -212,6 +221,7 @@ fi
 RESOLVED_COUNT=0
 SKIPPED_HUMAN=0
 SKIPPED_STALE=0
+WOULD_RESOLVE_COUNT=0
 FAILED_COUNT=0
 while IFS= read -r thread; do
   AUTHOR=$(echo "$thread" | jq -r .author)
@@ -254,6 +264,7 @@ while IFS= read -r thread; do
   if $DRY_RUN; then
     echo "  WOULD RESOLVE [$AUTHOR] $PATH_"
     echo "    $EXCERPT"
+    WOULD_RESOLVE_COUNT=$((WOULD_RESOLVE_COUNT + 1))
     continue
   fi
 
@@ -274,10 +285,18 @@ done < <(printf '%s\n' "$UNRESOLVED")
 
 echo ""
 if $DRY_RUN; then
-  echo "(dry-run; no threads modified)"
-  # Even in dry-run, surface that the PR is still blocked: callers can
-  # use exit code to gate auto-merge.
-  if [ "$SKIPPED_HUMAN" -gt 0 ] || [ "$SKIPPED_STALE" -gt 0 ]; then exit 3; fi
+  echo "(dry-run; no threads modified) — would-resolve: $WOULD_RESOLVE_COUNT, skipped (human): $SKIPPED_HUMAN, skipped (stale-HEAD): $SKIPPED_STALE"
+  # Codex r2 on PR #172: dry-run previously exited 0 when only
+  # current-HEAD bot threads remained (because dry-run does not mutate
+  # them and they didn't increment SKIPPED_*). Callers would treat
+  # the PR as "all clear" and proceed to merge into a still-BLOCKED PR.
+  # Fix: dry-run exits 3 if ANY actionable items remain (would-resolve,
+  # human-skipped, or stale-skipped). The only exit-0 path through
+  # auto-resolve-bots --dry-run is "no unresolved threads at all"
+  # which is already short-circuited above (UNRESOLVED is empty).
+  if [ "$WOULD_RESOLVE_COUNT" -gt 0 ] || [ "$SKIPPED_HUMAN" -gt 0 ] || [ "$SKIPPED_STALE" -gt 0 ]; then
+    exit 3
+  fi
   exit 0
 fi
 echo "Resolved: $RESOLVED_COUNT  Skipped (human): $SKIPPED_HUMAN  Skipped (stale-HEAD): $SKIPPED_STALE  Failed: $FAILED_COUNT"

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -99,46 +99,71 @@ fi
 OWNER="${REPO%/*}"
 NAME="${REPO#*/}"
 
-# Fetch all review threads with their isResolved state, author, and
-# first comment. Use GraphQL because reviewThreads aren't exposed via
-# the REST endpoint.
-THREADS=$(gh api graphql -f query='
-  query($owner: String!, $repo: String!, $pr: Int!) {
-    repository(owner: $owner, name: $repo) {
-      pullRequest(number: $pr) {
-        reviewThreads(first: 100) {
-          nodes {
-            id
-            isResolved
-            isOutdated
-            comments(first: 1) {
-              nodes {
-                author { login }
-                path
-                body
-                createdAt
+# Fetch the PR's current HEAD commit oid — used by --auto-resolve-bots
+# to verify each thread's latest comment is on the current HEAD before
+# resolving. Codex P2 on PR #172 caught that the docstring promised
+# this check but the code didn't enforce it.
+HEAD_OID=$(gh api "repos/$OWNER/$NAME/pulls/$PR_NUM" --jq .head.sha 2>/dev/null) || {
+  echo "Could not resolve PR HEAD oid for $REPO#$PR_NUM" >&2
+  exit 2
+}
+
+# Fetch all review threads with isResolved state, author, and the
+# LATEST comment's commit_id (so --auto-resolve-bots can verify
+# current-HEAD membership). Use GraphQL because reviewThreads aren't
+# exposed via REST. Paginate through reviewThreads — Codex P2 on PR
+# #172 caught that the prior `first: 100` could undercount on PRs
+# with many threads. Ditto comments: fetch `last: 1` to anchor the
+# resolved-against-HEAD check on the most recent comment per thread.
+THREADS_JSON='[]'
+CURSOR="null"
+while :; do
+  PAGE=$(gh api graphql -f query='
+    query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pr) {
+          reviewThreads(first: 50, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              isResolved
+              isOutdated
+              comments(last: 1) {
+                nodes {
+                  author { login }
+                  path
+                  body
+                  createdAt
+                  commit { oid }
+                }
               }
             }
           }
         }
       }
     }
+  ' -F owner="$OWNER" -F repo="$NAME" -F pr="$PR_NUM" -f cursor="$CURSOR" 2>&1) || {
+    echo "GraphQL query failed: $PAGE" >&2
+    exit 2
   }
-' -F owner="$OWNER" -F repo="$NAME" -F pr="$PR_NUM" 2>&1) || {
-  echo "GraphQL query failed: $THREADS" >&2
-  exit 2
-}
+  THREADS_JSON=$(jq -c --argjson acc "$THREADS_JSON" \
+    '$acc + .data.repository.pullRequest.reviewThreads.nodes' <<<"$PAGE")
+  HAS_NEXT=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$PAGE")
+  [ "$HAS_NEXT" = "true" ] || break
+  CURSOR=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<<"$PAGE")
+done
 
-UNRESOLVED=$(echo "$THREADS" | jq -c '
-  .data.repository.pullRequest.reviewThreads.nodes[]
+UNRESOLVED=$(echo "$THREADS_JSON" | jq -c '
+  .[]
   | select(.isResolved == false)
   | {
       id: .id,
       outdated: .isOutdated,
-      author: (.comments.nodes[0].author.login // "unknown"),
-      path: (.comments.nodes[0].path // "(no path)"),
-      created: (.comments.nodes[0].createdAt // ""),
-      excerpt: ((.comments.nodes[0].body // "") | .[0:160])
+      author: (.comments.nodes[-1].author.login // "unknown"),
+      path: (.comments.nodes[-1].path // "(no path)"),
+      created: (.comments.nodes[-1].createdAt // ""),
+      commit_oid: (.comments.nodes[-1].commit.oid // ""),
+      excerpt: ((.comments.nodes[-1].body // "") | .[0:160])
     }
 ')
 
@@ -170,17 +195,31 @@ fi
 # loop and the trailing summary is accurate.
 RESOLVED_COUNT=0
 SKIPPED_HUMAN=0
+SKIPPED_STALE=0
 FAILED_COUNT=0
 while IFS= read -r thread; do
   AUTHOR=$(echo "$thread" | jq -r .author)
   THREAD_ID=$(echo "$thread" | jq -r .id)
   PATH_=$(echo "$thread" | jq -r .path)
   EXCERPT=$(echo "$thread" | jq -r .excerpt)
+  COMMIT_OID=$(echo "$thread" | jq -r .commit_oid)
 
   if ! [[ "$AUTHOR" =~ $BOT_LOGINS_RE ]]; then
     echo "  SKIP (human author $AUTHOR): $PATH_"
     echo "    $EXCERPT"
     SKIPPED_HUMAN=$((SKIPPED_HUMAN + 1))
+    continue
+  fi
+
+  # Current-HEAD check (Codex P2 on PR #172). The advertised contract
+  # is "resolve only when the latest comment is on the current HEAD"
+  # — a thread anchored to an older commit means the agent's most
+  # recent push hasn't been re-reviewed by the bot, so resolving it
+  # would force-clear an unaddressed finding. Skip with a clear note.
+  if [ -n "$COMMIT_OID" ] && [ "$COMMIT_OID" != "$HEAD_OID" ]; then
+    echo "  SKIP (stale: latest comment on ${COMMIT_OID:0:7}, HEAD is ${HEAD_OID:0:7}): [$AUTHOR] $PATH_"
+    echo "    Push a fix commit (or rebuttal reply) to re-trigger the bot, then retry."
+    SKIPPED_STALE=$((SKIPPED_STALE + 1))
     continue
   fi
 
@@ -210,6 +249,6 @@ if $DRY_RUN; then
   echo "(dry-run; no threads modified)"
   exit 0
 fi
-echo "Resolved: $RESOLVED_COUNT  Skipped (human): $SKIPPED_HUMAN  Failed: $FAILED_COUNT"
+echo "Resolved: $RESOLVED_COUNT  Skipped (human): $SKIPPED_HUMAN  Skipped (stale-HEAD): $SKIPPED_STALE  Failed: $FAILED_COUNT"
 [ "$FAILED_COUNT" -gt 0 ] && exit 2
 exit 0

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -165,9 +165,13 @@ if [ "$MODE" = "list" ]; then
 fi
 
 # auto-resolve-bots mode: resolve bot threads, leave human threads alone.
+# Use process substitution (`< <(...)`) instead of `echo $UNRESOLVED | while`
+# so the loop runs in the parent shell — counter increments survive past the
+# loop and the trailing summary is accurate.
 RESOLVED_COUNT=0
 SKIPPED_HUMAN=0
-echo "$UNRESOLVED" | while IFS= read -r thread; do
+FAILED_COUNT=0
+while IFS= read -r thread; do
   AUTHOR=$(echo "$thread" | jq -r .author)
   THREAD_ID=$(echo "$thread" | jq -r .id)
   PATH_=$(echo "$thread" | jq -r .path)
@@ -197,12 +201,15 @@ echo "$UNRESOLVED" | while IFS= read -r thread; do
     RESOLVED_COUNT=$((RESOLVED_COUNT + 1))
   else
     echo "  FAILED [$AUTHOR] $PATH_ — mutation rejected" >&2
+    FAILED_COUNT=$((FAILED_COUNT + 1))
   fi
-done
+done < <(printf '%s\n' "$UNRESOLVED")
 
+echo ""
 if $DRY_RUN; then
-  echo ""
   echo "(dry-run; no threads modified)"
   exit 0
 fi
+echo "Resolved: $RESOLVED_COUNT  Skipped (human): $SKIPPED_HUMAN  Failed: $FAILED_COUNT"
+[ "$FAILED_COUNT" -gt 0 ] && exit 2
 exit 0

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -89,11 +89,27 @@ done
 
 [ -z "$PR_NUM" ] && usage
 
+# PR_NUM must be a positive integer (no leading zeros, no other chars).
+if ! [[ "$PR_NUM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid PR number: '$PR_NUM' (must be a positive integer)" >&2
+  exit 1
+fi
+
 if [ -z "$REPO" ]; then
   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
     echo "Could not resolve repo. Pass --repo owner/name." >&2
     exit 2
   }
+fi
+
+# --repo value validation. Codex r1 on PR #172 caught the missing
+# check. Must be `owner/name` where each side is GitHub-legal:
+# alphanumerics, hyphens, dots, underscores; no leading dash; ≤39
+# chars per GitHub's username rules but we only enforce the syntactic
+# shape — gh will reject genuinely-invalid combinations downstream.
+if ! [[ "$REPO" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "Invalid --repo value: '$REPO' (expected owner/name)" >&2
+  exit 1
 fi
 
 OWNER="${REPO%/*}"
@@ -211,13 +227,25 @@ while IFS= read -r thread; do
     continue
   fi
 
-  # Current-HEAD check (Codex P2 on PR #172). The advertised contract
-  # is "resolve only when the latest comment is on the current HEAD"
-  # — a thread anchored to an older commit means the agent's most
-  # recent push hasn't been re-reviewed by the bot, so resolving it
-  # would force-clear an unaddressed finding. Skip with a clear note.
-  if [ -n "$COMMIT_OID" ] && [ "$COMMIT_OID" != "$HEAD_OID" ]; then
-    echo "  SKIP (stale: latest comment on ${COMMIT_OID:0:7}, HEAD is ${HEAD_OID:0:7}): [$AUTHOR] $PATH_"
+  # Current-HEAD check. The advertised contract is "resolve only when
+  # the latest comment is on the current HEAD" — a thread anchored to
+  # an older commit (or with no commit linkage at all) means the
+  # agent's most recent push hasn't been re-reviewed by the bot, so
+  # resolving it would force-clear an unaddressed finding.
+  #
+  # Codex r1 on PR #172 caught that the previous check
+  # `if [ -n "$COMMIT_OID" ] && [ "$COMMIT_OID" != "$HEAD_OID" ]`
+  # treated EMPTY commit_oid as "matches HEAD" → bot threads with no
+  # commit linkage in the GraphQL response would be force-resolved
+  # silently. The safe default is the opposite: missing oid is
+  # treated as stale.
+  if [ -z "$COMMIT_OID" ] || [ "$COMMIT_OID" = "null" ] || [ "$COMMIT_OID" != "$HEAD_OID" ]; then
+    if [ -z "$COMMIT_OID" ] || [ "$COMMIT_OID" = "null" ]; then
+      reason="no commit linkage"
+    else
+      reason="latest comment on ${COMMIT_OID:0:7}, HEAD is ${HEAD_OID:0:7}"
+    fi
+    echo "  SKIP (stale: $reason): [$AUTHOR] $PATH_"
     echo "    Push a fix commit (or rebuttal reply) to re-trigger the bot, then retry."
     SKIPPED_STALE=$((SKIPPED_STALE + 1))
     continue
@@ -247,8 +275,19 @@ done < <(printf '%s\n' "$UNRESOLVED")
 echo ""
 if $DRY_RUN; then
   echo "(dry-run; no threads modified)"
+  # Even in dry-run, surface that the PR is still blocked: callers can
+  # use exit code to gate auto-merge.
+  if [ "$SKIPPED_HUMAN" -gt 0 ] || [ "$SKIPPED_STALE" -gt 0 ]; then exit 3; fi
   exit 0
 fi
 echo "Resolved: $RESOLVED_COUNT  Skipped (human): $SKIPPED_HUMAN  Skipped (stale-HEAD): $SKIPPED_STALE  Failed: $FAILED_COUNT"
+# Codex r1 on PR #172: previously this exited 0 even with stale or
+# human-authored threads remaining — callers would treat it as "all
+# clear" and proceed to merge into a still-BLOCKED PR. Exit codes:
+#   2 = mutation failure (transient: gh/network)
+#   3 = unresolved threads remain (human or stale-bot) — PR still
+#       conversation-resolution-blocked; address and retry
+#   0 = no unresolved threads on current HEAD
 [ "$FAILED_COUNT" -gt 0 ] && exit 2
+[ "$SKIPPED_HUMAN" -gt 0 ] || [ "$SKIPPED_STALE" -gt 0 ] && exit 3
 exit 0

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# resolve-pr-threads.sh — Enumerate and resolve open review threads on a PR.
+#
+# Branch protection on `main` typically requires
+# `required_conversation_resolution: true`, which means **every review
+# thread on the PR must be resolved** before `mergeStateStatus` flips
+# from `BLOCKED` to `CLEAN`. This includes CodeRabbit's `🧹 Nitpick` /
+# `🔵 Trivial` comments that don't block merge in CodeRabbit's own
+# model but DO block the conversation-resolution gate.
+#
+# The blocker is invisible in `gh pr checks` output — only the GitHub
+# UI surfaces it. This script fills the discoverability gap.
+#
+# Usage:
+#   scripts/resolve-pr-threads.sh <PR#> [--repo owner/name] [--list]
+#                                 [--auto-resolve-bots] [--dry-run]
+#
+# Modes:
+#   --list                  List unresolved threads with author + path +
+#                           first-comment excerpt. No mutations.
+#   --auto-resolve-bots     Resolve threads whose author is a bot
+#                           (CodeRabbit, Codex Connector, Dependabot)
+#                           AND whose latest comment is on the current
+#                           HEAD. Use ONLY when:
+#                           - The agent has already addressed each
+#                             finding in a fix commit on this HEAD, OR
+#                             posted a rebuttal reply, AND
+#                           - The bot author has not auto-resolved in
+#                             a reasonable window.
+#                           Per REVIEW_POLICY.md § Implementation notes
+#                           for branch protection gates: this is a
+#                           CLEAN-UP mechanism, not a policy override.
+#                           Human-authored threads are NEVER auto-
+#                           resolved regardless of mode.
+#   --dry-run               With --auto-resolve-bots, print what would
+#                           be resolved without mutating.
+#
+# Default mode (no flags): equivalent to --list.
+#
+# Exit codes:
+#   0 — no unresolved threads
+#   1 — bad arguments
+#   2 — gh failure (auth, missing PR, network)
+#   3 — unresolved threads exist (in --list mode); call again with
+#       --auto-resolve-bots after addressing findings, or resolve
+#       human-authored threads via the GitHub UI.
+#
+# References:
+#   nathanjohnpayne/mergepath#166 — the issue this closes
+#   matchline #181, #190, #192 — observed cases of conversation-
+#                                resolution blocker
+
+set -eo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Usage: scripts/resolve-pr-threads.sh <PR#> [--repo owner/name] [--list]
+                                            [--auto-resolve-bots] [--dry-run]
+
+  --list                List unresolved threads (default).
+  --auto-resolve-bots   Resolve bot-authored threads on current HEAD.
+  --dry-run             With --auto-resolve-bots, print without mutating.
+EOF
+  exit 1
+}
+
+PR_NUM=""
+REPO=""
+MODE="list"
+DRY_RUN=false
+BOT_LOGINS_RE='^(coderabbitai\[bot\]|chatgpt-codex-connector\[bot\]|dependabot\[bot\])$'
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --list) MODE="list"; shift ;;
+    --auto-resolve-bots) MODE="auto-resolve-bots"; shift ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    -h|--help) usage ;;
+    -*) echo "Unknown flag: $1" >&2; usage ;;
+    *)
+      if [ -z "$PR_NUM" ]; then PR_NUM="$1"
+      else echo "Unexpected positional: $1" >&2; usage
+      fi
+      shift
+      ;;
+  esac
+done
+
+[ -z "$PR_NUM" ] && usage
+
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
+    echo "Could not resolve repo. Pass --repo owner/name." >&2
+    exit 2
+  }
+fi
+
+OWNER="${REPO%/*}"
+NAME="${REPO#*/}"
+
+# Fetch all review threads with their isResolved state, author, and
+# first comment. Use GraphQL because reviewThreads aren't exposed via
+# the REST endpoint.
+THREADS=$(gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            comments(first: 1) {
+              nodes {
+                author { login }
+                path
+                body
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -F owner="$OWNER" -F repo="$NAME" -F pr="$PR_NUM" 2>&1) || {
+  echo "GraphQL query failed: $THREADS" >&2
+  exit 2
+}
+
+UNRESOLVED=$(echo "$THREADS" | jq -c '
+  .data.repository.pullRequest.reviewThreads.nodes[]
+  | select(.isResolved == false)
+  | {
+      id: .id,
+      outdated: .isOutdated,
+      author: (.comments.nodes[0].author.login // "unknown"),
+      path: (.comments.nodes[0].path // "(no path)"),
+      created: (.comments.nodes[0].createdAt // ""),
+      excerpt: ((.comments.nodes[0].body // "") | .[0:160])
+    }
+')
+
+if [ -z "$UNRESOLVED" ]; then
+  echo "No unresolved threads on PR #$PR_NUM."
+  exit 0
+fi
+
+UNRESOLVED_COUNT=$(echo "$UNRESOLVED" | wc -l | tr -d ' ')
+echo "Unresolved threads on $REPO#$PR_NUM: $UNRESOLVED_COUNT"
+echo ""
+
+# List mode: print and exit 3.
+if [ "$MODE" = "list" ]; then
+  echo "$UNRESOLVED" | jq -r '
+    "  [\(.author)] \(.path)" + (if .outdated then " (outdated)" else "" end) +
+    "\n    " + .excerpt + "\n"
+  '
+  echo "To resolve bot-authored threads where you have already addressed"
+  echo "the finding: re-run with --auto-resolve-bots."
+  echo "Human-authored threads must be resolved via the GitHub UI or by"
+  echo "asking the human. Per REVIEW_POLICY.md § Agent prohibitions."
+  exit 3
+fi
+
+# auto-resolve-bots mode: resolve bot threads, leave human threads alone.
+RESOLVED_COUNT=0
+SKIPPED_HUMAN=0
+echo "$UNRESOLVED" | while IFS= read -r thread; do
+  AUTHOR=$(echo "$thread" | jq -r .author)
+  THREAD_ID=$(echo "$thread" | jq -r .id)
+  PATH_=$(echo "$thread" | jq -r .path)
+  EXCERPT=$(echo "$thread" | jq -r .excerpt)
+
+  if ! [[ "$AUTHOR" =~ $BOT_LOGINS_RE ]]; then
+    echo "  SKIP (human author $AUTHOR): $PATH_"
+    echo "    $EXCERPT"
+    SKIPPED_HUMAN=$((SKIPPED_HUMAN + 1))
+    continue
+  fi
+
+  if $DRY_RUN; then
+    echo "  WOULD RESOLVE [$AUTHOR] $PATH_"
+    echo "    $EXCERPT"
+    continue
+  fi
+
+  if gh api graphql -f query='
+    mutation($id: ID!) {
+      resolveReviewThread(input: {threadId: $id}) {
+        thread { isResolved }
+      }
+    }
+  ' -F id="$THREAD_ID" >/dev/null 2>&1; then
+    echo "  RESOLVED [$AUTHOR] $PATH_"
+    RESOLVED_COUNT=$((RESOLVED_COUNT + 1))
+  else
+    echo "  FAILED [$AUTHOR] $PATH_ — mutation rejected" >&2
+  fi
+done
+
+if $DRY_RUN; then
+  echo ""
+  echo "(dry-run; no threads modified)"
+  exit 0
+fi
+exit 0


### PR DESCRIPTION
Closes #165 and #166. Two related friction points in the merge flow, addressed with mechanism enforcement (#165) and discoverability tooling (#166).

## What

### Mechanism enforcement (#165)

- **`scripts/hooks/label-removal-guard.sh`** — PreToolUse hook blocks `gh pr edit ... --remove-label <L>` and `--add-label <L>` for `needs-external-review`, `needs-human-review`, `policy-violation`. Quote-aware shlex tokenization (mirrors `gh-pr-guard.sh`); handles `--remove-label foo`, `--remove-label=foo`, global `-R/--repo` placement, and chained-command spoofing. **No break-glass override.**
- **`scripts/request-label-removal.sh`** — sanctioned helper. Posts a templated PR comment pinging `@nathanjohnpayne` with the one-line `gh pr edit` command. Optional iMessage notification via `MERGEPATH_NOTIFY_IMESSAGE_TO`.
- **`.claude/settings.json`** — registers the new hook alongside `gh-pr-guard.sh`.
- **`REVIEW_POLICY.md` § Agent prohibitions** — short paragraph documenting the rule + pointing at the helper.
- **`REVIEW_POLICY.md` § Implementation notes for branch protection gates** — frames `resolveReviewThread` as mechanism-not-policy with explicit prohibition on resolving human-authored threads.
- **`CLAUDE.md` step 10.6** — pointer to the helper + hook prohibition.

### Discoverability for thread-resolution (#166)

- **`scripts/resolve-pr-threads.sh`** — enumerates unresolved review threads via the GraphQL `reviewThreads` query (the data isn't exposed via REST). Default `--list` mode prints author + path + excerpt and exits 3 if any unresolved threads remain. `--auto-resolve-bots` resolves bot-authored threads via `resolveReviewThread` mutation — only when the agent has already addressed the finding. Human-authored threads are NEVER touched regardless of mode.
- **`CLAUDE.md` step 7.6** — explicit "resolve all review threads" step between CodeRabbit clearance and external-review-threshold check.
- **`CLAUDE.md` step 10.5** — pre-merge `mergeStateStatus === "CLEAN"` verification with the BLOCKED-without-failed-checks diagnosis hint.

## Why

**#165:** Per matchline learnings (PRs #173, #174, #178, #180), agents have repeatedly removed `needs-external-review` / `needs-human-review` / `policy-violation` labels after one-shot chat authorization. The canonical REVIEW_POLICY.md said this implicitly (by absence) but not as a prohibition. **Doctrinal text alone puts the load on every future agent reading the doc**; the right shape is mechanism enforcement.

**#166:** Branch protection on `main` typically sets `required_conversation_resolution: true`, so every review thread (including CodeRabbit nitpicks) must be resolved before `mergeStateStatus` flips from BLOCKED to CLEAN. The blocker is invisible in `gh pr checks` output — only the GitHub UI surfaces it. matchline #181 took ~30 minutes of diagnostic work on first encounter; subsequent PRs hit the same gate.

## Verification

- **Hook smoke-tested with five inputs:**
  - prohibited remove → blocked (exit 2)
  - allowed-label remove → allowed (exit 0)
  - unrelated `gh pr view` → allowed (exit 0)
  - `--remove-label=foo` form → blocked (exit 2)
  - chained command (`echo ok ; gh pr edit ...`) → blocked (exit 2)
- **`resolve-pr-threads.sh` smoke-tested** in `--list` mode against PR #169 (already-merged, no threads → exit 0 with "No unresolved threads on PR #169.").
- **End-to-end test of `--auto-resolve-bots`** requires a PR with unresolved bot threads — will verify on the next CodeRabbit-flagged PR after merge.

## Authoring-Agent

Authoring-Agent: claude

## Self-Review

- **Correctness:** hook tokenization is the same shape as `gh-pr-guard.sh` (quote-aware shlex via python3, NUL-delimited tempfile to preserve embedded newlines). The label-value scan walks tokens AFTER `gh ... pr edit` so global `-R`/`--repo` placement is handled. The prohibited-label regex is anchored to prevent prefix matches.
- **Regression risk:** hook denies only the three named labels; all other label edits unaffected. The thread-resolver script is read-only by default (`--list` mode); `--auto-resolve-bots` requires explicit flag AND only touches bot-authored threads (regex-anchored bot login list). The new doctrine sections in REVIEW_POLICY.md don't change any existing rule — they make implicit prohibitions explicit.
- **Style:** `hooks/label-removal-guard.sh` follows the same comment-block, function-shape, and cleanup-trap conventions as `hooks/gh-pr-guard.sh`. `resolve-pr-threads.sh` follows the `coderabbit-wait.sh` shape (`--repo` flag, `--dry-run`, tabular output).
- **Test coverage:** hook smoke tests cover the five canonical input shapes (verified passing); `resolve-pr-threads.sh` smoke-tested in `--list` mode against a clean PR.
- **Security/dependency hygiene:** no new dependencies. Hook reads stdin (Claude Code passes JSON via stdin to PreToolUse hooks); falls back to raw-command treatment if JSON parse fails. `resolve-pr-threads.sh` uses `gh` + `jq` (already required). No new tokens or permissions.

## Propagation

After merge, propagate to the 6 downstream consumers via the standard sync flow. The hook is canonical and propagates automatically once `.claude/settings.json` is in the canonical mirror set. #168 tracks the propagation tool that will make this one-command.

## Note on opening

This PR depends on PR #171 (active-account convention, #164) for the doctrinally-correct merge flow, but is independently mergeable — they don't touch the same files. Sequencing: merge #171 first, then this PR.
