### PR TITLE
feat(phase-4b): taxonomy doc + phase_4b_default schema + parser (#184, #185)

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -233,3 +233,34 @@ codex:
   # codex-review-check.sh gate (c) and codex-review-request.sh pre-flight
   # and poll scans.
   reaction_freshness_window_seconds: 1800
+
+# ---------------------------------------------------------------------------
+# Phase 4b proactive triggers (#158)
+# ---------------------------------------------------------------------------
+# Controls when Phase 4b (manual CLI fallback) fires as a FIRST-CLASS gate,
+# in addition to its existing fallback role on 4a unavailability/timeout/
+# escalation. Empirical evidence in #158: 4b's bug-catch rate is roughly
+# proportional to interaction-complexity of the change — state machines,
+# concurrency, transactional code, and prompt design consistently surfaced
+# real bugs that 4a cleared past. Pure-data and pure-helper PRs got nothing
+# past 4a.
+#
+# Options:
+#   fallback-only — current behavior. 4b only on 4a unavailability /
+#                   escalation / timeout. Use when 4b's latency cost
+#                   outweighs its catch-rate value (low-risk repo, mostly
+#                   data-plumbing PRs, etc.).
+#   complex-changes — run scripts/phase-4b-classifier.sh AFTER 4a clears
+#                     but BEFORE merging. If any of the five trigger
+#                     classes (REVIEW_POLICY.md § Phase 4b Triggers)
+#                     matches, post the 4b handoff before merge. New repos
+#                     created from this template default here.
+#   always — skip the classifier; post the 4b handoff for every
+#            external-review-threshold PR. Highest confidence, slowest
+#            cycle time. Use when every threshold-PR genuinely needs
+#            cross-agent review (e.g., security-sensitive repo).
+#
+# Existing repos without this field default to `fallback-only` per
+# scripts/codex-review-check.sh's parser — no behavior change without
+# explicit opt-in. See REVIEW_POLICY.md § Migration for existing consumers.
+phase_4b_default: complex-changes

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -272,6 +272,54 @@ Phase 4b is invoked when Phase 4a escalates to disagreement or runaway, times ou
 
 19b. `nathanjohnpayne` merges the PR. Done.
 
+### Phase 4b Triggers
+
+Phase 4b is documented above as a fallback (4a unavailable / escalates / times out). Per empirical evidence from matchline (#158: 9 PRs of the same author through both 4a and 4b — 4b caught 6+ real bugs on state-machine + concurrency + transactional changes that 4a cleared past), Phase 4b ALSO has high catch-rate value as a **first-class proactive gate** on a specific class of PR — not just as a fallback.
+
+The `phase_4b_default` field in `.github/review-policy.yml` controls when 4b fires proactively:
+
+| Value | Behavior |
+|-------|----------|
+| `fallback-only` | Current behavior. 4b only on 4a unavailability/escalation/timeout. |
+| `complex-changes` | Run `scripts/phase-4b-classifier.sh` AFTER 4a clears; if any trigger matches, post the 4b handoff before merging. |
+| `always` | Skip the classifier; post the 4b handoff for every external-review-threshold PR. |
+
+**Default for new repos:** `complex-changes` (the empirically validated middle ground). **Default for existing repos** that haven't added the field: `fallback-only` (no behavior change without explicit opt-in — see [Migration for existing consumers](#migration-for-existing-consumers) below).
+
+The five trigger classes the `complex-changes` mode keys on:
+
+1. **State-machine changes.** PRs introducing or modifying discriminated-union or finite-state-machine types driving UI or service behavior.
+   - **Detection:** diff includes new/modified types matching `type \w+ = \| \{ kind: "..."` or similar tagged-union patterns; OR PR body explicitly says "state machine."
+   - **Why it matters:** the bug is rarely in any single hunk — it's in the state-transition composition. Local-context LLM reviewers (4a) consistently miss this; cross-context CLI review (4b) consistently catches it.
+
+2. **Concurrency / transactional code.** PRs touching `runTransaction`, `Promise.all`, optimistic updates, subscription handling, or compare-and-set patterns.
+   - **Detection:** diff includes `runTransaction` / `setSnapshot` / `applyOptimistic` / `CAS` / `compare-and-set` keywords; OR modifies `**/transactions/`, `**/concurrency/` paths.
+   - **Why it matters:** invariant violations across concurrent operations (e.g., owner-uid re-check inside a tx after a tombstone-then-recreate race) require reasoning across pieces that look fine individually.
+
+3. **Prompt design or LLM contract changes.** PRs adding/modifying few-shot examples, system prompts, structured-output schemas, or grounding rules.
+   - **Detection:** paths matching `**/prompts/**`, `**/.v[0-9]+.md`, or LLM-tool-call schema files.
+   - **Why it matters:** few-shot drift (e.g., disjunctive→conjunctive operator changes in an example) is invisible to a diff reviewer that doesn't understand the prompt as a system.
+
+4. **Cross-cutting refactors.** PRs that change a contract used by ≥3 callers OR touch both the type layer and the service layer in the same diff.
+   - **Detection:** changed-files spread across ≥3 distinct top-level dirs OR include both `src/types/` AND `src/services/` (or the consumer repo's analogous layer pair).
+   - **Why it matters:** type/runtime split bugs surface when the type updates and runtime updates aren't in sync — same diff doesn't guarantee same semantics.
+
+5. **Validation / invariant-enforcement code.** PRs changing anything pinning a product invariant (e.g., zero-fabrication checks, owner-uid validation, approval-state derivation).
+   - **Detection:** paths matching `**/validation/**`, `**/security/**`, or `**/policies/**`; OR PR body explicit "invariant" mention.
+   - **Why it matters:** weakening an invariant doesn't trigger any obvious red flag in a per-hunk review — the test of correctness is whether the invariant still holds across the full system, which a cross-context reviewer is better positioned to evaluate.
+
+For PRs that match NONE of these classes, the classifier exits with `recommendation: fallback-only` and the standard 4a path is sufficient. The taxonomy is meant as a checklist, not a perfect predictor — agents should err on the side of invoking 4b when the heuristics are ambiguous.
+
+### Cycle-time budget
+
+Phase 4b adds latency. The human-mediated handoff typically adds 30 minutes to a few hours per PR — acceptable for high-risk changes (where a missed bug costs more than the latency) and corrosive for trivial ones (where the latency dwarfs the change). The taxonomy keeps that latency targeted at the changes that actually benefit. Repos with a high rate of state-machine or concurrency changes get more value from `complex-changes`; repos that mostly do data plumbing and pure-helper PRs get less and can stay on `fallback-only`.
+
+The classifier (`scripts/phase-4b-classifier.sh`) is the implementation; CLAUDE.md step 8.5 (or equivalent) is the operating instruction that consults the classifier; this section is the doctrinal taxonomy that drives both.
+
+### Migration for existing consumers
+
+When you pull this template change into an existing repo, the new `phase_4b_default` field is **optional**. Repos that do not add the field default to `fallback-only` — current behavior, no change. Opt in to the new proactive-trigger flow by adding `phase_4b_default: complex-changes` to your repo's `.github/review-policy.yml`. New repos created from the template inherit `complex-changes` as the default per the template's own `.github/review-policy.yml`.
+
 ### Flow Diagram
 
 ```

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -278,11 +278,13 @@ Phase 4b is documented above as a fallback (4a unavailable / escalates / times o
 
 The `phase_4b_default` field in `.github/review-policy.yml` controls when 4b fires proactively:
 
-| Value | Behavior |
-|-------|----------|
+| Value | Behavior (intended; full wiring lands in #186 + #187) |
+|-------|---------|
 | `fallback-only` | Current behavior. 4b only on 4a unavailability/escalation/timeout. |
 | `complex-changes` | Run `scripts/phase-4b-classifier.sh` AFTER 4a clears; if any trigger matches, post the 4b handoff before merging. |
 | `always` | Skip the classifier; post the 4b handoff for every external-review-threshold PR. |
+
+**Implementation status (this commit ships only the policy/parser piece):** the `phase_4b_default` field is parsed and validated by `scripts/codex-review-check.sh` (it exports `PHASE_4B_DEFAULT` for downstream consumers), but the runtime branching that ACTS on the field — running the classifier after 4a clears and posting a proactive 4b handoff — lands in [#187](https://github.com/nathanjohnpayne/mergepath/issues/187) (CLAUDE.md / AGENTS.md operating-instruction update). The classifier itself ships in [#186](https://github.com/nathanjohnpayne/mergepath/issues/186). Until both merge, setting `phase_4b_default: complex-changes` or `: always` is a no-op behaviorally — the parser accepts it, but the existing 4a→merge flow runs unchanged. This is intentional per the parent #158's three-PR ship sequence.
 
 **Default for new repos:** `complex-changes` (the empirically validated middle ground). **Default for existing repos** that haven't added the field: `fallback-only` (no behavior change without explicit opt-in — see [Migration for existing consumers](#migration-for-existing-consumers) below).
 

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -139,7 +139,7 @@ echo "policy_field (top-level scalar) tests — for phase_4b_default (#185)"
 # update. Documented inline rather than sourced from the script because
 # sourcing codex-review-check.sh runs its full top-level logic.
 policy_field_awk='
-  $1 == field":" {
+  /^[^[:space:]]/ && $1 == field":" {
     sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
     gsub(/^"/, "", $0)
     gsub(/"[[:space:]]*(#.*)?$/, "", $0)
@@ -170,6 +170,19 @@ assert_eq "policy_field reads field amid other top-level fields" "fallback-only"
 # Fixture: field with double quotes (matches the parser's quote-stripping).
 got=$(printf '%s\n' 'phase_4b_default: "complex-changes"' | awk -v field="phase_4b_default" "$policy_field_awk")
 assert_eq "policy_field strips surrounding quotes" "complex-changes" "$got"
+
+# Regression: nested same-named key under a parent block must NOT match
+# (Codex P2 on PR #189 — top-level lookup should be anchored to the
+# document root, not match indented occurrences of the same field name).
+nested=$(printf 'codex:\n  phase_4b_default: should-not-match\nphase_4b_default: complex-changes\n')
+got=$(echo "$nested" | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field ignores nested same-named keys; reads only top-level" "complex-changes" "$got"
+
+# Regression: nested key with NO top-level twin must return empty
+# (the parser shouldn't fall through to the indented match).
+nested_only=$(printf 'codex:\n  phase_4b_default: nested-only\n')
+got=$(echo "$nested_only" | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field returns empty when only a nested same-named key exists" "" "$got"
 
 # Fixture: real mergepath review-policy.yml has the field set; verify
 # end-to-end against the actual file so a typo in the schema-doc

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -131,6 +131,62 @@ src/auth/login.ts'
 assert_eq "end-to-end: parse output piped into matcher" "$want" "$got"
 
 echo
+echo "policy_field (top-level scalar) tests — for phase_4b_default (#185)"
+
+# Inline copy of the same awk policy_field uses inside
+# scripts/codex-review-check.sh. Keeping the test in lockstep with the
+# parser shape — if the parser changes, this awk literal needs the same
+# update. Documented inline rather than sourced from the script because
+# sourcing codex-review-check.sh runs its full top-level logic.
+policy_field_awk='
+  $1 == field":" {
+    sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+    gsub(/^"/, "", $0)
+    gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+    gsub(/[[:space:]]*#.*$/, "", $0)
+    sub(/[[:space:]]+$/, "", $0)
+    print
+    exit
+  }
+'
+
+# Fixture: field present at top level, no comments.
+got=$(printf '%s\n' "phase_4b_default: complex-changes" | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field reads phase_4b_default (bare value)" "complex-changes" "$got"
+
+# Fixture: field with a trailing inline comment.
+got=$(printf '%s\n' "phase_4b_default: always   # opt in to strict mode" | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field strips trailing inline comment" "always" "$got"
+
+# Fixture: field missing entirely (existing-consumer migration path).
+got=$(printf 'codex:\n  enabled: true\n' | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field returns empty when field absent (default falls to fallback-only)" "" "$got"
+
+# Fixture: field at top level surrounded by other top-level fields.
+mixed=$(printf 'external_review_threshold: 300\nphase_4b_default: fallback-only\ncoderabbit:\n  enabled: false\n')
+got=$(echo "$mixed" | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field reads field amid other top-level fields" "fallback-only" "$got"
+
+# Fixture: field with double quotes (matches the parser's quote-stripping).
+got=$(printf '%s\n' 'phase_4b_default: "complex-changes"' | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field strips surrounding quotes" "complex-changes" "$got"
+
+# Fixture: real mergepath review-policy.yml has the field set; verify
+# end-to-end against the actual file so a typo in the schema-doc
+# example doesn't pass the unit fixtures while breaking the real read.
+got=$(awk -v field="phase_4b_default" "$policy_field_awk" "$ROOT/.github/review-policy.yml")
+case "$got" in
+  fallback-only|complex-changes|always)
+    pass=$((pass + 1))
+    echo "  PASS: real .github/review-policy.yml has a valid phase_4b_default value ('$got')"
+    ;;
+  *)
+    fail=$((fail + 1))
+    echo "  FAIL: real .github/review-policy.yml phase_4b_default is missing or invalid (got '$got'; expected one of fallback-only / complex-changes / always)"
+    ;;
+esac
+
+echo
 if [ "$fail" -gt 0 ]; then
   echo "check_workflow_parsers: $fail FAIL / $pass PASS" >&2
   exit 1

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -128,11 +128,15 @@ codex_field() {
 # but without the in-block check — used for fields like `phase_4b_default`
 # (#185) that live at the document root rather than inside `codex:` /
 # `coderabbit:`. Outputs the value or empty on miss.
+#
+# Anchored to start-of-line (no leading whitespace) so a same-named
+# nested key under e.g. `codex:` doesn't accidentally match. Codex P2
+# on PR #189 caught the unanchored-match scope-bleed risk.
 policy_field() {
   local field=$1
   [ -f "$CONFIG" ] || return 0
   awk -v field="$field" '
-    $1 == field":" {
+    /^[^[:space:]]/ && $1 == field":" {
       sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
       gsub(/^"/, "", $0)
       gsub(/"[[:space:]]*(#.*)?$/, "", $0)

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -124,6 +124,42 @@ codex_field() {
   ' "$CONFIG"
 }
 
+# Read a top-level (block-less) scalar field. Same shape as codex_field
+# but without the in-block check — used for fields like `phase_4b_default`
+# (#185) that live at the document root rather than inside `codex:` /
+# `coderabbit:`. Outputs the value or empty on miss.
+policy_field() {
+  local field=$1
+  [ -f "$CONFIG" ] || return 0
+  awk -v field="$field" '
+    $1 == field":" {
+      sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+      gsub(/^"/, "", $0)
+      gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      gsub(/[[:space:]]*#.*$/, "", $0)
+      sub(/[[:space:]]+$/, "", $0)
+      print
+      exit
+    }
+  ' "$CONFIG"
+}
+
+# phase_4b_default — controls when Phase 4b fires proactively. Validated
+# against the three known values; reject unknowns with a clear error
+# pointing at REVIEW_POLICY.md § Phase 4b Triggers. Missing field defaults
+# to "fallback-only" (existing-consumer migration semantics per #188).
+PHASE_4B_DEFAULT=$(policy_field phase_4b_default)
+PHASE_4B_DEFAULT=${PHASE_4B_DEFAULT:-fallback-only}
+case "$PHASE_4B_DEFAULT" in
+  fallback-only|complex-changes|always) ;;
+  *)
+    echo "ERROR: phase_4b_default must be one of: fallback-only, complex-changes, always — got '$PHASE_4B_DEFAULT'" >&2
+    echo "       See REVIEW_POLICY.md § Phase 4b Triggers." >&2
+    exit 3
+    ;;
+esac
+export PHASE_4B_DEFAULT
+
 BOT_LOGIN=$(codex_field bot_login)
 BOT_LOGIN=${BOT_LOGIN:-"chatgpt-codex-connector[bot]"}
 


### PR DESCRIPTION
Closes #184 and #185. Folds in #188 (migration paragraph) since it's a 1-paragraph addition to the same `REVIEW_POLICY.md` § Phase 4b Triggers section sub-issue A creates — saves a follow-up doc PR.

This is **PR 1 of 3** for parent #158:
- This PR: #184 + #185 (+ #188 fold-in) — taxonomy doc + schema + parser. **No agent-behavior change yet.**
- Next PR: #186 — `scripts/phase-4b-classifier.sh` with 5 trigger detectors + tests
- Final PR: #187 — CLAUDE.md / AGENTS.md operating-instruction update (depends on this PR + the classifier)

## What

### #184 — REVIEW_POLICY.md § Phase 4b Triggers (taxonomy doc)

New subsection codifying the five-class taxonomy from #158's empirical observation. Each class has detection heuristic + why-it-matters explanation:

1. State-machine changes (discriminated unions, FSMs)
2. Concurrency / transactional code
3. Prompt design / LLM contract changes
4. Cross-cutting refactors
5. Validation / invariant-enforcement code

Plus cycle-time-budget framing and a "Migration for existing consumers" paragraph (the latter is sub-issue #188's deliverable, folded in here).

### #185 — `phase_4b_default` schema field + parser

`.github/review-policy.yml` gets a new top-level `phase_4b_default` field. Three options: `fallback-only` / `complex-changes` / `always`. Mergepath itself defaults to `complex-changes`; existing consumers without the field default to `fallback-only` (no behavior change without explicit opt-in).

`scripts/codex-review-check.sh` gains a new `policy_field` reader (top-level scalar, mirroring the existing in-block `codex_field`). Reads + validates + exports `PHASE_4B_DEFAULT`.

### Tests

`scripts/ci/check_workflow_parsers` extended with 6 new tests for the `policy_field` reader (bare value, trailing comment, missing field, mixed fields, quoted value, end-to-end against the real config). 13 → 19 tests, all PASS.

## Why no agent-behavior change yet

The parser exports the value but the classifier (sub-issue #186) and CLAUDE.md operating instructions (sub-issue #187) are what ACT on it. Intermediate state (field set but classifier not yet shipped) is intentional — it lets the schema land first and propagate to downstream consumers without forcing them to also pull in a not-yet-ready classifier.

## Verification

- `bash -n scripts/codex-review-check.sh` ✓
- `scripts/ci/check_workflow_parsers`: 19/19 PASS
- End-to-end run of `codex-review-check.sh` against an existing PR: parser + new export work; gate logic unchanged

## Authoring-Agent

Authoring-Agent: claude

## Self-Review

- **Correctness:** `policy_field` mirrors `codex_field`'s awk shape exactly, minus the in-block guard (top-level fields don't have one). Quote-stripping + comment-stripping behavior identical between the two readers. Validation rejects unknown values with a clear pointer at the doctrinal subsection.
- **Regression risk:** zero. New top-level field; existing parsers don't read it (so old codex-review-check.sh behavior is unchanged for the existing scalars). Existing-consumer migration explicit: missing field → `fallback-only` (the existing implicit behavior).
- **Style:** matches existing comment-block conventions in `.github/review-policy.yml` (header + commented option list + canonical reference). New REVIEW_POLICY.md subsection uses the same heading hierarchy and detection-heuristic format already established.
- **Test coverage:** 6 new fixtures covering happy path, edge cases (quotes, comments, missing field), and an end-to-end check against the real config so a schema-doc typo can't pass while breaking the live read.
- **Security/dependency hygiene:** no new dependencies, no new env vars beyond `PHASE_4B_DEFAULT` (export is intentional — sub-issue #186's classifier consumes it).

## Propagation

After merge: propagates to all 7 downstream consumers via the standard sync flow. Each consumer that doesn't add the field stays on `fallback-only` (no change). Consumers that opt in to `complex-changes` will see effects once #186 (classifier) and #187 (CLAUDE.md update) land.
