### PR TITLE
test(sync): assert per-consumer headers present before awk parsing (#216)

### DIFF
--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -98,6 +98,21 @@ fail() { echo "FAIL: $*" >&2; echo "---output---" >&2; echo "$output" >&2; exit 
 # Exit 1 because at least one consumer drifts.
 [[ "$exit_code" -eq 1 ]] || fail "expected exit 1 (drift), got $exit_code"
 
+# Per-consumer header presence checks (#216). The awk block-parsers
+# below use `/^<consumer-name>/` to extract a section, then grep for
+# ✓/✗/⊘ markers and `&& fail` on a hit. If the header line ever changes
+# shape (e.g., gains a leading prefix or a trailing suffix that breaks
+# the literal awk regex), the awk filter produces an empty stream, the
+# grep finds nothing, and the test silently passes — drift goes
+# undetected. These three explicit header presence assertions turn that
+# silent-pass into a loud failure.
+echo "$output" | grep -q "^clean-consumer" \
+  || fail "clean-consumer block missing from --audit output"
+echo "$output" | grep -q "^drifted" \
+  || fail "drifted block missing from --audit output"
+echo "$output" | grep -q "^missing-everything" \
+  || fail "missing-everything block missing from --audit output"
+
 # Clean consumer: every line should be ✓ in sync (the consumer-only extra
 # file under scripts/ci/ must NOT be flagged — kit type is allow-extras).
 echo "$output" | awk '


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Closes #216. Tiny test-fixture hardening flagged on PR #215 by CodeRabbit (and acknowledged as \"reasonable but non-blocking\" by nathanpayne-cursor in their APPROVED review).

`tests/test_sync_to_downstream.sh` uses awk block-parsing (`/^<consumer-name>/ ... /^[a-z]/ exit`) to extract per-consumer sections of `--audit` output, then greps for ✓/✗/⊘ symbols inside each block. If the consumer header line in `scripts/sync-to-downstream.sh` ever changes shape (e.g., adds a `(source: cache)` suffix, gains a leading `* `, changes indentation), the awk filter produces an empty stream, the `&& fail` hit-check finds nothing, and the test silently passes — drift goes undetected.

The exit-code check at line 99 (`[[ \"$exit_code\" -eq 1 ]] || fail`) is a coarse safety net but doesn't catch per-consumer assertion drift.

This PR adds three explicit `grep -q \"^<name>\"` presence assertions before the awk parsers run, one per test consumer (clean-consumer, drifted, missing-everything). If a header is reshaped, the test now fails loudly with a clear message instead of silently passing.

## Verification

- Existing test still passes against current `--audit` output (`bash tests/test_sync_to_downstream.sh` → `test_sync_to_downstream: PASS`).
- New assertion correctly fires on a synthetic mangled output (header prefixed with `* `):

  ```
  ASSERT FIRED (expected): clean-consumer block missing from --audit output
  ```

- The test loop at lines 95–122 (Layer 2 / audit mode) is the only block this affects. Layer 3 sync-mode assertions further down already use direct `grep -q \"would open PR\"` checks, which don't have the silent-block-parse failure mode.

## Net diff

15 lines added in `tests/test_sync_to_downstream.sh`. No production code changes.

## Self-Review

**Correctness.** The assertions match exactly the regex shape the awk parser uses (`/^clean-consumer/`, `/^missing-everything/`), and add `^drifted` for symmetry — the drifted block doesn't currently use awk (it uses direct path greps), but the same header-presence concern applies there if anyone refactors the assertions later. The `||` form is chosen so a missing header trips `fail` (which prints the full output for diagnosis); the original `&& fail` form would have been wrong here.

**Regression risk.** Test-only change. The new assertions add three additional assertions before the existing logic; existing assertions still execute. The new checks are at most one additional `grep` invocation on `$output` (already in memory).

**Style.** Followed the existing test's comment density and tone — added an explanatory comment block above the assertions describing the silent-pass failure mode.

**Test coverage.** This change *is* test coverage (#216 itself).

**Security / dependency hygiene.** None.

## Test plan

- [x] `bash tests/test_sync_to_downstream.sh` exits 0 with the new assertions in place.
- [x] Synthetic mangled-header output trips the new presence assertion.
- [ ] CI run on this PR (the test runs in `repo_lint.yml` per the existing canonical workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)