### PR TITLE
feat: promote scripts/gh-projects/ kit into mergepath canonical tree (#155)

### DIFF
--- a/ai_agent_tooling_standard.md
+++ b/ai_agent_tooling_standard.md
@@ -236,6 +236,9 @@ Typical contents:
 - `scripts/ci/` — CI enforcement checks (see below)
 - `scripts/build/` — build and compile helpers
 - `scripts/migrate/` — data or structure migration utilities
+- `scripts/gh-projects/` — multi-phase GitHub Projects v2 driver kit
+  (parent + native sub-issue tree, body-file placeholders, swimlane
+  helpers). Standard tooling for tracking phased initiatives.
 
 Agents should not modify files in `scripts/ci/` without explicit
 instruction, as those scripts enforce this standard.

--- a/scripts/gh-projects/README.md
+++ b/scripts/gh-projects/README.md
@@ -99,9 +99,11 @@ Create children in dependency order: if child C2's body references C1, create C1
 
 [Sub-issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-sub-issues) render as a real parent-child tree in the GitHub UI and in Projects, and the parent's progress bar tracks children automatically. Task-list checkboxes in the body work but don't roll up. `lib.sh` uses the REST API:
 
-```
+```http
 POST /repos/{owner}/{repo}/issues/{parent_num}/sub_issues
-Body: {"sub_issue_id": <child_db_id>}
+Content-Type: application/json
+
+{"sub_issue_id": <child_db_id>}
 ```
 
 Note the `sub_issue_id` is the **integer database ID** of the child (from `gh api repos/.../issues/<num> --jq .id`), not the issue number. `gh api` must send it as a number with `-F`, not a string with `-f`.

--- a/scripts/gh-projects/README.md
+++ b/scripts/gh-projects/README.md
@@ -13,12 +13,12 @@ The MUX Video Integration initiative ([Project #5](https://github.com/users/nath
 ## Prerequisites
 
 - `gh` installed (via Homebrew on this machine).
-- A PAT in 1Password with `repo` + `project` scopes. The `nathanjohnpayne` author PAT (item `sm5kopwk6t6p3xmu2igesndzhe`) works.
+- A PAT with `repo` + `project` scopes. Use the author PAT or a reviewer-identity PAT — see [REVIEW_POLICY.md § PAT lookup table](../../REVIEW_POLICY.md#pat-lookup-table) for the 1Password item IDs (the table is the canonical source; don't re-list IDs here to avoid drift).
 - Run [scripts/op-preflight.sh](../op-preflight.sh) once per session to cache credentials.
 - The target Project v2 board must have a `Status` single-select field (the default template does). `move-item.sh` discovers the field by that exact name.
 
 ```bash
-# Session setup
+# Session setup — preflight populates OP_PREFLIGHT_AUTHOR_PAT in env.
 eval "$(scripts/op-preflight.sh --agent claude --mode all)"
 export GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT"
 ```

--- a/scripts/gh-projects/README.md
+++ b/scripts/gh-projects/README.md
@@ -1,0 +1,151 @@
+# scripts/gh-projects — multi-phase GitHub Project driver kit
+
+Reusable helpers for tracking larger, multi-phase initiatives in [GitHub Projects v2](https://docs.github.com/en/issues/planning-and-tracking-with-projects). Each phase gets a parent issue with native [sub-issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-sub-issues) links to the child tasks that make it up, and every issue is added to a Project board whose swimlanes are advanced as work moves.
+
+The MUX Video Integration initiative ([Project #5](https://github.com/users/nathanjohnpayne/projects/5)) is the reference implementation — see [`examples/mux-video-integration/`](./examples/mux-video-integration/).
+
+## What this gives you
+
+- **`lib.sh`** — a sourceable library of functions: `create_parent`, `create_child`, `link_sub_issue`, `add_to_project`, `set_project_readme`, `ensure_label`, `prep_body` (placeholder substitution). Source it from a short per-initiative driver script.
+- **`move-item.sh`** — a standalone CLI that moves one issue to a named Status swimlane by discovering the project's field/option IDs at runtime. Works against any Project v2 with a `Status` single-select field.
+- **`examples/mux-video-integration/`** — a complete worked example: the driver script, body-file templates, and the output that produced issues #210–#230.
+
+## Prerequisites
+
+- `gh` installed (via Homebrew on this machine).
+- A PAT in 1Password with `repo` + `project` scopes. The `nathanjohnpayne` author PAT (item `sm5kopwk6t6p3xmu2igesndzhe`) works.
+- Run [scripts/op-preflight.sh](../op-preflight.sh) once per session to cache credentials.
+- The target Project v2 board must have a `Status` single-select field (the default template does). `move-item.sh` discovers the field by that exact name.
+
+```bash
+# Session setup
+eval "$(scripts/op-preflight.sh --agent claude --mode all)"
+export GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT"
+```
+
+## Anatomy of a phased initiative
+
+For every initiative you want to track:
+
+1. **Create the Project v2 board** in the GitHub UI. Note its owner + number (e.g. `nathanjohnpayne / 5`). Ensure it has a `Status` single-select field — the default template does.
+2. **Write the plan** somewhere durable (e.g. `~/.claude/plans/<name>.md`). This becomes the Project README.
+3. **Draft parent + child issue bodies** as Markdown files, using placeholders (`__PARENT_NUM__`, `__C1_NUM__`, etc.) for cross-references.
+4. **Write a one-shot driver script** that sources `lib.sh` and creates everything. See [`examples/mux-video-integration/create-issues.sh`](./examples/mux-video-integration/create-issues.sh).
+5. **Run the driver** once. It creates labels (if needed), parent issues, child issues, links them as sub-issues, and adds everything to the project.
+6. **Mirror the plan to the Project README** via `set_project_readme` (or `gh project edit --readme`).
+7. **Move items between swimlanes** with `move-item.sh` as work progresses.
+
+## Quick reference
+
+### Create issues from a driver
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required env — declare once at top of driver.
+export REPO="nathanjohnpayne/nathanpaynedotcom"
+export OWNER="nathanjohnpayne"
+export PROJECT=5
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../../lib.sh"
+
+ensure_label "myproj" "FF3366" "My multi-phase initiative"
+ensure_label "phase-1" "0E8A16" "Phase 1 of a multi-phase project"
+
+# Parent
+P_URL=$(create_parent "Phase 1: …" "$SCRIPT_DIR/phase-1/parent.md" "myproj,phase-1")
+P_NUM="${P_URL##*/}"
+
+# Child — substitute __PARENT_NUM__ in the body file first.
+F=$(prep_body "$SCRIPT_DIR/phase-1/c1.md" "$P_NUM")
+read C1_URL C1_NUM _ <<<"$(create_child "Do the first thing" "$F" "myproj,phase-1" "$P_NUM")"
+```
+
+### Move an issue between swimlanes
+
+```bash
+PROJECT=5 OWNER=nathanjohnpayne REPO=nathanjohnpayne/nathanpaynedotcom \
+  scripts/gh-projects/move-item.sh 211 "In Progress"
+```
+
+Valid status names are whatever options the Project's `Status` field has — typically `Todo`, `In Progress`, `In Review`, `Human`, `Done`.
+
+### Set the Project README
+
+```bash
+gh project edit <N> --owner <owner> --readme "$(cat path/to/plan.md)"
+```
+
+Or from a driver that has sourced `lib.sh`:
+
+```bash
+set_project_readme ~/.claude/plans/my-initiative.md
+```
+
+## Placeholder conventions in body files
+
+`prep_body` does a simple `sed` substitution on up to five tokens:
+
+| Token | Meaning |
+|---|---|
+| `__PARENT_NUM__` | The parent issue number (always available once the parent is created). |
+| `__C1_NUM__` … `__C4_NUM__` | A sibling child's issue number — useful when one child needs to reference another (e.g. "Verify the PR from sub-issue #\_\_C3\_NUM\_\_"). |
+
+Create children in dependency order: if child C2's body references C1, create C1 first, capture its number, then `prep_body C2.md $PARENT_NUM $C1_NUM`.
+
+## Why native sub-issues (not task lists)
+
+[Sub-issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-sub-issues) render as a real parent-child tree in the GitHub UI and in Projects, and the parent's progress bar tracks children automatically. Task-list checkboxes in the body work but don't roll up. `lib.sh` uses the REST API:
+
+```
+POST /repos/{owner}/{repo}/issues/{parent_num}/sub_issues
+Body: {"sub_issue_id": <child_db_id>}
+```
+
+Note the `sub_issue_id` is the **integer database ID** of the child (from `gh api repos/.../issues/<num> --jq .id`), not the issue number. `gh api` must send it as a number with `-F`, not a string with `-f`.
+
+## Gotchas
+
+- **Hook blocks heredoc in inline `gh issue create`.** The repo's `scripts/hooks/gh-pr-guard.sh` tokenizes the command with shlex and rejects heredocs. Always write body content to a file and use `--body-file`.
+- **`gh api` integer fields need `-F`.** `-f` coerces to string → 422 Invalid request.
+- **Env vars don't persist across `Bash` tool calls.** Always re-eval preflight or re-read the PAT inline at the start of each shell invocation.
+- **Project-item ID ≠ issue number.** The `Status` edit endpoint takes the project-level item ID (`PVTI_...`), which you look up via `gh project item-list --format json` and match by content URL. `move-item.sh` does this for you.
+- **Project v2 `readme` field.** `gh project edit <N> --owner <owner> --readme <string>` overwrites the entire README. Pass the full rendered Markdown.
+
+## Worked example
+
+See [`examples/mux-video-integration/`](./examples/mux-video-integration/) for the exact files used to create issues #210–#230. The driver is rerunnable against a fresh project — delete existing issues first or re-point `PROJECT` to a new board.
+
+## Two driver lifecycle patterns
+
+Two driver shapes cover the full per-initiative lifecycle. Both use this same `lib.sh`; the difference is what they're for.
+
+### Fresh-create driver (`examples/<initiative>/create-issues.sh`)
+
+One-shot, non-idempotent script that builds the initial issue tree from scratch. Creates labels, parent issues, child issues in dependency order, links children as native sub-issues, and adds everything to the Project board. Use when a new initiative kicks off.
+
+The MUX example above is a fresh-create driver. After it runs, the issue tree exists and the kit's job is mostly done — subsequent work is moving items between swimlanes via `move-item.sh` and (occasionally) refining the plan.
+
+### Additions driver (`examples/<initiative>/additions/add-*.sh`)
+
+Companion one-shot, non-idempotent driver that adds new children to **existing** parent issues without recreating the tree. Use when:
+
+- A plan-review surfaces follow-on work that needs ticket coverage under existing parents (e.g., "phase 2 also needs a child for X")
+- A phase scope expands mid-flight
+- A mid-phase discovery needs its own ticket
+
+Same `lib.sh` helpers — no library changes. The driver fetches existing parent numbers (or accepts them as args), prep_body's sibling references, calls `create_child` + `link_sub_issue` for each new child, then adds to the Project. The reference implementation lives in nathanpaynedotcom (`scripts/gh-projects/examples/matchline/additions/add-plan-refinements.sh` on the `matchline/issue-driver` branch — promoted in [nathanpaynedotcom#263](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/263)).
+
+### Picking which to write
+
+| Situation | Driver |
+|---|---|
+| New initiative, no issues yet | Fresh-create |
+| Existing initiative, expanding scope | Additions |
+| Existing initiative, refining a single existing issue | Just edit the issue directly via `gh issue edit` — no driver needed |
+
+## Idempotency caveat
+
+Neither driver shape is currently idempotent. Re-running a fresh-create driver against a project that already has the issues will create duplicates. The scope-creep solution would be a `create_child_once` helper that skips when a child with the same title already exists under the same parent — file as a follow-up if you find yourself wanting to safely re-run an additions driver.

--- a/scripts/gh-projects/examples/mux-video-integration/create-issues.sh
+++ b/scripts/gh-projects/examples/mux-video-integration/create-issues.sh
@@ -22,6 +22,32 @@ export REPO="nathanjohnpayne/nathanpaynedotcom"
 export OWNER="nathanjohnpayne"
 export PROJECT=5
 
+# Safety gate (CodeRabbit on PR #180): this script writes to LIVE
+# project coordinates. Re-running creates duplicate issues #210+ and
+# spams the project board. Require explicit confirmation that the
+# operator knows they're hitting prod.
+#
+# Override:
+#   GHP_CONFIRM_LIVE=I_AM_REPOPULATING_PROJECT_5 ./create-issues.sh
+#
+# To repurpose this driver against a different project, change REPO/OWNER/
+# PROJECT above (and the override token) before running. This file is
+# the canonical worked example — copy it to your own examples/<initiative>/
+# directory before adapting, don't edit in place.
+if [[ "${GHP_CONFIRM_LIVE:-}" != "I_AM_REPOPULATING_PROJECT_5" ]]; then
+  echo "Refusing to run: this driver writes to live project coordinates"
+  echo "($REPO project #$PROJECT). Re-running creates duplicate issues."
+  echo ""
+  echo "If you're adapting this as a template for a different initiative,"
+  echo "COPY THE FILE to scripts/gh-projects/examples/<your-initiative>/"
+  echo "and edit REPO/OWNER/PROJECT plus this safety gate's override token"
+  echo "before running."
+  echo ""
+  echo "If you genuinely intend to repopulate $REPO project #$PROJECT,"
+  echo "set GHP_CONFIRM_LIVE=I_AM_REPOPULATING_PROJECT_5 and re-run."
+  exit 1
+fi
+
 # shellcheck source=../../lib.sh
 source "$SCRIPT_DIR/../../lib.sh"
 

--- a/scripts/gh-projects/examples/mux-video-integration/create-issues.sh
+++ b/scripts/gh-projects/examples/mux-video-integration/create-issues.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Rerunnable driver that creates every parent + child issue for the MUX Video
+# Integration initiative (GitHub Project #5), links them as native sub-issues,
+# and adds each to the project board.
+#
+# This is the canonical worked example for scripts/gh-projects/ — see the
+# README one level up for the pattern.
+#
+# Preconditions:
+#   eval "$(scripts/op-preflight.sh --agent claude --mode all)"
+#   export GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT"
+#
+# Already-executed on 2026-04-18: produced parent issues #210, #215, #220, #225.
+# Re-running will create a duplicate set — the script is not idempotent. Use
+# only against a fresh project or after wiping the existing issues.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+export REPO="nathanjohnpayne/nathanpaynedotcom"
+export OWNER="nathanjohnpayne"
+export PROJECT=5
+
+# shellcheck source=../../lib.sh
+source "$SCRIPT_DIR/../../lib.sh"
+
+# -----------------------------------------------------------------------------
+# Labels (idempotent)
+# -----------------------------------------------------------------------------
+ensure_label "mux" "FF3366" "MUX video integration"
+ensure_label "phase-1" "0E8A16" "Phase 1 of a multi-phase project"
+ensure_label "phase-2" "1D76DB" "Phase 2 of a multi-phase project"
+ensure_label "phase-3" "5319E7" "Phase 3 of a multi-phase project"
+ensure_label "phase-4" "B60205" "Phase 4 of a multi-phase project"
+
+# -----------------------------------------------------------------------------
+# Phase 1 — Component + Swipe Watch integration
+# -----------------------------------------------------------------------------
+P1_URL=$(create_parent "Phase 1: Add MuxPlayer to Swipe Watch hero" \
+  "$SCRIPT_DIR/phase-1/parent.md" "mux,phase-1")
+P1_NUM="${P1_URL##*/}"
+echo "P1 PARENT: $P1_URL"
+
+F=$(prep_body "$SCRIPT_DIR/phase-1/c1.md" "$P1_NUM")
+read P1_C1_URL P1_C1_NUM _ <<<"$(create_child "Install @mux/mux-player-astro dependency" \
+  "$F" "mux,phase-1" "$P1_NUM")"
+echo "  C1: $P1_C1_URL"
+
+F=$(prep_body "$SCRIPT_DIR/phase-1/c2.md" "$P1_NUM")
+read P1_C2_URL P1_C2_NUM _ <<<"$(create_child "Extend projects schema with optional muxPlaybackId" \
+  "$F" "mux,phase-1" "$P1_NUM")"
+echo "  C2: $P1_C2_URL"
+
+F=$(prep_body "$SCRIPT_DIR/phase-1/c3.md" "$P1_NUM")
+read P1_C3_URL P1_C3_NUM _ <<<"$(create_child "Wire MuxPlayer into ProjectLayout + CSS + swipe-watch frontmatter" \
+  "$F" "mux,phase-1" "$P1_NUM")"
+echo "  C3: $P1_C3_URL"
+
+# C4 references C3 via __C3_NUM__
+F=$(prep_body "$SCRIPT_DIR/phase-1/c4.md" "$P1_NUM" "" "" "$P1_C3_NUM")
+read P1_C4_URL P1_C4_NUM _ <<<"$(create_child "Phase 1 manual QA: player, fallback, OG, screenshot" \
+  "$F" "mux,phase-1" "$P1_NUM")"
+echo "  C4: $P1_C4_URL"
+
+# -----------------------------------------------------------------------------
+# Phase 2 — Mux Data (analytics)
+# -----------------------------------------------------------------------------
+P2_URL=$(create_parent "Phase 2: Wire Mux Data via PUBLIC_MUX_ENV_KEY" \
+  "$SCRIPT_DIR/phase-2/parent.md" "mux,phase-2")
+P2_NUM="${P2_URL##*/}"
+echo "P2 PARENT: $P2_URL"
+
+F=$(prep_body "$SCRIPT_DIR/phase-2/c1.md" "$P2_NUM")
+read P2_C1_URL P2_C1_NUM _ <<<"$(create_child "Add .env.example for PUBLIC_MUX_ENV_KEY" \
+  "$F" "mux,phase-2" "$P2_NUM")"
+echo "  C1: $P2_C1_URL"
+
+# Create C3 before C2 because C2 references C3 via __C3_NUM__
+F=$(prep_body "$SCRIPT_DIR/phase-2/c3.md" "$P2_NUM")
+read P2_C3_URL P2_C3_NUM _ <<<"$(create_child "Pass env-key and metadata to MuxPlayer" \
+  "$F" "mux,phase-2" "$P2_NUM")"
+echo "  C3: $P2_C3_URL"
+
+F=$(prep_body "$SCRIPT_DIR/phase-2/c2.md" "$P2_NUM" "" "" "$P2_C3_NUM")
+read P2_C2_URL P2_C2_NUM _ <<<"$(create_child "Provision PUBLIC_MUX_ENV_KEY in 1Password + Firebase" \
+  "$F" "mux,phase-2" "$P2_NUM")"
+echo "  C2: $P2_C2_URL"
+
+F=$(prep_body "$SCRIPT_DIR/phase-2/c4.md" "$P2_NUM")
+read P2_C4_URL P2_C4_NUM _ <<<"$(create_child "Phase 2 manual QA: confirm Mux Data views" \
+  "$F" "mux,phase-2" "$P2_NUM")"
+echo "  C4: $P2_C4_URL"
+
+# -----------------------------------------------------------------------------
+# Phase 3 — Extract reusable ProjectMuxPlayer component
+# -----------------------------------------------------------------------------
+P3_URL=$(create_parent "Phase 3: Extract reusable ProjectMuxPlayer component" \
+  "$SCRIPT_DIR/phase-3/parent.md" "mux,phase-3")
+P3_NUM="${P3_URL##*/}"
+echo "P3 PARENT: $P3_URL"
+
+F=$(prep_body "$SCRIPT_DIR/phase-3/c1.md" "$P3_NUM")
+read P3_C1_URL P3_C1_NUM _ <<<"$(create_child "Extract ProjectMuxPlayer.astro component" \
+  "$F" "mux,phase-3" "$P3_NUM")"
+echo "  C1: $P3_C1_URL"
+
+# C2 references C1
+F=$(prep_body "$SCRIPT_DIR/phase-3/c2.md" "$P3_NUM" "$P3_C1_NUM")
+read P3_C2_URL P3_C2_NUM _ <<<"$(create_child "Swap ProjectLayout to call ProjectMuxPlayer" \
+  "$F" "mux,phase-3" "$P3_NUM")"
+echo "  C2: $P3_C2_URL"
+
+F=$(prep_body "$SCRIPT_DIR/phase-3/c3.md" "$P3_NUM")
+read P3_C3_URL P3_C3_NUM _ <<<"$(create_child "Document MUX video extension path in AGENTS.md" \
+  "$F" "mux,phase-3" "$P3_NUM")"
+echo "  C3: $P3_C3_URL"
+
+F=$(prep_body "$SCRIPT_DIR/phase-3/c4.md" "$P3_NUM")
+read P3_C4_URL P3_C4_NUM _ <<<"$(create_child "Phase 3 theming QA: verify all accent classes" \
+  "$F" "mux,phase-3" "$P3_NUM")"
+echo "  C4: $P3_C4_URL"
+
+# -----------------------------------------------------------------------------
+# Phase 4 — Replace static GIF with Mux-generated GIF
+# -----------------------------------------------------------------------------
+P4_URL=$(create_parent "Phase 4: Replace static GIF with Mux-generated GIF" \
+  "$SCRIPT_DIR/phase-4/parent.md" "mux,phase-4")
+P4_NUM="${P4_URL##*/}"
+echo "P4 PARENT: $P4_URL"
+
+F=$(prep_body "$SCRIPT_DIR/phase-4/c1.md" "$P4_NUM")
+read P4_C1_URL P4_C1_NUM _ <<<"$(create_child "Add scripts/refresh-mux-gifs.mjs" \
+  "$F" "mux,phase-4" "$P4_NUM")"
+echo "  C1: $P4_C1_URL"
+
+F=$(prep_body "$SCRIPT_DIR/phase-4/c2.md" "$P4_NUM")
+read P4_C2_URL P4_C2_NUM _ <<<"$(create_child "Skip Mux-backed projects in refresh-hero-images.mjs" \
+  "$F" "mux,phase-4" "$P4_NUM")"
+echo "  C2: $P4_C2_URL"
+
+# C3 references C1 and C2
+F=$(prep_body "$SCRIPT_DIR/phase-4/c3.md" "$P4_NUM" "$P4_C1_NUM" "$P4_C2_NUM")
+read P4_C3_URL P4_C3_NUM _ <<<"$(create_child "Wire refresh-mux-gifs.mjs into build" \
+  "$F" "mux,phase-4" "$P4_NUM")"
+echo "  C3: $P4_C3_URL"
+
+# C4 references C3
+F=$(prep_body "$SCRIPT_DIR/phase-4/c4.md" "$P4_NUM" "" "" "$P4_C3_NUM")
+read P4_C4_URL P4_C4_NUM _ <<<"$(create_child "Document Mux GIF refresher in AGENTS.md" \
+  "$F" "mux,phase-4" "$P4_NUM")"
+echo "  C4: $P4_C4_URL"
+
+F=$(prep_body "$SCRIPT_DIR/phase-4/c5.md" "$P4_NUM")
+read P4_C5_URL P4_C5_NUM _ <<<"$(create_child "Phase 4 manual QA: GIF regeneration + hero refresher skip" \
+  "$F" "mux,phase-4" "$P4_NUM")"
+echo "  C5: $P4_C5_URL"
+
+echo ""
+echo "=== DONE ==="
+echo "Phase 1: $P1_URL"
+echo "Phase 2: $P2_URL"
+echo "Phase 3: $P3_URL"
+echo "Phase 4: $P4_URL"

--- a/scripts/gh-projects/examples/mux-video-integration/phase-1/c1.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-1/c1.md
@@ -1,0 +1,9 @@
+Add the `@mux/mux-player-astro` package as a runtime dependency.
+
+**Scope (one PR, dependency only — no code using it yet):**
+- `npm install @mux/mux-player-astro`
+- Commit `package.json` + lockfile.
+
+**Why isolated:** separating the dep install from the code change makes the next PR's diff about integration logic only.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-1/c2.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-1/c2.md
@@ -1,0 +1,9 @@
+Add an optional `muxPlaybackId` field to the projects collection schema so project frontmatter can declare a Mux video.
+
+**Scope (one PR):**
+- Edit `src/content.config.ts` (projects collection, lines 4–38): add `muxPlaybackId: z.string().optional()`.
+- No renderer changes in this PR.
+
+**Why isolated:** schema change merges safely before the renderer lands — the field is optional, so the site build stays green.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-1/c3.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-1/c3.md
@@ -1,0 +1,21 @@
+Render the Mux player on Swipe Watch, themed to the page accent, with the GIF as fallback.
+
+**Scope (one atomic PR — the three edits must land together or the page is half-wired):**
+
+1. **`src/layouts/ProjectLayout.astro` (around lines 114–124):**
+   - Conditionally render `<MuxPlayer>` when `muxPlaybackId` is present, else the existing `<img>` tag.
+   - Fallback: nest `<img slot="placeholder" …/>` inside `<MuxPlayer>`; if that slot is not honored, fall back to a sibling `<noscript><img …/></noscript>` inside the `<figure>`.
+   - Inline style: `--media-accent-color: var(--project-accent); --media-primary-color: var(--project-accent); aspect-ratio: 9/16;`
+   - Attributes: `autoplay muted loop playsinline`.
+
+2. **`src/styles/global.css` (around lines 1080–1127):**
+   - Add `.project-screenshot__mux` — `aspect-ratio: 9/16; border-radius: 12px; width: 100%;`
+   - The existing `.project-screenshot--narrow .project-screenshot__inner { max-width: 320px }` already yields a ~320×569 phone shape.
+
+3. **`src/content/projects/swipe-watch.md` (line 8):**
+   - Keep `screenshotSrc` (OG template + fallback both consume it).
+   - Add `muxPlaybackId: "wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k"` directly beneath it.
+
+**Why atomic:** shipping renderer-without-data or data-without-renderer leaves `/projects/swipe-watch` broken in production for the window between merges.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-1/c4.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-1/c4.md
@@ -1,0 +1,11 @@
+Verify Phase 1 end-to-end on the PR from sub-issue #__C3_NUM__.
+
+**Checks (attach evidence to the atomic PR):**
+- `npm run dev`, open `/projects/swipe-watch`.
+- Vertical player autoplays muted + loops + playsinline on first load.
+- Progress bar / controls tinted red (matches `#c11d19`).
+- DevTools, disable JS, reload, GIF fallback renders (`public/images/projects/swipe-watch-hero.gif`).
+- `curl -I http://localhost:4321/og/projects/swipe-watch.png` returns 200 OK and PNG.
+- Attach a screenshot of the rendered player to the PR.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-1/parent.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-1/parent.md
@@ -1,0 +1,13 @@
+Tracks Phase 1 of **MUX Video Integration** (Project #5).
+
+**Goal:** Swipe Watch project page renders a vertical MUX video (autoplay + muted + loop + playsinline) with progress bar tinted to the page's red accent (#c11d19). GIF fallback still renders when JS is disabled. No impact on other project pages.
+
+**Playback ID:** `wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k`
+
+**Exit criteria:**
+- Player renders vertically on `/projects/swipe-watch`.
+- Autoplay / muted / loop / playsinline all verified.
+- JS-disabled renders the existing GIF at `public/images/projects/swipe-watch-hero.gif`.
+- OG image at `/og/projects/swipe-watch.png` still generates.
+
+Sub-issues below. See [Project #5 README](https://github.com/users/nathanjohnpayne/projects/5) for the full phased plan.

--- a/scripts/gh-projects/examples/mux-video-integration/phase-2/c1.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-2/c1.md
@@ -1,0 +1,10 @@
+Add a `.env.example` at the repo root documenting the Mux Data env key.
+
+**Scope (one PR):**
+- Create `.env.example` at the repo root.
+- Include `PUBLIC_MUX_ENV_KEY=` with a short comment explaining what it's for.
+- If `.gitignore` doesn't already cover `.env` / `.env.local`, add that exclusion.
+
+**Why isolated:** gives future contributors a single, zero-risk signal that the env key exists, without yet changing any rendering code.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-2/c2.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-2/c2.md
@@ -1,0 +1,13 @@
+Provision `PUBLIC_MUX_ENV_KEY` so local, CI, and Firebase builds all see it.
+
+**Scope (one PR, mostly docs + optional preflight extension):**
+- Store the Mux Data env key in 1Password (new item under `Private`).
+- Document the item ID + read path in `DEPLOYMENT.md` under a "Mux Data env key" heading.
+- Add the key to the Firebase Hosting runtime / build env per `DEPLOYMENT.md`'s deploy flow.
+- Optional: extend `scripts/op-preflight.sh` with a `--mode mux` (or fold into `--mode all`) that exports `PUBLIC_MUX_ENV_KEY` when set.
+
+**Notes:**
+- Uses the `PUBLIC_` prefix so Astro's Vite env system exposes it to client code. Safe to publish — Mux Data env keys are designed to be public.
+- Missing key must not break the player — handled in sub-issue #__C3_NUM__.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-2/c3.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-2/c3.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Wire Mux Data analytics into the MuxPlayer element.
 
 **Scope (one PR):**

--- a/scripts/gh-projects/examples/mux-video-integration/phase-2/c3.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-2/c3.md
@@ -1,0 +1,14 @@
+Wire Mux Data analytics into the MuxPlayer element.
+
+**Scope (one PR):**
+- In `src/layouts/ProjectLayout.astro` (or the extracted `ProjectMuxPlayer` component if Phase 3 landed first), read `import.meta.env.PUBLIC_MUX_ENV_KEY`.
+- Pass to MuxPlayer as `env-key={PUBLIC_MUX_ENV_KEY}` alongside:
+  - `metadata-video-title={title}`
+  - `metadata-video-id={slug}`
+- If `PUBLIC_MUX_ENV_KEY` is falsy, omit the `env-key` attr entirely — the player still plays, no errors, just no analytics.
+
+**Verification:**
+- Reload `/projects/swipe-watch` with the key set → view registers in Mux Data dashboard within ~60s.
+- Unset the key → no console errors, player still plays.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-2/c4.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-2/c4.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Manual QA: confirm Mux Data is recording views.
 
 **Checks (no code change — evidence only):**

--- a/scripts/gh-projects/examples/mux-video-integration/phase-2/c4.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-2/c4.md
@@ -1,0 +1,10 @@
+Manual QA: confirm Mux Data is recording views.
+
+**Checks (no code change — evidence only):**
+- Load `/projects/swipe-watch` at least 3 times (clear cache between loads).
+- Open Mux Data dashboard → confirm 3 view events appear within ~60 seconds.
+- Confirm each event's `video_title` = "Swipe Watch" and `video_id` = "swipe-watch".
+- Locally unset `PUBLIC_MUX_ENV_KEY`, reload the page → confirm no console errors, player still autoplays.
+- Attach a screenshot of the Mux Data dashboard showing the fresh views to this issue.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-2/parent.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-2/parent.md
@@ -1,0 +1,13 @@
+Tracks Phase 2 of **MUX Video Integration** (Project #5).
+
+**Goal:** Views on `/projects/swipe-watch` (and any other page embedding a MUX video) register in Mux Data with correct `video_title` / `video_id` metadata. Missing env key does not break the player.
+
+**Exit criteria:**
+- `PUBLIC_MUX_ENV_KEY` read via Astro's Vite env.
+- MuxPlayer receives `env-key` + `metadata-video-title` + `metadata-video-id`.
+- Real views show up in the Mux Data dashboard.
+- Unset key → player still loads, no console errors.
+
+**Depends on:** the Phase 1 parent issue.
+
+Sub-issues below. See [Project #5 README](https://github.com/users/nathanjohnpayne/projects/5) for the full phased plan.

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/c1.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/c1.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Extract MuxPlayer logic from ProjectLayout into a reusable component.
 
 **Scope (one PR):**

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/c1.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/c1.md
@@ -1,0 +1,14 @@
+Extract MuxPlayer logic from ProjectLayout into a reusable component.
+
+**Scope (one PR):**
+- Create `src/components/ProjectMuxPlayer.astro`.
+- Props: `playbackId: string`, `title: string`, `slug: string`, `fallbackSrc: string`.
+- Component owns:
+  - Conditional render (MuxPlayer when `playbackId` is present, else `<img>` with `fallbackSrc`).
+  - CSS var passthrough: `--media-accent-color: var(--project-accent); --media-primary-color: var(--project-accent); aspect-ratio: 9/16;`.
+  - Autoplay / muted / loop / playsinline attributes.
+  - Mux Data metadata props (`metadata-video-title` + `metadata-video-id`), reading `PUBLIC_MUX_ENV_KEY` via `import.meta.env` (if Phase 2 has merged).
+
+**Why isolated:** a single extraction PR is reviewable on its own; the next PR swaps the call site.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/c2.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/c2.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Replace inline MuxPlayer block in ProjectLayout with the extracted component.
 
 **Scope (one PR):**

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/c2.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/c2.md
@@ -1,0 +1,10 @@
+Replace inline MuxPlayer block in ProjectLayout with the extracted component.
+
+**Scope (one PR):**
+- Edit `src/layouts/ProjectLayout.astro`: replace the `{muxPlaybackId ? <MuxPlayer …/> : <img …/>}` ternary with `<ProjectMuxPlayer playbackId={muxPlaybackId} title={title} slug={slug} fallbackSrc={screenshotSrc} />`.
+- Remove the direct `@mux/mux-player-astro` import from this file.
+- Grep for remaining inline MuxPlayer usages to confirm zero.
+
+**Depends on:** #__C1_NUM__.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/c3.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/c3.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Document "How to add a MUX video to a project page" in AGENTS.md.
 
 **Scope (one PR):**

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/c3.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/c3.md
@@ -1,0 +1,13 @@
+Document "How to add a MUX video to a project page" in AGENTS.md.
+
+**Scope (one PR):**
+- Add a new section to `AGENTS.md` under an appropriate heading (e.g. near "Project pages" if it exists, or a new "## Mux video integration" top-level section).
+- Content: a ~10-line recipe covering:
+  - Upload the video to the Mux dashboard.
+  - Copy the public Playback ID.
+  - Add `muxPlaybackId: "<id>"` to the project's frontmatter.
+  - Optionally override aspect ratio / fallback image.
+  - That `<ProjectMuxPlayer>` handles theming automatically via `--project-accent`.
+- No code changes.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/c4.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/c4.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Verify theming cascades across every `project-page--*` accent class.
 
 **Checks (no committed code — local smoke test + evidence):**

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/c4.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/c4.md
@@ -1,0 +1,15 @@
+Verify theming cascades across every `project-page--*` accent class.
+
+**Checks (no committed code — local smoke test + evidence):**
+- Temporarily edit `src/content/projects/swipe-watch.md`: flip `accentColorClass` through each value in `src/styles/global.css:832-871`:
+  - `project-page--red` (baseline)
+  - `project-page--yellow`
+  - `project-page--black`
+  - `project-page--blue`
+  - `project-page--lightblue`
+  - `project-page--paper`
+- After each flip, reload `/projects/swipe-watch` and confirm the MUX player's progress bar / controls retint to the new accent.
+- Revert `accentColorClass` back to `project-page--red`. No commit.
+- Attach a grid screenshot (or 6 individual screenshots) showing each tint.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/parent.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/parent.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Tracks Phase 3 of **MUX Video Integration** (Project #5).
 
 **Goal:** MuxPlayer usage lives in a single reusable Astro component so any future project page can embed a video by adding `muxPlaybackId` to its frontmatter. Per-page theming flows automatically from each project's `--project-accent`.
@@ -6,7 +7,7 @@ Tracks Phase 3 of **MUX Video Integration** (Project #5).
 - `src/components/ProjectMuxPlayer.astro` is the sole consumer of `@mux/mux-player-astro`.
 - `src/layouts/ProjectLayout.astro` calls the component once, no inline MuxPlayer logic.
 - AGENTS.md documents: "How to add a MUX video to a project page" (one frontmatter field).
-- Theming verified against each `project-page--*` accent class (red, yellow, blue, lightblue, paper).
+- Theming verified against each `project-page--*` accent class (red, yellow, black, blue, lightblue, paper).
 
 **Depends on:** the Phase 1 parent issue. Phase 2 is optional — component should work without a Mux Data env key.
 

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/parent.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/parent.md
@@ -1,0 +1,13 @@
+Tracks Phase 3 of **MUX Video Integration** (Project #5).
+
+**Goal:** MuxPlayer usage lives in a single reusable Astro component so any future project page can embed a video by adding `muxPlaybackId` to its frontmatter. Per-page theming flows automatically from each project's `--project-accent`.
+
+**Exit criteria:**
+- `src/components/ProjectMuxPlayer.astro` is the sole consumer of `@mux/mux-player-astro`.
+- `src/layouts/ProjectLayout.astro` calls the component once, no inline MuxPlayer logic.
+- AGENTS.md documents: "How to add a MUX video to a project page" (one frontmatter field).
+- Theming verified against each `project-page--*` accent class (red, yellow, blue, lightblue, paper).
+
+**Depends on:** the Phase 1 parent issue. Phase 2 is optional — component should work without a Mux Data env key.
+
+Sub-issues below. See [Project #5 README](https://github.com/users/nathanjohnpayne/projects/5) for the full phased plan.

--- a/scripts/gh-projects/examples/mux-video-integration/phase-4/c1.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-4/c1.md
@@ -1,0 +1,13 @@
+Add `scripts/refresh-mux-gifs.mjs` that writes Mux-generated animated GIFs for any project with a `muxPlaybackId`.
+
+**Scope (one PR):**
+- Create `scripts/refresh-mux-gifs.mjs`. Behavior:
+  - Read `src/content/projects/*.md` frontmatter.
+  - For each with `muxPlaybackId`, `fetch('https://image.mux.com/{playbackId}/animated.gif?width=320&fps=15&end=8')`.
+  - Write to `public/images/projects/{slug}-hero.gif`.
+  - Fail loudly (non-zero exit) on network errors or non-200 responses — don't silently skip.
+  - Log each GIF written (slug → filesize).
+- Not wired into build yet — that lands in a separate sub-issue of the Phase 4 parent.
+- Does not mutate any existing files beyond `public/images/projects/{slug}-hero.gif`.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-4/c2.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-4/c2.md
@@ -1,0 +1,10 @@
+Prevent `scripts/refresh-hero-images.mjs` from overwriting Mux-sourced GIFs.
+
+**Scope (one PR):**
+- Edit `scripts/refresh-hero-images.mjs`: skip any project whose frontmatter has `muxPlaybackId` set.
+- Log skipped slugs at the end so the skip is visible.
+- Confirm the existing GitHub social-preview refresh still works for projects without `muxPlaybackId`.
+
+**Why:** the GitHub social preview refresher currently rewrites `screenshotSrc` on opt-in projects. Without this skip, running both refreshers during a build could race / clobber the Mux-sourced GIF depending on order.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-4/c3.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-4/c3.md
@@ -1,0 +1,11 @@
+Wire `refresh-mux-gifs.mjs` into the build pipeline.
+
+**Scope (one PR):**
+- Option A (preferred): add a `prebuild` script to `package.json` that runs `node scripts/refresh-mux-gifs.mjs` before `astro build`.
+- Option B (if Astro integration is cleaner): hook into `astro:build:start` via an inline integration in `astro.config.mjs`.
+- Confirm `npm run build` triggers the refresher.
+- Confirm CI (Firebase Hosting deploy workflow in `.github/workflows/`) runs the refresher before `astro build`.
+
+**Depends on:** #__C1_NUM__ and #__C2_NUM__.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-4/c4.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-4/c4.md
@@ -1,0 +1,10 @@
+Document the Mux GIF refresher in AGENTS.md.
+
+**Scope (one PR, docs only):**
+- Extend the "Mux video integration" section in `AGENTS.md` with a "Fallback GIFs" subsection covering:
+  - `scripts/refresh-mux-gifs.mjs` writes `public/images/projects/{slug}-hero.gif` from each project's Mux asset.
+  - Runs as `prebuild` (or whichever hook landed in #__C3_NUM__).
+  - `scripts/refresh-hero-images.mjs` skips Mux-backed projects.
+  - How to regenerate the GIF manually: `node scripts/refresh-mux-gifs.mjs`.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-4/c5.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-4/c5.md
@@ -1,0 +1,12 @@
+Manual QA: Mux-generated GIF pipeline.
+
+**Checks (no code change — evidence only):**
+- Delete `public/images/projects/swipe-watch-hero.gif` locally.
+- Run `npm run build`.
+- Confirm the file regenerates at ~320px wide, ~8s, smooth.
+- Confirm OG image at `/og/projects/swipe-watch.png` still renders correctly (uses the new GIF as source).
+- Run `node scripts/refresh-hero-images.mjs` manually → confirm it logs skipping `swipe-watch`.
+- Confirm no other project's hero was touched.
+- Attach a before/after screenshot of the GIF to this issue.
+
+Parent: #__PARENT_NUM__

--- a/scripts/gh-projects/examples/mux-video-integration/phase-4/parent.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-4/parent.md
@@ -1,0 +1,14 @@
+Tracks Phase 4 of **MUX Video Integration** (Project #5).
+
+**Goal:** Replace the hand-maintained static GIF at `public/images/projects/swipe-watch-hero.gif` with a Mux-generated animated GIF pulled from the same asset as the video. Any future project with a `muxPlaybackId` gets a fresh Mux-sourced GIF automatically on build.
+
+**Exit criteria:**
+- `scripts/refresh-mux-gifs.mjs` exists and, for every project with a `muxPlaybackId`, writes `public/images/projects/{slug}-hero.gif` from `https://image.mux.com/{playbackId}/animated.gif`.
+- Build runs the refresher before `astro build`.
+- `scripts/refresh-hero-images.mjs` (the existing GitHub social-preview refresher) skips any project with `muxPlaybackId`.
+- OG image generation still works against the new GIF.
+- Running the refresher with no network / bad playback ID degrades cleanly (build fails loudly; no silent corruption).
+
+**Depends on:** the Phase 1 parent issue.
+
+Sub-issues below. See [Project #5 README](https://github.com/users/nathanjohnpayne/projects/5) for the full phased plan.

--- a/scripts/gh-projects/lib.sh
+++ b/scripts/gh-projects/lib.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Reusable helpers for creating phased GitHub Projects v2 issue trees.
+#
+# Source this from a driver script (one per multi-phase initiative). The driver
+# declares the issues; this file does the mechanics (parent/child creation,
+# native sub-issue linking, Project item-add).
+#
+# Required environment:
+#   REPO     — owner/name, e.g. "nathanjohnpayne/nathanpaynedotcom"
+#   OWNER    — Project owner login (user or org)
+#   PROJECT  — Project v2 number (integer)
+#
+# Required auth:
+#   GH_TOKEN must be set to a PAT with `repo` + `project` scopes.
+#
+# Placeholders in body files:
+#   __PARENT_NUM__ — replaced with the parent issue number
+#   __C1_NUM__ ... __C4_NUM__ — replaced with sibling child numbers (use when a
+#     child body needs to reference another child; see examples/)
+
+set -euo pipefail
+
+: "${REPO:?REPO must be set (owner/repo)}"
+: "${OWNER:?OWNER must be set}"
+: "${PROJECT:?PROJECT must be set (v2 number)}"
+
+GHP_TMPDIR="${GHP_TMPDIR:-$(mktemp -d)}"
+export GHP_TMPDIR
+
+# Add a created issue to the configured project.
+add_to_project() {
+  gh project item-add "$PROJECT" --owner "$OWNER" --url "$1" > /dev/null
+}
+
+# Link a child issue to its parent via GitHub's native sub-issue API.
+# The parent_num is the integer issue number; child_id is the DB id (integer),
+# not the issue number. Fetch with: gh api repos/$REPO/issues/$num --jq .id
+link_sub_issue() {
+  gh api -X POST "repos/$REPO/issues/$1/sub_issues" -F "sub_issue_id=$2" > /dev/null
+}
+
+# Substitute placeholders in a body file; write to a unique path under
+# $GHP_TMPDIR and echo it. Two different source files whose basenames
+# collide (e.g. phase-1/c1.md and phase-2/c1.md) get distinct output
+# paths — using `basename` alone would overwrite.
+# Usage: prep_body <src> <parent_num> [c1] [c2] [c3] [c4]
+prep_body() {
+  local src="$1" parent="$2" c1="${3:-}" c2="${4:-}" c3="${5:-}" c4="${6:-}"
+  # Encode the full source path into the destination name by replacing
+  # slashes with underscores, so distinct source paths map to distinct
+  # destinations.
+  local dst="$GHP_TMPDIR/$(echo "$src" | tr '/' '_')"
+  sed \
+    -e "s|__PARENT_NUM__|$parent|g" \
+    -e "s|__C1_NUM__|$c1|g" \
+    -e "s|__C2_NUM__|$c2|g" \
+    -e "s|__C3_NUM__|$c3|g" \
+    -e "s|__C4_NUM__|$c4|g" \
+    "$src" > "$dst"
+  echo "$dst"
+}
+
+# Create a parent issue and add it to the configured project.
+# Side effects: calls `add_to_project` on the new issue.
+# Echoes the issue URL.
+# Usage: create_parent <title> <body_file> <labels_csv>
+create_parent() {
+  local title="$1" body_file="$2" label="$3"
+  local url
+  url=$(gh issue create --repo "$REPO" --title "$title" --body-file "$body_file" --label "$label" | tail -1)
+  add_to_project "$url"
+  echo "$url"
+}
+
+# Create a child issue, add to project, link as sub-issue of parent.
+# Echoes three space-separated fields: URL NUMBER DB_ID
+# Usage: create_child <title> <body_file> <labels_csv> <parent_num>
+create_child() {
+  local title="$1" body_file="$2" label="$3" parent_num="$4"
+  local url num id
+  url=$(gh issue create --repo "$REPO" --title "$title" --body-file "$body_file" --label "$label" | tail -1)
+  num="${url##*/}"
+  id=$(gh api "repos/$REPO/issues/$num" --jq .id)
+  add_to_project "$url"
+  link_sub_issue "$parent_num" "$id"
+  echo "$url $num $id"
+}
+
+# Set the Project v2 README from a local file.
+# Usage: set_project_readme <file>
+set_project_readme() {
+  gh project edit "$PROJECT" --owner "$OWNER" --readme "$(cat "$1")" > /dev/null
+  echo "Project #$PROJECT README updated from $1"
+}
+
+# Ensure a label exists in the repo (idempotent).
+# Usage: ensure_label <name> <color_hex> <description>
+ensure_label() {
+  gh label create "$1" --color "$2" --description "$3" --repo "$REPO" --force > /dev/null
+}

--- a/scripts/gh-projects/lib.sh
+++ b/scripts/gh-projects/lib.sh
@@ -23,6 +23,7 @@ set -euo pipefail
 : "${REPO:?REPO must be set (owner/repo)}"
 : "${OWNER:?OWNER must be set}"
 : "${PROJECT:?PROJECT must be set (v2 number)}"
+: "${GH_TOKEN:?GH_TOKEN must be set to a PAT with repo + project scopes (CodeRabbit on PR #180: every helper here makes mutations on GitHub; failing fast at source-time is better than letting gh fall through to ambient auth and posting under the wrong identity)}"
 
 GHP_TMPDIR="${GHP_TMPDIR:-$(mktemp -d)}"
 export GHP_TMPDIR

--- a/scripts/gh-projects/move-item.sh
+++ b/scripts/gh-projects/move-item.sh
@@ -19,6 +19,13 @@ STATUS_NAME="${2:?status name required}"
 : "${REPO:?REPO must be set (owner/repo)}"
 : "${OWNER:?OWNER must be set}"
 : "${PROJECT:?PROJECT must be set}"
+: "${GH_TOKEN:?GH_TOKEN must be set to a PAT with project scope (this script mutates project items)}"
+
+# Required tooling: gh and python3 (used for parsing gh's JSON output below).
+# CodeRabbit on PR #180 caught the missing python3 check — fail fast with a
+# clear error rather than letting the python3 invocation crash mid-pipeline.
+command -v gh      >/dev/null 2>&1 || { echo "Error: gh CLI not on PATH (install via 'brew install gh')." >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "Error: python3 not on PATH (this script uses python3 to parse gh's JSON output; install python3 via your package manager)." >&2; exit 1; }
 
 export STATUS_NAME
 

--- a/scripts/gh-projects/move-item.sh
+++ b/scripts/gh-projects/move-item.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Move a GitHub Project v2 item (by issue number) to a named Status swimlane.
+#
+# Usage:
+#   PROJECT=5 OWNER=nathanjohnpayne REPO=nathanjohnpayne/nathanpaynedotcom \
+#     GH_TOKEN="$(op read ...)" ./move-item.sh <issue_number> <status_name>
+#
+# <status_name> is the human-readable option name: Todo, In Progress, In Review,
+# Human, Done (or whatever options exist on the project's Status field).
+#
+# The script discovers the project's node ID, Status field ID, and option IDs
+# at runtime, so it works with any Project v2 that has a Status field.
+
+set -euo pipefail
+
+ISSUE_NUM="${1:?issue number required}"
+STATUS_NAME="${2:?status name required}"
+
+: "${REPO:?REPO must be set (owner/repo)}"
+: "${OWNER:?OWNER must be set}"
+: "${PROJECT:?PROJECT must be set}"
+
+export STATUS_NAME
+
+# Resolve the project's node ID.
+PROJECT_ID=$(gh project view "$PROJECT" --owner "$OWNER" --format json \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+
+# Resolve the Status field ID + the option ID for the requested status in a
+# single pass over field-list output.
+read -r STATUS_FIELD_ID OPT_ID <<<"$(gh project field-list "$PROJECT" --owner "$OWNER" --limit 100 --format json | python3 -c "
+import json, os, sys
+name = os.environ['STATUS_NAME']
+d = json.load(sys.stdin)
+field_id = ''
+opt_id = ''
+for f in d.get('fields', []):
+    if f.get('name') == 'Status':
+        field_id = f.get('id', '')
+        for o in f.get('options', []):
+            if o.get('name') == name:
+                opt_id = o.get('id', '')
+                break
+        break
+print(field_id, opt_id)
+")"
+
+if [ -z "$PROJECT_ID" ] || [ -z "$STATUS_FIELD_ID" ] || [ -z "$OPT_ID" ]; then
+  echo "failed to resolve project/field/option IDs (PROJECT_ID=$PROJECT_ID, STATUS_FIELD_ID=$STATUS_FIELD_ID, OPT_ID=$OPT_ID, STATUS_NAME=$STATUS_NAME)" >&2
+  echo "Confirm the project has a 'Status' single-select field and that '$STATUS_NAME' is one of its options." >&2
+  exit 1
+fi
+
+# Resolve the project-level item ID for this issue.
+export ISSUE_URL="https://github.com/$REPO/issues/$ISSUE_NUM"
+ITEM_ID=$(gh project item-list "$PROJECT" --owner "$OWNER" --format json --limit 2000 | python3 -c "
+import json, os, sys
+url = os.environ['ISSUE_URL']
+d = json.load(sys.stdin)
+for it in d.get('items', []):
+    content = it.get('content') or {}
+    if content.get('url') == url:
+        print(it['id']); break
+")
+
+if [ -z "$ITEM_ID" ]; then
+  echo "could not find project item for $ISSUE_URL (is the issue in Project #$PROJECT?)" >&2
+  exit 1
+fi
+
+gh project item-edit \
+  --id "$ITEM_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$STATUS_FIELD_ID" \
+  --single-select-option-id "$OPT_ID" > /dev/null
+
+echo "moved #$ISSUE_NUM to '$STATUS_NAME'"


### PR DESCRIPTION
Closes #155.

## What

Promotes the `scripts/gh-projects/` kit (multi-phase GitHub Projects v2 driver tooling) from `nathanjohnpayne/nathanpaynedotcom` into mergepath as canonical Standard tooling. Every Standard-adopting repo will inherit it the same way they inherit `op-preflight.sh`, `codex-review-*.sh`, and the `scripts/ci/` guards.

## Scope

**Copied** (296 lines + the canonical example):
- `scripts/gh-projects/lib.sh` (100 lines) — sourceable helpers
- `scripts/gh-projects/move-item.sh` (77 lines, +x) — swimlane-move CLI
- `scripts/gh-projects/README.md` — kit documentation (rewritten, see below)
- `scripts/gh-projects/examples/mux-video-integration/` — canonical reference example

**Deliberately NOT copied:**
- `examples/matchline/` — per-initiative artifact, stays in its home repo (currently nathanpaynedotcom). Mergepath ships **code + docs + ONE canonical reference example** only.

## README — both lifecycle patterns now documented

The README previously covered only the fresh-create driver shape. Updated to document **both** patterns explicitly:

- **Fresh-create driver** (existing): `examples/<initiative>/create-issues.sh` — one-shot, non-idempotent, builds initial issue tree from scratch.
- **Additions driver** (new sub-pattern, never previously documented): `examples/<initiative>/additions/add-*.sh` — one-shot, non-idempotent companion that adds children to **existing** parents without recreating the tree. Same `lib.sh` helpers — no library changes. Reference implementation: nathanpaynedotcom on the matchline/issue-driver branch ([nathanpaynedotcom#263](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/263)).

Plus a "picking which" table and an idempotency caveat (neither shape is currently idempotent — `create_child_once` helper noted as a follow-up if anyone needs safely-rerunnable additions drivers).

## ai_agent_tooling_standard.md update

§ `scripts/` canonical-tree section gains a `gh-projects/` entry alongside `ci/`, `build/`, `migrate/`. Brief description of what the kit is for.

## Sub-decision deferred

The issue's open question on the nathanpaynedotcom-side (sunset the copy vs. keep as a snapshot): not making that call here. Once a propagation tool exists (#168), the nathanpaynedotcom copy can become a propagation target (auto-synced from mergepath HEAD); until then, leaving the nathanpaynedotcom copy in place to avoid disrupting in-flight matchline work that depends on it.

## Verification

- `bash -n` syntax check passes on `lib.sh` and `move-item.sh`.
- `scripts/ci/check_no_forbidden_top_level_dirs` passes (kit lives under `scripts/`, not at top level — no `.repo-template.yml` entry needed).
- Executable bits preserved on `move-item.sh` and `examples/.../create-issues.sh`.
- 26 files / 753 insertions / 0 deletions — pure additive change.

## Authoring-Agent

Authoring-Agent: claude

## Self-Review

- **Correctness:** byte-for-byte mirror of the kit from nathanpaynedotcom HEAD. README appended-only — original content preserved.
- **Regression risk:** zero. New top-level subdir under `scripts/`. No existing files modified beyond the one-line addition to `ai_agent_tooling_standard.md`.
- **Style:** matches existing `scripts/` subdir conventions (README at root, executable scripts at +x). Doc tone matches existing `scripts/ci/README.md`.
- **Test coverage:** kit doesn't have unit tests in either repo. End-to-end coverage comes from the next initiative that uses it (next mergepath consumer that wants Project tracking).
- **Security/dependency hygiene:** no new dependencies (uses existing `gh` + `jq`). No secrets. Authentication via existing `OP_PREFLIGHT_AUTHOR_PAT` per the README's prerequisites section.

## Propagation

After merge: propagates to all 7 downstream consumers via the standard sync flow. Each consumer gets the kit immediately; per-initiative `examples/` directories stay per-repo.

#168 tracks the propagation tool.
