### PR TITLE
fix(#164 follow-up): GH_TOKEN-immune active-account check + purge stale write-path docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,13 +31,21 @@ This repository uses a multi-identity AI agent code review system. The full poli
    This triggers biometric prompts once and writes a chmod-600 session
    file at `$XDG_CACHE_HOME/mergepath/op-preflight-<agent>.env` so fresh
    subshells can reuse the credentials (see REVIEW_POLICY.md § Phase 0).
-   Use `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"` for reviewer commands and
-   `GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT"` for author commands.
+   `gh` resolves auth differently for read vs write paths: read paths
+   (`gh api user`, GETs, helper scripts) honor `GH_TOKEN`; write paths
+   (`gh pr review`, `gh pr create`, `gh pr merge`, `gh pr edit`) use
+   the keyring's **active** account. Set the active account once per
+   machine: `gh auth switch -u nathanpayne-{your-agent}`. Then use
+   `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"` (or `$OP_PREFLIGHT_AUTHOR_PAT`)
+   only for read-path API calls and helper scripts. For author-identity
+   writes (PR create/merge/label edits), wrap the call in a temporary
+   `gh auth switch -u nathanjohnpayne && ... && gh auth switch -u nathanpayne-{your-agent}`.
+   See REVIEW_POLICY.md § Reviewer PAT Quick Start for the full convention.
    Run `scripts/op-preflight.sh --agent {your-agent} --purge` (or
    `--purge-all`) at end of session to delete the cached PATs.
 1. Author code as nathanjohnpayne. File a PR.
-2. Switch to your reviewer identity (e.g., nathanpayne-claude). Review the PR. Post comments.
-3. Switch back to nathanjohnpayne. Address each comment. Push fix commits.
+2. Review the PR under your reviewer identity. With your agent identity active per the convention above, just run `gh pr review <PR#> --comment --body "..."` — the byline is your reviewer identity. Post comments.
+3. Address each comment via fix commits (commits use git config, no gh auth involved — byline stays nathanjohnpayne).
 4. Repeat steps 2–3 until the reviewer identity approves with no outstanding issues.
 5. If this repo has `coderabbit.enabled: true` in `.github/review-policy.yml`:
    a. **Wait** for CodeRabbit to post its review on the current HEAD. Prefer `scripts/coderabbit-wait.sh <PR#>` over an ad-hoc poll — it anchors "cleared" on the HEAD committer date (closing the race that let auto-merge fire pre-CodeRabbit; see #136) and handles CodeRabbit's non-auto-retrying rate-limit state by parsing the published window and posting `@coderabbitai, try again.` itself (see #138). Exit codes: `0` cleared, `2` findings, `4` grace-window timeout (advisory — log and skip), `5` rate-limit stalled (alert the human, do not proceed).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,11 @@ explicitly authorizes a break-glass override in chat.
   label edits (`gh pr review`, `gh pr create`, `gh pr merge`,
   `gh pr edit`, `gh api -X POST repos/.../pulls/.../reviews`) use the
   keyring's **active** account regardless of `GH_TOKEN`. The byline is
-  whoever `gh auth status` shows as `Active: true` when the call lands.
+  whoever owns the active keyring entry — read it with `gh config get
+  -h github.com user`, NOT `gh auth status`. (`gh auth status` is
+  GH_TOKEN-poisonable: when GH_TOKEN is set, it reports the GH_TOKEN
+  entry as Active and the keyring entry as inactive, even though
+  writes still attribute to the keyring.)
 
 Each agent's working machine has the agent identity as the **active**
 gh account, set once per machine: `gh auth switch -u nathanpayne-claude`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,12 @@ keyring active is your agent identity. No switch needed for commits.
    `$HOME/.cache/mergepath/`). Safe to re-run at the top of every tool
    call — within the TTL (4h default, override via
    `OP_PREFLIGHT_TTL_SECONDS`) the script reads the session file and
-   emits the same exports without a new biometric prompt. All subsequent
-   steps use `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"` (reviewer) or
-   `GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT"` (author) instead of `op read`.
+   emits the same exports without a new biometric prompt. Read-path
+   API calls and helper scripts use
+   `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"` (or `…AUTHOR_PAT`) instead
+   of `op read`. Write paths (`gh pr review` / `create` / `merge` /
+   `edit`) use the active keyring account regardless of `GH_TOKEN`
+   per the Active-account convention above.
    Run `scripts/op-preflight.sh --agent claude --purge` at end of
    session to wipe the cache. If preflight was not run (or failed), fall
    back to inline `op read` (original pattern).

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -371,28 +371,41 @@ Use the item ID (not the item title) to avoid shell issues with parentheses in
 
 ### Reviewer PAT quick check
 
-Before asking a reviewer identity to approve a PR, verify the token with
-`gh api user` and then reuse the same explicit `GH_TOKEN` override for
-`gh pr review`:
+`gh` resolves auth differently for read paths vs write paths — the
+canonical convention is in `REVIEW_POLICY.md` § Reviewer PAT Quick Start
+and `CLAUDE.md` § Active-account convention. Short form:
+
+- **Read paths** (`gh api user`, GETs, `gh pr view`) honor `GH_TOKEN`.
+- **Write paths** (`gh pr review`, `gh pr create`, `gh pr merge`,
+  `gh pr edit`, `gh api -X POST`) use the keyring's **active**
+  account regardless of `GH_TOKEN`. Set the active account once per
+  machine: `gh auth switch -u nathanpayne-<agent>`.
 
 ```bash
-# Example: verify the Claude reviewer identity before approving a PR
+# Read-path identity check — GH_TOKEN works here.
 GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
   gh api user --jq '.login'
 # expected: nathanpayne-claude
 
-GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
-  gh pr review <PR#> --repo <owner/repo> --approve --body "Review comment"
+# Write-path: with the agent identity active, GH_TOKEN is irrelevant
+# for the byline. Just run the command.
+gh pr review <PR#> --repo <owner/repo> --comment --body "Review comment"
+
+# Author-identity write: switch around the call.
+gh auth switch -u nathanjohnpayne && \
+  gh pr merge <PR#> --squash --delete-branch && \
+  gh auth switch -u nathanpayne-claude
 ```
 
 - Use the item ID from the table above for your agent identity. Do not use the 1Password item title.
-- If `gh auth status` still shows `nathanjohnpayne`, that is okay.
-  `GH_TOKEN=...` overrides the ambient login for that command.
+- `gh auth status` should show your **agent identity** as `Active: true`.
+  Fix once with `gh auth switch -u nathanpayne-<agent>`. The
+  `op-preflight.sh` script warns when active ≠ expected.
 - On local interactive machines, the `op read` command itself may trigger the
   1Password biometric prompt even if `op whoami` says you are not signed in.
-- `Review Can not approve your own pull request` means the wrong GitHub
-  identity is still being used. Check the table above and verify you are using
-  your agent's item ID, not the author identity's.
+- `Review Can not approve your own pull request` means you are the active
+  account on a PR you authored. Switch to a different agent's reviewer
+  identity (or skip self-approve per the no-self-approve rule).
 
 ### Token rotation (as needed)
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -391,10 +391,11 @@ GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
 # for the byline. Just run the command.
 gh pr review <PR#> --repo <owner/repo> --comment --body "Review comment"
 
-# Author-identity write: switch around the call.
+# Author-identity write: switch around the call. Substitute your
+# agent identity (claude / cursor / codex) for the switch-back.
 gh auth switch -u nathanjohnpayne && \
   gh pr merge <PR#> --squash --delete-branch && \
-  gh auth switch -u nathanpayne-claude
+  gh auth switch -u nathanpayne-<agent>
 ```
 
 - Use the item ID from the table above for your agent identity. Do not use the 1Password item title.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -399,9 +399,11 @@ gh auth switch -u nathanjohnpayne && \
 ```
 
 - Use the item ID from the table above for your agent identity. Do not use the 1Password item title.
-- `gh auth status` should show your **agent identity** as `Active: true`.
-  Fix once with `gh auth switch -u nathanpayne-<agent>`. The
-  `op-preflight.sh` script warns when active ≠ expected.
+- Verify the keyring active account with `gh config get -h github.com user`
+  (NOT `gh auth status` — that command honors GH_TOKEN and
+  mis-reports when GH_TOKEN is set). Fix once with
+  `gh auth switch -u nathanpayne-<agent>`. The `op-preflight.sh`
+  script warns when active ≠ expected.
 - On local interactive machines, the `op read` command itself may trigger the
   1Password biometric prompt even if `op whoami` says you are not signed in.
 - `Review Can not approve your own pull request` means you are the active

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -51,20 +51,18 @@ need a temporary `gh auth switch -u nathanjohnpayne` around them,
 paired with a switch-back. See nathanjohnpayne/mergepath#164 for the
 empirical diagnosis (matchline PRs #181, #182).
 
-PATs are still required for read-path API calls and for the helper
-scripts (`coderabbit-wait.sh`, `codex-review-request.sh`,
-`codex-review-check.sh`) that drive the review pipeline.
-
-Note that `coderabbit-wait.sh` and `codex-review-request.sh` are
-**not** purely read-path: both can POST a retry / re-trigger comment
-on the PR (`gh api --method POST .../issues/{pr}/comments`). The PAT
-in `GH_TOKEN` authenticates the API call, but the **byline of the
-posted comment** is the keyring's active account (same as any other
-gh write-path call) — so the active-account convention applies to
-these helpers too. Set the active account once per machine
-(`gh auth switch -u nathanpayne-<agent>`) and the comments attribute
-correctly. The retry comment content (`@coderabbitai, try again.`)
-is identity-agnostic, so a wrong byline isn't load-bearing — but
+PATs are still required for the helper scripts (`coderabbit-wait.sh`,
+`codex-review-request.sh`, `codex-review-check.sh`) that drive the
+review pipeline. Of these, `codex-review-check.sh` is purely
+read-path; `coderabbit-wait.sh` and `codex-review-request.sh` BOTH
+post comments on the PR (a retry trigger and an `@codex review`
+trigger respectively, via `gh pr comment` or `gh api`). The PAT in
+`GH_TOKEN` authenticates the API call, but the **byline of the
+posted comment** is the keyring's active account — so the
+active-account convention applies to these helpers too. Set the
+active account once per machine (`gh auth switch -u nathanpayne-<agent>`)
+and the comments attribute correctly. The trigger-comment bodies are
+identity-agnostic, so a wrong byline isn't load-bearing — but
 matters for audit-trail consistency.
 
 #### PAT lookup table
@@ -563,9 +561,14 @@ Short form:
 GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq '.login'
 # expected: nathanpayne-claude
 
-# Helper scripts that wrap read-path API calls:
-GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/coderabbit-wait.sh <PR#>
+# Read-only helper:
 GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-check.sh <PR#>
+
+# Helpers that may also POST a trigger comment — GH_TOKEN authenticates
+# the API call, but the comment byline is the active keyring account.
+# Set active = nathanpayne-<agent> once per machine; then byline is correct.
+GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/coderabbit-wait.sh <PR#>
+GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-request.sh <PR#>
 
 # ── Write-path: active keyring is the byline; GH_TOKEN is ignored ──
 

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -41,7 +41,11 @@ To add a new agent, register a GitHub account following the pattern `nathanpayne
 - **Write paths** (`gh pr review`, `gh pr create`, `gh pr merge`,
   `gh pr edit`, `gh api -X POST repos/.../pulls/.../reviews`) use the
   keyring's **active** account regardless of `GH_TOKEN`. The byline is
-  whoever `gh auth status` shows as `Active: true`.
+  whoever owns the active keyring entry — read it with `gh config get
+  -h github.com user`, NOT `gh auth status` (the latter is
+  GH_TOKEN-poisonable: with GH_TOKEN set it reports the GH_TOKEN entry
+  as Active and the keyring entry as inactive, masking real
+  mismatches).
 
 Each agent's working machine has the agent identity as the **active**
 gh account, set once: `gh auth switch -u nathanpayne-<agent>`.
@@ -93,11 +97,13 @@ gh auth switch -u nathanjohnpayne && \
 ```
 
 - Use the item ID from the lookup table above for your agent identity. Do not use the 1Password item title.
-- `gh auth status` should show your **agent identity** as `Active: true`.
-  If it shows `nathanjohnpayne` instead, reviewer-identity writes will
-  attribute to nathanjohnpayne (not the reviewer). Fix once with
-  `gh auth switch -u nathanpayne-<agent>`. The `op-preflight.sh` script
-  warns when active ≠ expected.
+- Verify the keyring active account with `gh config get -h github.com user`
+  (NOT `gh auth status` — that command honors GH_TOKEN and will
+  mis-report when GH_TOKEN is set). The result should be your agent
+  identity (`nathanpayne-<agent>`). If it shows `nathanjohnpayne`
+  instead, reviewer-identity writes will attribute to nathanjohnpayne
+  (not the reviewer). Fix once with `gh auth switch -u nathanpayne-<agent>`.
+  The `op-preflight.sh` script warns when active ≠ expected.
 - If `op whoami` says you are not signed in, still run the `op read ...`
   command in an interactive TTY. That is what triggers the 1Password biometric
   prompt on local machines.
@@ -584,9 +590,11 @@ gh auth switch -u nathanjohnpayne && \
 ```
 
 - Use the item ID from the [PAT lookup table](#pat-lookup-table) for your agent identity. Do not use the 1Password item title.
-- `gh auth status` should show your **agent identity** as `Active: true`.
-  Fix once with `gh auth switch -u nathanpayne-<agent>`. The
-  `op-preflight.sh` script warns when active ≠ expected.
+- Verify the keyring active account with `gh config get -h github.com user`
+  (NOT `gh auth status` — that command honors GH_TOKEN and
+  mis-reports when GH_TOKEN is set). Fix once with
+  `gh auth switch -u nathanpayne-<agent>`. The `op-preflight.sh`
+  script warns when active ≠ expected.
 - If `op whoami` says you are not signed in, still run the `op read ...`
   command in an interactive TTY. That is what triggers the 1Password biometric
   prompt on local machines.

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -55,6 +55,18 @@ PATs are still required for read-path API calls and for the helper
 scripts (`coderabbit-wait.sh`, `codex-review-request.sh`,
 `codex-review-check.sh`) that drive the review pipeline.
 
+Note that `coderabbit-wait.sh` and `codex-review-request.sh` are
+**not** purely read-path: both can POST a retry / re-trigger comment
+on the PR (`gh api --method POST .../issues/{pr}/comments`). The PAT
+in `GH_TOKEN` authenticates the API call, but the **byline of the
+posted comment** is the keyring's active account (same as any other
+gh write-path call) — so the active-account convention applies to
+these helpers too. Set the active account once per machine
+(`gh auth switch -u nathanpayne-<agent>`) and the comments attribute
+correctly. The retry comment content (`@coderabbitai, try again.`)
+is identity-agnostic, so a wrong byline isn't load-bearing — but
+matters for audit-trail consistency.
+
 #### PAT lookup table
 
 | Agent | Reviewer Identity | 1Password Item ID | `op read` path |

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -130,8 +130,8 @@ Replace `claude` with `cursor` or `codex` depending on which agent is running. T
 | `all` | Everything (recommended) |
 
 After preflight, these environment variables are set:
-- `OP_PREFLIGHT_REVIEWER_PAT` — use with `GH_TOKEN=` for reviewer commands
-- `OP_PREFLIGHT_AUTHOR_PAT` — use with `GH_TOKEN=` for author commands
+- `OP_PREFLIGHT_REVIEWER_PAT` — use with `GH_TOKEN=` for reviewer-identity **read-path** API calls and helper scripts (`coderabbit-wait.sh`, `codex-review-request.sh`, `codex-review-check.sh`). Write paths (`gh pr review` / `create` / `merge` / `edit`) use the active keyring account regardless of `GH_TOKEN` — see [Reviewer PAT Quick Start](#reviewer-pat-quick-start).
+- `OP_PREFLIGHT_AUTHOR_PAT` — use with `GH_TOKEN=` for author-identity read-path API calls. For author-identity writes (PR create / merge / label edit), use the `gh auth switch -u nathanjohnpayne && ... && gh auth switch -u nathanpayne-<agent>` switch-around pattern.
 - `GOOGLE_APPLICATION_CREDENTIALS` — used automatically by gcloud/Firebase scripts
 - `OP_PREFLIGHT_DONE=1` — flag indicating preflight has been run
 

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -532,39 +532,53 @@ git remote set-url origin git@github.com:nathanjohnpayne/repo-name.git
 
 ### GitHub API authentication (gh CLI)
 
-For posting PR reviews and comments under a reviewer identity, use `gh` with an
-explicit PAT from 1Password. Do not rely on the GitHub connector session or on
-the ambient `gh` login. Refer to the [PAT lookup table](#pat-lookup-table) for
-your agent's 1Password item ID.
+`gh` resolves auth differently for read paths vs write paths — the
+canonical convention is documented in [Reviewer PAT Quick Start](#reviewer-pat-quick-start).
+Short form:
+
+- **Read paths** (`gh api user`, GETs, `gh pr view`, `gh pr checks`)
+  honor `GH_TOKEN`. Pass it inline per command.
+- **Write paths** (`gh pr review`, `gh pr create`, `gh pr merge`,
+  `gh pr edit`, `gh api -X POST`) use the keyring's **active** account
+  regardless of `GH_TOKEN`. The active account is set once per machine
+  via `gh auth switch -u nathanpayne-<agent>`; `op-preflight.sh` warns
+  if active ≠ expected.
 
 ```bash
-# ── Preferred: use preflight-cached PATs (no biometric prompts) ──
+# ── Read-path: GH_TOKEN works ──
 
-# As reviewer (after running op-preflight.sh):
+# Verify which identity a PAT resolves to (read path):
 GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq '.login'
 # expected: nathanpayne-claude
 
-GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" \
-  gh pr review <PR#> --repo <owner/repo> --approve --body "Review comment"
+# Helper scripts that wrap read-path API calls:
+GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/coderabbit-wait.sh <PR#>
+GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-check.sh <PR#>
 
-# As author (merge, address comments, etc.):
-GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT" gh pr merge <PR#> --merge
+# ── Write-path: active keyring is the byline; GH_TOKEN is ignored ──
 
-# ── Fallback: inline op read (triggers biometric if session expired) ──
+# Reviewer-identity write (your agent identity is active by default):
+gh pr review <PR#> --repo <owner/repo> --comment --body "Review comment"
 
-GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
-  gh pr review <PR#> --repo <owner/repo> --approve --body "Review comment"
+# Author-identity write: temporary switch-around so the byline is
+# nathanjohnpayne, paired with switch-back so active state never lingers
+# wrong for subsequent reviewer-identity writes:
+gh auth switch -u nathanjohnpayne && \
+  gh pr merge <PR#> --squash --delete-branch && \
+  gh auth switch -u nathanpayne-<agent>
 ```
 
 - Use the item ID from the [PAT lookup table](#pat-lookup-table) for your agent identity. Do not use the 1Password item title.
-- If `gh auth status` shows `nathanjohnpayne`, that is fine.
-  `GH_TOKEN=...` overrides the ambient login for that command.
+- `gh auth status` should show your **agent identity** as `Active: true`.
+  Fix once with `gh auth switch -u nathanpayne-<agent>`. The
+  `op-preflight.sh` script warns when active ≠ expected.
 - If `op whoami` says you are not signed in, still run the `op read ...`
   command in an interactive TTY. That is what triggers the 1Password biometric
   prompt on local machines.
-- If GitHub returns `Review Can not approve your own pull request`, the wrong
-  reviewer identity is still being used. Check the [PAT lookup table](#pat-lookup-table)
-  and verify you are using your agent's item ID, not the author identity's.
+- If GitHub returns `Review Can not approve your own pull request`, you
+  are the active account on a PR you authored. Switch to a different
+  agent's reviewer identity (or skip self-approve per the no-self-approve
+  rule).
 
 > **If `op read` fails with a sign-in or biometric error here**, follow the pause-and-prompt procedure in `docs/agents/operating-rules.md` under "1Password CLI authentication failures." Do not hardcode tokens, skip review, or retry in a loop.
 

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -52,19 +52,25 @@
 #   Format:      bash-sourceable KEY='value' lines (printf %q-escaped)
 #   TTL anchor:  OP_PREFLIGHT_CREATED_AT_EPOCH (embedded in file, not mtime)
 #
-# After eval, downstream scripts and agent commands use the exported env
-# vars for READ-path operations and helper scripts. WRITE-path operations
-# (`gh pr review`, `gh pr create`, `gh pr merge`, `gh pr edit`) use the
-# keyring's active account regardless of GH_TOKEN — see
-# CLAUDE.md § Active-account convention. Examples:
-#   # Read paths honor GH_TOKEN:
+# After eval, downstream usage splits along the gh read/write boundary
+# (see CLAUDE.md § Active-account convention):
+#
+#   # Read-path: GH_TOKEN authenticates and sets the byline.
 #   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq .login
+#   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-check.sh <PR#>
+#
+#   # Helpers that may also POST a trigger comment — GH_TOKEN authenticates
+#   # the API call, but the comment byline is the active keyring account.
 #   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/coderabbit-wait.sh <PR#>
-#   # Write paths use active keyring (this script warns if active != expected):
+#   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-request.sh <PR#>
+#
+#   # Write-path: active keyring is the byline; GH_TOKEN is irrelevant.
+#   # This script warns if active != expected.
 #   gh pr review <PR#> --comment --body "..."   # active = nathanpayne-<agent>
 #   gh auth switch -u nathanjohnpayne && gh pr merge <PR#> ... && \
 #     gh auth switch -u nathanpayne-<agent>     # author write
-#   # gcloud/firebase use GOOGLE_APPLICATION_CREDENTIALS automatically
+#
+#   # gcloud/firebase use GOOGLE_APPLICATION_CREDENTIALS automatically.
 
 set -eo pipefail
 umask 077  # Restrict file permissions before any mktemp/cache writes

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -55,7 +55,7 @@
 # After eval, downstream usage splits along the gh read/write boundary
 # (see CLAUDE.md § Active-account convention):
 #
-#   # Read-path: GH_TOKEN authenticates and sets the byline.
+#   # Read-path: GH_TOKEN authenticates the request (no byline involved).
 #   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq .login
 #   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-check.sh <PR#>
 #

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -53,9 +53,17 @@
 #   TTL anchor:  OP_PREFLIGHT_CREATED_AT_EPOCH (embedded in file, not mtime)
 #
 # After eval, downstream scripts and agent commands use the exported env
-# vars instead of calling op directly:
-#   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh pr review ...
-#   GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT"   gh pr merge ...
+# vars for READ-path operations and helper scripts. WRITE-path operations
+# (`gh pr review`, `gh pr create`, `gh pr merge`, `gh pr edit`) use the
+# keyring's active account regardless of GH_TOKEN — see
+# CLAUDE.md § Active-account convention. Examples:
+#   # Read paths honor GH_TOKEN:
+#   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq .login
+#   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/coderabbit-wait.sh <PR#>
+#   # Write paths use active keyring (this script warns if active != expected):
+#   gh pr review <PR#> --comment --body "..."   # active = nathanpayne-<agent>
+#   gh auth switch -u nathanjohnpayne && gh pr merge <PR#> ... && \
+#     gh auth switch -u nathanpayne-<agent>     # author write
 #   # gcloud/firebase use GOOGLE_APPLICATION_CREDENTIALS automatically
 
 set -eo pipefail
@@ -312,19 +320,25 @@ warn_active_account_mismatch() {
   command -v gh >/dev/null 2>&1 || return 0
   local expected="nathanpayne-${AGENT}"
   local actual=""
-  # Capture in a way that cannot abort the parent script under
-  # `set -eo pipefail` if `gh auth status` fails (no login, network
-  # blip) or if the awk pipeline returns no match. Codex P1 on PR
-  # #171: bare `actual=$(... | awk ... | head -1)` propagates the
-  # failure and terminates the whole script. Wrap in a subshell with
-  # pipefail disabled and `|| true` to neutralize both failure modes.
-  actual=$( ( set +o pipefail; gh auth status 2>/dev/null | awk '
-    /Active account: true/ {found=1; next}
-    /account / && found { print $NF; found=0; exit }
-  ' | head -1 ) || true )
-  if [[ -z "$actual" ]]; then
-    actual=$(gh api user --jq .login 2>/dev/null || true)
-  fi
+  # Use `gh config get -h github.com user` to read the active keyring
+  # account. This is the GH_TOKEN-immune signal:
+  #
+  #   - `gh auth status` honors GH_TOKEN — when GH_TOKEN is set, gh
+  #     reports the GH_TOKEN entry as Active: true and flips the
+  #     keyring entry to Active: false, even though writes still use
+  #     the keyring active. Codex CHANGES_REQUESTED on #171 reproduced
+  #     this masking: GH_TOKEN=<codex PAT> + keyring active=claude
+  #     made `gh auth status` parsers report codex as active, masking
+  #     the mismatch the warn function exists to surface.
+  #
+  #   - `gh config get -h github.com user` reads the keyring's stored
+  #     active username directly from ~/.config/gh/hosts.yml. It does
+  #     NOT honor GH_TOKEN. Verified: returns `nathanpayne-claude`
+  #     unchanged with and without GH_TOKEN set.
+  #
+  # Wrap in `|| true` so a `gh config` failure (corrupt hosts.yml,
+  # no gh login) cannot abort the parent under `set -eo pipefail`.
+  actual=$(gh config get -h github.com user 2>/dev/null || true)
   if [[ -n "$actual" ]] && [[ "$actual" != "$expected" ]]; then
     echo "# WARNING: gh active account is '$actual' (expected '$expected')." >&2
     echo "#   Reviewer-identity writes (gh pr review) will mis-attribute." >&2


### PR DESCRIPTION
Follow-up to #171 (#164). Codex `nathanpayne-codex` posted a CHANGES_REQUESTED review on #171 seconds before that PR merged at 04:11:02; merge proceeded because mergeStateStatus was CLEAN. Both findings are real — fixing forward in this PR.

## What

### Finding 1 (P1) — `warn_active_account_mismatch` masked by ambient `GH_TOKEN`

Two compounded bugs in the prior implementation:

1. **awk parser order was wrong.** `gh auth status` emits `Logged in to github.com account NAME (keyring)` BEFORE `Active account: true`, not after. The parser expected the opposite order and emitted `(keyring)` (the trailing field) instead of `NAME` on the rare cases it parsed at all.
2. **Even with a corrected `gh auth status` parser, the output is poisoned when `GH_TOKEN` is set.** gh reports the GH_TOKEN entry as `Active: true` and the keyring entry as `Active: false`, even though writes still attribute to the keyring active. The `gh api user --jq .login` fallback had the same defect.

Codex reproduced the masking with: keyring active = `nathanpayne-claude`, expected = `codex`, `GH_TOKEN` = codex PAT → warn function exited 0 silently. A subsequent `gh pr review` would attribute to `nathanpayne-claude`, defeating the warning's purpose.

**Fix:** switch to `gh config get -h github.com user`, which reads the active keyring user directly from `~/.config/gh/hosts.yml`. This endpoint does NOT honor `GH_TOKEN`. Also dropped the `gh api user` fallback — a falsely-reassuring warning is worse than no warning.

### Finding 2 (P2) — stale write-path docs

Two sites still told agents to use `GH_TOKEN=... gh pr review` / `gh pr merge`, contradicting the new convention shipped in #171:

- **`REVIEW_POLICY.md` § GitHub API authentication (gh CLI)** — full section rewritten to lead with the read/write split, point at the canonical Quick Start, and show the author-identity switch-around. Replaced the load-bearing wrong line ("if `gh auth status` shows `nathanjohnpayne`, that is fine. `GH_TOKEN` overrides…").
- **`scripts/op-preflight.sh` header** — examples block updated to scope `GH_TOKEN` to read-path/helper-script use and show the switch-around for author writes.

## Verification

Four scenarios, all pass:

| Scenario | Expected | Observed |
|----------|----------|----------|
| keyring=claude, expected=codex (mismatch) | WARN | ✅ WARN |
| keyring=claude, expected=codex, GH_TOKEN=bogus (masking attempt) | WARN | ✅ WARN |
| keyring=claude, expected=claude (match) | silent | ✅ silent |
| `--mode deploy`, no `--agent` | silent | ✅ silent |

The GH_TOKEN-spoofing case is the regression-test for Codex's exact reproduction.

## Authoring-Agent

Authoring-Agent: claude

## Self-Review

- **Correctness:** `gh config get -h github.com user` was empirically verified to be GH_TOKEN-immune (returns `nathanpayne-claude` regardless of `GH_TOKEN` value). It reads from the local hosts.yml configstore, not from any token-resolved API.
- **Regression risk:** the function is still warn-only — exit 0 in all paths via `|| true`. If `gh config get` fails (corrupt hosts.yml, no gh login), `actual=""` and no warn fires (matches pre-existing failure mode of the prior `gh auth status` path).
- **Style:** comment block updated to explain WHY `gh auth status` doesn't work and WHY `gh config get` does. The two doc sites use parallel structure (read-path examples first, write-path with switch-around second).
- **Test coverage:** four-scenario smoke test in the commit message; the GH_TOKEN-masking case is the new regression test for Codex's finding.
- **Security/dependency hygiene:** no new dependencies, no new env vars, no new API surface. The `gh config get` call is read-only and local.

## Propagation

After merge, propagates to the 6 downstream consumers via the standard sync flow alongside #171's content.
