### PR TITLE
chore(manifest): add tadlockpsychiatry as 8th consumer

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -37,6 +37,9 @@ consumers:
   - name: swipewatch
     repo: nathanjohnpayne/swipewatch
     visibility: public
+  - name: tadlockpsychiatry
+    repo: nathanjohnpayne/tadlockpsychiatry
+    visibility: private
 
 # Path types:
 #   canonical  — byte-for-byte mirror. Any difference is drift.


### PR DESCRIPTION
Adds [tadlockpsychiatry](https://github.com/nathanjohnpayne/tadlockpsychiatry) to the propagation manifest.

Surfaced as missing from `.mergepath-sync.yml` while planning the live propagation of [#148](https://github.com/nathanjohnpayne/mergepath/issues/148) against `c3b0df0` after [#217](https://github.com/nathanjohnpayne/mergepath/pull/217) merged. The repo already carries the canonical surface (`agent-review.yml`, `pr-review-policy.yml`, `dependabot-auto-merge.yml`, the standard `scripts/{op-preflight,coderabbit-wait,codex-review-request,codex-review-check,hooks/gh-pr-guard}.sh`, plus its own `deploy.sh` / Cloudflare / Firebase plumbing) and shares the same canonical-drift profile as the other 7 consumers.

After this change:

```
$ scripts/ci/check_sync_manifest
check_sync_manifest: PASS (8 consumer(s), 16 path entry/entries)

$ scripts/sync-to-downstream.sh c3b0df0 --dry-run | grep -c "would open PR"
8
```

Audit run reports the same backlog the other 7 consumers have:

```
$ scripts/sync-to-downstream.sh --audit --no-clone --repos tadlockpsychiatry
tadlockpsychiatry (nathanjohnpayne/tadlockpsychiatry)
  ✗ scripts/op-preflight.sh                            drift: 177 diff line(s)
  ✓ scripts/coderabbit-wait.sh                         in sync
  ✓ scripts/codex-review-request.sh                    in sync
  ✗ scripts/codex-review-check.sh                      drift: 107 diff line(s)
  ⊘ scripts/phase-4b-classifier.sh                     missing entirely
  ⊘ scripts/resolve-pr-threads.sh                      missing entirely
  ⊘ scripts/request-label-removal.sh                   missing entirely
  ✓ scripts/hooks/gh-pr-guard.sh                       in sync
  ⊘ scripts/hooks/label-removal-guard.sh               missing entirely
  ✗ .github/workflows/agent-review.yml                 drift: 4 diff line(s)
  ✗ .github/workflows/pr-review-policy.yml             drift: 4 diff line(s)
  ✗ .github/workflows/dependabot-auto-merge.yml        drift: 118 diff line(s)
  ⊘ .github/workflows/auto-clear-blocking-labels.yml   missing entirely
  ✓ .github/workflows/pr-audit.yml                     in sync
  ✗ scripts/ci/                                        drift: 2 file(s) drifted, 11 file(s) missing
  ⊘ scripts/gh-projects/                               missing entirely
```

No exclusions needed — the standard `consumers: all` opt-in covers it.

Authoring-Agent: claude

## Self-Review

- **Correctness.** One-line addition to `.mergepath-sync.yml`. Manifest validates against `scripts/ci/check_sync_manifest` (now reports 8 consumers). Test fixture unchanged (consumer count is computed dynamically). Audit + dry-run smoke both pick up the new consumer correctly.
- **Regression risk.** Low. Only effect is that read-only audit and dry-run sync planning now include tadlockpsychiatry. No actual writes to the consumer happen until someone runs live sync mode against it.
- **Style.** Matches the existing consumers list entry shape exactly.
- **Test coverage.** No new tests. Existing tests pass. The added consumer is exercised by the existing audit + dry-run smoke commands shown above.
- **Security / dependency hygiene.** No new attack surface. The repo is private; the manifest documents its visibility for the same reason it does for the other private consumers.

## Test plan

- [x] `scripts/ci/check_sync_manifest` passes (8 consumers, 16 paths)
- [x] `tests/test_sync_to_downstream.sh` passes
- [x] `scripts/sync-to-downstream.sh --audit --no-clone --repos tadlockpsychiatry` reports drift
- [x] `scripts/sync-to-downstream.sh c3b0df0 --dry-run` plans 8 consumer PRs (was 7)
- [ ] CI green on this PR