### PR TITLE
feat(automation): periodic scheduled sweep for stale labels (#197)

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -264,3 +264,17 @@ codex:
 # scripts/codex-review-check.sh's parser — no behavior change without
 # explicit opt-in. See REVIEW_POLICY.md § Migration for existing consumers.
 phase_4b_default: complex-changes
+
+# ---------------------------------------------------------------------------
+# Auto-clear blocking labels (#195/#197)
+# ---------------------------------------------------------------------------
+# Knobs for .github/workflows/auto-clear-blocking-labels.yml. The
+# event-driven evaluate-and-clear job ships unconditionally; the
+# periodic scheduled-sweep job below is optional.
+auto_clear_labels:
+  # Periodic sweep catches the 👍-after-last-push case: Codex reacts
+  # on the PR issue with no synchronize / pull_request_review /
+  # workflow_run event to fire the event-driven path. Defaults to
+  # true; set false if the every-15-minute cron is too noisy for a
+  # given repo's PR volume.
+  scheduled_sweep_enabled: true

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -56,7 +56,12 @@ jobs:
     # Self-fire loop guard: when this workflow's label removal fires
     # the `unlabeled` event for `needs-external-review`, skip — we
     # just removed it; nothing to do.
+    # Schedule guard: cron runs the scheduled-sweep job below; the
+    # event-driven path is moot for scheduled invocations. CR Major
+    # on PR #213 r2 — without this, every 15-min cron paid for an
+    # extra checkout-only no-op job.
     if: |
+      github.event_name != 'schedule' &&
       !(
         github.event_name == 'pull_request_target' &&
         github.event.action == 'unlabeled' &&
@@ -267,11 +272,23 @@ jobs:
           # processes ALL matching PRs in repos with high open-PR
           # counts. 500 is comfortably above any realistic limit for
           # a single repo's needs-external-review queue (would imply
-          # ~500 PRs awaiting review — itself an alarm). If we ever
-          # see this hit in practice, paginate via the search API.
-          mapfile -t prs < <(gh pr list --repo "$REPO" --state open \
+          # ~500 PRs awaiting review — itself an alarm).
+          # CR Major on PR #213 r2: capture gh output + exit status
+          # separately. The prior `mapfile -t prs < <(gh ...)` form
+          # swallowed gh's exit code via process substitution, so a
+          # gh failure (auth, rate limit, network) silently became
+          # "0 PRs found" and the sweep no-op'd instead of failing
+          # loudly.
+          if ! prs_raw=$(gh pr list --repo "$REPO" --state open \
             --label needs-external-review --limit 500 \
-            --json number --jq '.[].number')
+            --json number --jq '.[].number'); then
+            echo "::error::Failed to list open PRs with needs-external-review on $REPO"
+            exit 1
+          fi
+          prs=()
+          if [ -n "$prs_raw" ]; then
+            mapfile -t prs <<<"$prs_raw"
+          fi
           echo "Found ${#prs[@]} PR(s) with needs-external-review on $REPO"
           if [ "${#prs[@]}" -eq 0 ]; then
             echo "prs=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -35,6 +35,14 @@ on:
       - "Agent Review Pipeline"
       - "repo-lint"
     types: [completed]
+  # Periodic sweep — catches the 👍-after-last-push case (codex
+  # reacts on the PR issue but no synchronize / review / workflow_run
+  # event fires, so the event-driven path stays inert). Runs every
+  # 15 minutes against any open PR carrying needs-external-review.
+  # Idempotent (no-op when label absent or gate not yet met). Sub-C
+  # of #191. See scheduled-sweep job below for the cadence knob.
+  schedule:
+    - cron: '*/15 * * * *'
 
 permissions:
   pull-requests: write
@@ -194,4 +202,103 @@ jobs:
             esac
             echo "::endgroup::"
           done <<<"$PR_NUMBERS"
+          exit "$had_infra_error"
+
+  scheduled-sweep:
+    name: Periodic sweep for stale needs-external-review labels
+    # Catches the 👍-after-last-push case (#197). Only fires on
+    # schedule; the event-driven evaluate-and-clear job above
+    # handles the common path. Idempotent: running twice on the
+    # same PR with no state change is a no-op (label-present check
+    # + read-only gate evaluation).
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo (for codex-review-check.sh)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Schedule events have no PR context, so default GITHUB_REF
+          # is the default branch already — pin explicitly for
+          # consistency with the security stance of the event-driven
+          # job above.
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Find PRs carrying needs-external-review
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Read the per-repo cadence/enable knob from review-policy.yml.
+          # Defaults: enabled=true. Operators can opt out by setting
+          #   auto_clear_labels:
+          #     scheduled_sweep_enabled: false
+          # in their .github/review-policy.yml.
+          CONFIG=".github/review-policy.yml"
+          enabled=true
+          if [ -f "$CONFIG" ]; then
+            val=$(awk '
+              /^auto_clear_labels:/ {in_block=1; next}
+              in_block && /^[^[:space:]]/ {exit}
+              in_block && /^[[:space:]]+scheduled_sweep_enabled:/ {
+                gsub(/.*: */, ""); gsub(/[[:space:]]/, ""); print; exit
+              }
+            ' "$CONFIG")
+            [ "$val" = "false" ] && enabled=false
+          fi
+          if [ "$enabled" = "false" ]; then
+            echo "Scheduled sweep disabled for $REPO via review-policy.yml; skipping."
+            echo "prs=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # List open PRs carrying the label.
+          mapfile -t prs < <(gh pr list --repo "$REPO" --state open \
+            --label needs-external-review --json number --jq '.[].number')
+          echo "Found ${#prs[@]} PR(s) with needs-external-review on $REPO"
+          if [ "${#prs[@]}" -eq 0 ]; then
+            echo "prs=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo 'prs<<EOF'
+            printf '%s\n' "${prs[@]}"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Re-evaluate gate per PR
+        if: steps.find.outputs.prs != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRS: ${{ steps.find.outputs.prs }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          had_infra_error=0
+          while IFS= read -r PR; do
+            [ -z "$PR" ] && continue
+            echo "::group::Sweep PR #$PR"
+            set +e
+            scripts/codex-review-check.sh "$PR"
+            rc=$?
+            set -e
+            case "$rc" in
+              0)
+                echo "Gate passes — removing needs-external-review label."
+                if gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
+                  comment_body='**Automated label removal (scheduled sweep).** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD between event triggers (typical: Codex 👍 after the last push, with no synchronize / review / workflow_run event to fire the event-driven path). Removed `needs-external-review`. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#197) for the sweep doctrine.'
+                  gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
+                    || echo "::warning::Failed to post attribution comment for PR #$PR"
+                else
+                  echo "::warning::Failed to remove needs-external-review on PR #$PR"
+                fi
+                ;;
+              1) echo "Gate not yet met — leaving label in place." ;;
+              3) echo "::error::codex-review-check.sh rc=3 on PR #$PR"; had_infra_error=1 ;;
+              *) echo "::error::unexpected rc=$rc on PR #$PR"; had_infra_error=1 ;;
+            esac
+            echo "::endgroup::"
+          done <<<"$PRS"
           exit "$had_infra_error"

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -239,11 +239,19 @@ jobs:
           CONFIG=".github/review-policy.yml"
           enabled=true
           if [ -f "$CONFIG" ]; then
+            # CR Major on PR #213: strip trailing YAML comments
+            # before comparing — `false  # opt out` was previously
+            # being parsed as `false#optout`, leaving the sweep
+            # enabled even when the operator explicitly disabled it.
             val=$(awk '
               /^auto_clear_labels:/ {in_block=1; next}
               in_block && /^[^[:space:]]/ {exit}
               in_block && /^[[:space:]]+scheduled_sweep_enabled:/ {
-                gsub(/.*: */, ""); gsub(/[[:space:]]/, ""); print; exit
+                sub(/#.*/, "")
+                gsub(/.*: */, "")
+                gsub(/[[:space:]]/, "")
+                print
+                exit
               }
             ' "$CONFIG")
             [ "$val" = "false" ] && enabled=false
@@ -254,9 +262,16 @@ jobs:
             exit 0
           fi
 
-          # List open PRs carrying the label.
+          # List open PRs carrying the label. CR Major on PR #213:
+          # `--limit 500` overrides gh's default of 30 so the sweep
+          # processes ALL matching PRs in repos with high open-PR
+          # counts. 500 is comfortably above any realistic limit for
+          # a single repo's needs-external-review queue (would imply
+          # ~500 PRs awaiting review — itself an alarm). If we ever
+          # see this hit in practice, paginate via the search API.
           mapfile -t prs < <(gh pr list --repo "$REPO" --state open \
-            --label needs-external-review --json number --jq '.[].number')
+            --label needs-external-review --limit 500 \
+            --json number --jq '.[].number')
           echo "Found ${#prs[@]} PR(s) with needs-external-review on $REPO"
           if [ "${#prs[@]}" -eq 0 ]; then
             echo "prs=" >> "$GITHUB_OUTPUT"

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -122,6 +122,31 @@ else
   echo "  FAIL: opt-out parser must strip trailing YAML comments (CR Major on PR #213)" >&2
 fi
 
+# CR Major on PR #213 r2: evaluate-and-clear must skip on cron runs.
+# Without this guard, every 15-min sweep paid for a checkout-only
+# no-op job before the event resolver decided 'schedule' was
+# unsupported.
+if grep -qE -- "github\.event_name != 'schedule'" "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: evaluate-and-clear skips schedule events (cron runs only the sweep job)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: evaluate-and-clear must skip schedule events (CR Major on PR #213 r2)" >&2
+fi
+
+# CR Major on PR #213 r2: sweep must capture `gh pr list` exit
+# status separately, not via process substitution into mapfile (which
+# swallows the producer's exit code, silently turning a gh failure
+# into "0 PRs found").
+if grep -qE -- 'if ! prs_raw=\$\(gh pr list' "$WORKFLOW" && \
+   grep -qE -- 'echo "::error::Failed to list open PRs' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: sweep captures gh pr list exit status (no silent failure on gh error)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: sweep must capture gh pr list status separately, not via mapfile <(...) (CR Major on PR #213 r2)" >&2
+fi
+
 # workflow_run must listen to the EXACT upstream workflow names. A
 # rename or typo on either side would silently break the auto-clear
 # without this test catching it. CR Trivial on PR #202 r2.

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -69,6 +69,27 @@ else
   echo "  PASS: check_suite trigger absent (regression closed for codex P1 on #202)"
 fi
 
+# Schedule trigger present (#197 sub-C of #191) — catches the
+# 👍-after-last-push case where no event-driven trigger fires.
+if grep -qE "^[[:space:]]+schedule:" "$WORKFLOW" && \
+   grep -qE "^[[:space:]]+- cron:" "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: schedule trigger configured for periodic sweep (#197)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: missing schedule trigger for periodic sweep (#197 sub-C of #191)" >&2
+fi
+
+# scheduled-sweep job exists and is gated to schedule-only events.
+if grep -qE "^[[:space:]]+scheduled-sweep:" "$WORKFLOW" && \
+   grep -qE "github\.event_name == 'schedule'" "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: scheduled-sweep job gated to schedule events"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: scheduled-sweep job missing or not gated to schedule events" >&2
+fi
+
 # workflow_run must listen to the EXACT upstream workflow names. A
 # rename or typo on either side would silently break the auto-clear
 # without this test catching it. CR Trivial on PR #202 r2.
@@ -170,6 +191,11 @@ echo "auto-clear-blocking-labels.yml bash syntax test"
 
 block_dir=$(mktemp -d)
 # awk extracts each `run: |` block to a separate file in $block_dir.
+# Exit a run block when ANY non-empty line drops to indent <= base
+# (the `run:` line's own indent), not just column-0. This catches
+# job/step transitions like `  scheduled-sweep:` (under `jobs:`) and
+# `      - name: Foo` (under steps:) which would otherwise be
+# treated as continuations of the prior bash block.
 awk -v outdir="$block_dir" '
   /^[[:space:]]+run:[[:space:]]+\|[[:space:]]*$/ {
     if (in_run) { close(outfile) }
@@ -177,10 +203,12 @@ awk -v outdir="$block_dir" '
     match($0, /^[[:space:]]+/); base_indent = RLENGTH
     in_run = 1; next
   }
-  in_run && /^[^[:space:]]/ {
-    close(outfile); in_run = 0; next
-  }
+  in_run && NF == 0 { print > outfile; next }
   in_run {
+    match($0, /^[[:space:]]*/); cur_indent = RLENGTH
+    if (cur_indent <= base_indent) {
+      close(outfile); in_run = 0; next
+    }
     # Strip the YAML run-block indentation (base_indent + 2 spaces).
     sub("^[[:space:]]{" (base_indent + 2) "}", "")
     print > outfile

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -71,23 +71,55 @@ fi
 
 # Schedule trigger present (#197 sub-C of #191) — catches the
 # 👍-after-last-push case where no event-driven trigger fires.
+# CR Minor on PR #213: anchor to the actual cron entry (not just
+# any `schedule:` / `cron:` text anywhere) so a comment couldn't
+# satisfy the assertion.
 if grep -qE "^[[:space:]]+schedule:" "$WORKFLOW" && \
-   grep -qE "^[[:space:]]+- cron:" "$WORKFLOW"; then
+   grep -qF -- "- cron: '*/15 * * * *'" "$WORKFLOW"; then
   pass=$((pass + 1))
-  echo "  PASS: schedule trigger configured for periodic sweep (#197)"
+  echo "  PASS: schedule trigger configured with 15-min cron (#197)"
 else
   fail=$((fail + 1))
-  echo "  FAIL: missing schedule trigger for periodic sweep (#197 sub-C of #191)" >&2
+  echo "  FAIL: missing schedule trigger or expected cron entry (#197 sub-C of #191)" >&2
 fi
 
 # scheduled-sweep job exists and is gated to schedule-only events.
+# Anchor to the executable `if:` line so a string in a comment
+# couldn't satisfy the assertion. CR Minor on PR #213.
 if grep -qE "^[[:space:]]+scheduled-sweep:" "$WORKFLOW" && \
-   grep -qE "github\.event_name == 'schedule'" "$WORKFLOW"; then
+   grep -qE "^[[:space:]]+if:[[:space:]]+github\.event_name == 'schedule'" "$WORKFLOW"; then
   pass=$((pass + 1))
-  echo "  PASS: scheduled-sweep job gated to schedule events"
+  echo "  PASS: scheduled-sweep job gated by executable 'if: ... schedule' line"
 else
   fail=$((fail + 1))
-  echo "  FAIL: scheduled-sweep job missing or not gated to schedule events" >&2
+  echo "  FAIL: scheduled-sweep job missing or not gated to schedule events (executable line)" >&2
+fi
+
+# CR Major on PR #213: gh pr list defaults to --limit 30. The sweep
+# must use a higher limit so repos with many open needs-external-review
+# PRs get them ALL processed, not just the first 30.
+# `gh pr list` is split across multiple lines via shell continuation,
+# so the assertion is split too: `gh pr list` exists AND `--limit
+# <≥100>` appears within 5 lines after it.
+if grep -qE -- 'gh pr list' "$WORKFLOW" && \
+   awk '/gh pr list/,/[^\\\\]$/' "$WORKFLOW" | grep -qE -- '--limit [1-9][0-9]{2,}'; then
+  pass=$((pass + 1))
+  echo "  PASS: gh pr list uses --limit ≥100 (handles >30-PR repos)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gh pr list must use --limit ≥100 to override default of 30 (CR Major on PR #213)" >&2
+fi
+
+# CR Major on PR #213: opt-out parser must strip trailing YAML
+# comments. `scheduled_sweep_enabled: false  # opt out` was being
+# parsed as `false#optout`. The fix is `sub(/#.*/, "")` before the
+# value extraction.
+if grep -qE 'sub\(/#\.\*/, ""\)' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: opt-out parser strips trailing YAML comments"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: opt-out parser must strip trailing YAML comments (CR Major on PR #213)" >&2
 fi
 
 # workflow_run must listen to the EXACT upstream workflow names. A


### PR DESCRIPTION
Closes #197. Sub-C of parent #191.

## Why

Catches the thumbs-up-after-last-push case the event-driven path misses: Codex reacts to the PR issue but no `synchronize` / `pull_request_review` / `workflow_run` event fires, so `auto-clear-blocking-labels.yml` stays inert and the label sticks. Sweep runs every 15 minutes against any open PR carrying `needs-external-review`.

## What

- **Schedule trigger** added to existing workflow (`cron: '*/15 * * * *'`).
- **scheduled-sweep job**, gated to schedule-only events:
  - Reads per-repo enable knob from `.github/review-policy.yml` (`auto_clear_labels.scheduled_sweep_enabled`, default true).
  - Lists open PRs carrying the label (`gh pr list --label needs-external-review`).
  - Runs `codex-review-check.sh` per PR.
  - On rc=0: removes label + posts attribution comment.
  - Same security stance as the event-driven job: checkout pinned to default_branch, fail-closed on rc=3 / unexpected rc.
- **Config knob** in mergepath's own `.github/review-policy.yml` (default: true). Downstream consumers can opt out.
- **Test additions** (21/21 pass):
  - Schedule trigger present + scheduled-sweep job gated to schedule events.
  - Bash-block extractor tightened to exit on indent-decrease (not just column-0) so the new job's YAML doesn't leak into the bash syntax check.

## Self-Review

- **Correctness**: sweep job mirrors the event-driven job's per-PR logic. Same gate script, same attribution-comment shape, idempotent.
- **Regression risk**: low. Additive job; existing event-driven job untouched. Worst case if buggy: visible failures every 15 min on broken PRs, or silent no-op (label stays — current state).
- **Coverage**: 2 new structural tests + 1 fixed extractor; 21/21 pass.
- **Style**: matches existing job shape.
- **Security**: same checkout-pin + same `secrets.GITHUB_TOKEN` minimum permissions as the event-driven job.

## What's left for parent #191

After #196 (doctrine carve-out) lands too, parent #191 can close. #196 is in PR #212 currently in review.

Authoring-Agent: claude