### PR TITLE
feat(firebase): prefer project SA key over preflight ADC + log selected source credential (#137 + #154)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -620,9 +620,44 @@ Each project's SA key is stored in the 1Password **Firebase** vault with the nam
 ## Secrets Management
 
 - No API keys or secrets should be committed to the repository.
-- **Deploy auth uses the project Firebase-vault SA key as the default credential** (#154 — codified after recurring `firebase login --reauth` friction from #137 traced to RAPT/refresh-token expiry on the shared 1Password ADC). The SA key lives in the 1Password Firebase vault — it's not stored on disk except as a tempfile during a single deploy invocation, and never committed to a repo. Impersonated credentials remain available for cases where the SA key isn't provisioned, but the policy default is to provision the key per-project per § First-Time Setup.
+- **Deploy auth uses the project Firebase-vault SA key as the default credential** (#154 — codified after recurring `firebase login --reauth` friction from #137 traced to RAPT/refresh-token expiry on the shared 1Password ADC). The SA key lives in the 1Password Firebase vault — it's not stored on disk except as a tempfile during a single deploy invocation, and never committed to a repo. Impersonated credentials remain available for cases where the SA key isn't provisioned, but the policy default is to provision the key per-project per § Provisioning the Firebase-vault SA key below.
 - Runtime secrets can still use `op://Private/<item>/<field>` references in committed template files and `op inject` into gitignored runtime files when a repo actually needs 1Password-managed application secrets.
 - Never commit resolved secret output, service-account JSON, or ADC credentials.
+
+### Provisioning the Firebase-vault SA key
+
+Run once per Firebase project, after `op-firebase-setup` has created the `firebase-deployer` service account:
+
+```bash
+PROJECT_ID="{project-id}"
+SA_EMAIL="firebase-deployer@${PROJECT_ID}.iam.gserviceaccount.com"
+KEY_PATH="$(mktemp -t firebase-sa-key.json)"
+
+# 1. Generate a JSON key for the deployer SA. Requires the
+#    iam.serviceAccountKeyAdmin role (or roles/owner) on the project.
+gcloud iam service-accounts keys create "$KEY_PATH" \
+  --iam-account="$SA_EMAIL" \
+  --project="$PROJECT_ID"
+
+# 2. Upload to the 1Password Firebase vault as a document with the
+#    canonical title "{project-id} — Firebase Deployer SA Key" (this
+#    is the exact title materialize_firebase_vault_sa_key reads in
+#    op-firebase-deploy).
+op document create "$KEY_PATH" \
+  --vault Firebase \
+  --title "${PROJECT_ID} — Firebase Deployer SA Key"
+
+# 3. Wipe the local copy. The key now lives only in 1Password +
+#    on-disk tempfiles created/destroyed during single deploy runs.
+rm -f "$KEY_PATH"
+
+# 4. Verify: a routine deploy should now log
+#    "[op-firebase-deploy] source credential: project Firebase-vault
+#    SA key (...)" and run without prompting for firebase login --reauth.
+op-firebase-deploy --only hosting   # or whatever target
+```
+
+Rotation (e.g., key compromised, GCP-side key expiry, agent identity change): repeat steps 1–4 with `--key-file-type=json` on `gcloud iam service-accounts keys create`. Old key on the SA can be deleted via `gcloud iam service-accounts keys delete <key-id>` after the new one is verified.
 
 ## Auth Maintenance
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -194,15 +194,21 @@ When prompted:
 
 This creates `firebase.json` and `.firebaserc`. Commit both.
 
-### 4. Set up keyless deploy impersonation
+### 4. Set up the deployer service account
 
 ```bash
 op-firebase-setup {project-id}
 ```
 
-See [First-Time Setup](#first-time-setup) for details. After this, deploys use short-lived impersonated credentials instead of stored keys.
+See [First-Time Setup](#first-time-setup) for details. This creates the `firebase-deployer` service account, grants the necessary deploy roles, and configures impersonation as a fallback path.
 
-If `op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential` does not exist yet, seed it once by running `gcloud auth application-default login`, then copy `~/.config/gcloud/application_default_credentials.json` into the 1Password item `Private/GCP ADC`, field `credential`. After that, the normal maintainer flow returns to 1Password-backed, non-browser auth.
+### 5. Provision the Firebase-vault SA key (preferred default)
+
+After `op-firebase-setup` runs, follow [§ Secrets Management → Provisioning the Firebase-vault SA key](#provisioning-the-firebase-vault-sa-key) to materialize the SA key into the 1Password Firebase vault. This is the **preferred default** credential for routine deploys (interactive + CI) per #154 — it avoids the recurring `firebase login --reauth` friction (#137) caused by RAPT/refresh-token expiry on the shared 1Password ADC.
+
+Impersonation remains as a fallback path; it kicks in when the project SA key isn't provisioned yet.
+
+If `op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential` does not exist yet, seed it once by running `gcloud auth application-default login`, then copy `~/.config/gcloud/application_default_credentials.json` into the 1Password item `Private/GCP ADC`, field `credential`. The shared ADC is rank-4 fallback in the `op-firebase-deploy` resolver.
 
 ---
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -134,7 +134,7 @@ If both machines modified the same 1Password item:
 - [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) (`gcloud`) installed
 - [1Password CLI](https://developer.1password.com/docs/cli/) (`op`) installed and signed in
 - `gcloud`, `op-firebase-deploy`, and `op-firebase-setup` on PATH (see Script Installation below)
-- Access to the project SA key in `op://Firebase/{project-id} — Firebase Deployer SA Key` (preferred for CI/headless) or the shared 1Password source credential `op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential`, or another explicit `GOOGLE_APPLICATION_CREDENTIALS` file
+- Access to the project SA key in `op://Firebase/{project-id} — Firebase Deployer SA Key` (the **preferred default** for both interactive and CI/headless deploys per #154 — the most stable credential, no daily-reauth churn from #137), with the shared 1Password ADC `op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential` as a fallback, plus support for an explicit `GOOGLE_APPLICATION_CREDENTIALS` file as the highest-priority override
 - Permission to create resources in the target Firebase/GCP project and impersonate the deployer service account
 
 ## Script Installation
@@ -508,11 +508,17 @@ op-firebase-deploy --only functions
 
 `op-firebase-deploy`:
 1. Auto-detects the Firebase project from `.firebaserc`
-2. Reads source credentials in order: `GOOGLE_APPLICATION_CREDENTIALS`, then the project SA key from `op://Firebase/{project-id} — Firebase Deployer SA Key`, then `op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential`, then `~/.config/gcloud/application_default_credentials.json`
-3. If the source credential is a `service_account` key matching the target `firebase-deployer@{project-id}.iam.gserviceaccount.com`, uses it directly (no impersonation wrapper needed — faster, no `serviceAccountTokenCreator` required)
-4. Otherwise, unwraps nested impersonated credentials if needed, stamps the target project into `quota_project_id`, and writes a temporary `impersonated_service_account` credential file
-5. Runs `firebase deploy --non-interactive`
-6. Cleans up the temp credentials on exit
+2. Reads source credentials in this order (per #154):
+   1. **Genuinely user-supplied `GOOGLE_APPLICATION_CREDENTIALS`** — when a human explicitly set the env var (debugging, alternate project, one-off flow). The script distinguishes this from preflight-injected ADC by comparing against `OP_PREFLIGHT_ADC_TMPFILE`.
+   2. **Project SA key** from `op://Firebase/{project-id} — Firebase Deployer SA Key` — the **default day-to-day deploy credential**, both interactive and CI. Stable, no RAPT/refresh-token expiry.
+   3. **Preflight-injected `GOOGLE_APPLICATION_CREDENTIALS`** — used when no project SA key is provisioned. The shared 1Password ADC's RAPT-expiry surface (#137) is the cost of this fallback; consumers wanting stable deploys should provision the project SA key.
+   4. **Shared 1Password ADC** read directly from `op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential` — used when neither preflight nor SA key are available.
+   5. **Local ADC file** `~/.config/gcloud/application_default_credentials.json` — last resort.
+3. Logs the selected credential source on stderr (`[op-firebase-deploy] source credential: ...`) so deploy auth debugging is no longer opaque.
+4. If the source credential is a `service_account` key matching the target `firebase-deployer@{project-id}.iam.gserviceaccount.com`, uses it directly (no impersonation wrapper needed — faster, no `serviceAccountTokenCreator` required).
+5. Otherwise, unwraps nested impersonated credentials if needed, stamps the target project into `quota_project_id`, and writes a temporary `impersonated_service_account` credential file.
+6. Runs `firebase deploy --non-interactive`.
+7. Cleans up the temp credentials on exit.
 
 No browser prompt is needed for routine use once a valid credential exists in the resolution chain and the 1Password CLI is unlocked.
 
@@ -614,7 +620,7 @@ Each project's SA key is stored in the 1Password **Firebase** vault with the nam
 ## Secrets Management
 
 - No API keys or secrets should be committed to the repository.
-- Deploy auth should use short-lived impersonated credentials, not stored service-account keys.
+- **Deploy auth uses the project Firebase-vault SA key as the default credential** (#154 — codified after recurring `firebase login --reauth` friction from #137 traced to RAPT/refresh-token expiry on the shared 1Password ADC). The SA key lives in the 1Password Firebase vault — it's not stored on disk except as a tempfile during a single deploy invocation, and never committed to a repo. Impersonated credentials remain available for cases where the SA key isn't provisioned, but the policy default is to provision the key per-project per § First-Time Setup.
 - Runtime secrets can still use `op://Private/<item>/<field>` references in committed template files and `op inject` into gitignored runtime files when a repo actually needs 1Password-managed application secrets.
 - Never commit resolved secret output, service-account JSON, or ADC credentials.
 

--- a/scripts/firebase/op-firebase-deploy
+++ b/scripts/firebase/op-firebase-deploy
@@ -273,22 +273,47 @@ fi
 echo "[op-firebase-deploy] source credential: ${SOURCE_CRED_DESCRIPTION:-unknown}" >&2
 
 if ! source_cred_is_usable "$SOURCE_CRED_FILE"; then
+  # Distinguish a GENUINELY user-supplied GOOGLE_APPLICATION_CREDENTIALS
+  # (exit immediately — the human meant it) from a preflight-injected
+  # one (fall through to lower ranks). Codex P2 on PR #181 caught that
+  # the prior unconditional equality check exited 1 even when the env
+  # var was preflight's, masking ranks 4-5 fallbacks (shared op ADC,
+  # local ADC) that were specifically designated for this case.
   if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" && "$SOURCE_CRED_FILE" == "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
-    echo "Error: GOOGLE_APPLICATION_CREDENTIALS points to an unusable credential file: $SOURCE_CRED_FILE" >&2
-    exit 1
+    if [[ -n "${OP_PREFLIGHT_ADC_TMPFILE:-}" && "$SOURCE_CRED_FILE" == "${OP_PREFLIGHT_ADC_TMPFILE}" ]]; then
+      # Preflight-injected and unusable — log and continue down the
+      # fallback chain. Don't treat as explicit override.
+      echo "[op-firebase-deploy] preflight-injected ADC ($SOURCE_CRED_FILE) is unusable; falling through to shared op ADC + local ADC" >&2
+    else
+      echo "Error: GOOGLE_APPLICATION_CREDENTIALS points to an unusable credential file: $SOURCE_CRED_FILE" >&2
+      exit 1
+    fi
   fi
 
   cleanup_source_cred
   SOURCE_CRED_FILE=""
   SOURCE_CRED_TMPFILE=""
 
-  if [[ -f "$DEFAULT_ADC_FILE" ]]; then
+  # Rank 4 fallback: shared op ADC (in case the preflight tempfile is
+  # stale but a fresh op read of the same item works).
+  resolved="$(materialize_op_source_cred "$DEFAULT_ADC_OP_URI" || true)"
+  if [[ -n "$resolved" ]]; then
+    SOURCE_CRED_FILE="$resolved"
+    SOURCE_CRED_TMPFILE="$resolved"
+    SOURCE_CRED_DESCRIPTION="shared 1Password ADC ($DEFAULT_ADC_OP_URI; rank 4 fallback after rank-3 unusable)"
+    echo "[op-firebase-deploy] source credential: $SOURCE_CRED_DESCRIPTION" >&2
+  fi
+
+  # Rank 5 fallback: local ADC file on disk.
+  if ! source_cred_is_usable "$SOURCE_CRED_FILE" && [[ -f "$DEFAULT_ADC_FILE" ]]; then
     SOURCE_CRED_FILE="$DEFAULT_ADC_FILE"
+    SOURCE_CRED_DESCRIPTION="local ADC file ($DEFAULT_ADC_FILE; rank 5 fallback)"
+    echo "[op-firebase-deploy] source credential: $SOURCE_CRED_DESCRIPTION" >&2
   fi
 
   if ! source_cred_is_usable "$SOURCE_CRED_FILE"; then
     echo "Error: No usable GCP source credential found." >&2
-    echo "Refresh the shared 1Password GCP ADC item or provide a working GOOGLE_APPLICATION_CREDENTIALS file." >&2
+    echo "Provision the project Firebase-vault SA key (preferred — see DEPLOYMENT.md § Secrets Management), refresh the shared 1Password GCP ADC item, or provide a working GOOGLE_APPLICATION_CREDENTIALS file." >&2
     exit 1
   fi
 fi

--- a/scripts/firebase/op-firebase-deploy
+++ b/scripts/firebase/op-firebase-deploy
@@ -267,10 +267,12 @@ if ! resolve_source_cred_file; then
   exit 1
 fi
 
-# Log which credential source was selected (#137 + #154 — debugging
-# deploy auth was previously opaque). Goes to stderr so deploy
-# stdout/stderr stays clean for log-grepping by the caller.
-echo "[op-firebase-deploy] source credential: ${SOURCE_CRED_DESCRIPTION:-unknown}" >&2
+# Note: the source-credential log line fires AFTER the usability check
+# below settles, so a credential that gets rejected and falls through
+# to ranks 4/5 doesn't get its name in the log. CodeRabbit r1 on
+# PR #181 caught the prior position of this log (right after
+# resolve_source_cred_file) being misleading when the initial
+# candidate failed the usability check.
 
 if ! source_cred_is_usable "$SOURCE_CRED_FILE"; then
   # Distinguish a GENUINELY user-supplied GOOGLE_APPLICATION_CREDENTIALS
@@ -301,14 +303,12 @@ if ! source_cred_is_usable "$SOURCE_CRED_FILE"; then
     SOURCE_CRED_FILE="$resolved"
     SOURCE_CRED_TMPFILE="$resolved"
     SOURCE_CRED_DESCRIPTION="shared 1Password ADC ($DEFAULT_ADC_OP_URI; rank 4 fallback after rank-3 unusable)"
-    echo "[op-firebase-deploy] source credential: $SOURCE_CRED_DESCRIPTION" >&2
   fi
 
   # Rank 5 fallback: local ADC file on disk.
   if ! source_cred_is_usable "$SOURCE_CRED_FILE" && [[ -f "$DEFAULT_ADC_FILE" ]]; then
     SOURCE_CRED_FILE="$DEFAULT_ADC_FILE"
     SOURCE_CRED_DESCRIPTION="local ADC file ($DEFAULT_ADC_FILE; rank 5 fallback)"
-    echo "[op-firebase-deploy] source credential: $SOURCE_CRED_DESCRIPTION" >&2
   fi
 
   if ! source_cred_is_usable "$SOURCE_CRED_FILE"; then
@@ -317,6 +317,12 @@ if ! source_cred_is_usable "$SOURCE_CRED_FILE"; then
     exit 1
   fi
 fi
+
+# Source-credential log AFTER the usability check + any fallback walk
+# settles. This guarantees the logged name matches the credential the
+# subsequent firebase deploy actually uses, not a candidate that got
+# rejected mid-flow.
+echo "[op-firebase-deploy] source credential: ${SOURCE_CRED_DESCRIPTION:-unknown}" >&2
 
 python3 - <<'PY' "$SOURCE_CRED_FILE" "$ADC_TMPFILE" "$SA_EMAIL" "$PROJECT"
 import json

--- a/scripts/firebase/op-firebase-deploy
+++ b/scripts/firebase/op-firebase-deploy
@@ -166,7 +166,16 @@ resolve_source_cred_file() {
   fi
 
   # 1. Genuinely user-supplied GOOGLE_APPLICATION_CREDENTIALS
-  if [[ -n "$explicit_file" && -f "$explicit_file" && "$is_preflight_injected" -eq 0 ]]; then
+  if [[ -n "$explicit_file" && "$is_preflight_injected" -eq 0 ]]; then
+    if [[ ! -f "$explicit_file" ]]; then
+      # User explicitly set GOOGLE_APPLICATION_CREDENTIALS to a path
+      # that doesn't exist. Fail fast — silently falling through to
+      # other sources would deploy with a different identity/project
+      # than the caller asked for. Codex r1 Phase 4b on PR #181.
+      echo "Error: GOOGLE_APPLICATION_CREDENTIALS points to a missing file: $explicit_file" >&2
+      echo "Either fix the path or unset GOOGLE_APPLICATION_CREDENTIALS to fall through to the project SA key / preflight ADC / shared ADC chain." >&2
+      exit 1
+    fi
     SOURCE_CRED_FILE="$explicit_file"
     SOURCE_CRED_DESCRIPTION="explicit GOOGLE_APPLICATION_CREDENTIALS ($explicit_file)"
     return 0

--- a/scripts/firebase/op-firebase-deploy
+++ b/scripts/firebase/op-firebase-deploy
@@ -130,12 +130,45 @@ materialize_firebase_vault_sa_key() {
 }
 
 resolve_source_cred_file() {
+  # Precedence (#154 — codified policy decision):
+  #
+  #   1. Genuinely user-supplied GOOGLE_APPLICATION_CREDENTIALS
+  #   2. Project-specific SA key from 1Password Firebase vault
+  #   3. Preflight-injected GOOGLE_APPLICATION_CREDENTIALS
+  #      (op-preflight.sh's ADC tempfile)
+  #   4. Shared ADC from 1Password Private vault
+  #   5. Local ADC file on disk
+  #
+  # Step 1 differs from steps 3-5 by deliberately ranking the
+  # genuinely-explicit override above the project SA key — if a human
+  # set GOOGLE_APPLICATION_CREDENTIALS in the shell themselves
+  # (debugging, one-off flow, alternate project), they meant it.
+  #
+  # Step 3 is a NEW behavior change (was step 1 in the prior
+  # implementation): when GOOGLE_APPLICATION_CREDENTIALS came from
+  # op-preflight.sh's --mode deploy, the ADC is the shared 1Password
+  # ADC item (which suffers from refresh-token RAPT expiry — see
+  # mergepath#137). Falling through to the project SA key first means
+  # routine deploys use the more-stable credential without the
+  # daily-reauth churn.
+  #
+  # The marker that distinguishes (1) from (3): the OP_PREFLIGHT_ADC_TMPFILE
+  # env var. Preflight sets it to the same path as
+  # GOOGLE_APPLICATION_CREDENTIALS when it injects an ADC; if the two
+  # match, the GOOGLE_APPLICATION_CREDENTIALS is preflight-injected,
+  # not user-set.
   local explicit_file="${GOOGLE_APPLICATION_CREDENTIALS:-}"
+  local preflight_tmpfile="${OP_PREFLIGHT_ADC_TMPFILE:-}"
   local resolved=""
+  local is_preflight_injected=0
+  if [[ -n "$explicit_file" && -n "$preflight_tmpfile" && "$explicit_file" == "$preflight_tmpfile" ]]; then
+    is_preflight_injected=1
+  fi
 
-  # 1. Explicit GOOGLE_APPLICATION_CREDENTIALS
-  if [[ -n "$explicit_file" && -f "$explicit_file" ]]; then
+  # 1. Genuinely user-supplied GOOGLE_APPLICATION_CREDENTIALS
+  if [[ -n "$explicit_file" && -f "$explicit_file" && "$is_preflight_injected" -eq 0 ]]; then
     SOURCE_CRED_FILE="$explicit_file"
+    SOURCE_CRED_DESCRIPTION="explicit GOOGLE_APPLICATION_CREDENTIALS ($explicit_file)"
     return 0
   fi
 
@@ -144,20 +177,34 @@ resolve_source_cred_file() {
   if [[ -n "$resolved" ]]; then
     SOURCE_CRED_FILE="$resolved"
     SOURCE_CRED_TMPFILE="$resolved"
+    SOURCE_CRED_DESCRIPTION="project Firebase-vault SA key ($PROJECT — Firebase Deployer SA Key)"
     return 0
   fi
 
-  # 3. Shared ADC from 1Password Private vault
+  # 3. Preflight-injected GOOGLE_APPLICATION_CREDENTIALS — used when
+  #    no project SA key exists. The shared ADC's RAPT-expiry surface
+  #    (#137) is the cost of this fallback; consumers wanting stable
+  #    deploys should provision the project SA key per DEPLOYMENT.md.
+  if [[ -n "$explicit_file" && -f "$explicit_file" && "$is_preflight_injected" -eq 1 ]]; then
+    SOURCE_CRED_FILE="$explicit_file"
+    SOURCE_CRED_DESCRIPTION="preflight-injected ADC (shared 1Password ADC; subject to RAPT expiry — see #137)"
+    return 0
+  fi
+
+  # 4. Shared ADC from 1Password Private vault (no preflight, but the
+  #    item is reachable directly).
   resolved="$(materialize_op_source_cred "$DEFAULT_ADC_OP_URI" || true)"
   if [[ -n "$resolved" ]]; then
     SOURCE_CRED_FILE="$resolved"
     SOURCE_CRED_TMPFILE="$resolved"
+    SOURCE_CRED_DESCRIPTION="shared 1Password ADC ($DEFAULT_ADC_OP_URI)"
     return 0
   fi
 
-  # 4. Local ADC file on disk
+  # 5. Local ADC file on disk
   if [[ -f "$DEFAULT_ADC_FILE" ]]; then
     SOURCE_CRED_FILE="$DEFAULT_ADC_FILE"
+    SOURCE_CRED_DESCRIPTION="local ADC file ($DEFAULT_ADC_FILE; subject to RAPT expiry — see #137)"
     return 0
   fi
 
@@ -219,6 +266,11 @@ if ! resolve_source_cred_file; then
   echo "Set GOOGLE_APPLICATION_CREDENTIALS, unlock 1Password item $DEFAULT_ADC_OP_URI, or create $DEFAULT_ADC_FILE." >&2
   exit 1
 fi
+
+# Log which credential source was selected (#137 + #154 — debugging
+# deploy auth was previously opaque). Goes to stderr so deploy
+# stdout/stderr stays clean for log-grepping by the caller.
+echo "[op-firebase-deploy] source credential: ${SOURCE_CRED_DESCRIPTION:-unknown}" >&2
 
 if ! source_cred_is_usable "$SOURCE_CRED_FILE"; then
   if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" && "$SOURCE_CRED_FILE" == "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then


### PR DESCRIPTION
Closes #137 and #154 (paired). #154's policy decision is what makes #137's symptom go away — the project SA key has stable auth (no RAPT/refresh-token expiry like the shared 1Password ADC), so routine deploys stop hitting the daily `firebase login --reauth` failure mode.

## What

Codified credential-resolution policy in `scripts/firebase/op-firebase-deploy`:

| Rank | Source | Notes |
|------|--------|-------|
| 1 | **Genuinely user-supplied `GOOGLE_APPLICATION_CREDENTIALS`** | Highest priority. Distinguished from preflight-injected via `OP_PREFLIGHT_ADC_TMPFILE` marker. |
| 2 | **Project Firebase-vault SA key** | New default for routine deploys (interactive + CI). |
| 3 | **Preflight-injected `GOOGLE_APPLICATION_CREDENTIALS`** | Fallback when no SA key exists. |
| 4 | **Shared 1Password ADC** | Last-resort 1Password path. |
| 5 | **Local ADC file** | Last-resort local path. |

Plus a new `[op-firebase-deploy] source credential: <description>` log line at deploy startup so debugging deploy auth is no longer opaque.

## Why

#137 traced the recurring "Authentication Error: Your credentials are no longer valid" failure to RAPT/refresh-token expiry on the shared 1Password ADC. The workaround is `firebase login --reauth` — daily friction. Per #154's open questions, the cleanest fix isn't "make Firebase CLI handle ADC better" (it's a firebase-tools bug we don't control); it's "stop using the unstable credential as the default."

The project Firebase-vault SA key has none of these failure modes. It already existed but was ranked below explicit `GOOGLE_APPLICATION_CREDENTIALS` — and `op-preflight.sh --mode deploy` injects exactly that env var. So the SA key was never reached on agent-driven deploys. The fix: distinguish preflight's injection from a user's deliberate override, and rank the SA key above the preflight-injected ADC.

## Open question (#154 #1) resolution

The mechanism preserves explicit user overrides: if `GOOGLE_APPLICATION_CREDENTIALS` is set AND `OP_PREFLIGHT_ADC_TMPFILE` is unset OR points to a different path, treat as user-set and honor at rank 1. Otherwise (preflight set both to the same path), it's the preflight injection — drop to rank 3.

## Verification

- `bash -n scripts/firebase/op-firebase-deploy` passes.
- `scripts/ci/check_required_root_files` passes.
- End-to-end: this PR has no observable effect on mergepath itself (no Firebase project), so verification will land on the next downstream consumer that runs `op-firebase-deploy`. The new source-credential log line will name which credential was selected — easy to verify the SA key is being picked.

## DEPLOYMENT.md updates

- § Prerequisites: project SA key called out as preferred default (was "preferred for CI/headless").
- § Deployment Steps: full per-step credential precedence list with the new ordering + the new log line documented.
- § Secrets Management: removed the contradictory "deploy auth should use short-lived impersonated credentials, not stored service-account keys" line — that text predated the empirical finding. Replaced with the current policy.

## Authoring-Agent

Authoring-Agent: claude

## Self-Review

- **Correctness:** the preflight-distinguishing logic compares both `$GOOGLE_APPLICATION_CREDENTIALS` and `$OP_PREFLIGHT_ADC_TMPFILE`. Marker variable was already exported by op-preflight.sh per the existing schema (verified by grepping op-preflight.sh — `OP_PREFLIGHT_ADC_TMPFILE` is in EXPORTS and SESSION_LINES arrays, propagated through cache-hit path).
- **Regression risk:** for repos that have never provisioned a Firebase-vault SA key, behavior is unchanged — the resolver falls through to rank 3 (preflight-injected) which is what they were getting before. For repos WITH a SA key, the deploy now uses that instead of preflight ADC, removing the daily-reauth surface.
- **Style:** matches existing `op-firebase-deploy` conventions (helper-functions block, descriptive comment headers per stage, stderr-only log lines).
- **Test coverage:** end-to-end auto-test on this surface requires an actual Firebase project + the SA key item in 1Password Firebase vault; no easy unit-testable seam. Verification is observational on next downstream deploy.
- **Security/dependency hygiene:** no new dependencies. The SA key was already retrievable via the existing `materialize_firebase_vault_sa_key` helper; this PR just changes when it's preferred. Key still lives in 1Password — no new on-disk persistence beyond the existing tempfile lifecycle.

## Out of scope (#154 open questions 3 & 4)

- Q3 (should op-firebase-setup create/store/refresh the SA key?): out of scope. File as separate enhancement if a future bootstrap flow should auto-populate the Firebase-vault item.
- Q4 (DEPLOYMENT.md "impersonation as default" framing): addressed in this PR via the § Secrets Management rewrite.

## Propagation

After merge: propagates to all 7 downstream consumers via the standard sync flow. Each consumer that has a project SA key in their Firebase vault gets the stability win immediately; consumers without get unchanged behavior (rank 3 fallback).

#168 tracks the propagation tool.
