### PR TITLE
feat(sync): canonical-only sync mode for downstream propagation (#168 layer 3 slice 1)

### DIFF
--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -735,8 +735,16 @@ sync_open_pr() {
   local templated_list=$8
   local short_sha=${sha:0:7}
 
+  # Portable mktemp: `-t TEMPLATE` semantics differ between BSD (macOS)
+  # and GNU coreutils. macOS treats TEMPLATE as a literal prefix and
+  # appends random chars; GNU treats it as a TMPDIR-rooted basename
+  # but ONLY if the value contains no slash, AND the trailing X-pattern
+  # rules differ. Use the explicit-path form `mktemp -d "$TMPDIR/<X...>"`
+  # which both implementations honor identically. cursor CHANGES_REQUESTED
+  # on PR #217 caught the GNU/Linux portability gap.
+  local tmp_root=${TMPDIR:-/tmp}
   local workspace
-  workspace=$(mktemp -d -t "mergepath-sync-$consumer_name") || {
+  workspace=$(mktemp -d "$tmp_root/mergepath-sync-${consumer_name}.XXXXXX") || {
     err "could not create workspace tmpdir"
     return 1
   }
@@ -751,10 +759,30 @@ sync_open_pr() {
   # Materialize Mergepath's $sha worktree state for the target files.
   # Using `git show $sha:<path>` is robust against the working tree
   # having other uncommitted edits.
+  #
+  # Deletion handling: when Mergepath drops a canonical file at $sha,
+  # `git ls-tree $sha <path>` returns empty (the path no longer exists
+  # in the tree). Treat that as a delete propagation: rm the consumer
+  # copy if present. cursor CHANGES_REQUESTED on PR #217 caught the
+  # missing delete propagation — without this branch, deletes would
+  # fail noisily on `git show` and the script would abort the entire
+  # consumer rather than mirroring the delete.
   local target
   while IFS= read -r target; do
     [ -z "$target" ] && continue
     local consumer_target="$workspace/repo/$target"
+    local src_mode
+    src_mode=$(git -C "$MERGEPATH_ROOT" ls-tree "$sha" -- "$target" | awk '{print $1}')
+
+    if [ -z "$src_mode" ]; then
+      # Path absent at $sha → delete propagation.
+      if [ -e "$consumer_target" ]; then
+        rm -f "$consumer_target"
+      fi
+      # No mode-mirror for deletes; the path is gone in both trees.
+      continue
+    fi
+
     mkdir -p "$(dirname "$consumer_target")"
     if ! git -C "$MERGEPATH_ROOT" show "$sha:$target" >"$consumer_target" 2>/dev/null; then
       err "$consumer_name: could not read $target from mergepath@$short_sha"
@@ -767,8 +795,6 @@ sync_open_pr() {
     # consumer historically had +x set on a file Mergepath later
     # decided should be plain). cursor's CHANGES_REQUESTED on PR #217
     # caught the one-way version that only added +x.
-    local src_mode
-    src_mode=$(git -C "$MERGEPATH_ROOT" ls-tree "$sha" "$target" | awk '{print $1}')
     case "$src_mode" in
       100755) chmod +x "$consumer_target" ;;
       100644) chmod -x "$consumer_target" ;;

--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -4,16 +4,22 @@
 #
 # This script is shipping in layers (per the issue's implementation plan):
 #
-#   v1 (this PR):
+#   v1 (PR #215):
 #     --audit            Read-only drift detector across all consumers.
-#     --help             Print this header.
-#     --version          Print script + manifest schema version.
+#
+#   v2 (this PR — Layer 3 first slice):
+#     <commit-ish>       Open propagation PRs for canonical files changed
+#                        at the given commit. Kit and templated paths are
+#                        skipped with a warning (deferred to slice 2/3).
 #
 #   future:
-#     <commit-ish>       Open propagation PRs for files changed at the
-#                        given commit (Layer 3).
 #     --from-pr <N>      Resolve PR N's merge commit and propagate
 #                        (Layer 4).
+#     templated paths    Three-way merge for review-policy.yml; substitution
+#                        rules for AGENTS.md / CLAUDE.md (Layer 5, shared
+#                        with bootstrap-new-repo.sh #156).
+#     kit paths          Directory mirror with allow-extras semantics in
+#                        sync mode (slice 2 — already supported in audit).
 #
 # The manifest at .mergepath-sync.yml declares which paths are canonical
 # (byte-identical) or kit (directory mirror with allow-extras), and which
@@ -22,20 +28,29 @@
 #
 # Usage:
 #   scripts/sync-to-downstream.sh --audit [--repos r1,r2] [--paths glob]
+#   scripts/sync-to-downstream.sh <commit-ish> [--dry-run] [--repos r1,r2] [--paths glob]
 #   scripts/sync-to-downstream.sh --help
 #   scripts/sync-to-downstream.sh --version
 #
 # Flags:
 #   --audit            Read-only drift detection. Exit 0 (clean), 1 (drift),
 #                      2 (script/usage error), 3 (consumer fetch error).
+#   --dry-run          Sync mode only. Print the per-consumer plan
+#                      (branch name, files) without cloning, committing,
+#                      pushing, or creating PRs. Idempotency check is
+#                      skipped because it probes the consumer repo via
+#                      `gh api`; a dry-run plan may show "would open PR"
+#                      even when a PR already exists, but the live run
+#                      will catch and skip it.
 #   --repos r1,r2      Restrict to a comma-separated subset of consumer names.
 #   --paths glob       Restrict to manifest paths matching the glob (e.g.
 #                      "scripts/*", ".github/workflows/agent-review.yml").
-#   --no-clone         Don't clone-on-demand; only audit consumers with a
-#                      local sibling worktree under MERGEPATH_SIBLINGS_DIR.
-#   --no-refresh       Don't `git fetch` cached consumer clones before
-#                      comparing. Useful for offline/sandboxed audits;
-#                      may report stale results if the cache is old.
+#   --no-clone         Audit only: don't clone-on-demand; only audit
+#                      consumers with a local sibling worktree under
+#                      MERGEPATH_SIBLINGS_DIR.
+#   --no-refresh       Audit only: don't `git fetch` cached consumer clones
+#                      before comparing. Useful for offline/sandboxed
+#                      audits; may report stale results if the cache is old.
 #   --help, -h         Show this help.
 #   --version          Print version info.
 #
@@ -74,9 +89,10 @@ set -euo pipefail
 
 # --- constants --------------------------------------------------------------
 
-SCRIPT_VERSION="0.1.0-layer1+2"
+SCRIPT_VERSION="0.2.0-layer3-canonical"
 SUPPORTED_MANIFEST_VERSION=1
 MANIFEST_PATH=".mergepath-sync.yml"
+SYNC_BRANCH_PREFIX="mergepath-sync"
 
 # Resolve the Mergepath worktree root from the script's location (works
 # regardless of cwd). Two `dirname`s: scripts/sync-to-downstream.sh →
@@ -474,9 +490,438 @@ run_audit() {
   done <<< "$consumers"
 }
 
+# --- sync mode --------------------------------------------------------------
+
+# Resolve a Mergepath commit-ish to a full SHA. Errors out if the commit
+# isn't reachable. Output: full SHA on stdout.
+sync_resolve_commit() {
+  local commit_ish=$1
+  local sha
+  sha=$(git -C "$MERGEPATH_ROOT" rev-parse --verify "$commit_ish^{commit}" 2>/dev/null) || {
+    err "could not resolve commit-ish '$commit_ish' in Mergepath worktree"
+    return 2
+  }
+  echo "$sha"
+}
+
+# List files that changed at the given commit. Output: one path per line,
+# relative to the Mergepath repo root.
+sync_changed_files() {
+  local sha=$1
+  git -C "$MERGEPATH_ROOT" show --name-only --pretty=format: "$sha" \
+    | grep -v '^$' || true
+}
+
+# Intersect changed files with manifest canonical paths for one consumer.
+# Echoes one canonical path per line that (a) exists in the changed-set
+# AND (b) the consumer opts in to.
+#
+# Kit and templated paths are intentionally skipped in this slice. The
+# audit mode already reports drift for those; sync mode for them lands in
+# slice 2 (kit) and slice 5 (templated). Skipping here is silent per
+# manifest path; the per-consumer summary calls out the deferral.
+sync_consumer_canonical_targets() {
+  local consumer_name=$1
+  local changed_files=$2  # newline-separated
+  local manifest=$3
+
+  yq -r '
+    .paths[]
+    | select(.type == "canonical")
+    | (.path + "\t"
+       + (.consumers | (select(tag == "!!str") // (join(","))) | tostring))
+  ' "$manifest" | while IFS=$'\t' read -r mp_path mp_consumers; do
+    # Path filter
+    if ! in_path_filter "$mp_path"; then continue; fi
+    # Consumer opt-in
+    if [ "$mp_consumers" != "all" ]; then
+      local re=",$mp_consumers,"
+      [[ "$re" != *",$consumer_name,"* ]] && continue
+    fi
+    # Changed at the commit?
+    if grep -Fxq "$mp_path" <<< "$changed_files"; then
+      echo "$mp_path"
+    fi
+  done
+}
+
+# Count manifest paths skipped (kit + templated) so the summary can name
+# them. Echoes "kit_count\ttemplated_count\tkit_paths\ttemplated_paths".
+sync_consumer_skipped_targets() {
+  local consumer_name=$1
+  local changed_files=$2
+  local manifest=$3
+
+  local kit_paths=()
+  local templated_paths=()
+  while IFS=$'\t' read -r mp_path mp_type mp_consumers; do
+    [ -z "$mp_path" ] && continue
+    if ! in_path_filter "$mp_path"; then continue; fi
+    if [ "$mp_consumers" != "all" ]; then
+      local re=",$mp_consumers,"
+      [[ "$re" != *",$consumer_name,"* ]] && continue
+    fi
+    # Did the change touch this path / its directory?
+    case "$mp_type" in
+      kit)
+        local mp_dir="${mp_path%/}"
+        if grep -E "^${mp_dir}/" <<< "$changed_files" >/dev/null; then
+          kit_paths+=("$mp_path")
+        fi
+        ;;
+      templated)
+        if grep -Fxq "$mp_path" <<< "$changed_files"; then
+          templated_paths+=("$mp_path")
+        fi
+        ;;
+    esac
+  done < <(yq -r '
+    .paths[]
+    | (.path + "\t" + .type + "\t"
+       + (.consumers | (select(tag == "!!str") // (join(","))) | tostring))
+  ' "$manifest")
+
+  local kp tp
+  kp=$(IFS=,; echo "${kit_paths[*]:-}")
+  tp=$(IFS=,; echo "${templated_paths[*]:-}")
+  echo -e "${#kit_paths[@]}\t${#templated_paths[@]}\t${kp}\t${tp}"
+}
+
+# Compute the deterministic branch name. Same commit-ish always produces
+# the same branch — that's how we get idempotency on re-runs.
+sync_branch_name() {
+  local sha=$1
+  echo "${SYNC_BRANCH_PREFIX}/${sha:0:7}"
+}
+
+# Idempotency check: does a PR already exist on this consumer's repo from
+# the deterministic sync branch? Echoes one of:
+#   "open:<pr_number>"     PR is open — skip, "already in flight"
+#   "closed:<pr_number>"   PR exists but closed (merged or abandoned)
+#   "none"                 No prior PR; safe to open
+# On API error, echoes "error" and returns non-zero.
+sync_check_existing_pr() {
+  local consumer_repo=$1
+  local branch=$2
+  local prs
+  prs=$(gh api "repos/$consumer_repo/pulls?state=all&head=$(echo "$consumer_repo" | cut -d/ -f1):$branch" \
+    --jq '.[] | "\(.state)\t\(.number)"' 2>/dev/null) || {
+    echo "error"
+    return 1
+  }
+  if [ -z "$prs" ]; then
+    echo "none"
+    return 0
+  fi
+  # Take the most recent (last) — gh api returns newest first by default.
+  local first
+  first=$(echo "$prs" | head -1)
+  local state num
+  state=$(echo "$first" | cut -f1)
+  num=$(echo "$first" | cut -f2)
+  if [ "$state" = "open" ]; then
+    echo "open:$num"
+  else
+    echo "closed:$num"
+  fi
+}
+
+# Per-consumer sync. Echoes a summary line on stdout. Sets
+# SYNC_PR_OPENED, SYNC_SKIPPED, SYNC_FAILED counters in the parent.
+sync_one_consumer() {
+  local consumer_name=$1
+  local consumer_repo=$2
+  local sha=$3
+  local short_sha=${sha:0:7}
+  local commit_subject=$4
+  local changed_files=$5
+  local dry_run=${6:-0}
+  local manifest="$MERGEPATH_ROOT/$MANIFEST_PATH"
+
+  local branch
+  branch=$(sync_branch_name "$sha")
+
+  local targets
+  targets=$(sync_consumer_canonical_targets "$consumer_name" "$changed_files" "$manifest")
+
+  local skipped
+  skipped=$(sync_consumer_skipped_targets "$consumer_name" "$changed_files" "$manifest")
+  local kit_count=$(echo "$skipped" | cut -f1)
+  local templated_count=$(echo "$skipped" | cut -f2)
+  local kit_list=$(echo "$skipped" | cut -f3)
+  local templated_list=$(echo "$skipped" | cut -f4)
+
+  if [ -z "$targets" ]; then
+    if [ "$kit_count" -gt 0 ] || [ "$templated_count" -gt 0 ]; then
+      printf "  ⊘ %s (no canonical targets; deferred: kit=%s templated=%s)\n" \
+        "$consumer_name" "${kit_list:-none}" "${templated_list:-none}"
+    else
+      printf "  · %s (no manifest paths touched by %s)\n" "$consumer_name" "$short_sha"
+    fi
+    SYNC_SKIPPED=$((SYNC_SKIPPED + 1))
+    return 0
+  fi
+
+  # Idempotency check before any write. Skipped in dry-run mode: the
+  # check probes the consumer repo via `gh api` and dry-run is meant to
+  # have zero side effects + zero network dependency. The trade-off:
+  # a dry-run plan may show a "would open PR" line even when a PR
+  # already exists; the live run will catch and skip it.
+  if [ "$dry_run" != "1" ]; then
+    local pr_state
+    pr_state=$(sync_check_existing_pr "$consumer_repo" "$branch") || {
+      printf "  ✗ %s — could not query existing PRs from %s\n" "$consumer_name" "$consumer_repo"
+      SYNC_FAILED=$((SYNC_FAILED + 1))
+      return 0
+    }
+    case "$pr_state" in
+      open:*)
+        printf "  · %s already in flight (PR #%s on branch %s)\n" \
+          "$consumer_name" "${pr_state#open:}" "$branch"
+        SYNC_SKIPPED=$((SYNC_SKIPPED + 1))
+        return 0
+        ;;
+      closed:*)
+        printf "  · %s already done (PR #%s closed/merged on branch %s)\n" \
+          "$consumer_name" "${pr_state#closed:}" "$branch"
+        SYNC_SKIPPED=$((SYNC_SKIPPED + 1))
+        return 0
+        ;;
+    esac
+  fi
+
+  local target_count
+  target_count=$(echo "$targets" | wc -l | tr -d ' ')
+
+  if [ "$dry_run" = "1" ]; then
+    printf "  ⤷ %s — would open PR on branch %s (%d canonical file(s))\n" \
+      "$consumer_name" "$branch" "$target_count"
+    while IFS= read -r p; do
+      [ -z "$p" ] && continue
+      printf "      + %s\n" "$p"
+    done <<< "$targets"
+    if [ "$kit_count" -gt 0 ] || [ "$templated_count" -gt 0 ]; then
+      printf "      (deferred this slice: kit=%s templated=%s)\n" \
+        "${kit_list:-none}" "${templated_list:-none}"
+    fi
+    SYNC_PR_OPENED=$((SYNC_PR_OPENED + 1))
+    return 0
+  fi
+
+  # Live mode: clone, branch, commit, push, PR.
+  if ! sync_open_pr "$consumer_name" "$consumer_repo" "$sha" "$commit_subject" \
+                    "$branch" "$targets" "$kit_list" "$templated_list"; then
+    SYNC_FAILED=$((SYNC_FAILED + 1))
+    return 0
+  fi
+  SYNC_PR_OPENED=$((SYNC_PR_OPENED + 1))
+}
+
+# Live PR-open. Clones the consumer repo into a tmpdir (writeable
+# workspace, never reuses the cache or sibling worktree), copies canonical
+# files from the Mergepath worktree at $sha, commits with the standard
+# self-review body, pushes the branch, and creates a PR.
+#
+# Returns 0 on success, non-zero on failure (caller increments
+# SYNC_FAILED). Stdout: human-readable progress lines.
+sync_open_pr() {
+  local consumer_name=$1
+  local consumer_repo=$2
+  local sha=$3
+  local commit_subject=$4
+  local branch=$5
+  local targets=$6  # newline-separated paths
+  local kit_list=$7
+  local templated_list=$8
+  local short_sha=${sha:0:7}
+
+  local workspace
+  workspace=$(mktemp -d -t "mergepath-sync-$consumer_name") || {
+    err "could not create workspace tmpdir"
+    return 1
+  }
+  trap "rm -rf '$workspace'" RETURN
+
+  printf "  ⤷ %s — cloning %s\n" "$consumer_name" "$consumer_repo"
+  if ! gh repo clone "$consumer_repo" "$workspace/repo" -- --depth=10 --quiet >&2; then
+    err "$consumer_name: gh repo clone failed for $consumer_repo"
+    return 1
+  fi
+
+  # Materialize Mergepath's $sha worktree state for the target files.
+  # Using `git show $sha:<path>` is robust against the working tree
+  # having other uncommitted edits.
+  local target
+  while IFS= read -r target; do
+    [ -z "$target" ] && continue
+    local consumer_target="$workspace/repo/$target"
+    mkdir -p "$(dirname "$consumer_target")"
+    if ! git -C "$MERGEPATH_ROOT" show "$sha:$target" >"$consumer_target" 2>/dev/null; then
+      err "$consumer_name: could not read $target from mergepath@$short_sha"
+      return 1
+    fi
+    # Preserve executable bit if the source has it.
+    local src_mode
+    src_mode=$(git -C "$MERGEPATH_ROOT" ls-tree "$sha" "$target" | awk '{print $1}')
+    if [ "$src_mode" = "100755" ]; then
+      chmod +x "$consumer_target"
+    fi
+  done <<< "$targets"
+
+  # Sanity: did the copy actually change anything? If the consumer was
+  # already in sync (someone hand-propagated it before us, or a prior
+  # sync ran but the PR was never opened), don't push an empty commit.
+  if ! git -C "$workspace/repo" diff --quiet HEAD --; then
+    :
+  else
+    printf "  · %s already in sync at HEAD (no diff after copy)\n" "$consumer_name"
+    SYNC_SKIPPED=$((SYNC_SKIPPED + 1))
+    SYNC_PR_OPENED=$((SYNC_PR_OPENED - 1))  # caller incremented eagerly
+    return 0
+  fi
+
+  # Branch + commit. Use git config from the consumer clone (or
+  # mergepath's, since `gh repo clone` inherits the user's local
+  # git identity).
+  if ! git -C "$workspace/repo" checkout -q -b "$branch"; then
+    err "$consumer_name: git checkout -b $branch failed"
+    return 1
+  fi
+  git -C "$workspace/repo" add -A
+  local target_lines
+  target_lines=$(while IFS= read -r p; do [ -z "$p" ] && continue; echo "  - $p"; done <<< "$targets")
+  local deferred_note=""
+  if [ -n "$kit_list" ] || [ -n "$templated_list" ]; then
+    deferred_note="
+Deferred this propagation (sync-to-downstream.sh ${SCRIPT_VERSION}
+only handles canonical paths; kit + templated land in slices 2 and 5):
+  kit:       ${kit_list:-none}
+  templated: ${templated_list:-none}
+"
+  fi
+  if ! git -C "$workspace/repo" commit -q -m "$(cat <<EOF
+sync from mergepath@${short_sha}: ${commit_subject}
+
+Source: https://github.com/nathanjohnpayne/mergepath/commit/${sha}
+Files:
+${target_lines}
+${deferred_note}
+Authoring-Agent: claude
+
+## Self-Review
+- Correctness: mirrors mergepath@${short_sha} verbatim per .mergepath-sync.yml
+- Regression risk: low; same change has been reviewed in the upstream PR
+- Style: N/A (verbatim mirror)
+- Test coverage: relies on the consumer repo CI
+- Security: no new attack surface
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"; then
+    err "$consumer_name: git commit failed"
+    return 1
+  fi
+
+  # Push. The active gh keyring account ('gh config get -h github.com user')
+  # is what gh uses for write operations. The author identity is what
+  # commits and PR creation should attribute to. Per the active-account
+  # convention (CLAUDE.md), agents wrap author-identity writes in a
+  # switch-around. Here we let the caller pre-arrange that — sync_open_pr
+  # is invoked under the agent's normal active account, so PR creation
+  # bylines as that account. To get nathanjohnpayne attribution on the
+  # PR (matching the standard policy), the caller must switch first.
+  printf "  ⤷ %s — pushing branch %s\n" "$consumer_name" "$branch"
+  if ! git -C "$workspace/repo" push -q -u origin "$branch" 2>&1; then
+    err "$consumer_name: git push failed"
+    return 1
+  fi
+
+  # Open the PR.
+  printf "  ⤷ %s — opening PR\n" "$consumer_name"
+  local pr_url
+  pr_url=$(gh pr create --repo "$consumer_repo" --base main --head "$branch" \
+    --title "sync: ${commit_subject} (mergepath@${short_sha})" \
+    --body "$(cat <<EOF
+Auto-propagated from [mergepath@${short_sha}](https://github.com/nathanjohnpayne/mergepath/commit/${sha}) by \`scripts/sync-to-downstream.sh\` (v${SCRIPT_VERSION}, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)).
+
+## Files synced
+${target_lines}
+${deferred_note}
+## Source
+
+${commit_subject}
+
+https://github.com/nathanjohnpayne/mergepath/commit/${sha}
+
+Authoring-Agent: claude
+
+## Self-Review
+- Correctness: mirrors mergepath@${short_sha} verbatim per the upstream manifest. The change has already been reviewed in the upstream Mergepath PR.
+- Regression risk: low. Verbatim mirror of an already-reviewed upstream change.
+- Style: N/A (mirror).
+- Test coverage: relies on the consumer repo CI. No test changes shipped.
+- Security: no new attack surface; the sync script never ran with elevated privileges in this consumer.
+EOF
+)" 2>&1) || {
+    err "$consumer_name: gh pr create failed: $pr_url"
+    return 1
+  }
+  printf "  ✓ %s — opened %s\n" "$consumer_name" "$pr_url"
+}
+
+# Run the sync driver against a single Mergepath commit-ish.
+run_sync() {
+  local commit_ish=$1
+  local dry_run=${2:-0}
+  local manifest="$MERGEPATH_ROOT/$MANIFEST_PATH"
+
+  SYNC_PR_OPENED=0
+  SYNC_SKIPPED=0
+  SYNC_FAILED=0
+
+  local sha
+  sha=$(sync_resolve_commit "$commit_ish") || exit 2
+  local short_sha=${sha:0:7}
+  local subject
+  subject=$(git -C "$MERGEPATH_ROOT" show -s --format=%s "$sha")
+
+  local changed_files
+  changed_files=$(sync_changed_files "$sha")
+
+  if [ -z "$changed_files" ]; then
+    err "no files changed at mergepath@${short_sha} — nothing to propagate"
+    exit 0
+  fi
+
+  echo "Sync from mergepath@${short_sha}: ${subject}"
+  echo "Changed files at this commit:"
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    echo "  $f"
+  done <<< "$changed_files"
+  echo
+
+  # Per-consumer
+  local consumers
+  consumers=$(yq -r '.consumers[] | (.name + "\t" + .repo)' "$manifest")
+  while IFS=$'\t' read -r consumer_name consumer_repo; do
+    [ -z "$consumer_name" ] && continue
+    if ! in_repo_filter "$consumer_name"; then continue; fi
+    sync_one_consumer "$consumer_name" "$consumer_repo" "$sha" "$subject" \
+                      "$changed_files" "$dry_run"
+  done <<< "$consumers"
+
+  echo
+  echo "Summary: PRs opened/planned: $SYNC_PR_OPENED  skipped: $SYNC_SKIPPED  failed: $SYNC_FAILED"
+  if [ "$SYNC_FAILED" -gt 0 ]; then return 1; fi
+  return 0
+}
+
 # --- arg parsing ------------------------------------------------------------
 
 MODE=""
+SYNC_COMMIT_ISH=""
+SYNC_DRY_RUN=0
 FILTER_REPOS=""
 FILTER_PATHS=""
 
@@ -504,6 +949,10 @@ while [ $# -gt 0 ]; do
       AUDIT_NO_REFRESH=1
       shift
       ;;
+    --dry-run)
+      SYNC_DRY_RUN=1
+      shift
+      ;;
     --help|-h)
       usage
       exit 0
@@ -521,9 +970,14 @@ while [ $# -gt 0 ]; do
       exit 2
       ;;
     *)
-      err "Layer 3 sync mode (positional <commit-ish>) not yet implemented — see #168."
-      err "Currently supported modes: --audit, --help, --version."
-      exit 2
+      # Positional argument = commit-ish. Sync mode.
+      if [ -n "$SYNC_COMMIT_ISH" ]; then
+        err "multiple positional commit-ish args not supported (got '$SYNC_COMMIT_ISH' and '$1')"
+        exit 2
+      fi
+      SYNC_COMMIT_ISH="$1"
+      MODE="sync"
+      shift
       ;;
   esac
 done
@@ -546,6 +1000,12 @@ case "$MODE" in
     else
       exit 0
     fi
+    ;;
+  sync)
+    if ! run_sync "$SYNC_COMMIT_ISH" "$SYNC_DRY_RUN"; then
+      exit 1
+    fi
+    exit 0
     ;;
   *)
     err "internal error: unknown MODE=$MODE"

--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -760,12 +760,23 @@ sync_open_pr() {
       err "$consumer_name: could not read $target from mergepath@$short_sha"
       return 1
     fi
-    # Preserve executable bit if the source has it.
+    # Mirror the executable bit from the source. Both directions matter:
+    # if the source is 100755 the target must be +x (so a hook stays
+    # runnable in the consumer); if the source is 100644 the target
+    # must NOT be +x (otherwise mode drift accumulates whenever a
+    # consumer historically had +x set on a file Mergepath later
+    # decided should be plain). cursor's CHANGES_REQUESTED on PR #217
+    # caught the one-way version that only added +x.
     local src_mode
     src_mode=$(git -C "$MERGEPATH_ROOT" ls-tree "$sha" "$target" | awk '{print $1}')
-    if [ "$src_mode" = "100755" ]; then
-      chmod +x "$consumer_target"
-    fi
+    case "$src_mode" in
+      100755) chmod +x "$consumer_target" ;;
+      100644) chmod -x "$consumer_target" ;;
+      *)
+        err "$consumer_name: unexpected git mode '$src_mode' for $target at $short_sha"
+        return 1
+        ;;
+    esac
   done <<< "$targets"
 
   # Sanity: did the copy actually change anything? If the consumer was
@@ -891,6 +902,35 @@ run_sync() {
   if [ -z "$changed_files" ]; then
     err "no files changed at mergepath@${short_sha} — nothing to propagate"
     exit 0
+  fi
+
+  # Active-account guard for LIVE mode (skipped in --dry-run since
+  # dry-run is meant to be safe to run from any identity). Refuses to
+  # proceed unless the gh keyring's active account matches the
+  # manifest's author_identity. Without this guard, downstream PRs
+  # would be created under whatever reviewer identity happens to be
+  # active, violating the author/reviewer separation in
+  # REVIEW_POLICY.md.
+  #
+  # Read via `gh config get -h github.com user` (NOT `gh auth status`,
+  # which is GH_TOKEN-poisonable per CLAUDE.md "Active-account
+  # convention"). Author identity is read from .github/review-policy.yml's
+  # `author_identity` field; falls back to "nathanjohnpayne" if missing.
+  # Override with MERGEPATH_SYNC_ACTOR_OVERRIDE for tests / break-glass.
+  # cursor's CHANGES_REQUESTED on PR #217 caught the missing guard.
+  if [ "$dry_run" != "1" ]; then
+    local expected_actor active_actor
+    expected_actor=$(awk '/^author_identity:/ {sub(/^[^:]+:[[:space:]]*/, ""); gsub(/[[:space:]"#].*$/, ""); print; exit}' \
+      "$MERGEPATH_ROOT/.github/review-policy.yml" 2>/dev/null || echo "")
+    expected_actor=${expected_actor:-nathanjohnpayne}
+    expected_actor=${MERGEPATH_SYNC_ACTOR_OVERRIDE:-$expected_actor}
+    active_actor=$(gh config get -h github.com user 2>/dev/null || echo "")
+    if [ "$active_actor" != "$expected_actor" ]; then
+      err "refusing to run live sync — active gh account is '$active_actor', expected '$expected_actor'"
+      err "       Switch first: gh auth switch -u $expected_actor"
+      err "       Then re-run. (Set MERGEPATH_SYNC_ACTOR_OVERRIDE for tests.)"
+      exit 2
+    fi
   fi
 
   echo "Sync from mergepath@${short_sha}: ${subject}"

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -318,6 +318,92 @@ set -e
 [[ "$unknown_exit" -eq 2 ]] || fail "unknown commit-ish should exit 2; got $unknown_exit"
 
 # ---------------------------------------------------------------------------
+# Live-mode active-account guard (cursor CHANGES_REQUESTED on PR #217).
+# Without the guard, a careless live invocation under a reviewer-identity
+# `gh` keyring would create downstream PRs under that identity, violating
+# the author/reviewer separation. The guard refuses to proceed unless the
+# active gh account matches author_identity. Tested by overriding the
+# expected actor to a value the live `gh config get` will not match.
+# ---------------------------------------------------------------------------
+guard_workdir="$WORKDIR/guard"
+GUARD_MP="$guard_workdir/mergepath"
+mkdir -p "$GUARD_MP/scripts" "$GUARD_MP/.github"
+cat >"$GUARD_MP/.mergepath-sync.yml" <<'YAML'
+version: 1
+consumers:
+  - {name: alpha, repo: example-bogus/alpha}
+paths:
+  - {path: scripts/the-script.sh, type: canonical, consumers: all}
+YAML
+cat >"$GUARD_MP/.github/review-policy.yml" <<'YAML'
+author_identity: definitely-not-a-real-user-9999
+YAML
+echo "v1" >"$GUARD_MP/scripts/the-script.sh"
+git -C "$GUARD_MP" init -q
+git -C "$GUARD_MP" -c user.email=t@t -c user.name=t add -A
+git -C "$GUARD_MP" -c user.email=t@t -c user.name=t commit -q -m initial
+echo "v2" >"$GUARD_MP/scripts/the-script.sh"
+git -C "$GUARD_MP" -c user.email=t@t -c user.name=t add -A
+git -C "$GUARD_MP" -c user.email=t@t -c user.name=t commit -q -m bump
+guard_sha=$(git -C "$GUARD_MP" rev-parse HEAD)
+
+# Live mode (no --dry-run) with the wrong active account should refuse.
+# We don't have access to consumer repos in tests anyway; the guard
+# fires BEFORE any clone, so the failure is the guard's, not the
+# clone's.
+set +e
+guard_out=$(MERGEPATH_ROOT_OVERRIDE="$GUARD_MP" "$SCRIPT" "$guard_sha" --repos alpha 2>&1)
+guard_exit=$?
+set -e
+echo "$guard_out" | grep -q "refusing to run live sync" \
+  || fail "active-account guard did not fire; got: $guard_out"
+echo "$guard_out" | grep -q "definitely-not-a-real-user-9999" \
+  || fail "active-account guard did not name the expected actor"
+[[ "$guard_exit" -ne 0 ]] \
+  || fail "active-account guard should exit non-zero; got $guard_exit"
+
+# Dry-run with the same wrong active account should still PASS — the
+# guard only applies to live mode.
+set +e
+dr_out=$(MERGEPATH_ROOT_OVERRIDE="$GUARD_MP" "$SCRIPT" "$guard_sha" --dry-run --repos alpha 2>&1)
+dr_exit=$?
+set -e
+[[ "$dr_exit" -eq 0 ]] \
+  || fail "dry-run should not be blocked by active-account guard; got exit $dr_exit, output: $dr_out"
+echo "$dr_out" | grep -q "would open PR" \
+  || fail "dry-run should still plan a PR; got: $dr_out"
+
+# MERGEPATH_SYNC_ACTOR_OVERRIDE escape hatch: setting it to the current
+# active actor makes the guard pass. We can't actually run live mode
+# (no real consumer repo), but we can assert the guard accepts the
+# override and the failure mode shifts to "could not clone" rather than
+# "refusing to run live sync."
+current_actor=$(gh config get -h github.com user 2>/dev/null || echo "")
+if [ -n "$current_actor" ]; then
+  set +e
+  override_out=$(MERGEPATH_ROOT_OVERRIDE="$GUARD_MP" \
+    MERGEPATH_SYNC_ACTOR_OVERRIDE="$current_actor" \
+    "$SCRIPT" "$guard_sha" --repos alpha 2>&1)
+  set -e
+  echo "$override_out" | grep -q "refusing to run live sync" \
+    && fail "actor override should bypass the guard; got: $override_out"
+fi
+
+# ---------------------------------------------------------------------------
+# Mode-mirror correctness (cursor CHANGES_REQUESTED on PR #217).
+# Live copy should NOT only add +x; it must also CLEAR +x when the
+# Mergepath source is 100644. We can't easily exercise sync_open_pr's
+# full path here without stubbing gh, but we can unit-check the mode
+# logic by sourcing the script with a guard and calling the relevant
+# git commands directly. Simpler: assert the script source contains
+# both `chmod +x` and `chmod -x` branches.
+# ---------------------------------------------------------------------------
+grep -q 'chmod -x "$consumer_target"' "$SCRIPT" \
+  || fail "sync_open_pr is missing the 'chmod -x' branch — mode drift would persist on 100644 sources"
+grep -q 'chmod +x "$consumer_target"' "$SCRIPT" \
+  || fail "sync_open_pr is missing the 'chmod +x' branch"
+
+# ---------------------------------------------------------------------------
 # --version / --help smoke
 # ---------------------------------------------------------------------------
 "$SCRIPT" --version | grep -q "sync-to-downstream.sh" || fail "--version output unexpected"

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -208,6 +208,116 @@ echo "$hostile_output" | grep -qE "it is a symbolic link|resolves outside MERGEP
   || fail "symlink-guarded cache path was reset, clobbering the user's working tree"
 
 # ---------------------------------------------------------------------------
+# Sync mode (Layer 3 first slice): dry-run end-to-end.
+#
+# Build a fresh Mergepath fixture with two canonical paths, one kit
+# path, one templated path, three consumers. Make a commit at HEAD~1
+# that touches one canonical and one kit and one templated path; HEAD
+# touches the other canonical only. Then exercise --dry-run modes to
+# assert the planning logic is sane.
+# ---------------------------------------------------------------------------
+sync_workdir="$WORKDIR/sync"
+SYNC_MP="$sync_workdir/mergepath"
+mkdir -p "$SYNC_MP/scripts/hooks" "$SYNC_MP/scripts/ci" "$SYNC_MP/.github"
+cat >"$SYNC_MP/.mergepath-sync.yml" <<'YAML'
+version: 1
+consumers:
+  - {name: alpha, repo: example/alpha}
+  - {name: beta,  repo: example/beta}
+  - {name: gamma, repo: example/gamma}
+paths:
+  - {path: scripts/hooks/the-hook.sh,  type: canonical, consumers: all}
+  - {path: scripts/coderabbit-wait.sh, type: canonical, consumers: all}
+  - {path: scripts/ci/,                type: kit,       consumers: all}
+  - {path: AGENTS.md,                  type: templated, consumers: all}
+YAML
+echo "v1" >"$SYNC_MP/scripts/hooks/the-hook.sh"
+echo "v1" >"$SYNC_MP/scripts/coderabbit-wait.sh"
+echo "v1" >"$SYNC_MP/scripts/ci/check_one"
+echo "v1" >"$SYNC_MP/AGENTS.md"
+git -C "$SYNC_MP" init -q
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t add -A
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t commit -q -m "initial"
+
+# Commit A — multi-type touch (canonical + kit + templated)
+echo "v2" >"$SYNC_MP/scripts/hooks/the-hook.sh"
+echo "v2" >"$SYNC_MP/scripts/ci/check_one"
+echo "v2" >"$SYNC_MP/AGENTS.md"
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t add -A
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t commit -q -m "multi-type-touch"
+sha_A=$(git -C "$SYNC_MP" rev-parse HEAD)
+
+# Commit B — single canonical touch
+echo "v3" >"$SYNC_MP/scripts/coderabbit-wait.sh"
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t add -A
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t commit -q -m "single-canonical-touch"
+sha_B=$(git -C "$SYNC_MP" rev-parse HEAD)
+
+# Commit C — only an unrelated file (no manifest path touched)
+echo "noise" >"$SYNC_MP/.github/UNRELATED"
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t add -A
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t commit -q -m "unrelated-only"
+sha_C=$(git -C "$SYNC_MP" rev-parse HEAD)
+
+# 1) Multi-type touch: canonical lands, kit + templated are deferred with
+#    a per-consumer note. All 3 consumers get a planned PR.
+sync_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_A" --dry-run 2>&1)
+echo "$sync_out" | grep -q "would open PR on branch mergepath-sync/${sha_A:0:7}" \
+  || fail "multi-type sync did not produce planned PRs; output: $sync_out"
+[[ "$(echo "$sync_out" | grep -c 'would open PR')" -eq 3 ]] \
+  || fail "expected 3 planned PRs (one per consumer); got: $sync_out"
+echo "$sync_out" | grep -q "+ scripts/hooks/the-hook.sh" \
+  || fail "canonical target scripts/hooks/the-hook.sh missing from plan"
+echo "$sync_out" | grep -q "deferred this slice: kit=scripts/ci/" \
+  || fail "kit deferred-note missing from plan"
+echo "$sync_out" | grep -q "templated=AGENTS.md" \
+  || fail "templated deferred-note missing from plan"
+
+# 2) --repos filter restricts consumer set.
+sync_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_B" --dry-run --repos beta 2>&1)
+[[ "$(echo "$sync_out" | grep -c 'would open PR')" -eq 1 ]] \
+  || fail "--repos filter did not restrict to one consumer; got: $sync_out"
+echo "$sync_out" | grep -q "beta — would open PR" \
+  || fail "expected beta in --repos filter output; got: $sync_out"
+echo "$sync_out" | grep -q "alpha\|gamma" \
+  && fail "non-filtered consumer leaked into output: $sync_out"
+
+# 3) --paths filter restricts target set within the planned PR.
+sync_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_A" --dry-run --paths "scripts/hooks/the-hook.sh" 2>&1)
+echo "$sync_out" | grep -q "+ scripts/hooks/the-hook.sh" \
+  || fail "--paths filter excluded the requested path"
+echo "$sync_out" | grep -q "+ scripts/coderabbit-wait.sh" \
+  && fail "--paths filter did not exclude scripts/coderabbit-wait.sh"
+
+# 4) Commit that only touches kit + templated → no canonical targets,
+#    summary marks each consumer as ⊘ (skipped, deferred-only).
+deferred_only_sha=$(git -C "$SYNC_MP" rev-list HEAD --reverse | sed -n '2p')  # commit A
+# Re-derive: we want a commit that is kit-only or templated-only, not
+# the multi-type one. Make a fresh commit just for this case.
+echo "v4" >"$SYNC_MP/scripts/ci/check_one"
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t add -A
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t commit -q -m "kit-only"
+sha_D=$(git -C "$SYNC_MP" rev-parse HEAD)
+
+sync_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_D" --dry-run 2>&1)
+echo "$sync_out" | grep -q "no canonical targets" \
+  || fail "kit-only commit should report 'no canonical targets' per consumer; got: $sync_out"
+echo "$sync_out" | grep -q "would open PR" \
+  && fail "kit-only commit should not plan any PRs (canonical-only slice)"
+
+# 5) Commit that touches no manifest path at all → "no manifest paths touched".
+sync_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_C" --dry-run 2>&1)
+echo "$sync_out" | grep -q "no manifest paths touched" \
+  || fail "unrelated-only commit should report 'no manifest paths touched'; got: $sync_out"
+
+# 6) Resolution of an unknown commit-ish exits 2 cleanly.
+set +e
+"$SCRIPT" deadbeefdeadbeefdeadbeef --dry-run 2>/dev/null
+unknown_exit=$?
+set -e
+[[ "$unknown_exit" -eq 2 ]] || fail "unknown commit-ish should exit 2; got $unknown_exit"
+
+# ---------------------------------------------------------------------------
 # --version / --help smoke
 # ---------------------------------------------------------------------------
 "$SCRIPT" --version | grep -q "sync-to-downstream.sh" || fail "--version output unexpected"

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -404,6 +404,29 @@ grep -q 'chmod +x "$consumer_target"' "$SCRIPT" \
   || fail "sync_open_pr is missing the 'chmod +x' branch"
 
 # ---------------------------------------------------------------------------
+# Deletion propagation + tmpdir portability (cursor CHANGES_REQUESTED on
+# PR #217). Two source-grep assertions because the live cycle isn't
+# unit-testable without stubbing gh:
+#
+# 1. The materialization loop must check `git ls-tree` for a path
+#    BEFORE trying `git show`, and if the path is absent at the sha,
+#    rm the consumer copy instead of failing on a missing blob.
+# 2. The mktemp invocation must use the explicit `$TMPDIR/<X-pattern>`
+#    form (portable across BSD/macOS and GNU/Linux), not `mktemp -d -t
+#    "literal-prefix"` (BSD-specific behavior).
+# ---------------------------------------------------------------------------
+grep -q 'ls-tree "$sha" -- "$target"' "$SCRIPT" \
+  || fail "materialization loop is missing the ls-tree pre-check; deletes would fail on git show"
+grep -q '\[ -z "\$src_mode" \]' "$SCRIPT" \
+  || fail "materialization loop is missing the absent-at-sha branch (rm consumer copy on delete propagation)"
+grep -q 'rm -f "\$consumer_target"' "$SCRIPT" \
+  || fail "materialization loop is missing 'rm -f \$consumer_target' for delete propagation"
+grep -q 'mktemp -d "\$tmp_root/mergepath-sync-' "$SCRIPT" \
+  || fail "mktemp invocation is missing the portable \$TMPDIR/<prefix>.XXXXXX form"
+grep -q 'mktemp -d -t "mergepath-sync' "$SCRIPT" \
+  && fail "mktemp invocation still uses the BSD-specific '-t literal-prefix' form (not GNU portable)"
+
+# ---------------------------------------------------------------------------
 # --version / --help smoke
 # ---------------------------------------------------------------------------
 "$SCRIPT" --version | grep -q "sync-to-downstream.sh" || fail "--version output unexpected"


### PR DESCRIPTION
Builds on [#215](https://github.com/nathanjohnpayne/mergepath/pull/215) (manifest + read-only audit). Implements the first slice of Layer 3 sync mode per [#168](https://github.com/nathanjohnpayne/mergepath/issues/168).

## What this slice ships

`scripts/sync-to-downstream.sh <commit-ish> [--dry-run] [--repos r1,r2] [--paths glob]`

- **Canonical paths only.** Kit and templated paths are detected when a commit touches them, and called out in the per-consumer summary as deferred (they land in slices 2 and 5).
- **Idempotency** via deterministic branch name `mergepath-sync/<short-sha>`. Existing open PR → "already in flight"; closed/merged → "already done". Skipped in dry-run (which is meant to be network-free).
- **Dry-run mode** prints the full per-consumer plan: branch, canonical files, deferred kit/templated counts. Zero side effects.
- **Live mode** clones each consumer into a fresh tmpdir workspace (never reuses `MERGEPATH_SYNC_CACHE` — that's read-only audit territory), copies files via `git show <sha>:<path>` (so Mergepath uncommitted edits don't leak), preserves the executable bit when the source has it, commits with the standard `Authoring-Agent` + `## Self-Review` body, pushes the deterministic branch, and creates a PR via `gh pr create` against the consumer's `main`.

## Dogfood verification

Dry-run against the #148 fix commit (`c3b0df0`, the dependabot exemption fix) plans the right thing:

```
$ scripts/sync-to-downstream.sh c3b0df0 --dry-run
Sync from mergepath@c3b0df0: fix(workflows): use PR author login for Dependabot exemptions (#148, #162) (#169)
Changed files at this commit:
  .github/workflows/agent-review.yml
  .github/workflows/pr-review-policy.yml

  ⤷ matchline — would open PR on branch mergepath-sync/c3b0df0 (2 canonical file(s))
      + .github/workflows/agent-review.yml
      + .github/workflows/pr-review-policy.yml
  [...6 more consumers...]

Summary: PRs opened/planned: 7  skipped: 0  failed: 0
```

This matches the propagation backlog the audit surfaced in #215. Once this PR merges, the next step is to actually run it against `c3b0df0` in live mode and shepherd the resulting 7 PRs through their respective review flows. That's a separate operational step, not part of this code change.

## Test coverage

The fixture test (`tests/test_sync_to_downstream.sh`) now covers:

- Multi-type touch: canonical lands; kit+templated noted as deferred per consumer.
- `--repos` filter restricts the consumer set.
- `--paths` filter restricts target paths within the planned PR.
- Kit-only commit reports "no canonical targets" per consumer.
- Unrelated-only commit reports "no manifest paths touched".
- Unknown commit-ish exits 2 cleanly.

The live clone/push/PR-create cycle is intentionally NOT exercised in the test fixture — that would require either stubbing `gh` via PATH override (a lot of plumbing for limited additional coverage given the planning logic is fully tested) or hitting the real network (defeats the purpose of a unit test). The live path is conceptually simple file-copy + git plumbing and was verified by hand via the dry-run smoke against `c3b0df0` above.

Authoring-Agent: claude

## Self-Review

- **Correctness.** Sync mode resolves the commit-ish in the Mergepath worktree (errors out cleanly on unknown), enumerates changed files at that commit, intersects with manifest canonical paths per consumer, and either prints the dry-run plan or runs the full clone→branch→commit→push→PR cycle. Materializes content via `git show <sha>:<path>` rather than working-tree reads so an unrelated uncommitted edit in the Mergepath worktree can't leak into a propagation PR. Preserves executable bit when the source tree has `100755` mode.
- **Regression risk.** Audit mode behavior is unchanged — verified by re-running the existing smoke against `matchline / scripts/op-preflight.sh` (still reports the same 177-line drift). New code is gated entirely behind the positional commit-ish arg path; existing flag-based modes (`--audit`, `--help`, `--version`) untouched.
- **Style.** Bash + yq + gh; matches the conventions of [scripts/codex-review-check.sh](scripts/codex-review-check.sh) and the v1 audit helpers. Heredoc bodies for commit + PR body avoid apostrophes (bash parser is grumpy about apostrophes inside `$(cat <<EOF ...)` even though the spec says they should be literal). One inline note on this in the source.
- **Test coverage.** Six new dry-run assertion cases in the fixture (counted above). Live cycle is documented as out-of-scope for this PR's tests with rationale. Existing fixture cases (audit, symlink guard, worktree `.git` file, arg validation) still pass — verified locally.
- **Security / dependency hygiene.** No new external dependencies. Live mode uses `gh repo clone` + `git push` + `gh pr create` — same surface as our existing PR workflow. Workspace is a `mktemp -d` and torn down via `trap RETURN` so a failure mid-cycle doesn't leak credentials or partial commits onto disk.

## Test plan

- [x] `tests/test_sync_to_downstream.sh` — full suite passes
- [x] `scripts/ci/check_sync_manifest` — passes
- [x] `bash -n scripts/sync-to-downstream.sh` — clean parse
- [x] `scripts/sync-to-downstream.sh --version` / `--help` — print
- [x] `scripts/sync-to-downstream.sh --audit ...` — unchanged (177-line matchline drift still reported correctly)
- [x] `scripts/sync-to-downstream.sh c3b0df0 --dry-run` — plans 7 PRs as expected
- [x] `scripts/sync-to-downstream.sh c3b0df0 --dry-run --repos matchline` — single-consumer plan
- [x] `scripts/sync-to-downstream.sh c3b0df0 --dry-run --paths ".github/workflows/pr-review-policy.yml"` — single-path plan
- [ ] CI green on this PR
- [ ] Post-merge: dogfood live propagation against `c3b0df0` (separate operational step)