### PR TITLE
fix(resolve-pr-threads): BOT_LOGINS_RE matches both REST and GraphQL bot-login formats (#182)

### DIFF
--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -68,7 +68,13 @@ PR_NUM=""
 REPO=""
 MODE="list"
 DRY_RUN=false
-BOT_LOGINS_RE='^(coderabbitai\[bot\]|chatgpt-codex-connector\[bot\]|dependabot\[bot\])$'
+# Match both REST and GraphQL bot-login formats. The REST API returns
+# `coderabbitai[bot]`; GraphQL `author{login}` returns `coderabbitai`
+# (un-suffixed user-facing handle). The trailing `(\[bot\])?` accepts
+# either form so the auto-resolve mode works with the GraphQL data
+# this script reads. Caught on PR #180 review when every CR thread
+# was skipped as "human author" — see #182.
+BOT_LOGINS_RE='^(coderabbitai|chatgpt-codex-connector|dependabot)(\[bot\])?$'
 
 while [ $# -gt 0 ]; do
   case "$1" in


### PR DESCRIPTION
Closes #182.

## What

`BOT_LOGINS_RE` in `scripts/resolve-pr-threads.sh` now matches both REST (`coderabbitai[bot]`) and GraphQL (`coderabbitai`) bot-login formats. The trailing `(\[bot\])?` makes the suffix optional.

```diff
-BOT_LOGINS_RE='^(coderabbitai\[bot\]|chatgpt-codex-connector\[bot\]|dependabot\[bot\])$'
+BOT_LOGINS_RE='^(coderabbitai|chatgpt-codex-connector|dependabot)(\[bot\])?$'
```

## Why

The REST API returns `coderabbitai[bot]` for bot users; GraphQL `author{login}` returns the un-suffixed user-facing handle (`coderabbitai`). The script reads from GraphQL but the regex was REST-shaped — so `--auto-resolve-bots` skipped every bot thread as "human author."

Reproduced on PR #180:
```
$ scripts/resolve-pr-threads.sh 180 --auto-resolve-bots
  SKIP (human author coderabbitai): scripts/gh-projects/.../parent.md
  ...
Resolved: 0  Skipped (human): 9  Skipped (stale-HEAD): 0  Failed: 0
```

All 9 threads were CodeRabbit-authored — should have been auto-resolved. Workaround on PR #180: direct `gh api graphql resolveReviewThread` calls.

## Verification

8-case regex test (all correct):
- `coderabbitai` ✓ MATCH
- `coderabbitai[bot]` ✓ MATCH
- `chatgpt-codex-connector` ✓ MATCH
- `chatgpt-codex-connector[bot]` ✓ MATCH
- `dependabot` ✓ MATCH
- `dependabot[bot]` ✓ MATCH
- `nathanpayne-claude` ✗ no (correct — human reviewer)
- `github-actions[bot]` ✗ no (correct — not in the bot allowlist; would also need policy thought before auto-resolving its threads)

## Authoring-Agent

Authoring-Agent: claude

## Self-Review

- **Correctness:** the optional `(\[bot\])?` suffix is anchored at end-of-string, so partial matches like `coderabbitai-malicious` still don't match. Verified by the 8-case test.
- **Regression risk:** zero — the regex previously matched only REST format; now matches REST + GraphQL. The script reads from GraphQL, so REST format never appears in practice — the change is purely additive in actual data flow.
- **Style:** matches existing comment-block conventions (history reference + #issue link).
- **Test coverage:** 8-case regex test in commit message; live verification will land on the next PR with bot threads after this merges.
- **Security/dependency hygiene:** zero surface change.

## Propagation

After merge: propagates to all 7 downstream consumers via the standard sync flow.
