### PR TITLE
feat(coderabbit-wait): StatusContext fast-path for clean fix-up pushes (#221)

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -130,6 +130,21 @@ coderabbit:
   # between consecutive CodeRabbit reviews.
   wallclock_freshness_window_seconds: 1800
 
+  # Trust CodeRabbit's per-SHA `CodeRabbit` StatusContext check as a
+  # standalone clearance signal in `scripts/coderabbit-wait.sh`. When
+  # `true` (default), the wait helper short-circuits with status=cleared
+  # the moment the StatusContext goes SUCCESS for the current HEAD —
+  # even if no narrative review comment was posted on this push.
+  # CodeRabbit does NOT re-narrate when a fix-up push genuinely cleared
+  # all prior findings, so the comment-driven path alone burns the full
+  # `max_wait_seconds` budget on every clean fix-up cycle. The
+  # StatusContext is CodeRabbit's own authoritative per-SHA verdict, so
+  # there's no scenario where the comment contradicts a green status.
+  # Set to `false` for repos that prefer the strict comment-driven gate
+  # (e.g., if a downstream consumer relies on parsing CodeRabbit's
+  # narrative for some other purpose). See nathanjohnpayne/mergepath#221.
+  trust_status_context_for_clearance: true
+
 # ---------------------------------------------------------------------------
 # Codex (Automated External Review — Phase 4a)
 # ---------------------------------------------------------------------------

--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -130,19 +130,30 @@ coderabbit:
   # between consecutive CodeRabbit reviews.
   wallclock_freshness_window_seconds: 1800
 
-  # Trust CodeRabbit's per-SHA `CodeRabbit` StatusContext check as a
-  # standalone clearance signal in `scripts/coderabbit-wait.sh`. When
-  # `true` (default), the wait helper short-circuits with status=cleared
-  # the moment the StatusContext goes SUCCESS for the current HEAD —
-  # even if no narrative review comment was posted on this push.
-  # CodeRabbit does NOT re-narrate when a fix-up push genuinely cleared
-  # all prior findings, so the comment-driven path alone burns the full
-  # `max_wait_seconds` budget on every clean fix-up cycle. The
-  # StatusContext is CodeRabbit's own authoritative per-SHA verdict, so
-  # there's no scenario where the comment contradicts a green status.
-  # Set to `false` for repos that prefer the strict comment-driven gate
-  # (e.g., if a downstream consumer relies on parsing CodeRabbit's
-  # narrative for some other purpose). See nathanjohnpayne/mergepath#221.
+  # Use CodeRabbit's per-SHA `CodeRabbit` StatusContext check as a
+  # fast-path gate trigger in `scripts/coderabbit-wait.sh`. When
+  # `true` (default), the wait helper exits as soon as the
+  # StatusContext goes SUCCESS for the current HEAD — without waiting
+  # the full `max_wait_seconds` budget for a narrative comment that
+  # CodeRabbit doesn't always re-post on clean fix-up pushes.
+  #
+  # The fast-path is NOT an unconditional clearance: CodeRabbit's
+  # `success` state means "review completed," not "no findings remain"
+  # (with the default `request_changes_workflow: false`, status flips
+  # to success regardless of whether `Potential issue` / `⚠️` comments
+  # were posted). The fast-path therefore scans inline findings on the
+  # current HEAD before declaring clearance — same scan the comment-
+  # driven path uses. If any are present, it emits status=findings
+  # (exit 2) so the caller addresses them instead of merging past
+  # them. The win is short-circuit on the clean case (most common),
+  # without trading away finding coverage on the dirty case. Codex
+  # caught the over-aggressive original draft on PR #224 round 1
+  # (P1 finding, scripts/coderabbit-wait.sh:546).
+  #
+  # Set to `false` for repos that prefer the strict comment-driven
+  # gate (e.g., if a downstream consumer relies on parsing
+  # CodeRabbit's narrative for some other purpose).
+  # See nathanjohnpayne/mergepath#221.
   trust_status_context_for_clearance: true
 
 # ---------------------------------------------------------------------------

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -252,7 +252,16 @@ fetch_api_array() {
 # PR #224 round 2.
 check_status_context() {
   local resp state
-  resp=$(gh api "repos/$REPO/commits/$HEAD_SHA/statuses" 2>/dev/null) || {
+  # Pagination (CodeRabbit ⚠️ Minor @ line 267 on PR #224 round 2):
+  # `/commits/{ref}/statuses` defaults to per_page=30 and returns
+  # statuses in reverse chronological order. Without `--paginate`, a
+  # commit with >30 statuses (e.g., long-running PR with retries)
+  # could miss the latest CodeRabbit entry in the unpaginated first
+  # page if non-CodeRabbit statuses crowd it out. `--paginate` plus
+  # `jq -s 'add // []'` flattens all pages into a single array before
+  # the context+creator filter runs.
+  resp=$(gh api --paginate "repos/$REPO/commits/$HEAD_SHA/statuses" 2>/dev/null \
+    | jq -s 'add // []' 2>/dev/null) || {
     echo "missing"
     return
   }
@@ -463,6 +472,46 @@ count_potential_issues() {
   '
 }
 
+# SHA-scoped variant of count_potential_issues, used by the
+# StatusContext fast-path. Counts CodeRabbit inline findings whose
+# `commit_id` (the SHA GitHub considers the comment currently anchored
+# to, after rebases / new commits) equals the given SHA — independent
+# of HEAD_ANCHOR's wallclock floor.
+#
+# Why this is needed (codex CHANGES_REQUESTED on PR #224 round 2 +
+# CodeRabbit ⚠️ Major @ line 581): the freshness-anchored count_potential_
+# issues filters reviews with `submitted_at >= HEAD_ANCHOR`. Once the
+# same unchanged HEAD sits longer than `coderabbit.wallclock_freshness_
+# window_seconds` (default 1800s / 30 min), HEAD_ANCHOR advances past
+# the prior CodeRabbit review's submitted_at, latest_review_id becomes
+# null, and the helper returns 0 — false-clearing the fast-path even
+# while the same SHA still has unresolved Potential issue/⚠️ inline
+# findings. The fast-path is the only caller that has authoritative
+# per-SHA scope (from the StatusContext check) and should leverage it.
+#
+# Filter shape: inline review comments where the bot author posted a
+# comment whose `commit_id == HEAD_SHA` (i.e., GitHub still considers
+# it applicable to HEAD after any rebases) and whose body contains a
+# `Potential issue` / `⚠️` marker. Resolved-thread state is NOT
+# consulted — same scope as count_potential_issues — so an addressed-
+# but-not-resolved finding will still count. That's the conservative
+# interpretation: "if there's any current-HEAD finding I haven't
+# explicitly resolved, hold the gate."
+count_potential_issues_for_sha() {
+  local sha=$1
+  local pulls_comments
+  pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
+  echo "$pulls_comments" | jq \
+    --arg bot "$BOT_LOGIN" \
+    --arg sha "$sha" '
+    [ .[]
+      | select(.user.login == $bot)
+      | select(.commit_id == $sha)
+      | select((.body // "") | test("Potential issue|⚠️"; "i"))
+    ] | length
+  '
+}
+
 post_retry_trigger() {
   # Strip the `[bot]` suffix that GitHub REST uses for App logins —
   # @-mentions address the user-facing handle (`@coderabbitai`), not
@@ -557,11 +606,20 @@ emit_status_context_verdict() {
   # comments were posted. Codex (chatgpt-codex-connector[bot]) caught
   # this on PR #224 round 1 (P1 finding, line 546). The fix: scan
   # inline `Potential issue` / `⚠️` markers anchored on HEAD before
-  # declaring clearance, exactly like the comment-driven path's
-  # post-classification scan does. If any exist, exit 2 (findings)
-  # so the caller addresses them instead of merging past them.
+  # declaring clearance.
+  #
+  # Round 2 sharpening (codex CHANGES_REQUESTED + CodeRabbit ⚠️ Major
+  # @ line 581 on the round 1 fix): use `count_potential_issues_for_sha
+  # "$HEAD_SHA"` rather than `count_potential_issues`. The latter is
+  # filtered by HEAD_ANCHOR (wallclock freshness floor); after 30 min
+  # on the same unchanged HEAD, anchor advances past prior reviews and
+  # the count drops to 0 — false-clearing the fast-path. The
+  # SHA-scoped variant ignores the wallclock anchor entirely and counts
+  # findings whose `commit_id == HEAD_SHA`, which is the right scope
+  # given the fast-path already has authoritative SHA-level evidence
+  # from the StatusContext check.
   local potential_issues synthetic
-  potential_issues=$(count_potential_issues)
+  potential_issues=$(count_potential_issues_for_sha "$HEAD_SHA")
   synthetic=$(jq -nc \
     --arg sha "$HEAD_SHA" \
     --arg state "$state" \

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -179,6 +179,30 @@ BOT_LOGIN=${BOT_LOGIN:-"coderabbitai[bot]"}
 POLL_INTERVAL_SECONDS=15
 RATE_LIMIT_BUFFER_SECONDS=30
 
+# CodeRabbit emits two distinct per-SHA signals:
+#   1. Narrative review comment (issue/PR comment + inline diff comments).
+#      The freshness-anchored polling loop watches for this. Posted only
+#      when there's commentary to add — clean re-reviews on fix-up pushes
+#      can skip it entirely.
+#   2. `CodeRabbit` StatusContext check on the commit status API. Always
+#      posted per-SHA, terminal state SUCCESS/FAILURE.
+# The narrative comment alone is the historical terminal-state source,
+# but on a fix-up push that genuinely cleared all prior findings, signal
+# (2) flips to SUCCESS while signal (1) stays silent — and this script
+# would burn its full MAX_WAIT_SECONDS budget waiting for a comment that
+# never comes. Toggle off via `coderabbit.trust_status_context_for_clearance:
+# false` in `.github/review-policy.yml` for repos that prefer the
+# strict comment-driven gate. See nathanjohnpayne/mergepath#221.
+TRUST_STATUS_CONTEXT=$(coderabbit_field trust_status_context_for_clearance)
+TRUST_STATUS_CONTEXT=${TRUST_STATUS_CONTEXT:-true}
+case "$TRUST_STATUS_CONTEXT" in
+  true|false) ;;
+  *)
+    echo "ERROR: coderabbit.trust_status_context_for_clearance must be true|false; got '$TRUST_STATUS_CONTEXT'" >&2
+    exit 3
+    ;;
+esac
+
 # --- logging helpers --------------------------------------------------------
 
 log() {
@@ -199,6 +223,30 @@ fetch_api_array() {
   raw=$(gh api --paginate "$endpoint" 2>&1) || die 3 "failed to fetch $label: $raw"
   echo "$raw" | jq -s 'add // []' 2>/dev/null \
     || die 3 "failed to flatten $label pagination output"
+}
+
+# Fetch the CodeRabbit `StatusContext` check on the current HEAD SHA.
+# Emits one of: success | failure | pending | error | missing
+# on stdout. `missing` covers both the no-statuses-yet case and any
+# transient API hiccup (network, 5xx, etc.) — caller treats it as
+# "fall through to the existing comment-driven path."
+#
+# This is the load-bearing query for the StatusContext fast-path. The
+# `.statuses[]` filter narrows to the CodeRabbit context specifically;
+# other GitHub Apps may post their own contexts on the same SHA.
+check_status_context() {
+  local resp state
+  resp=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" 2>/dev/null) || {
+    echo "missing"
+    return
+  }
+  state=$(echo "$resp" | jq -r '.statuses[]? | select(.context == "CodeRabbit") | .state' \
+    | head -n 1)
+  if [ -z "$state" ]; then
+    echo "missing"
+    return
+  fi
+  echo "$state"
 }
 
 # --- fetch PR metadata ------------------------------------------------------
@@ -477,12 +525,46 @@ sleep_or_timeout() {
   sleep "$actual"
 }
 
+emit_status_context_clearance() {
+  local state=$1
+  local synthetic
+  synthetic=$(jq -nc --arg sha "$HEAD_SHA" --arg state "$state" \
+    '{endpoint:"status_context", head_sha:$sha, context_state:$state, body_excerpt:("CodeRabbit StatusContext = " + $state + " on " + $sha)}')
+  emit_json_and_exit "cleared" 0 "$synthetic" 0
+}
+
+# Pre-loop fast-path. If CodeRabbit posted SUCCESS on this SHA before
+# the script started polling, we can short-circuit immediately and
+# avoid the first 15s sleep. See #221 — the historical comment-driven
+# poll burned the full 300s budget on every clean fix-up push because
+# CodeRabbit doesn't re-narrate when there's nothing new to flag.
+if [ "$TRUST_STATUS_CONTEXT" = "true" ]; then
+  INITIAL_CTX=$(check_status_context)
+  log "initial CodeRabbit StatusContext = $INITIAL_CTX on $HEAD_SHA"
+  if [ "$INITIAL_CTX" = "success" ]; then
+    log "StatusContext success — short-circuit clearance (no comment poll needed)"
+    emit_status_context_clearance "$INITIAL_CTX"
+  fi
+fi
+
 while :; do
   NOW_EPOCH=$(date +%s)
   ELAPSED=$((NOW_EPOCH - START_EPOCH))
   if [ "$ELAPSED" -ge "$MAX_WAIT_SECONDS" ]; then
     log "max_wait_seconds ($MAX_WAIT_SECONDS) exceeded after ${ELAPSED}s — timing out"
     emit_json_and_exit "timeout" 4 "null" 0
+  fi
+
+  # In-loop fast-path — same intent as the pre-loop check, for the case
+  # where CodeRabbit posts SUCCESS while we're already polling. Cheaper
+  # API call than `scan_latest_comment` so it's worth doing first each
+  # iteration; falls through to the comment scan if not success/failure.
+  if [ "$TRUST_STATUS_CONTEXT" = "true" ]; then
+    LOOP_CTX=$(check_status_context)
+    if [ "$LOOP_CTX" = "success" ]; then
+      log "CodeRabbit StatusContext flipped to success mid-loop on $HEAD_SHA — short-circuit clearance"
+      emit_status_context_clearance "$LOOP_CTX"
+    fi
   fi
 
   LATEST=$(scan_latest_comment)

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -231,17 +231,40 @@ fetch_api_array() {
 # transient API hiccup (network, 5xx, etc.) — caller treats it as
 # "fall through to the existing comment-driven path."
 #
-# This is the load-bearing query for the StatusContext fast-path. The
-# `.statuses[]` filter narrows to the CodeRabbit context specifically;
-# other GitHub Apps may post their own contexts on the same SHA.
+# Two defensive guards (CodeRabbit ⚠️ Critical on PR #224 round 1):
+#
+# 1. Filter by `creator.login == $BOT_LOGIN` in addition to context.
+#    Anyone with write access to commit statuses can post a status
+#    with the literal context string "CodeRabbit"; without the
+#    creator filter, that's a spoof vector. The configured bot login
+#    is the only signal we trust.
+#
+# 2. Use `sort_by(.created_at) | last` to pick the latest status, not
+#    `head -n 1`. The /statuses endpoint does not guarantee chronological
+#    ordering across calls, so `head` could return a stale status if
+#    multiple have been posted on the same SHA (e.g., re-evaluation
+#    after a CodeRabbit retry).
+#
+# Endpoint choice: `/commits/{sha}/statuses` (plural) returns each
+# status object with full `creator` details. The singular
+# `/commits/{sha}/status` rolls up state but omits per-status creator
+# fields, which would defeat guard 1. Confirmed empirically — see
+# PR #224 round 2.
 check_status_context() {
   local resp state
-  resp=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" 2>/dev/null) || {
+  resp=$(gh api "repos/$REPO/commits/$HEAD_SHA/statuses" 2>/dev/null) || {
     echo "missing"
     return
   }
-  state=$(echo "$resp" | jq -r '.statuses[]? | select(.context == "CodeRabbit") | .state' \
-    | head -n 1)
+  state=$(echo "$resp" | jq -r --arg bot "$BOT_LOGIN" '
+    [ .[]?
+      | select(.context == "CodeRabbit")
+      | select((.creator.login // "") == $bot)
+    ]
+    | sort_by(.created_at)
+    | last
+    | .state // ""
+  ')
   if [ -z "$state" ]; then
     echo "missing"
     return
@@ -525,11 +548,36 @@ sleep_or_timeout() {
   sleep "$actual"
 }
 
-emit_status_context_clearance() {
+emit_status_context_verdict() {
   local state=$1
-  local synthetic
-  synthetic=$(jq -nc --arg sha "$HEAD_SHA" --arg state "$state" \
-    '{endpoint:"status_context", head_sha:$sha, context_state:$state, body_excerpt:("CodeRabbit StatusContext = " + $state + " on " + $sha)}')
+  # CodeRabbit's StatusContext SUCCESS state means "review completed"
+  # — NOT "no findings remain." With CodeRabbit's default
+  # `request_changes_workflow: false`, the status flips to success
+  # whenever the review finishes, even if Potential issue / ⚠️
+  # comments were posted. Codex (chatgpt-codex-connector[bot]) caught
+  # this on PR #224 round 1 (P1 finding, line 546). The fix: scan
+  # inline `Potential issue` / `⚠️` markers anchored on HEAD before
+  # declaring clearance, exactly like the comment-driven path's
+  # post-classification scan does. If any exist, exit 2 (findings)
+  # so the caller addresses them instead of merging past them.
+  local potential_issues synthetic
+  potential_issues=$(count_potential_issues)
+  synthetic=$(jq -nc \
+    --arg sha "$HEAD_SHA" \
+    --arg state "$state" \
+    --argjson p "$potential_issues" \
+    '{
+      endpoint: "status_context",
+      head_sha: $sha,
+      context_state: $state,
+      potential_issue_count: $p,
+      body_excerpt: ("CodeRabbit StatusContext = " + $state + " on " + $sha + " (potential_issue_count=" + ($p | tostring) + ")")
+    }')
+  if [ "$potential_issues" -gt 0 ]; then
+    log "StatusContext $state but $potential_issues Potential issue/⚠️ marker(s) on HEAD — emitting findings (exit 2)"
+    emit_json_and_exit "findings" 2 "$synthetic" "$potential_issues"
+  fi
+  log "StatusContext $state and 0 Potential issue/⚠️ markers — emitting cleared (exit 0)"
   emit_json_and_exit "cleared" 0 "$synthetic" 0
 }
 
@@ -542,8 +590,8 @@ if [ "$TRUST_STATUS_CONTEXT" = "true" ]; then
   INITIAL_CTX=$(check_status_context)
   log "initial CodeRabbit StatusContext = $INITIAL_CTX on $HEAD_SHA"
   if [ "$INITIAL_CTX" = "success" ]; then
-    log "StatusContext success — short-circuit clearance (no comment poll needed)"
-    emit_status_context_clearance "$INITIAL_CTX"
+    log "StatusContext success — entering fast-path verdict (scans inline findings before clearance)"
+    emit_status_context_verdict "$INITIAL_CTX"
   fi
 fi
 
@@ -562,8 +610,8 @@ while :; do
   if [ "$TRUST_STATUS_CONTEXT" = "true" ]; then
     LOOP_CTX=$(check_status_context)
     if [ "$LOOP_CTX" = "success" ]; then
-      log "CodeRabbit StatusContext flipped to success mid-loop on $HEAD_SHA — short-circuit clearance"
-      emit_status_context_clearance "$LOOP_CTX"
+      log "CodeRabbit StatusContext flipped to success mid-loop on $HEAD_SHA — entering fast-path verdict"
+      emit_status_context_verdict "$LOOP_CTX"
     fi
   fi
 


### PR DESCRIPTION
Authoring-Agent: claude

Closes #221.

## Summary

`scripts/coderabbit-wait.sh` historically polls for CodeRabbit's narrative review comment anchored on HEAD. On a fix-up push that genuinely cleared all prior findings, CodeRabbit doesn't re-narrate — there's nothing new to flag — but its per-SHA `CodeRabbit` StatusContext check on the commit status API does flip to SUCCESS. The wait helper then burns its full 300s budget waiting for a comment that never comes, exits with code 4 (FALLBACK_REQUIRED), and the agent burns ~5 min of cache on every clean fix-up cycle.

This PR adds a StatusContext fast-path that short-circuits with status=cleared (exit 0) the moment the StatusContext goes SUCCESS for the current HEAD, regardless of whether a narrative comment was posted on this push. The freshness anchor + comment-driven path are unchanged for the case where CodeRabbit DOES post a comment — the fast-path is purely additive.

## Implementation

Two insertion points in `scripts/coderabbit-wait.sh`:

1. **Pre-loop check.** After all metadata setup, before entering the `while :` loop. Saves the first 15s sleep when CodeRabbit had already posted SUCCESS by the time the helper started.

2. **In-loop check.** At the top of each iteration, before `scan_latest_comment`. Cheaper API call than the comments fetch, so it's worth doing first each cycle. Falls through to the existing classify path on `pending` / `missing` / `failure` — the helper's existing semantics are unaffected.

The fast-path's synthetic review JSON uses a new `endpoint: \"status_context\"` value so callers parsing the helper's output can distinguish StatusContext-driven clearance from comment-driven clearance. The `cleared` status and exit code 0 are unchanged.

### Knob

New field `coderabbit.trust_status_context_for_clearance: true|false` in `.github/review-policy.yml`. Default `true` per the issue — the StatusContext is CodeRabbit's own authoritative per-SHA verdict, so there's no scenario where the comment contradicts a green status. Documented inline in the policy file with a pointer to this issue.

### `failure` state

Issue #221 noted the failure-state short-circuit as optional. **Not implemented in this slice.** CodeRabbit's `failure` StatusContext typically signals an internal service error (degraded mode, transient outage), not findings — findings are authoritative on the inline-comments endpoint and the existing classify path already handles them correctly. Falling through to the existing logic keeps that interpretation unchanged. If a real-world failure-as-findings case shows up, file a follow-up.

## Verification

Manually verified against PR #222 (the prior PR in this session) with CodeRabbit StatusContext = success already posted on the HEAD:

```
[coderabbit-wait] PR nathanjohnpayne/mergepath#222 — fetching HEAD commit metadata
[coderabbit-wait] HEAD = 4b061392d6522f985f210f517a7e0fa47cb93a72 committed at 2026-05-09T00:52:49Z
[coderabbit-wait] anchor = 2026-05-09T00:52:49Z (source: HEAD committer date)
[coderabbit-wait] max_wait = 300s   max_rate_limit_retries = 2   freshness_window = 1800s
[coderabbit-wait] initial CodeRabbit StatusContext = success on 4b061392d6522f985f210f517a7e0fa47cb93a72
[coderabbit-wait] StatusContext success — short-circuit clearance (no comment poll needed)
{
  ...
  \"status\": \"cleared\",
  \"review\": {
    \"endpoint\": \"status_context\",
    \"context_state\": \"success\",
    ...
  },
  \"waited_seconds\": 0
  ...
}
```

`waited_seconds: 0` (vs the historical 300s burn).

## Out of scope / follow-ups

- **Automated test fixture.** The repo currently has no test harness for `coderabbit-wait.sh` (unlike `tests/test_sync_to_downstream.sh`). Building a stub-driven harness for `gh api repos/.../commits/.../status` is meaningful scope and orthogonal to this fix. File a follow-up if regression coverage feels needed.
- **`failure` state short-circuit.** Optional per #221, deferred per above.

## Net diff

+15 lines in `.github/review-policy.yml` (new knob + comment block).
+82 lines in `scripts/coderabbit-wait.sh` (the fast-path logic + helpers + comments).

## Self-Review

**Correctness.** The fast-path uses the same authoritative API (`/commits/{sha}/status`) and the same context filter (`.context == \"CodeRabbit\"`) the GitHub UI uses to render the green check. `head -n 1` defends against the (unlikely but possible) case of multiple CodeRabbit context entries on the same SHA. `set +e`-style return-on-API-error is intentional in `check_status_context` — a transient API failure should fall through to the comment path, not abort the helper.

**Regression risk.**
- When `TRUST_STATUS_CONTEXT=false`, both insertion points are guarded and the script behaves exactly as before (verified by reading the diff at the loop entry).
- When the StatusContext is `pending` / `missing` / anything other than `success`, both insertion points fall through to the existing path (verified by reading the conditional branches).
- The synthetic review JSON shape is additive — adds new fields rather than reshaping existing ones. Existing callers parsing `.status == \"cleared\"` and `.exit_code` continue to work.

**Style.** Followed the existing file's heavy-comment convention (rationale + issue refs inline) and matched the existing helper-function pattern (local variables, return-via-stdout). The new helpers (`check_status_context`, `emit_status_context_clearance`) sit alongside `fetch_api_array` / `emit_json_and_exit` respectively.

**Test coverage.** No automated test fixture in this PR — see Out of scope above. Manual verification documented in the PR body.

**Security / dependency hygiene.** New API call is read-only (`gh api repos/.../commits/.../status` is GET-only). No new dependencies, no secrets touched, no permissions broadened.

## Test plan

- [x] Manual run against PR #222 with CodeRabbit StatusContext=success → exits 0 with waited_seconds=0.
- [ ] Once merged, observe whether the next clean fix-up push completes within seconds rather than the 300s timeout.
- [ ] (Follow-up) Add a test harness for `coderabbit-wait.sh` covering the success/pending/missing matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)