### PR TITLE
fix(resolve-pr-threads): cursor-null typing + totalCount cross-check (#192)

### DIFF
--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -51,6 +51,12 @@ jobs:
       - name: check_workflow_parsers
         run: ./scripts/ci/check_workflow_parsers
 
+      - name: check_phase_4b_classifier
+        run: ./scripts/ci/check_phase_4b_classifier
+
+      - name: check_resolve_pr_threads
+        run: ./scripts/ci/check_resolve_pr_threads
+
       - name: check_governance_files
         run: |
           MISSING=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,11 +181,13 @@ keyring active is your agent identity. No switch needed for commits.
      ```
 
      For each unresolved bot-authored thread where the finding is
-     addressed on the current HEAD, resolve via:
+     addressed on the current HEAD, resolve via (same PAT pinning
+     as the read above — the mutation is reviewer-attributed):
 
      ```bash
-     gh api graphql -f query='mutation { resolveReviewThread(input:
-       {threadId: "THREAD_ID"}) { thread { isResolved } } }'
+     GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api graphql -f query='
+       mutation { resolveReviewThread(input:
+         {threadId: "THREAD_ID"}) { thread { isResolved } } }'
      ```
 
      Same agent-prohibitions apply: do not resolve human-authored

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,44 @@ keyring active is your agent identity. No switch needed for commits.
      human-authored threads must be resolved via the GitHub UI or by
      asking the human; the helper refuses to touch them.
 
+     **Escape hatch — if the script reports clean but merge fails.**
+     If `scripts/resolve-pr-threads.sh` exits 0 ("no unresolved
+     threads") AND the merge attempt errors with `GraphQL: All
+     comments must be resolved. (mergePullRequest)`, the script
+     undercount detector either didn't fire or the threads endpoint
+     is briefly inconsistent. Drop to the manual GraphQL query:
+
+     ```bash
+     gh api graphql -f query='
+       query {
+         repository(owner: "OWNER", name: "REPO") {
+           pullRequest(number: PR_NUM) {
+             reviewThreads(first: 100) {
+               nodes {
+                 id
+                 isResolved
+                 comments(first: 1) {
+                   nodes { author { login } path body }
+                 }
+               }
+             }
+           }
+         }
+       }' --jq '.data.repository.pullRequest.reviewThreads.nodes
+                 | map(select(.isResolved != true))'
+     ```
+
+     For each unresolved bot-authored thread where the finding is
+     addressed on the current HEAD, resolve via:
+
+     ```bash
+     gh api graphql -f query='mutation { resolveReviewThread(input:
+       {threadId: "THREAD_ID"}) { thread { isResolved } } }'
+     ```
+
+     Same agent-prohibitions apply: do not resolve human-authored
+     threads via this path either. See #192 for the bug history.
+
 ## Before merging
 
 8. Check `.github/review-policy.yml` for the external review threshold.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,8 @@ keyring active is your agent identity. No switch needed for commits.
      truncate and mask threads):
 
      ```bash
-     gh api graphql -f query='
+     # Read-path: pin to preflight reviewer PAT per the auth split.
+     GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api graphql -f query='
        query {
          repository(owner: "OWNER", name: "REPO") {
            pullRequest(number: PR_NUM) {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,10 @@ keyring active is your agent identity. No switch needed for commits.
      threads") AND the merge attempt errors with `GraphQL: All
      comments must be resolved. (mergePullRequest)`, the script
      undercount detector either didn't fire or the threads endpoint
-     is briefly inconsistent. Drop to the manual GraphQL query:
+     is briefly inconsistent. Drop to the manual GraphQL query
+     (note the `totalCount` check — the API caps at 100 nodes per
+     page; without the assert, a >100-thread PR would silently
+     truncate and mask threads):
 
      ```bash
      gh api graphql -f query='
@@ -154,6 +157,8 @@ keyring active is your agent identity. No switch needed for commits.
          repository(owner: "OWNER", name: "REPO") {
            pullRequest(number: PR_NUM) {
              reviewThreads(first: 100) {
+               totalCount
+               pageInfo { hasNextPage endCursor }
                nodes {
                  id
                  isResolved
@@ -164,8 +169,14 @@ keyring active is your agent identity. No switch needed for commits.
              }
            }
          }
-       }' --jq '.data.repository.pullRequest.reviewThreads.nodes
-                 | map(select(.isResolved != true))'
+       }' --jq '
+         if .data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage
+         then "ERROR: PR has >100 review threads; paginate with after:$endCursor"
+              | halt_error(2)
+         else .data.repository.pullRequest.reviewThreads.nodes
+              | map(select(.isResolved != true))
+         end
+       '
      ```
 
      For each unresolved bot-authored thread where the finding is

--- a/scripts/ci/check_resolve_pr_threads
+++ b/scripts/ci/check_resolve_pr_threads
@@ -324,6 +324,127 @@ else
   echo "$out" | sed 's/^/      /' >&2
 fi
 
+# ── Test 6: two-page pagination + cursor accumulation
+# CR Major on PR #194 r3 — without exercising the multi-page path,
+# a paginator regression on the happy path stays green. Stub returns
+# page 1 with hasNextPage=true + endCursor="CURSOR1", page 2 with
+# hasNextPage=false. Final state: 2 nodes accumulated, totalCount=2,
+# script exits 0. Also asserts the 2nd call's argv contains
+# `-f cursor=CURSOR1` (the post-first-call branch is exercised).
+echo
+echo "resolve-pr-threads.sh two-page pagination test (CR Major on #194)"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+echo "$@" >> "$GH_ARGV_LOG"
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        # Determine page from whether `cursor=CURSOR1` is in argv.
+        if [[ " $* " == *" cursor=CURSOR1 "* ]]; then
+          # Page 2: remaining node, no next page.
+          cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":2,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"T2","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"b","body":"y","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}}
+]}}}}}
+JSON
+        else
+          # Page 1: first node, hasNextPage=true.
+          cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":2,"pageInfo":{"hasNextPage":true,"endCursor":"CURSOR1"},"nodes":[
+  {"id":"T1","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}}
+]}}}}}
+JSON
+        fi
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "abc123def"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+GH_ARGV_LOG="$SCRATCH/gh-argv-page.log"
+: > "$GH_ARGV_LOG"
+
+set +e
+out=$(GH_ARGV_LOG="$GH_ARGV_LOG" PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+# Must (a) exit 0 with "no unresolved threads" (both nodes are
+# isResolved=true and totalCount=2 matches accumulated), (b) include
+# `-f cursor=CURSOR1` in the second-page call argv.
+if [ "$rc" = "0" ] && echo "$out" | grep -q "No unresolved threads" && grep -qE -- '-f cursor=CURSOR1' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: page 2 fetched with -f cursor=CURSOR1; accumulated count matches totalCount"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: pagination regression (rc=$rc)" >&2
+  echo "      output:" >&2; echo "$out" | sed 's/^/        /' >&2
+  echo "      argv log:" >&2; sed 's/^/        /' "$GH_ARGV_LOG" >&2
+fi
+
+# ── Test 7: keyring fallback when neither preflight nor GH_TOKEN set
+# CR Major on PR #194 r3 — the prior `GH_TOKEN="${VAR:-${OTHER:-}}"`
+# pattern set GH_TOKEN to empty when both unset, blocking gh's
+# keyring fallback. The conditional gh_read wrapper must NOT pass
+# GH_TOKEN= (empty) when no PAT is available.
+echo
+echo "resolve-pr-threads.sh keyring fallback (no empty GH_TOKEN trap)"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+echo "ENV_GH_TOKEN_PRESENT=${GH_TOKEN+yes}" >> "$GH_ARGV_LOG"
+echo "ENV_GH_TOKEN_VALUE=${GH_TOKEN:-<unset>}" >> "$GH_ARGV_LOG"
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":0,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "abc123def"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+GH_ARGV_LOG="$SCRATCH/gh-argv-keyring.log"
+: > "$GH_ARGV_LOG"
+
+# Crucially: unset both PAT vars in the subshell environment.
+set +e
+out=$(GH_ARGV_LOG="$GH_ARGV_LOG" PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+# Stub captured env state. Assert GH_TOKEN was NOT set (or NOT empty).
+# An empty GH_TOKEN would show ENV_GH_TOKEN_PRESENT=yes + ENV_GH_TOKEN_VALUE=<unset>
+# (which renders as just the unset placeholder). Need to confirm absence
+# of the "ENV_GH_TOKEN_PRESENT=yes" line on graphql calls.
+if [ "$rc" = "0" ] && ! grep -q "^ENV_GH_TOKEN_PRESENT=yes$" "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: GH_TOKEN unset (not empty) when no PAT available — keyring fallback engaged"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: GH_TOKEN was set (possibly empty) — keyring fallback would be blocked (rc=$rc)" >&2
+  echo "      env capture:" >&2; sed 's/^/        /' "$GH_ARGV_LOG" >&2
+fi
+
 echo
 if [ "$fail" -eq 0 ]; then
   echo "check_resolve_pr_threads: PASS ($pass tests)"

--- a/scripts/ci/check_resolve_pr_threads
+++ b/scripts/ci/check_resolve_pr_threads
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# check_resolve_pr_threads — regression tests for scripts/resolve-pr-threads.sh
+#
+# Closes the test gap that let PR #189's silent-undercount bug ship
+# (cursor passed as `-f cursor=null` → string "null" → API silently
+# returned wrong thread set). See #192 for the post-mortem.
+#
+# Tests stub `gh` via PATH-prepend so they exercise the script's
+# argument construction and exit-code paths without live API calls.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/resolve-pr-threads.sh"
+
+pass=0
+fail=0
+
+# ── Test 1: cursor-null typing
+# The script must send `-F cursor=null` (typed null) on the first
+# call, NOT `-f cursor=null` (string "null"). The stub captures
+# the gh argv to a side file so we can inspect what was actually sent.
+echo "resolve-pr-threads.sh cursor-null typing test (#192 regression)"
+
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+# Capture all argv to a file the test harness reads. Then return a
+# minimal valid GraphQL response so the script doesn't bail.
+echo "$@" >> "$GH_ARGV_LOG"
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        # Match how the script's GraphQL response is shaped: empty
+        # threads list with totalCount=0 → script reports "no
+        # unresolved threads" and exits 0.
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":0,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        # HEAD oid fetch
+        echo "abc123def"
+        exit 0
+        ;;
+    esac
+    ;;
+  repo)
+    # `gh repo view --json nameWithOwner` fallback
+    printf '{"nameWithOwner":"test/repo"}\n'
+    exit 0
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+GH_ARGV_LOG="$SCRATCH/gh-argv.log"
+: > "$GH_ARGV_LOG"
+
+set +e
+out=$(GH_ARGV_LOG="$GH_ARGV_LOG" PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+# The first GraphQL call (cursor=null path) must use `-F cursor=null`
+# not `-f cursor=null`. Grep the captured argv for the typed flag.
+if grep -qE -- '-F cursor=null' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: first call uses -F cursor=null (typed null)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: expected -F cursor=null in first GraphQL call argv" >&2
+  echo "      argv log:" >&2
+  sed 's/^/        /' "$GH_ARGV_LOG" >&2
+fi
+
+# Negative assertion: must NOT use `-f cursor=null` (string "null")
+# anywhere — the prior bug.
+if grep -qE -- '-f cursor=null' "$GH_ARGV_LOG"; then
+  fail=$((fail + 1))
+  echo "  FAIL: regression — -f cursor=null (string 'null') was sent" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: no -f cursor=null anywhere in argv (regression closed)"
+fi
+
+# ── Test 2: totalCount cross-validation catches undercount
+echo
+echo "resolve-pr-threads.sh totalCount cross-validation test"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        # Simulate the bug condition: totalCount=3 but only 2 nodes
+        # returned. Script must exit 2 with the undercount-detected
+        # error (not silently report "no unresolved threads").
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":3,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"T1","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z","commit":{"oid":"abc"}}]}},
+  {"id":"T2","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"b","body":"y","createdAt":"2026-01-01T00:00:00Z","commit":{"oid":"abc"}}]}}
+]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "abc123def"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+set +e
+out=$(PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" = "2" ] && echo "$out" | grep -q "GraphQL undercount detected"; then
+  pass=$((pass + 1))
+  echo "  PASS: totalCount > returned → exit 2 with undercount error"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: undercount should exit 2 (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ── Test 3: equal totalCount and returned → no undercount error
+echo
+echo "resolve-pr-threads.sh equal-count happy-path test"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":2,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"T1","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z","commit":{"oid":"abc"}}]}},
+  {"id":"T2","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"b","body":"y","createdAt":"2026-01-01T00:00:00Z","commit":{"oid":"abc"}}]}}
+]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "abc123def"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+set +e
+out=$(PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" = "0" ] && echo "$out" | grep -q "No unresolved threads"; then
+  pass=$((pass + 1))
+  echo "  PASS: totalCount == returned (all resolved) → exit 0 + clean message"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: equal counts + all resolved should exit 0 (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ── Test 4: defensive isResolved != true catches null
+echo
+echo "resolve-pr-threads.sh defensive isResolved-null test"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        # isResolved is null on one thread — defensive `!= true`
+        # filter must treat it as unresolved and surface it.
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"T1","isResolved":null,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z","commit":{"oid":"abc"}}]}}
+]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "abc123def"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+set +e
+out=$(PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+# In list mode (default), unresolved threads exit 3 with the listing.
+if [ "$rc" = "3" ] && echo "$out" | grep -q "Unresolved threads on test/repo#99999"; then
+  pass=$((pass + 1))
+  echo "  PASS: null isResolved treated as unresolved (defensive)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: null isResolved should be treated as unresolved (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "check_resolve_pr_threads: PASS ($pass tests)"
+  exit 0
+else
+  echo "check_resolve_pr_threads: FAIL ($fail of $((pass + fail)) tests)" >&2
+  exit 1
+fi

--- a/scripts/ci/check_resolve_pr_threads
+++ b/scripts/ci/check_resolve_pr_threads
@@ -102,10 +102,11 @@ case "$1" in
         # Simulate the bug condition: totalCount=3 but only 2 nodes
         # returned. Script must exit 2 with the undercount-detected
         # error (not silently report "no unresolved threads").
+        # Stub uses the new commentsFirst/commentsLast alias shape.
         cat <<'JSON'
 {"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":3,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
-  {"id":"T1","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z","commit":{"oid":"abc"}}]}},
-  {"id":"T2","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"b","body":"y","createdAt":"2026-01-01T00:00:00Z","commit":{"oid":"abc"}}]}}
+  {"id":"T1","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}},
+  {"id":"T2","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"b","body":"y","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}}
 ]}}}}}
 JSON
         exit 0
@@ -146,8 +147,8 @@ case "$1" in
       graphql)
         cat <<'JSON'
 {"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":2,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
-  {"id":"T1","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z","commit":{"oid":"abc"}}]}},
-  {"id":"T2","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"b","body":"y","createdAt":"2026-01-01T00:00:00Z","commit":{"oid":"abc"}}]}}
+  {"id":"T1","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}},
+  {"id":"T2","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"b","body":"y","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}}
 ]}}}}}
 JSON
         exit 0
@@ -190,7 +191,7 @@ case "$1" in
         # filter must treat it as unresolved and surface it.
         cat <<'JSON'
 {"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
-  {"id":"T1","isResolved":null,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z","commit":{"oid":"abc"}}]}}
+  {"id":"T1","isResolved":null,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}}
 ]}}}}}
 JSON
         exit 0
@@ -217,6 +218,63 @@ if [ "$rc" = "3" ] && echo "$out" | grep -q "Unresolved threads on test/repo#999
 else
   fail=$((fail + 1))
   echo "  FAIL: null isResolved should be treated as unresolved (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ── Test 5: HEAD-anchor uses commentsLast (codex P2 #194 regression)
+# A thread where commentsFirst points at an old commit and commentsLast
+# points at the truly-latest one. The script must surface the
+# commentsLast oid as the thread's commit_oid for the HEAD-anchor
+# check, NOT commentsFirst's. Prior shape (`comments(first: 50)` +
+# `[-1]`) would silently return the wrong oid for >50-comment threads.
+echo
+echo "resolve-pr-threads.sh HEAD-anchor uses commentsLast (codex P2 on #194)"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        # commentsFirst.commit.oid would be "OLDOID" (anchored to
+        # original review commit), commentsLast.commit.oid is "NEWOID"
+        # (truly-latest comment from a much later push). The script
+        # must read commit_oid from commentsLast.
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"T1","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"src/foo.ts","body":"original review","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"NEWOIDcurrent"}}]}}
+]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "NEWOIDcurrent"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+set +e
+out=$(PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo --auto-resolve-bots --dry-run 2>&1)
+rc=$?
+set -e
+
+# With --dry-run --auto-resolve-bots, the script reports "would resolve"
+# only when commit_oid matches HEAD_OID. If it correctly picked
+# commentsLast's "NEWOIDcurrent" (matching HEAD_OID), the output
+# includes "would resolve". If it picked commentsFirst's commit (which
+# we don't even populate here), it would skip-as-stale.
+if echo "$out" | grep -qE "WOULD RESOLVE|would-resolve: [1-9]"; then
+  pass=$((pass + 1))
+  echo "  PASS: HEAD anchor read from commentsLast (current-HEAD bot thread is auto-resolvable)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: expected would-resolve output (rc=$rc)" >&2
   echo "$out" | sed 's/^/      /' >&2
 fi
 

--- a/scripts/ci/check_resolve_pr_threads
+++ b/scripts/ci/check_resolve_pr_threads
@@ -126,9 +126,9 @@ out=$(PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
 rc=$?
 set -e
 
-if [ "$rc" = "2" ] && echo "$out" | grep -q "GraphQL undercount detected"; then
+if [ "$rc" = "2" ] && echo "$out" | grep -q "GraphQL count mismatch"; then
   pass=$((pass + 1))
-  echo "  PASS: totalCount > returned → exit 2 with undercount error"
+  echo "  PASS: totalCount > returned → exit 2 with count-mismatch error"
 else
   fail=$((fail + 1))
   echo "  FAIL: undercount should exit 2 (rc=$rc)" >&2
@@ -218,6 +218,52 @@ if [ "$rc" = "3" ] && echo "$out" | grep -q "Unresolved threads on test/repo#999
 else
   fail=$((fail + 1))
   echo "  FAIL: null isResolved should be treated as unresolved (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ── Test 4b: totalCount cross-validation also fails on over-count
+# CR Major on PR #194 r2 — a duplicate-page / cursor-reset regression
+# in the pagination loop would produce returned > totalCount; the
+# equality check must fail on that case too, not just under-count.
+echo
+echo "resolve-pr-threads.sh totalCount over-count detection (CR Major on #194)"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        # totalCount=1 but 2 nodes returned (simulated duplicate page).
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"T1","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}},
+  {"id":"T1","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}}
+]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "abc123def"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+set +e
+out=$(PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" = "2" ] && echo "$out" | grep -q "GraphQL count mismatch"; then
+  pass=$((pass + 1))
+  echo "  PASS: returned > totalCount → exit 2 with count-mismatch error"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: over-count should exit 2 (rc=$rc)" >&2
   echo "$out" | sed 's/^/      /' >&2
 fi
 

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -110,8 +110,22 @@ if ! [[ "$PR_NUM" =~ ^[1-9][0-9]*$ ]]; then
   exit 1
 fi
 
+# Resolve the read PAT once + define the wrapper before any `gh`
+# call. CR Major on PR #194 r4 caught that the bare `gh repo view`
+# and `gh api` invocations below this point would still hit the
+# empty-GH_TOKEN keyring-fallback trap. Centralizing the wrapper
+# above all read-path gh calls fixes it.
+READ_GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}"
+gh_read() {
+  if [ -n "$READ_GH_TOKEN" ]; then
+    GH_TOKEN="$READ_GH_TOKEN" gh "$@"
+  else
+    gh "$@"
+  fi
+}
+
 if [ -z "$REPO" ]; then
-  REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
+  REPO=$(gh_read repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
     echo "Could not resolve repo. Pass --repo owner/name." >&2
     exit 2
   }
@@ -134,7 +148,7 @@ NAME="${REPO#*/}"
 # to verify each thread's latest comment is on the current HEAD before
 # resolving. Codex P2 on PR #172 caught that the docstring promised
 # this check but the code didn't enforce it.
-HEAD_OID=$(gh api "repos/$OWNER/$NAME/pulls/$PR_NUM" --jq .head.sha 2>/dev/null) || {
+HEAD_OID=$(gh_read api "repos/$OWNER/$NAME/pulls/$PR_NUM" --jq .head.sha 2>/dev/null) || {
   echo "Could not resolve PR HEAD oid for $REPO#$PR_NUM" >&2
   exit 2
 }
@@ -219,20 +233,6 @@ QUERY='
     }
   }
 '
-# Resolve the read PAT once. CR Major on PR #194 r3 caught that
-# `GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}" gh ...`
-# sets GH_TOKEN to an empty string when both env vars are unset, and
-# gh CLI treats an empty GH_TOKEN as "env var present, refuse keyring
-# fallback" — meaning the script silently fails to authenticate at all
-# when run outside a preflight session. Conditional set is required.
-READ_GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}"
-gh_read() {
-  if [ -n "$READ_GH_TOKEN" ]; then
-    GH_TOKEN="$READ_GH_TOKEN" gh "$@"
-  else
-    gh "$@"
-  fi
-}
 while :; do
   # Read-path: pin to preflight reviewer PAT when available; otherwise
   # let gh use its keyring fallback (no empty-GH_TOKEN trap).

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -219,21 +219,31 @@ QUERY='
     }
   }
 '
+# Resolve the read PAT once. CR Major on PR #194 r3 caught that
+# `GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}" gh ...`
+# sets GH_TOKEN to an empty string when both env vars are unset, and
+# gh CLI treats an empty GH_TOKEN as "env var present, refuse keyring
+# fallback" — meaning the script silently fails to authenticate at all
+# when run outside a preflight session. Conditional set is required.
+READ_GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}"
+gh_read() {
+  if [ -n "$READ_GH_TOKEN" ]; then
+    GH_TOKEN="$READ_GH_TOKEN" gh "$@"
+  else
+    gh "$@"
+  fi
+}
 while :; do
-  # Read-path: pin to preflight reviewer PAT per the auth split
-  # documented in the repo's machine-level CLAUDE.md. Falls through
-  # to the active keyring account only when preflight wasn't run
-  # (env var unset / empty).
+  # Read-path: pin to preflight reviewer PAT when available; otherwise
+  # let gh use its keyring fallback (no empty-GH_TOKEN trap).
   if [ -z "$CURSOR" ]; then
-    PAGE=$(GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}" \
-      gh api graphql -f query="$QUERY" \
+    PAGE=$(gh_read api graphql -f query="$QUERY" \
       -F owner="$OWNER" -F repo="$NAME" -F pr="$PR_NUM" -F cursor=null 2>&1) || {
       echo "GraphQL query failed: $PAGE" >&2
       exit 2
     }
   else
-    PAGE=$(GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}" \
-      gh api graphql -f query="$QUERY" \
+    PAGE=$(gh_read api graphql -f query="$QUERY" \
       -F owner="$OWNER" -F repo="$NAME" -F pr="$PR_NUM" -f cursor="$CURSOR" 2>&1) || {
       echo "GraphQL query failed: $PAGE" >&2
       exit 2

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -152,11 +152,15 @@ HEAD_OID=$(gh api "repos/$OWNER/$NAME/pulls/$PR_NUM" --jq .head.sha 2>/dev/null)
 #    state branching below sends GraphQL null on the first call,
 #    then a real cursor string on subsequent pages.
 #
-# 2. `comments(first: 50)` — fetch up to 50 comments per thread
-#    instead of `comments(last: 1)`. PR review threads almost never
-#    exceed 50 comments; fetching them all lets us pick first
-#    (original author/body/path) AND last (HEAD anchor commit_oid)
-#    deterministically from one response.
+# 2. Two GraphQL aliases — `commentsFirst: comments(first: 1)` for
+#    the original review's author/path/body (what the user/agent
+#    needs to recognize the thread) AND `commentsLast: comments(last:
+#    1)` for the HEAD-anchor commit_oid (the truly-latest comment).
+#    Earlier draft used `comments(first: 50)` and indexed `[-1]` for
+#    the last comment, but Codex P2 on PR #194 caught that >50-comment
+#    threads (rare but possible — bot churn over a long-lived PR)
+#    would misclassify HEAD anchor. The dual-alias shape is
+#    deterministic for any thread depth.
 #
 # 3. `totalCount` cross-validation — after assembling THREADS_JSON,
 #    compare the returned node count against the API's reported
@@ -190,12 +194,22 @@ QUERY='
             id
             isResolved
             isOutdated
-            comments(first: 50) {
+            # `commentsFirst` for the original review (excerpt + author).
+            # `commentsLast` for the HEAD-anchor commit_oid — `last: 1`
+            # guarantees the truly-latest comment regardless of thread
+            # depth. Codex P2 on PR #194 caught that `first: 50` would
+            # misclassify HEAD anchor on threads with >50 comments
+            # (rare but possible — bot churn).
+            commentsFirst: comments(first: 1) {
               nodes {
                 author { login }
                 path
                 body
                 createdAt
+              }
+            }
+            commentsLast: comments(last: 1) {
+              nodes {
                 commit { oid }
               }
             }
@@ -251,14 +265,13 @@ UNRESOLVED=$(echo "$THREADS_JSON" | jq -c '
   | {
       id: .id,
       outdated: .isOutdated,
-      # First comment = original review (what the human/agent needs
-      # to recognize the thread). Last comment = HEAD-anchor target
-      # (where the bot is now expected to re-review).
-      author: (.comments.nodes[0].author.login // "unknown"),
-      path: (.comments.nodes[0].path // "(no path)"),
-      created: (.comments.nodes[0].createdAt // ""),
-      commit_oid: (.comments.nodes[-1].commit.oid // ""),
-      excerpt: ((.comments.nodes[0].body // "") | .[0:160])
+      # commentsFirst = original review (excerpt + author for display).
+      # commentsLast = guaranteed-latest comment (HEAD anchor commit_oid).
+      author: (.commentsFirst.nodes[0].author.login // "unknown"),
+      path: (.commentsFirst.nodes[0].path // "(no path)"),
+      created: (.commentsFirst.nodes[0].createdAt // ""),
+      commit_oid: (.commentsLast.nodes[0].commit.oid // ""),
+      excerpt: ((.commentsFirst.nodes[0].body // "") | .[0:160])
     }
 ')
 

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -220,14 +220,20 @@ QUERY='
   }
 '
 while :; do
+  # Read-path: pin to preflight reviewer PAT per the auth split
+  # documented in the repo's machine-level CLAUDE.md. Falls through
+  # to the active keyring account only when preflight wasn't run
+  # (env var unset / empty).
   if [ -z "$CURSOR" ]; then
-    PAGE=$(gh api graphql -f query="$QUERY" \
+    PAGE=$(GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}" \
+      gh api graphql -f query="$QUERY" \
       -F owner="$OWNER" -F repo="$NAME" -F pr="$PR_NUM" -F cursor=null 2>&1) || {
       echo "GraphQL query failed: $PAGE" >&2
       exit 2
     }
   else
-    PAGE=$(gh api graphql -f query="$QUERY" \
+    PAGE=$(GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}" \
+      gh api graphql -f query="$QUERY" \
       -F owner="$OWNER" -F repo="$NAME" -F pr="$PR_NUM" -f cursor="$CURSOR" 2>&1) || {
       echo "GraphQL query failed: $PAGE" >&2
       exit 2
@@ -241,17 +247,20 @@ while :; do
   CURSOR=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<<"$PAGE")
 done
 
-# totalCount cross-validation — undercount detection.
+# totalCount cross-validation — fail on ANY mismatch (under OR over).
+# Equality check, not `< totalCount`: an over-count would indicate a
+# duplicate-page / cursor-reset regression in the pagination loop and
+# is just as bad as an undercount. CR Major on PR #194 r2.
 RETURNED_COUNT=$(jq -r 'length' <<<"$THREADS_JSON")
-if [ "$RETURNED_COUNT" -lt "$TOTAL_COUNT" ]; then
+if [ "$RETURNED_COUNT" != "$TOTAL_COUNT" ]; then
   cat >&2 <<EOF
-ERROR: GraphQL undercount detected on $REPO#$PR_NUM.
+ERROR: GraphQL count mismatch on $REPO#$PR_NUM.
        reviewThreads.totalCount = $TOTAL_COUNT, but the paginated query
-       returned $RETURNED_COUNT nodes. This is the eventual-consistency /
-       cache-shape failure mode that masked unresolved threads on
-       PR #189 (May 2026 — see scripts/resolve-pr-threads.sh header).
-       Do NOT trust the "no unresolved threads" output below; fall back
-       to the manual GraphQL escape hatch in CLAUDE.md § 7.6.
+       returned $RETURNED_COUNT nodes. Either undercount (cursor-typing
+       bug per #192) or overcount (duplicate-page / cursor-reset
+       regression). Do NOT trust the "no unresolved threads" output
+       below; fall back to the manual GraphQL escape hatch in
+       CLAUDE.md § 7.6.
 EOF
   exit 2
 fi

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -139,62 +139,126 @@ HEAD_OID=$(gh api "repos/$OWNER/$NAME/pulls/$PR_NUM" --jq .head.sha 2>/dev/null)
   exit 2
 }
 
-# Fetch all review threads with isResolved state, author, and the
-# LATEST comment's commit_id (so --auto-resolve-bots can verify
-# current-HEAD membership). Use GraphQL because reviewThreads aren't
-# exposed via REST. Paginate through reviewThreads — Codex P2 on PR
-# #172 caught that the prior `first: 100` could undercount on PRs
-# with many threads. Ditto comments: fetch `last: 1` to anchor the
-# resolved-against-HEAD check on the most recent comment per thread.
+# Fetch all review threads with isResolved state. Three design
+# choices, all load-bearing:
+#
+# 1. `-F cursor=null` (typed) on the first call, NOT `-f cursor=null`
+#    (string). The prior code used `-f cursor=null` which sent the
+#    literal STRING "null" as the cursor; GitHub's GraphQL endpoint
+#    interpreted that as a real cursor and silently returned the
+#    wrong thread set. This was the actual root cause of the
+#    PR #189 undercount (May 2026 — initially misdiagnosed as
+#    eventual consistency; #192 has the post-mortem). The cursor-
+#    state branching below sends GraphQL null on the first call,
+#    then a real cursor string on subsequent pages.
+#
+# 2. `comments(first: 50)` — fetch up to 50 comments per thread
+#    instead of `comments(last: 1)`. PR review threads almost never
+#    exceed 50 comments; fetching them all lets us pick first
+#    (original author/body/path) AND last (HEAD anchor commit_oid)
+#    deterministically from one response.
+#
+# 3. `totalCount` cross-validation — after assembling THREADS_JSON,
+#    compare the returned node count against the API's reported
+#    totalCount. If they disagree the script reports on stderr +
+#    exits 2 rather than the silent "no unresolved threads" output
+#    that bit PR #189. Belt-and-suspenders: even with the cursor fix
+#    above, a future API quirk could re-introduce undercount; the
+#    cross-check catches it.
+#
+# Codex P2 on PR #172 caught that the prior `first: 100` (no pager)
+# could undercount on PRs with many threads — paginating with
+# `first: 50` + cursor preserves that fix.
 THREADS_JSON='[]'
-CURSOR="null"
-while :; do
-  PAGE=$(gh api graphql -f query='
-    query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
-      repository(owner: $owner, name: $repo) {
-        pullRequest(number: $pr) {
-          reviewThreads(first: 50, after: $cursor) {
-            pageInfo { hasNextPage endCursor }
-            nodes {
-              id
-              isResolved
-              isOutdated
-              comments(last: 1) {
-                nodes {
-                  author { login }
-                  path
-                  body
-                  createdAt
-                  commit { oid }
-                }
+TOTAL_COUNT=0
+# CURSOR sentinel "" means "first call — send GraphQL null". A string
+# value "null" is NOT the same: passing it via `-f cursor=null` sends
+# the literal string "null" which GitHub interprets as a real cursor
+# and silently returns the wrong thread set. Always use `-F` (typed)
+# for null on first call; switch to `-f` (string) once we have a real
+# cursor. This was the actual root cause of the PR #189 undercount —
+# not eventual consistency.
+CURSOR=""
+QUERY='
+  query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 50, after: $cursor) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            isResolved
+            isOutdated
+            comments(first: 50) {
+              nodes {
+                author { login }
+                path
+                body
+                createdAt
+                commit { oid }
               }
             }
           }
         }
       }
     }
-  ' -F owner="$OWNER" -F repo="$NAME" -F pr="$PR_NUM" -f cursor="$CURSOR" 2>&1) || {
-    echo "GraphQL query failed: $PAGE" >&2
-    exit 2
   }
+'
+while :; do
+  if [ -z "$CURSOR" ]; then
+    PAGE=$(gh api graphql -f query="$QUERY" \
+      -F owner="$OWNER" -F repo="$NAME" -F pr="$PR_NUM" -F cursor=null 2>&1) || {
+      echo "GraphQL query failed: $PAGE" >&2
+      exit 2
+    }
+  else
+    PAGE=$(gh api graphql -f query="$QUERY" \
+      -F owner="$OWNER" -F repo="$NAME" -F pr="$PR_NUM" -f cursor="$CURSOR" 2>&1) || {
+      echo "GraphQL query failed: $PAGE" >&2
+      exit 2
+    }
+  fi
   THREADS_JSON=$(jq -c --argjson acc "$THREADS_JSON" \
     '$acc + .data.repository.pullRequest.reviewThreads.nodes' <<<"$PAGE")
+  TOTAL_COUNT=$(jq -r '.data.repository.pullRequest.reviewThreads.totalCount' <<<"$PAGE")
   HAS_NEXT=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$PAGE")
   [ "$HAS_NEXT" = "true" ] || break
   CURSOR=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<<"$PAGE")
 done
 
+# totalCount cross-validation — undercount detection.
+RETURNED_COUNT=$(jq -r 'length' <<<"$THREADS_JSON")
+if [ "$RETURNED_COUNT" -lt "$TOTAL_COUNT" ]; then
+  cat >&2 <<EOF
+ERROR: GraphQL undercount detected on $REPO#$PR_NUM.
+       reviewThreads.totalCount = $TOTAL_COUNT, but the paginated query
+       returned $RETURNED_COUNT nodes. This is the eventual-consistency /
+       cache-shape failure mode that masked unresolved threads on
+       PR #189 (May 2026 — see scripts/resolve-pr-threads.sh header).
+       Do NOT trust the "no unresolved threads" output below; fall back
+       to the manual GraphQL escape hatch in CLAUDE.md § 7.6.
+EOF
+  exit 2
+fi
+
 UNRESOLVED=$(echo "$THREADS_JSON" | jq -c '
   .[]
-  | select(.isResolved == false)
+  # `!= true` instead of `== false` so a null/missing isResolved
+  # field is treated as unresolved (defensive — prefer to surface
+  # noise over silently skip).
+  | select(.isResolved != true)
   | {
       id: .id,
       outdated: .isOutdated,
-      author: (.comments.nodes[-1].author.login // "unknown"),
-      path: (.comments.nodes[-1].path // "(no path)"),
-      created: (.comments.nodes[-1].createdAt // ""),
+      # First comment = original review (what the human/agent needs
+      # to recognize the thread). Last comment = HEAD-anchor target
+      # (where the bot is now expected to re-review).
+      author: (.comments.nodes[0].author.login // "unknown"),
+      path: (.comments.nodes[0].path // "(no path)"),
+      created: (.comments.nodes[0].createdAt // ""),
       commit_oid: (.comments.nodes[-1].commit.oid // ""),
-      excerpt: ((.comments.nodes[-1].body // "") | .[0:160])
+      excerpt: ((.comments.nodes[0].body // "") | .[0:160])
     }
 ')
 


### PR DESCRIPTION
Closes #192.

## Root cause

Misdiagnosed in the issue body as eventual consistency. Real cause: an argument-typing bug.

The script paginated `reviewThreads` with `-f cursor="$CURSOR"`. On the first call `$CURSOR="null"` (the literal string). `gh api`'s `-f` flag sends values as strings, so GitHub received `cursor: "null"` (JSON string), interpreted it as a real opaque cursor, and silently returned the wrong thread set. Reproduced deterministically on closed PR #189: `totalCount=3` but only 2 nodes returned by the script.

Direct verification:
```
gh api graphql ... -f cursor=null  → returns 2 nodes (BUG)
gh api graphql ... -F cursor=null  → returns 3 nodes (CORRECT)
```

## Fix

- **First call uses `-F cursor=null`** (typed conversion → real GraphQL null). Subsequent pages use `-f cursor="$CURSOR"` (real cursor string from the prior `endCursor`).
- **`totalCount` cross-validation**: if `returned < totalCount`, exit 2 with a clear undercount error instead of the silent "no unresolved threads" output that masked the bug. Belt-and-suspenders against future API quirks.
- **`comments(last: 1)` → `comments(first: 50)`**: threads almost never exceed 50 comments; one fetch gives both first comment (original review for excerpt) and last comment (HEAD anchor for current-HEAD check).
- **Defensive `select(.isResolved != true)`**: null/missing field treated as unresolved (prefer noise over silent skip).

## Test coverage

New `scripts/ci/check_resolve_pr_threads` with 5 tests:
1. First-call argv contains `-F cursor=null` (positive)
2. First-call argv does NOT contain `-f cursor=null` (negative — closes the regression)
3. `totalCount > returned` → exit 2 with undercount error
4. `totalCount == returned` (all resolved) → exit 0 + clean message
5. `isResolved: null` → treated as unresolved (defensive)

Wired into `repo_lint.yml`. While there: also wired the previously-unrun `check_phase_4b_classifier` (committed in PR #190 but no workflow ever invoked it — separate gap).

## Doc

`CLAUDE.md § 7.6` now includes the manual GraphQL escape hatch agents can paste when the script reports clean but the merge errors with `All comments must be resolved`. Explicit fallback for the case where this script's defenses ever get bypassed.

## Self-Review

- **Correctness**: cursor-null fix verified by direct API test on PR #189 data. `totalCount` cross-validation reproduces the original bug condition under test.
- **Regression risk**: low — existing exit codes and CLI surface unchanged; new paths are additive.
- **Coverage**: 5 new tests; wired into CI alongside two previously-unwired test suites.
- **Style**: matches existing `scripts/ci/check_*` shape (PATH-prepended gh stub, set +e/-e brackets).
- **Security/dependency hygiene**: no new deps; no auth changes.

Authoring-Agent: claude