### PR TITLE
feat(op-preflight): wire Cloudflare cache-purge token (#167)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -477,7 +477,7 @@ The guards (see [mergepath#77](https://github.com/nathanjohnpayne/mergepath/issu
 
 Both guards can be bypassed with `--force` for break-glass scenarios. Never use `--force` during routine deploys.
 
-Cloudflare cache purge runs when `CF_API_TOKEN` and `CF_ZONE_ID` are set in the environment (typical source: `op read 'op://...'`). Without both variables the purge step no-ops with a clear log line.
+Cloudflare cache purge runs when `CF_API_TOKEN` and `CF_ZONE_ID` are set in the environment. `CF_API_TOKEN` is sourced automatically by `scripts/op-preflight.sh --mode deploy` (or `--mode all`) from the shared "All Domains — Cache Purge API token" 1Password item — no `op read` needed in your shell. `CF_ZONE_ID` is per-repo; each downstream consumer sets its own zone ID (e.g., in the repo's bootstrap or as a hardcoded value in its `scripts/deploy.sh` wrapper) since one CF token covers all domains but each domain has its own zone. Without both variables the purge step no-ops with a clear log line.
 
 **Do not run `op-firebase-deploy` or `firebase deploy` directly for routine deploys.** They skip the branch + freshness guards and the cache purge. Direct invocation is reserved for debugging or one-off flows where the deploy surface is known.
 

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -26,7 +26,7 @@
 #
 # Modes:
 #   review  — reviewer PAT + author PAT + SSH key warming
-#   deploy  — GCP ADC credential
+#   deploy  — GCP ADC credential + Cloudflare cache-purge token
 #   all     — everything (default)
 #
 # Flags:
@@ -105,6 +105,15 @@ TTL_SECONDS="${OP_PREFLIGHT_TTL_SECONDS:-$DEFAULT_TTL_SECONDS}"
 
 # ── GCP ADC ───────────────────────────────────────────────────────────
 DEFAULT_ADC_OP_URI="${GCP_ADC_OP_URI:-op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential}"
+
+# ── Cloudflare Cache Purge token (#167) ───────────────────────────────
+# Shared API token with Purge:Edit permission across all domains. Wired
+# into preflight so scripts/deploy.sh's existing CF purge step
+# (currently no-op when CF_API_TOKEN is unset) actually fires on
+# agent-driven deploys without an extra biometric prompt. CF_ZONE_ID
+# is intentionally NOT sourced here — it's per-repo and lives in each
+# downstream consumer's own bootstrap, not in this shared wiring.
+DEFAULT_CF_TOKEN_OP_URI="${CF_TOKEN_OP_URI:-op://Private/4x6wslp3f6pal5t6h3jhhe63ie/credential}"
 SSH_AUTHOR_HOST="github.com"
 
 # ── Parse arguments ───────────────────────────────────────────────────
@@ -195,6 +204,7 @@ if $DRY_RUN; then
   fi
   if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
     echo "# Would read: GCP ADC ($DEFAULT_ADC_OP_URI)" >&2
+    echo "# Would read: Cloudflare cache-purge token ($DEFAULT_CF_TOKEN_OP_URI)" >&2
   fi
   exit 0
 fi
@@ -359,6 +369,7 @@ emit_from_session_file() (
   # stdout+exit; parent stays clean.
   unset OP_PREFLIGHT_REVIEWER_PAT OP_PREFLIGHT_AUTHOR_PAT
   unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+  unset CF_API_TOKEN
   unset OP_PREFLIGHT_DONE OP_PREFLIGHT_AGENT OP_PREFLIGHT_MODE
   unset OP_PREFLIGHT_CREATED_AT_EPOCH OP_PREFLIGHT_TTL_SECONDS
 
@@ -423,6 +434,8 @@ emit_from_session_file() (
     printf 'export GOOGLE_APPLICATION_CREDENTIALS=%q\n' "$GOOGLE_APPLICATION_CREDENTIALS"
   [[ -n "${OP_PREFLIGHT_ADC_TMPFILE:-}" ]] && \
     printf 'export OP_PREFLIGHT_ADC_TMPFILE=%q\n' "$OP_PREFLIGHT_ADC_TMPFILE"
+  [[ -n "${CF_API_TOKEN:-}" ]] && \
+    printf 'export CF_API_TOKEN=%q\n' "$CF_API_TOKEN"
   printf 'export OP_PREFLIGHT_DONE=1\n'
   printf 'export OP_PREFLIGHT_AGENT=%q\n' "$AGENT"
   exit 0
@@ -568,6 +581,20 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
     rm -f "$ADC_TMPFILE"
     echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2
     SUMMARY+=("GCP ADC: SKIPPED (not available)")
+  fi
+
+  # Cloudflare cache-purge token (#167). Optional — if 1Password is
+  # unreachable for this item the deploy still proceeds; deploy.sh's
+  # CF purge step gracefully no-ops on empty CF_API_TOKEN.
+  echo "# Preflight: reading Cloudflare cache-purge token..." >&2
+  cf_token=$(op read "$DEFAULT_CF_TOKEN_OP_URI" 2>/dev/null || true)
+  if [[ -n "$cf_token" ]]; then
+    EXPORTS+=("export CF_API_TOKEN=$(printf '%q' "$cf_token")")
+    SESSION_LINES+=("CF_API_TOKEN=$(printf '%q' "$cf_token")")
+    SUMMARY+=("Cloudflare cache-purge token: loaded")
+  else
+    echo "# Warning: could not read Cloudflare cache-purge token. CF_API_TOKEN not exported; deploy.sh will skip the purge step." >&2
+    SUMMARY+=("Cloudflare cache-purge token: SKIPPED (not available)")
   fi
 fi
 


### PR DESCRIPTION
Closes #167.

## What

Wire the shared "All Domains — Cache Purge API token" 1Password item (`op://Private/4x6wslp3f6pal5t6h3jhhe63ie/credential`) into `scripts/op-preflight.sh` under `--mode deploy` (and therefore `--mode all`). After `eval "$(scripts/op-preflight.sh --agent <name> --mode all)"`, `CF_API_TOKEN` is exported in the parent shell AND persisted to the chmod-600 session file alongside the existing PATs and GCP ADC. The cache-hit fast path on subsequent invocations re-emits `CF_API_TOKEN` with no biometric prompt.

`DEPLOYMENT.md` L480 updated to reflect the new flow.

## Why

`scripts/deploy.sh` has implemented Cloudflare cache purge since #135 — it runs when both `CF_API_TOKEN` and `CF_ZONE_ID` are set in the env, otherwise logs a clear skip line and continues. Until now, nothing in the preflight pipeline materialized those env vars, so routine **agent-driven** deploys silently skipped the purge unless an operator manually `op read`-ed the token first — which never happens for agent flows since each tool call spawns a fresh subshell.

Same failure mode as #139 fixed for PATs.

## Sub-decision: where CF_ZONE_ID lives

This PR intentionally does **not** source `CF_ZONE_ID`. The shared CF token covers all domains, but each domain has its own zone — so `CF_ZONE_ID` is per-repo. Each downstream consumer sets its own zone ID in its bootstrap or hardcoded in its `scripts/deploy.sh` wrapper. (Mergepath itself has no Cloudflare zone behind a build artifact — `mergepath.nathanpayne.com` is a 301 to GitHub — so this PR has no observable effect on mergepath; it lights up the next time a downstream consumer with a zone deploys under preflight.)

If a future repo wants per-repo CF zone IDs in 1Password (e.g., a sibling field on each project's deploy item), that's a separate PR.

## Verification

- `bash -n` syntax check passes.
- `--dry-run` output now includes `Would read: Cloudflare cache-purge token (op://Private/.../credential)`.
- Live run with cached deploy session (no biometric): emits `export CF_API_TOKEN=...`; summary line `Cloudflare cache-purge token: loaded`.
- Cache-hit path's unset block + emit block updated so `emit_from_session_file` passes the cached value through cleanly. Tested by re-running `--mode all` after the initial fetch and confirming `CF_API_TOKEN` is re-exported with no biometric.
- Failure mode: if `op read` fails (1Password offline, item revoked), preflight emits a non-fatal warning + summary line `Cloudflare cache-purge token: SKIPPED (not available)`, and `deploy.sh` gracefully no-ops on the empty `CF_API_TOKEN` per its existing `[[ -z "${CF_API_TOKEN:-}" ]]` check.

## Authoring-Agent

Authoring-Agent: claude

## Self-Review

- **Correctness:** mirrors the GCP ADC wiring shape exactly (fetch in deploy block, EXPORTS/SESSION_LINES/SUMMARY arrays, cache-hit unset + emit). Differs in one place: `CF_API_TOKEN` is treated as **optional** in the cache-hit validation (vs. ADC which forces refresh on missing). Reason: deploy.sh gracefully no-ops on empty CF_API_TOKEN, so partial-cache penalty isn't worth it. Caller invariant preserved: a fresh `--mode deploy` always tries to fetch; a cache hit re-emits whatever was cached.
- **Regression risk:** zero for non-deploy modes (`--mode review` block unchanged). For deploy mode: a previously-cached session file written before this PR won't have `CF_API_TOKEN`, so the cache-hit path emits PATs + ADC as before with no CF_API_TOKEN export — equivalent to the pre-PR behavior. The next live `--mode deploy` (after TTL or `--refresh`) populates the cache with CF_API_TOKEN.
- **Style:** matches existing comment-block conventions; new constant lives next to `DEFAULT_ADC_OP_URI` with a short rationale. Header `Modes:` line updated for consistency.
- **Test coverage:** `bash -n` passes; live behavioral check on dry-run + cache-hit path. End-to-end deploy-with-purge requires a downstream repo with an actual CF zone — will verify on next downstream consumer that runs preflight + deploy.
- **Security/dependency hygiene:** no new dependencies, no new permissions. The CF token is read once via `op read` (same primitive as ADC), persisted to the same chmod-600 session file under `$XDG_CACHE_HOME/mergepath/`. No network call beyond the existing 1Password fetch. The token gets exported as `CF_API_TOKEN` to the eval-ing shell — same exposure model as `OP_PREFLIGHT_REVIEWER_PAT`.

## Propagation

After merge, this propagates to all 7 downstream consumers via the standard sync flow. No per-repo config required to receive the token — once preflight ships the new wiring, every downstream deploy-mode preflight gets `CF_API_TOKEN` automatically. Each consumer that wants the purge to actually fire needs to set its own `CF_ZONE_ID` (sub-decision deferred per above).

#168 tracks the propagation tool that will make this one-command instead of 7 manual sync PRs.
