### PR TITLE
feat(automation): auto-clear-blocking-labels.yml workflow (#195)

### DIFF
--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -1,0 +1,140 @@
+name: Auto-clear blocking labels
+
+# Closes the manual-label-removal toil documented in #191.
+#
+# When the codex-review-check.sh merge gate clears (CI green +
+# reviewer-identity APPROVED + Codex cleared on HEAD), this workflow
+# removes the `needs-external-review` label automatically. Without it,
+# every over-threshold PR requires the human to do
+# `gh pr edit <N> --remove-label needs-external-review` after agents
+# have done all the actual review work.
+#
+# Scope: ONLY removes `needs-external-review`. `needs-human-review`
+# and `policy-violation` remain manual-only by design (see
+# REVIEW_POLICY.md § Agent prohibitions). The doctrine carve-out for
+# this workflow ships in #196.
+
+on:
+  pull_request_target:
+    types: [synchronize, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted]
+  check_suite:
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  contents: read
+  checks: read
+
+jobs:
+  evaluate-and-clear:
+    name: Re-evaluate codex-review-check gate
+    runs-on: ubuntu-latest
+    # Self-fire loop guard: when this workflow's label removal fires
+    # the `unlabeled` event for `needs-external-review`, skip — we
+    # just removed it; nothing to do.
+    if: |
+      !(
+        github.event_name == 'pull_request_target' &&
+        github.event.action == 'unlabeled' &&
+        github.event.label.name == 'needs-external-review'
+      )
+    steps:
+      - name: Checkout repo (for codex-review-check.sh)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Need full history so codex-review-check can inspect the
+          # PR HEAD against base. The script doesn't currently do that
+          # but a future tightening might.
+          fetch-depth: 0
+
+      - name: Resolve PR number from event
+        id: pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_JSON: ${{ toJSON(github.event) }}
+        run: |
+          # Each event surfaces PR number(s) differently. Emit a
+          # newline-separated list (most events have exactly one PR).
+          # check_suite.completed can attach to multiple PRs in
+          # principle, so we enumerate.
+          case "$EVENT_NAME" in
+            pull_request_target|pull_request_review)
+              prs=$(jq -r '.pull_request.number' <<<"$EVENT_JSON")
+              ;;
+            check_suite)
+              prs=$(jq -r '.check_suite.pull_requests[].number' <<<"$EVENT_JSON")
+              ;;
+            *)
+              echo "Unsupported event: $EVENT_NAME" >&2
+              exit 0  # don't fail; just skip
+              ;;
+          esac
+          if [ -z "$prs" ]; then
+            echo "No PR number resolvable from event; skipping." >&2
+            echo "numbers=" >> "$GITHUB_OUTPUT"
+          else
+            # Multi-line output: use a heredoc per Actions docs.
+            {
+              echo 'numbers<<EOF'
+              echo "$prs"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Re-evaluate gate per PR + remove label on pass
+        if: steps.pr.outputs.numbers != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBERS: ${{ steps.pr.outputs.numbers }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          # codex-review-check.sh exits:
+          #   0 = gate passes
+          #   1 = gate fails (one or more of CI/reviewer/codex not met)
+          #   3 = config/arg error (real failure — bubble up)
+          while IFS= read -r PR; do
+            [ -z "$PR" ] && continue
+            echo "::group::Evaluating PR #$PR"
+
+            # Skip if label not present (no-op, common case on
+            # synchronize/check_suite for under-threshold PRs).
+            HAS_LABEL=$(gh pr view "$PR" --repo "$REPO" --json labels \
+              --jq '[.labels[].name] | contains(["needs-external-review"])')
+            if [ "$HAS_LABEL" != "true" ]; then
+              echo "Label needs-external-review not present; nothing to clear."
+              echo "::endgroup::"
+              continue
+            fi
+
+            set +e
+            scripts/codex-review-check.sh "$PR"
+            rc=$?
+            set -e
+
+            case "$rc" in
+              0)
+                echo "Gate passes — removing needs-external-review label."
+                gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review
+                gh pr comment "$PR" --repo "$REPO" --body "$(cat <<'COMMENT'
+                **Automated label removal.** \`scripts/codex-review-check.sh\` cleared the merge gate on this HEAD (CI green + reviewer-identity APPROVED + Codex cleared). Removed \`needs-external-review\` so Label Gate passes and the PR can merge. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#195) for the trigger doctrine.
+                COMMENT
+                )"
+                ;;
+              1)
+                echo "Gate not yet met — leaving label in place."
+                ;;
+              3)
+                echo "::error::codex-review-check.sh config/arg error (rc=3) on PR #$PR"
+                # Don't exit non-zero; one bad PR shouldn't kill the
+                # whole sweep on check_suite events that may have
+                # multiple PRs attached.
+                ;;
+              *)
+                echo "::warning::codex-review-check.sh unexpected rc=$rc on PR #$PR"
+                ;;
+            esac
+            echo "::endgroup::"
+          done <<<"$PR_NUMBERS"

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -167,10 +167,12 @@ jobs:
                   echo "::endgroup::"
                   continue
                 fi
-                gh pr comment "$PR" --repo "$REPO" --body "$(cat <<'COMMENT'
-                **Automated label removal.** \`scripts/codex-review-check.sh\` cleared the merge gate on this HEAD (CI green + reviewer-identity APPROVED + Codex cleared). Removed \`needs-external-review\` so Label Gate passes and the PR can merge. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#195) for the trigger doctrine.
-                COMMENT
-                )" || echo "::warning::Failed to post attribution comment for PR #$PR"
+                # Direct string body (NOT a heredoc — heredoc closing
+                # delimiter must be column-0 unless using `<<-` with
+                # tabs; YAML run blocks make that brittle).
+                comment_body='**Automated label removal.** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD (CI green + reviewer-identity APPROVED + Codex cleared). Removed `needs-external-review` so Label Gate passes and the PR can merge. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#195) for the trigger doctrine.'
+                gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
+                  || echo "::warning::Failed to post attribution comment for PR #$PR"
                 ;;
               1)
                 echo "Gate not yet met — leaving label in place."

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -183,7 +183,11 @@ jobs:
                 had_infra_error=1
                 ;;
               *)
-                echo "::warning::codex-review-check.sh unexpected rc=$rc on PR #$PR"
+                echo "::error::codex-review-check.sh unexpected rc=$rc on PR #$PR (contract drift — failing job)"
+                # Fail-closed: any rc outside 0/1/3 is contract drift.
+                # Better to fail loudly than leave the label stuck
+                # behind a silently-broken gate. CR Major on PR #202 r3.
+                had_infra_error=1
                 ;;
             esac
             echo "::endgroup::"

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -58,6 +58,15 @@ jobs:
       - name: Checkout repo (for codex-review-check.sh)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          # SECURITY: pin to the default branch so we always run the
+          # TRUSTED copy of scripts/codex-review-check.sh — never the
+          # PR's own version. Without this, on pull_request_review
+          # events GITHUB_REF defaults to refs/pull/<N>/merge and
+          # actions/checkout pulls the PR's HEAD; combined with this
+          # workflow's `pull-requests: write` permission, a malicious
+          # PR could modify the gate script to remove arbitrary labels
+          # or post arbitrary comments. CR Critical on PR #202 r2.
+          ref: ${{ github.event.repository.default_branch }}
           # Need full history so codex-review-check can inspect the
           # PR HEAD against base. The script doesn't currently do that
           # but a future tightening might.
@@ -117,11 +126,16 @@ jobs:
           # codex-review-check.sh exits:
           #   0 = gate passes
           #   1 = gate fails (one or more of CI/reviewer/codex not met)
-          #   3 = config/arg error (real failure — bubble up)
+          #   3 = config/arg error (real infrastructure failure)
           # CR Major on PR #202 r1: every gh call gets explicit error
           # handling so a transient failure (rate limit, 5xx) on one
           # PR doesn't abort the sweep, AND no early gh failure is
           # silently swallowed by an asymmetric set -e/+e dance.
+          # CR Major on PR #202 r2: rc=3 (infrastructure error) sets a
+          # sentinel; after the sweep finishes we exit non-zero if any
+          # PR hit it, so the workflow doesn't go green when gate
+          # evaluation was actually impossible.
+          had_infra_error=0
           while IFS= read -r PR; do
             [ -z "$PR" ] && continue
             echo "::group::Evaluating PR #$PR"
@@ -163,9 +177,10 @@ jobs:
                 ;;
               3)
                 echo "::error::codex-review-check.sh config/arg error (rc=3) on PR #$PR"
-                # Don't exit non-zero; one bad PR shouldn't kill the
-                # whole sweep on workflow_run events that may have
-                # multiple PRs attached.
+                # Don't exit non-zero mid-loop — keep sweeping other
+                # PRs on a multi-PR workflow_run trigger. But set
+                # the sentinel so the job exits non-zero at the end.
+                had_infra_error=1
                 ;;
               *)
                 echo "::warning::codex-review-check.sh unexpected rc=$rc on PR #$PR"
@@ -173,3 +188,4 @@ jobs:
             esac
             echo "::endgroup::"
           done <<<"$PR_NUMBERS"
+          exit "$had_infra_error"

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -19,7 +19,21 @@ on:
     types: [synchronize, labeled, unlabeled]
   pull_request_review:
     types: [submitted]
-  check_suite:
+  # workflow_run fires on completion of OTHER workflows. We target
+  # the three that produce the required-check signals codex-review-
+  # check.sh inspects: PR Review Policy (Label Gate, Self-Review,
+  # External Review Check), Agent Review Pipeline (auto-merge-on-
+  # approval, detect-disagreement, etc.), and repo-lint (lint).
+  # This replaces the prior `check_suite` trigger, which (per codex
+  # P1 on PR #202) does NOT fire for suites created by GitHub
+  # Actions — only for external CI providers. Without workflow_run,
+  # the common path of "reviewer approves → Actions CI catches up →
+  # gate now passes" produced no event and the label stayed stuck.
+  workflow_run:
+    workflows:
+      - "PR Review Policy"
+      - "Agent Review Pipeline"
+      - "repo-lint"
     types: [completed]
 
 permissions:
@@ -57,14 +71,23 @@ jobs:
         run: |
           # Each event surfaces PR number(s) differently. Emit a
           # newline-separated list (most events have exactly one PR).
-          # check_suite.completed can attach to multiple PRs in
+          # workflow_run.completed can attach to multiple PRs in
           # principle, so we enumerate.
           case "$EVENT_NAME" in
             pull_request_target|pull_request_review)
               prs=$(jq -r '.pull_request.number' <<<"$EVENT_JSON")
               ;;
-            check_suite)
-              prs=$(jq -r '.check_suite.pull_requests[].number' <<<"$EVENT_JSON")
+            workflow_run)
+              # Only act on successful runs of the listened workflows;
+              # a failed lint or PR Review Policy run won't have
+              # changed the gate state, so don't bother re-evaluating.
+              conclusion=$(jq -r '.workflow_run.conclusion' <<<"$EVENT_JSON")
+              if [ "$conclusion" != "success" ]; then
+                echo "workflow_run conclusion=$conclusion (not success); skipping." >&2
+                echo "numbers=" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              prs=$(jq -r '.workflow_run.pull_requests[].number' <<<"$EVENT_JSON")
               ;;
             *)
               echo "Unsupported event: $EVENT_NAME" >&2
@@ -90,19 +113,27 @@ jobs:
           PR_NUMBERS: ${{ steps.pr.outputs.numbers }}
           REPO: ${{ github.repository }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
           # codex-review-check.sh exits:
           #   0 = gate passes
           #   1 = gate fails (one or more of CI/reviewer/codex not met)
           #   3 = config/arg error (real failure — bubble up)
+          # CR Major on PR #202 r1: every gh call gets explicit error
+          # handling so a transient failure (rate limit, 5xx) on one
+          # PR doesn't abort the sweep, AND no early gh failure is
+          # silently swallowed by an asymmetric set -e/+e dance.
           while IFS= read -r PR; do
             [ -z "$PR" ] && continue
             echo "::group::Evaluating PR #$PR"
 
             # Skip if label not present (no-op, common case on
-            # synchronize/check_suite for under-threshold PRs).
-            HAS_LABEL=$(gh pr view "$PR" --repo "$REPO" --json labels \
-              --jq '[.labels[].name] | contains(["needs-external-review"])')
+            # synchronize/workflow_run for under-threshold PRs).
+            if ! HAS_LABEL=$(gh pr view "$PR" --repo "$REPO" --json labels \
+              --jq '[.labels[].name] | contains(["needs-external-review"])'); then
+              echo "::warning::Failed to query labels for PR #$PR; skipping."
+              echo "::endgroup::"
+              continue
+            fi
             if [ "$HAS_LABEL" != "true" ]; then
               echo "Label needs-external-review not present; nothing to clear."
               echo "::endgroup::"
@@ -117,11 +148,15 @@ jobs:
             case "$rc" in
               0)
                 echo "Gate passes — removing needs-external-review label."
-                gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review
+                if ! gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
+                  echo "::warning::Failed to remove needs-external-review on PR #$PR"
+                  echo "::endgroup::"
+                  continue
+                fi
                 gh pr comment "$PR" --repo "$REPO" --body "$(cat <<'COMMENT'
                 **Automated label removal.** \`scripts/codex-review-check.sh\` cleared the merge gate on this HEAD (CI green + reviewer-identity APPROVED + Codex cleared). Removed \`needs-external-review\` so Label Gate passes and the PR can merge. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#195) for the trigger doctrine.
                 COMMENT
-                )"
+                )" || echo "::warning::Failed to post attribution comment for PR #$PR"
                 ;;
               1)
                 echo "Gate not yet met — leaving label in place."
@@ -129,7 +164,7 @@ jobs:
               3)
                 echo "::error::codex-review-check.sh config/arg error (rc=3) on PR #$PR"
                 # Don't exit non-zero; one bad PR shouldn't kill the
-                # whole sweep on check_suite events that may have
+                # whole sweep on workflow_run events that may have
                 # multiple PRs attached.
                 ;;
               *)

--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -57,6 +57,9 @@ jobs:
       - name: check_resolve_pr_threads
         run: ./scripts/ci/check_resolve_pr_threads
 
+      - name: check_auto_clear_workflow
+        run: ./scripts/ci/check_auto_clear_workflow
+
       - name: check_governance_files
         run: |
           MISSING=0

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -95,6 +95,23 @@ else
   echo "  FAIL: checkout MUST pin ref to default_branch (CR Critical on #202 r2)" >&2
 fi
 
+# Least-privilege permissions: only the expected scopes should be
+# present. The security pin above guards checkout but doesn't catch
+# the case where the workflow later gains broader write scopes
+# (e.g., `actions: write`, `issues: write`, etc.). CR Major on PR
+# #202 r3 — codify the expected permission set so any future
+# scope expansion is surfaced as a CI failure.
+if grep -qE '^[[:space:]]+pull-requests:[[:space:]]+write$' "$WORKFLOW" && \
+   grep -qE '^[[:space:]]+contents:[[:space:]]+read$' "$WORKFLOW" && \
+   grep -qE '^[[:space:]]+checks:[[:space:]]+read$' "$WORKFLOW" && \
+   ! grep -qE '^[[:space:]]+(actions|attestations|deployments|discussions|id-token|issues|models|packages|pages|security-events|statuses):[[:space:]]+write$' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: workflow permissions stay least-privilege (only pull-requests:write + contents/checks:read)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: workflow permissions drifted from the expected least-privilege set" >&2
+fi
+
 # Sentinel: rc=3 from codex-review-check.sh sets had_infra_error and
 # the job exits non-zero at the end. Without this, gate-evaluation
 # infrastructure failures would silently leave the workflow green.
@@ -119,11 +136,15 @@ else
 fi
 
 # ── Test 4: scope discipline — only needs-external-review is removed
-if grep -qE 'remove-label needs-external-review' "$WORKFLOW" && \
-   ! grep -qE 'remove-label needs-human-review' "$WORKFLOW" && \
-   ! grep -qE 'remove-label policy-violation' "$WORKFLOW"; then
+# CR Major on PR #202 r3: tighten the positive grep to the actual
+# `gh pr edit ... --remove-label` executable line, not anywhere in
+# the file (header comments/attribution-message would otherwise
+# satisfy the match even if the executable line regressed).
+if grep -qE 'gh pr edit .+--remove-label needs-external-review' "$WORKFLOW" && \
+   ! grep -qE 'gh pr edit .+--remove-label needs-human-review' "$WORKFLOW" && \
+   ! grep -qE 'gh pr edit .+--remove-label policy-violation' "$WORKFLOW"; then
   pass=$((pass + 1))
-  echo "  PASS: scope discipline — only needs-external-review is auto-removed"
+  echo "  PASS: scope discipline — only needs-external-review is auto-removed (executable line)"
 else
   fail=$((fail + 1))
   echo "  FAIL: workflow either misses the target label or auto-removes a forbidden one" >&2

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# check_auto_clear_workflow — smoke tests for auto-clear-blocking-labels.yml
+#
+# The workflow itself runs in GitHub Actions; what we test here is the
+# YAML structure (parses, has the right triggers, has the self-fire
+# guard) and the PR-number resolution dispatch logic (which is bash
+# inside the workflow). Mirrors the integration-test gap that #195's
+# implementation plan flagged.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/auto-clear-blocking-labels.yml"
+
+pass=0
+fail=0
+
+# ── Test 1: workflow file exists and is valid YAML
+echo "auto-clear-blocking-labels.yml structural tests"
+
+if [ ! -f "$WORKFLOW" ]; then
+  echo "  FAIL: $WORKFLOW does not exist" >&2
+  exit 1
+fi
+
+# Parse via yq (preferred — no extra deps needed in GitHub-hosted
+# runner) → python3+PyYAML → grep fallback. Graceful skip when no
+# YAML parser is available rather than treating absence as failure.
+if command -v yq >/dev/null 2>&1; then
+  if yq eval '.' "$WORKFLOW" >/dev/null 2>&1; then
+    pass=$((pass + 1))
+    echo "  PASS: workflow YAML parses (via yq)"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: workflow YAML invalid (per yq)" >&2
+  fi
+elif python3 -c "import yaml" >/dev/null 2>&1; then
+  if python3 -c "import yaml; yaml.safe_load(open('$WORKFLOW'))" 2>/dev/null; then
+    pass=$((pass + 1))
+    echo "  PASS: workflow YAML parses (via python+PyYAML)"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: workflow YAML invalid (per python+PyYAML)" >&2
+  fi
+else
+  echo "  SKIP: no YAML parser available (install yq or PyYAML for this check)"
+fi
+
+# ── Test 2: required triggers present
+for trig in 'pull_request_target' 'pull_request_review' 'check_suite'; do
+  if grep -qE "^[[:space:]]+${trig}:" "$WORKFLOW"; then
+    pass=$((pass + 1))
+    echo "  PASS: trigger '$trig' configured"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: missing required trigger '$trig'" >&2
+  fi
+done
+
+# ── Test 3: self-fire loop guard present
+if grep -qE "github\.event\.action == 'unlabeled'" "$WORKFLOW" && \
+   grep -qE "github\.event\.label\.name == 'needs-external-review'" "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: self-fire loop guard for unlabeled+needs-external-review present"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: self-fire loop guard missing or malformed" >&2
+fi
+
+# ── Test 4: scope discipline — only needs-external-review is removed
+if grep -qE 'remove-label needs-external-review' "$WORKFLOW" && \
+   ! grep -qE 'remove-label needs-human-review' "$WORKFLOW" && \
+   ! grep -qE 'remove-label policy-violation' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: scope discipline — only needs-external-review is auto-removed"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: workflow either misses the target label or auto-removes a forbidden one" >&2
+fi
+
+# ── Test 5: PR-number resolution dispatch (extracted bash logic)
+# The workflow embeds this dispatch as inline bash. Extract the logic
+# pattern and exercise the three event shapes against canned
+# github.event payloads.
+echo
+echo "auto-clear-blocking-labels.yml PR-number resolution tests"
+
+dispatch() {
+  # Mirrors the workflow's case statement. Args: event_name,
+  # event_json (passed via stdin to jq).
+  local event_name="$1"
+  local event_json="$2"
+  case "$event_name" in
+    pull_request_target|pull_request_review)
+      jq -r '.pull_request.number' <<<"$event_json"
+      ;;
+    check_suite)
+      jq -r '.check_suite.pull_requests[].number' <<<"$event_json"
+      ;;
+    *)
+      echo "Unsupported event: $event_name" >&2
+      return 1
+      ;;
+  esac
+}
+
+# pull_request_target → 1 PR
+out=$(dispatch pull_request_target '{"pull_request":{"number":42}}')
+if [ "$out" = "42" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: pull_request_target resolves to PR number"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: pull_request_target dispatch (got: $out)" >&2
+fi
+
+# pull_request_review → 1 PR
+out=$(dispatch pull_request_review '{"pull_request":{"number":99}}')
+if [ "$out" = "99" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: pull_request_review resolves to PR number"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: pull_request_review dispatch (got: $out)" >&2
+fi
+
+# check_suite → multiple PRs
+out=$(dispatch check_suite '{"check_suite":{"pull_requests":[{"number":7},{"number":8}]}}')
+expected=$'7\n8'
+if [ "$out" = "$expected" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: check_suite enumerates multiple PRs"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: check_suite dispatch (got: $out)" >&2
+fi
+
+# check_suite with empty pull_requests → empty output (script then
+# skips per the `if [ -z "$prs" ]` guard upstream)
+out=$(dispatch check_suite '{"check_suite":{"pull_requests":[]}}')
+if [ -z "$out" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: check_suite with no PRs produces empty output (will be skipped)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: check_suite empty PRs should yield empty (got: $out)" >&2
+fi
+
+# Unsupported event → error (workflow exit 0 path with stderr message)
+set +e
+out=$(dispatch wat '{}' 2>&1)
+rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "Unsupported event"; then
+  pass=$((pass + 1))
+  echo "  PASS: unsupported event returns 1 with clear stderr"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: unsupported event handling (rc=$rc, out=$out)" >&2
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "check_auto_clear_workflow: PASS ($pass tests)"
+  exit 0
+else
+  echo "check_auto_clear_workflow: FAIL ($fail of $((pass + fail)) tests)" >&2
+  exit 1
+fi

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -159,6 +159,56 @@ else
   echo "  FAIL: workflow either misses the target label or auto-removes a forbidden one" >&2
 fi
 
+# ── Test 4c: bash syntax check on every `run:` block
+# Extract each `run: |` block to a temp file and feed to `bash -n`.
+# Catches heredoc/subshell errors that only surface at runtime.
+# Real bug from PR #202 r5: `gh pr comment ... --body "$(cat <<'COMMENT'
+# ... COMMENT )"` had the closing `COMMENT` indented, which is
+# invalid heredoc syntax — this test would have caught it pre-merge.
+echo
+echo "auto-clear-blocking-labels.yml bash syntax test"
+
+block_dir=$(mktemp -d)
+# awk extracts each `run: |` block to a separate file in $block_dir.
+awk -v outdir="$block_dir" '
+  /^[[:space:]]+run:[[:space:]]+\|[[:space:]]*$/ {
+    if (in_run) { close(outfile) }
+    n++; outfile = outdir "/block-" n ".sh"
+    match($0, /^[[:space:]]+/); base_indent = RLENGTH
+    in_run = 1; next
+  }
+  in_run && /^[^[:space:]]/ {
+    close(outfile); in_run = 0; next
+  }
+  in_run {
+    # Strip the YAML run-block indentation (base_indent + 2 spaces).
+    sub("^[[:space:]]{" (base_indent + 2) "}", "")
+    print > outfile
+  }
+  END { if (in_run) close(outfile) }
+' "$WORKFLOW"
+
+extracted_count=$(ls -1 "$block_dir" 2>/dev/null | wc -l | tr -d ' ')
+syntax_errors=0
+for f in "$block_dir"/block-*.sh; do
+  [ -f "$f" ] || continue
+  if ! err=$(bash -n "$f" 2>&1); then
+    fail=$((fail + 1))
+    syntax_errors=$((syntax_errors + 1))
+    echo "  FAIL: bash syntax error in $(basename "$f")" >&2
+    echo "$err" | sed 's/^/    /' >&2
+  fi
+done
+rm -rf "$block_dir"
+
+if [ "$syntax_errors" -eq 0 ] && [ "$extracted_count" -gt 0 ]; then
+  pass=$((pass + 1))
+  echo "  PASS: all $extracted_count run blocks have valid bash syntax"
+elif [ "$extracted_count" = "0" ]; then
+  fail=$((fail + 1))
+  echo "  FAIL: extracted 0 run blocks (extraction logic broken?)" >&2
+fi
+
 # ── Test 5: PR-number resolution dispatch (extracted bash logic)
 # The workflow embeds this dispatch as inline bash. Extract the logic
 # pattern and exercise the three event shapes against canned

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -95,21 +95,28 @@ else
   echo "  FAIL: checkout MUST pin ref to default_branch (CR Critical on #202 r2)" >&2
 fi
 
-# Least-privilege permissions: only the expected scopes should be
-# present. The security pin above guards checkout but doesn't catch
-# the case where the workflow later gains broader write scopes
-# (e.g., `actions: write`, `issues: write`, etc.). CR Major on PR
-# #202 r3 — codify the expected permission set so any future
-# scope expansion is surfaced as a CI failure.
-if grep -qE '^[[:space:]]+pull-requests:[[:space:]]+write$' "$WORKFLOW" && \
-   grep -qE '^[[:space:]]+contents:[[:space:]]+read$' "$WORKFLOW" && \
-   grep -qE '^[[:space:]]+checks:[[:space:]]+read$' "$WORKFLOW" && \
-   ! grep -qE '^[[:space:]]+(actions|attestations|deployments|discussions|id-token|issues|models|packages|pages|security-events|statuses):[[:space:]]+write$' "$WORKFLOW"; then
+# Least-privilege permissions: parse the permissions block and
+# compare against the EXACT expected set, not a denylist. Codifies
+# the expected permission shape so any drift (added scope, changed
+# read↔write) is surfaced as a CI failure. CR Major on PR #202 r4
+# (denylist approach was incomplete — missed artifact-metadata,
+# repository-projects, vulnerability-alerts).
+perm_block=$(
+  awk '
+    /^permissions:/ {in_block=1; next}
+    in_block && /^[^[:space:]]/ {exit}
+    in_block && NF { sub(/^[[:space:]]+/, "", $0); print }
+  ' "$WORKFLOW" | sort
+)
+expected_perms=$'checks: read\ncontents: read\npull-requests: write'
+if [ "$perm_block" = "$expected_perms" ]; then
   pass=$((pass + 1))
-  echo "  PASS: workflow permissions stay least-privilege (only pull-requests:write + contents/checks:read)"
+  echo "  PASS: workflow permissions exactly match the least-privilege set"
 else
   fail=$((fail + 1))
-  echo "  FAIL: workflow permissions drifted from the expected least-privilege set" >&2
+  echo "  FAIL: workflow permissions drifted from expected least-privilege set" >&2
+  echo "      expected:" >&2; echo "$expected_perms" | sed 's/^/        /' >&2
+  echo "      got:" >&2; echo "$perm_block" | sed 's/^/        /' >&2
 fi
 
 # Sentinel: rc=3 from codex-review-check.sh sets had_infra_error and

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -123,10 +123,12 @@ fi
 # the job exits non-zero at the end. Without this, gate-evaluation
 # infrastructure failures would silently leave the workflow green.
 # CR Major on PR #202 r2.
-if grep -qF "had_infra_error=1" "$WORKFLOW" && \
-   grep -qE 'exit "?\$had_infra_error"?' "$WORKFLOW"; then
+# CR Major on PR #202 r5: anchored to start-of-line + word boundary
+# so commented-out occurrences don't satisfy the assertion.
+if grep -qE '^[[:space:]]*had_infra_error=1([[:space:]]|$)' "$WORKFLOW" && \
+   grep -qE '^[[:space:]]*exit[[:space:]]+"?\$had_infra_error"?([[:space:]]|$)' "$WORKFLOW"; then
   pass=$((pass + 1))
-  echo "  PASS: rc=3 sets infra-error sentinel + job exits non-zero on it"
+  echo "  PASS: rc=3 sets infra-error sentinel + job exits non-zero on it (executable lines)"
 else
   fail=$((fail + 1))
   echo "  FAIL: rc=3 from codex-review-check.sh must surface as job failure (sentinel + final exit)" >&2

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -69,6 +69,45 @@ else
   echo "  PASS: check_suite trigger absent (regression closed for codex P1 on #202)"
 fi
 
+# workflow_run must listen to the EXACT upstream workflow names. A
+# rename or typo on either side would silently break the auto-clear
+# without this test catching it. CR Trivial on PR #202 r2.
+for wf in 'PR Review Policy' 'Agent Review Pipeline' 'repo-lint'; do
+  if grep -qF -- "- \"$wf\"" "$WORKFLOW"; then
+    pass=$((pass + 1))
+    echo "  PASS: workflow_run listens to '$wf'"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: workflow_run missing '$wf'" >&2
+  fi
+done
+
+# SECURITY: checkout MUST pin to default branch ref for
+# pull_request_review safety. CR Critical on PR #202 r2 — without
+# the explicit ref, a malicious PR could supply its own version of
+# scripts/codex-review-check.sh and have it run with this workflow's
+# pull-requests:write permissions.
+if grep -qF "ref: \${{ github.event.repository.default_branch }}" "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: checkout pinned to default_branch (security: blocks PR-controlled gate-script execution)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: checkout MUST pin ref to default_branch (CR Critical on #202 r2)" >&2
+fi
+
+# Sentinel: rc=3 from codex-review-check.sh sets had_infra_error and
+# the job exits non-zero at the end. Without this, gate-evaluation
+# infrastructure failures would silently leave the workflow green.
+# CR Major on PR #202 r2.
+if grep -qF "had_infra_error=1" "$WORKFLOW" && \
+   grep -qE 'exit "?\$had_infra_error"?' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: rc=3 sets infra-error sentinel + job exits non-zero on it"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: rc=3 from codex-review-check.sh must surface as job failure (sentinel + final exit)" >&2
+fi
+
 # ── Test 3: self-fire loop guard present
 if grep -qE "github\.event\.action == 'unlabeled'" "$WORKFLOW" && \
    grep -qE "github\.event\.label\.name == 'needs-external-review'" "$WORKFLOW"; then

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -47,7 +47,9 @@ else
 fi
 
 # ── Test 2: required triggers present
-for trig in 'pull_request_target' 'pull_request_review' 'check_suite'; do
+# Codex P1 on PR #202 r1: workflow_run replaces check_suite (which
+# doesn't fire for Actions-created suites).
+for trig in 'pull_request_target' 'pull_request_review' 'workflow_run'; do
   if grep -qE "^[[:space:]]+${trig}:" "$WORKFLOW"; then
     pass=$((pass + 1))
     echo "  PASS: trigger '$trig' configured"
@@ -56,6 +58,16 @@ for trig in 'pull_request_target' 'pull_request_review' 'check_suite'; do
     echo "  FAIL: missing required trigger '$trig'" >&2
   fi
 done
+
+# Negative: workflow_run is the canonical post-CI signal. check_suite
+# would silently fail to fire for GitHub-Actions-created suites.
+if grep -qE "^[[:space:]]+check_suite:" "$WORKFLOW"; then
+  fail=$((fail + 1))
+  echo "  FAIL: check_suite trigger should NOT be present (codex P1 on #202 — doesn't fire for Actions suites)" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: check_suite trigger absent (regression closed for codex P1 on #202)"
+fi
 
 # ── Test 3: self-fire loop guard present
 if grep -qE "github\.event\.action == 'unlabeled'" "$WORKFLOW" && \
@@ -87,19 +99,25 @@ echo "auto-clear-blocking-labels.yml PR-number resolution tests"
 
 dispatch() {
   # Mirrors the workflow's case statement. Args: event_name,
-  # event_json (passed via stdin to jq).
+  # event_json. Unsupported events return 0 (matching the workflow's
+  # `exit 0  # don't fail; just skip` semantics — CR Minor on PR #202).
   local event_name="$1"
   local event_json="$2"
   case "$event_name" in
     pull_request_target|pull_request_review)
       jq -r '.pull_request.number' <<<"$event_json"
       ;;
-    check_suite)
-      jq -r '.check_suite.pull_requests[].number' <<<"$event_json"
+    workflow_run)
+      local conclusion
+      conclusion=$(jq -r '.workflow_run.conclusion' <<<"$event_json")
+      if [ "$conclusion" != "success" ]; then
+        return 0  # workflow's "skip on non-success" path
+      fi
+      jq -r '.workflow_run.pull_requests[].number' <<<"$event_json"
       ;;
     *)
       echo "Unsupported event: $event_name" >&2
-      return 1
+      return 0  # workflow exit 0 on unsupported (don't fail; just skip)
       ;;
   esac
 }
@@ -124,36 +142,48 @@ else
   echo "  FAIL: pull_request_review dispatch (got: $out)" >&2
 fi
 
-# check_suite → multiple PRs
-out=$(dispatch check_suite '{"check_suite":{"pull_requests":[{"number":7},{"number":8}]}}')
+# workflow_run success → multiple PRs
+out=$(dispatch workflow_run '{"workflow_run":{"conclusion":"success","pull_requests":[{"number":7},{"number":8}]}}')
 expected=$'7\n8'
 if [ "$out" = "$expected" ]; then
   pass=$((pass + 1))
-  echo "  PASS: check_suite enumerates multiple PRs"
+  echo "  PASS: workflow_run (success) enumerates multiple PRs"
 else
   fail=$((fail + 1))
-  echo "  FAIL: check_suite dispatch (got: $out)" >&2
+  echo "  FAIL: workflow_run (success) dispatch (got: $out)" >&2
 fi
 
-# check_suite with empty pull_requests → empty output (script then
-# skips per the `if [ -z "$prs" ]` guard upstream)
-out=$(dispatch check_suite '{"check_suite":{"pull_requests":[]}}')
+# workflow_run failure → empty (don't bother re-evaluating gate when
+# the upstream workflow itself failed)
+out=$(dispatch workflow_run '{"workflow_run":{"conclusion":"failure","pull_requests":[{"number":7}]}}')
 if [ -z "$out" ]; then
   pass=$((pass + 1))
-  echo "  PASS: check_suite with no PRs produces empty output (will be skipped)"
+  echo "  PASS: workflow_run (failure conclusion) skips re-evaluation"
 else
   fail=$((fail + 1))
-  echo "  FAIL: check_suite empty PRs should yield empty (got: $out)" >&2
+  echo "  FAIL: workflow_run failure should produce empty (got: $out)" >&2
 fi
 
-# Unsupported event → error (workflow exit 0 path with stderr message)
+# workflow_run with empty pull_requests → empty (script then skips
+# per the `if [ -z "$prs" ]` guard upstream)
+out=$(dispatch workflow_run '{"workflow_run":{"conclusion":"success","pull_requests":[]}}')
+if [ -z "$out" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: workflow_run with no PRs produces empty output (will be skipped)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: workflow_run empty PRs should yield empty (got: $out)" >&2
+fi
+
+# Unsupported event → exit 0 with stderr message (matches workflow
+# behavior; CR Minor on PR #202 r1 fixed the prior return-1 mismatch)
 set +e
 out=$(dispatch wat '{}' 2>&1)
 rc=$?
 set -e
-if [ "$rc" = "1" ] && echo "$out" | grep -q "Unsupported event"; then
+if [ "$rc" = "0" ] && echo "$out" | grep -q "Unsupported event"; then
   pass=$((pass + 1))
-  echo "  PASS: unsupported event returns 1 with clear stderr"
+  echo "  PASS: unsupported event returns 0 with clear stderr (matches workflow)"
 else
   fail=$((fail + 1))
   echo "  FAIL: unsupported event handling (rc=$rc, out=$out)" >&2


### PR DESCRIPTION
Closes #195. Sub-A of parent #191.

## Why

Eliminates the manual `gh pr edit --remove-label needs-external-review` toil that hits every over-threshold PR after external review clears — the friction we just lived through on PR #194 in the same session that filed #195.

## What

New workflow `.github/workflows/auto-clear-blocking-labels.yml`:

- **Triggers**: `pull_request_target` (synchronize, labeled, unlabeled) + `pull_request_review` (submitted) + `check_suite` (completed). The three surfaces that signal "merge gate state may have just changed."
- **Per-PR action**: if `needs-external-review` label present, run `scripts/codex-review-check.sh` (read-only, exits 0 on pass). On exit 0, remove the label via `secrets.GITHUB_TOKEN` and post an attribution comment.
- **Self-fire loop guard**: `if:` skips when the `unlabeled` event is itself for `needs-external-review` (we just removed it).
- **Scope discipline**: ONLY removes `needs-external-review`. `needs-human-review` and `policy-violation` remain manual-only per REVIEW_POLICY.md § Agent prohibitions. The doctrine carve-out for this workflow ships in [#196](https://github.com/nathanjohnpayne/mergepath/issues/196).

## Test coverage

New `scripts/ci/check_auto_clear_workflow` with 10 tests:

- **Structural** (4): triggers present (×3), self-fire guard present, scope discipline (only target label is removed).
- **Dispatch** (5): PR-number resolution for `pull_request_target`, `pull_request_review`, `check_suite` (multi-PR), `check_suite` (empty), unsupported event.
- **Bonus**: optional YAML parse via yq → PyYAML → graceful skip.

Wired into `repo_lint.yml` alongside the other check_* suites.

## Live verification

Happens on the next over-threshold PR after this lands. Expected: human does NOT need to remove `needs-external-review` for the PR to merge.

## Self-Review

- **Correctness**: workflow follows #195's implementation plan exactly. Self-fire guard prevents recursion. Scope-limited to one label per doctrinal constraint.
- **Regression risk**: low — additive new workflow; no changes to existing review/merge surfaces. Worst case if buggy: label stays on PR (current state), human removes it manually (current path).
- **Coverage**: 10 unit tests; wired into CI.
- **Style**: matches existing workflow file shape (pinned action SHA, permissions block, env-driven inputs).
- **Security/dependency hygiene**: uses `secrets.GITHUB_TOKEN` with `pull-requests:write` scope only — minimal permissions per least-privilege.

Authoring-Agent: claude