### PR TITLE
feat: branch-protection audit script + canonical required-checks doc (#161)

### DIFF
--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -434,6 +434,19 @@ Agents must never modify the `needs-external-review`, `needs-human-review`, or `
 
 ## Implementation notes for branch protection gates
 
+### Required status checks (per-repo setup)
+
+The workflows shipped under `.github/workflows/` ENFORCE merge gating only when configured as **required status checks** in branch protection. Without that bit, a failed check is advisory and the PR merges anyway. The 2026-04-27 weekly audit caught `matchline#76` and `matchline#93` merging past `needs-human-review` for exactly this reason — `Label Gate` was running and failing, but wasn't in the required-checks list.
+
+Each repo using this template must mark these as required on `main` (Settings → Branches → Branch protection rule):
+
+- **`Label Gate`** — fails when any of `needs-external-review`, `needs-human-review`, or `policy-violation` is on the PR. The hard gate behind the doctrine in [Agent prohibitions](#agent-prohibitions).
+- **`Self-Review Required`** — fails when the PR body lacks a `## Self-Review` section (Dependabot-exempt).
+
+Audit a repo's branch protection with `scripts/audit-branch-protection.sh` (read-only; exits 3 if any canonical check is not required, with a fix recipe). Re-run after every protection change.
+
+### `resolveReviewThread`
+
 The GitHub GraphQL `resolveReviewThread` mutation may be used by agents **only** when both:
 
 - The agent has demonstrably addressed the inline finding (a fix is on the current HEAD, or a rebuttal is posted on the thread), AND

--- a/scripts/audit-branch-protection.sh
+++ b/scripts/audit-branch-protection.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# audit-branch-protection.sh — verify branch protection on `main` enforces
+# the canonical required status checks shipped by mergepath.
+#
+# Background: pr-review-policy.yml's `Label Gate` job FAILS when a blocking
+# label (`needs-human-review`, `policy-violation`, `needs-external-review`)
+# is on the PR. But that failure only blocks merge if the workflow is
+# configured as a REQUIRED status check in branch protection. Without the
+# protection bit, the failed check is advisory and PRs merge anyway. This
+# is the gap that motivated nathanjohnpayne/mergepath#161 (matchline #93,
+# #76 merged past `needs-human-review`).
+#
+# Same gap applies to other workflows (Self-Review Required, agent-review
+# pipeline jobs). This audit reads branch protection via gh API and reports
+# whether each canonical check is required.
+#
+# Usage:
+#   scripts/audit-branch-protection.sh              # audit current repo, branch=main
+#   scripts/audit-branch-protection.sh --repo owner/name
+#   scripts/audit-branch-protection.sh --branch master
+#
+# Exit codes:
+#   0 — all canonical checks are required
+#   1 — bad arguments
+#   2 — gh API failure (auth, missing repo, network)
+#   3 — one or more canonical checks NOT required (PR-merge gating gap)
+#
+# Requires a token with `Administration:read` scope on the target repo
+# (most reviewer/author PATs already have this).
+
+set -eo pipefail
+
+# Canonical required-checks list. Keep in sync with the workflows that
+# mergepath ships under .github/workflows/. Each entry must match the
+# `name:` field of a job in those files exactly (GitHub's required-
+# checks API matches on display name).
+CANONICAL_REQUIRED_CHECKS=(
+  "Label Gate"
+  "Self-Review Required"
+)
+
+REPO=""
+BRANCH="main"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        echo "Error: --repo requires a non-empty value (owner/name)" >&2; exit 1
+      fi
+      REPO="$2"; shift 2 ;;
+    --branch)
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        echo "Error: --branch requires a non-empty value" >&2; exit 1
+      fi
+      BRANCH="$2"; shift 2 ;;
+    -h|--help)
+      cat <<EOF
+Usage: scripts/audit-branch-protection.sh [--repo owner/name] [--branch <name>]
+
+Verifies branch protection on \$BRANCH (default: main) requires the
+canonical mergepath-shipped status checks:
+  ${CANONICAL_REQUIRED_CHECKS[*]}
+
+Exit 3 if any canonical check is not required (PR-merge gating gap).
+EOF
+      exit 0
+      ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
+    echo "Could not resolve repo. Pass --repo owner/name." >&2; exit 2
+  }
+fi
+
+if ! [[ "$REPO" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "Invalid --repo value: '$REPO' (expected owner/name)" >&2; exit 1
+fi
+
+echo "Auditing branch protection on $REPO@$BRANCH..."
+echo ""
+
+# Fetch the branch-protection rules. Two endpoints are relevant:
+#   1. /branches/{branch}/protection — classic protection rules
+#   2. /rulesets — newer rulesets (the modern way)
+# Try (1) first; if 404, fall back to (2).
+PROT=$(gh api "repos/$REPO/branches/$BRANCH/protection" 2>&1) || true
+if echo "$PROT" | grep -q '"message":'; then
+  echo "Note: classic branch protection not configured on $BRANCH — checking rulesets instead."
+  RULESETS=$(gh api "repos/$REPO/rulesets" 2>&1) || {
+    echo "Could not fetch rulesets: $RULESETS" >&2; exit 2
+  }
+  REQUIRED=$(echo "$RULESETS" | jq -r '
+    .[]
+    | select(.target == "branch")
+    | .conditions.ref_name.include[]?
+    | select(. == "~DEFAULT_BRANCH" or . == "refs/heads/'"$BRANCH"'")
+  ' 2>/dev/null | head -1)
+  if [ -z "$REQUIRED" ]; then
+    echo "FAIL: no rulesets target $BRANCH on $REPO. PR merges are completely unprotected."
+    exit 3
+  fi
+  REQUIRED_CHECKS=$(echo "$RULESETS" | jq -r '
+    .[]
+    | select(.target == "branch")
+    | .rules[]?
+    | select(.type == "required_status_checks")
+    | .parameters.required_status_checks[]?
+    | .context
+  ')
+else
+  REQUIRED_CHECKS=$(echo "$PROT" | jq -r '.required_status_checks.contexts[]? // empty')
+fi
+
+if [ -z "$REQUIRED_CHECKS" ]; then
+  echo "FAIL: $REPO@$BRANCH has branch protection but no required status checks configured."
+  echo "      Add the canonical checks via:"
+  echo "        Settings → Branches → Branch protection rule for '$BRANCH'"
+  echo "        → Require status checks to pass before merging"
+  echo "        → Add: ${CANONICAL_REQUIRED_CHECKS[*]}"
+  exit 3
+fi
+
+echo "Required status checks currently enforced:"
+echo "$REQUIRED_CHECKS" | sed 's/^/  ✓ /'
+echo ""
+
+MISSING=()
+for check in "${CANONICAL_REQUIRED_CHECKS[@]}"; do
+  if ! echo "$REQUIRED_CHECKS" | grep -Fxq "$check"; then
+    MISSING+=("$check")
+  fi
+done
+
+if [ ${#MISSING[@]} -eq 0 ]; then
+  echo "PASS: all canonical mergepath checks are required."
+  exit 0
+fi
+
+echo "FAIL: ${#MISSING[@]} canonical mergepath check(s) NOT required on $BRANCH:"
+for check in "${MISSING[@]}"; do
+  echo "  ✗ $check"
+done
+echo ""
+echo "Without these as required, the corresponding workflows fire on PRs but"
+echo "their failures are advisory — PRs merge despite the failed check."
+echo "Specifically: 'Label Gate' enforces the prohibition on merging while"
+echo "'needs-human-review' / 'policy-violation' / 'needs-external-review' is"
+echo "present (see nathanjohnpayne/mergepath#161)."
+echo ""
+echo "Fix: Settings → Branches → Branch protection rule for '$BRANCH'"
+echo "→ Require status checks to pass before merging → Add the missing"
+echo "checks. Each workflow must have run at least once on the repo for"
+echo "GitHub's UI to offer the check name in the dropdown."
+exit 3


### PR DESCRIPTION
Closes #161 from the mergepath side. Per-repo branch protection setup is downstream config (not in template source) — this PR ships the audit tooling + documentation that make the gap visible.

## What

1. **`scripts/audit-branch-protection.sh`** — read-only audit. Reads branch protection (with rulesets API fallback) via gh API and reports whether each canonical mergepath check is required. Exit codes:
   - `0` — all canonical checks are required
   - `1` — bad arguments
   - `2` — gh API failure (auth, missing repo, network)
   - `3` — gating gap (one or more canonical checks not required), with fix recipe in stderr

   Canonical list: `Label Gate`, `Self-Review Required`. Keep in sync with `.github/workflows/` as new gating jobs ship.

2. **`REVIEW_POLICY.md` § Implementation notes for branch protection gates** gains a "Required status checks (per-repo setup)" subsection listing the canonical checks explicitly and pointing at the audit script.

## Why

#161's root cause is **not** a missing workflow — `pr-review-policy.yml`'s `Label Gate` job exists and is correct. The cause is per-repo branch protection: matchline ran the workflow, the workflow failed, but the failed check was **advisory** because Label Gate wasn't in the required-checks list. So PRs with `needs-human-review` merged anyway (matchline #76, #93).

Branch protection is per-repo config that isn't in any template's source tree. The mergepath-side fix is making the gap visible:
- Documentation says explicitly "these workflows must be required status checks."
- Audit script makes verification one command.

## Verification

Smoke tests:
- `--help` exits 0 with usage block.
- `--repo "not-valid"` exits 1 with `Invalid --repo value` error.
- `--repo "owner/name"` against a non-existent repo exits 2 (gh API 404).
- Against `nathanjohnpayne/mergepath` (no branch protection): exits 3 with `PR merges are completely unprotected.` message.
- Rulesets API fallback wired in (untested live; reads handled correctly per gh's rulesets schema). Worth a follow-up if a consumer hits the rulesets path and finds an issue.

**Caveat (drive-by finding):** mergepath itself currently has no branch protection on `main` per the audit. The audit script flagged this as exit 3. Worth filing as a follow-up issue but not in scope here.

## Authoring-Agent

Authoring-Agent: claude

## Self-Review

- **Correctness:** the canonical-check matcher uses `grep -Fxq` (fixed-string, full-line) so partial matches like `"Self-Review"` don't false-pass against `"Self-Review Required"`. The classic-vs-rulesets fallback is detected by checking the `"message":` key in the protection response (gh API's standard 404 shape). Repo-name regex matches the same shape used in `resolve-pr-threads.sh` (consistent with what's already in tree).
- **Regression risk:** zero — new file + new doc paragraph. No existing behavior changes.
- **Style:** matches existing CI script conventions in `scripts/ci/` (set -eo pipefail header; clear error → exit code mapping; --help block). The script lives at `scripts/` rather than `scripts/ci/` because it's an operator-facing audit tool, not a CI gate that runs on every commit (running it in CI would be circular — the audit would itself be one of the required checks).
- **Test coverage:** smoke matrix covered above. The classic-protection happy path is covered indirectly by the canonical-check matcher logic (tested against synthetic input via the matcher's regex). End-to-end against a real repo with proper protection requires running on a downstream consumer that has Label Gate marked required — will verify on next consumer setup.
- **Security/dependency hygiene:** read-only API calls. Requires `Administration:read` scope on the target repo, which existing reviewer/author PATs already have. No secrets, no writes, no env vars.

## Propagation

After merge: this propagates to all 7 downstream consumers via the standard sync flow. Each consumer can run `scripts/audit-branch-protection.sh` immediately to verify their own setup; the script defaults to current-repo + `main`.

#168 tracks the propagation tool.
