### PR TITLE
feat(merge-gate): accept Phase 4b APPROVED on HEAD as gate (c) clearance (#218)

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -162,15 +162,25 @@ coderabbit:
 #        a) required CI checks are green
 #        b) an approving review from a registered reviewer identity
 #           (`available_reviewers`) is present on the PR
-#        c) Codex has signaled clearance on the current HEAD in one of two
-#           forms — NEVER an `APPROVED` review state, because the Codex
-#           GitHub App does not post `APPROVED` reviews:
+#        c) Codex (or a Phase 4b substitute reviewer) has signaled
+#           clearance on the current HEAD via one of three forms — the
+#           Codex bot signals NEVER include an `APPROVED` review state,
+#           because the Codex GitHub App does not post `APPROVED`
+#           reviews:
 #            - a `COMMENTED` review from `chatgpt-codex-connector[bot]`
 #              on or after the latest commit, with no unaddressed P0/P1
 #              inline findings on the `/pulls/{pr}/comments` endpoint, OR
 #            - a 👍 / `+1` reaction from `chatgpt-codex-connector[bot]`
-#              on the PR issue, posted after the latest commit
-#      See #29 for the observational evidence behind this behavior.
+#              on the PR issue, posted after the latest commit, OR
+#            - **Phase 4b substitute** (when `allow_phase_4b_substitute:
+#              true`, see below): an `APPROVED` review on the current
+#              HEAD (`commit_id == HEAD_SHA`) from a non-author identity
+#              in `available_reviewers`. This is the fallback when the
+#              Codex App is unavailable / times out / hits usage limits;
+#              the external CLI reviewer carries the cross-agent merge
+#              gate per REVIEW_POLICY.md § Phase 4b. See #218.
+#      See #29 for the observational evidence behind the Codex bot
+#      behavior, and #218 for the Phase 4b substitute path.
 codex:
   enabled: true
 

--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -234,6 +234,24 @@ codex:
   # and poll scans.
   reaction_freshness_window_seconds: 1800
 
+  # When true (default), `codex-review-check.sh` accepts an APPROVED
+  # review on the current HEAD from a non-author identity in
+  # `available_reviewers` as a Codex-equivalent gate (c) clearance.
+  # This is the merge gate's understanding of Phase 4b clearance: when
+  # the Codex GitHub App is unavailable (not review-ready, timed out,
+  # agent usage limits hit), Phase 4b kicks in and an external CLI
+  # reviewer (e.g., nathanpayne-cursor) posts APPROVED on the current
+  # HEAD. Without this knob ON, gate (c) requires a Codex bot signal
+  # (👍 or COMMENTED-on-HEAD) that will never arrive in Phase 4b, and
+  # the auto-clear-blocking-labels workflow fails to remove
+  # `needs-external-review` until a human clears it manually.
+  #
+  # Set to false for repos that genuinely require Codex clearance and
+  # not a substitute Phase 4b reviewer (e.g., a repo where the Codex
+  # App provides domain-specific checks no other reviewer matches).
+  # See nathanjohnpayne/mergepath#218.
+  allow_phase_4b_substitute: true
+
 # ---------------------------------------------------------------------------
 # Phase 4b proactive triggers (#158)
 # ---------------------------------------------------------------------------

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -268,7 +268,7 @@ An agent proceeds to 4a first. If 4a escalates, times out, or is disabled, the a
      - **Gate (b)** — one of:
        - **Branch 1 (cross-agent):** a reviewer identity from `available_reviewers` has posted an `APPROVED` review (Phase 2 internal self-peer review by a DIFFERENT agent than the author)
        - **Branch 2 (same-agent fallback, #170):** the PR's `Authoring-Agent:` matches an entry in `available_reviewers` AND `chatgpt-codex-connector[bot]` has a fresh 👍 reaction on the PR issue (timestamped at-or-after the same `REACTION_THRESHOLD` gate (c) uses). This is the normal path for single-agent sessions where the no-self-approve rule prohibits the author's reviewer identity from approving — Codex's external review is the cross-agent signal that substitutes for an APPROVED state.
-     - **Gate (c)** — Codex has signaled clearance on the current HEAD via one of the two forms in step 12a
+     - **Gate (c)** — Codex has signaled clearance on the current HEAD via one of the two forms in step 12a, OR a Phase 4b substitute clearance has landed (an `APPROVED` review on the current HEAD from a non-author identity in `available_reviewers`). The Phase 4b substitute is the merge gate's understanding of Phase 4b clearance — without it, a PR that clears via Phase 4b would leave gate (c) failing forever and the auto-clear workflow would not remove `needs-external-review`. Toggle via `codex.allow_phase_4b_substitute: true|false` in `.github/review-policy.yml` (default `true`; #218).
 
      **The merge gate must never require an `APPROVED` review state from `chatgpt-codex-connector[bot]` — the app does not emit that state.** This point is load-bearing; a merge gate that looks for Codex APPROVED will never be satisfied and the Phase 4a happy path will be unreachable.
 
@@ -297,6 +297,8 @@ Phase 4b is invoked when Phase 4a escalates to disagreement or runaway, times ou
 18b. If the external reviewer flags **observations** or **risks** while approving, those are converted to GitHub Issues on the repo, assigned to `nathanjohnpayne` (see [Post-Merge Issue Creation](#post-merge-issue-creation)).
 
 19b. `nathanjohnpayne` merges the PR. Done.
+
+**Auto-clear of `needs-external-review` on Phase 4b clearance.** The `auto-clear-blocking-labels.yml` workflow's gate-evaluation script (`scripts/codex-review-check.sh`) accepts a Phase 4b external reviewer's `APPROVED` on the current HEAD as gate (c) clearance equivalent to Codex (governed by `codex.allow_phase_4b_substitute` in `.github/review-policy.yml`, default `true`; #218). The auto-clear workflow then removes `needs-external-review` on the next event-driven trigger or scheduled sweep — no human-driven label removal is needed on the Phase 4b happy path. Set the knob to `false` for repos that genuinely require Codex-only clearance (e.g., where the Codex App provides domain-specific checks no other reviewer matches).
 
 ### Phase 4b Triggers
 

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -598,6 +598,7 @@ codex:
   max_review_rounds: 2                        # runaway guard; 3rd round escalates
   review_timeout_seconds: 600                 # per-round poll timeout
   require_ci_green: true                      # merge gate
+  allow_phase_4b_substitute: true             # accept Phase 4b APPROVED on HEAD as gate (c) clearance (#218)
 ```
 
 > **Note on `enabled` flags (both `coderabbit` and `codex`).** These flags govern **agent behavior only** — whether the authoring agent waits for the corresponding review in its phase. They do NOT control whether the underlying GitHub App runs. Both apps run based on their own install state on GitHub, independent of what this YAML says. Setting `enabled: false` alone will cause the agent to skip the corresponding phase while the app continues to post reviews silently in the background. This may be desired as a "dark launch," but can confuse readers who expect the flag to mean "off." To fully disable an integration, uninstall the GitHub App AND set the flag to false.

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -762,6 +762,14 @@ fi
 # HEAD_SHA match — no time-window approximation needed since the
 # review API returns the exact SHA the review was submitted on.
 #
+# Latest-state-per-reviewer filter (Codex P1 round 1 on PR #225):
+# group reviews on HEAD by reviewer identity, take each reviewer's
+# most-recent review on this SHA, then accept ONLY if that latest
+# state is APPROVED. Without this guard, a reviewer who first APPROVED
+# then later submitted CHANGES_REQUESTED on the same HEAD would still
+# satisfy the substitute via the stale APPROVED. Mirrors gate (b)
+# branch 1's same-shaped filter (line 547 above).
+#
 # When this branch fires, the auto-clear-blocking-labels workflow
 # correctly removes `needs-external-review` on the next event-driven
 # trigger or scheduled sweep, instead of stalling on a permanently-
@@ -772,20 +780,22 @@ if [ "$CLEARED" != "true" ] && [ "$ALLOW_PHASE_4B_SUBSTITUTE" = "true" ]; then
     --arg author "$PR_AUTHOR" \
     --arg sha "$HEAD_SHA" '
       [ .[]
-        | select(.state == "APPROVED")
+        | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
         | select(.commit_id == $sha)
         | select(.user.login as $u | $reviewers | index($u))
         | select(.user.login != $author)
       ]
-      | sort_by(.submitted_at)
-      | last
+      | group_by(.user.login)
+      | map(max_by(.submitted_at))
+      | map(select(.state == "APPROVED"))
+      | first
       | if . == null then "" else .user.login + "|" + .submitted_at end
   ')
   if [ -n "$PHASE_4B_APPROVER" ]; then
     PHASE_4B_LOGIN="${PHASE_4B_APPROVER%|*}"
     PHASE_4B_TIME="${PHASE_4B_APPROVER#*|}"
     CLEARED=true
-    CLEARANCE_REASON="Phase 4b substitute: APPROVED review from $PHASE_4B_LOGIN @ $PHASE_4B_TIME on $HEAD_SHA (codex.allow_phase_4b_substitute=true)"
+    CLEARANCE_REASON="Phase 4b substitute: latest-state APPROVED on HEAD from $PHASE_4B_LOGIN @ $PHASE_4B_TIME (codex.allow_phase_4b_substitute=true)"
   fi
 fi
 

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -25,13 +25,25 @@
 #       nathanpayne-cursor, nathanpayne-codex) is present on the PR,
 #       from an account != the PR author.
 #
-#   (c) Codex has cleared on or after the current HEAD commit via one
-#       of two signals:
+#   (c) Codex (or a Phase 4b substitute reviewer) has cleared on or
+#       after the current HEAD commit via one of three signals:
 #
 #         - A COMMENTED review from the Codex bot on the current HEAD
 #           with NO unaddressed P0/P1 inline findings, OR
 #         - A +1 / 👍 reaction from the Codex bot on the PR issue
-#           with created_at >= current HEAD committer date.
+#           with created_at >= current HEAD committer date, OR
+#         - **Phase 4b substitute (#218):** an APPROVED review on the
+#           current HEAD (`commit_id == HEAD_SHA`) from a non-author
+#           identity in `available_reviewers`, gated on
+#           `codex.allow_phase_4b_substitute` (default true). This
+#           handles the case where the Codex App is unavailable
+#           (not review-ready, timeout, agent usage limits) and an
+#           external CLI reviewer (e.g., nathanpayne-cursor or
+#           nathanpayne-codex) carries the cross-agent merge gate
+#           per REVIEW_POLICY.md § Phase 4b. Set the knob to false
+#           for repos that genuinely require Codex bot clearance and
+#           not a substitute Phase 4b reviewer. Mirrors gate (b)
+#           branch 1's filter shape, scoped to HEAD via commit_id.
 #
 #       The merge gate explicitly does NOT require an APPROVED review
 #       state from the Codex bot. The ChatGPT Codex Connector GitHub

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -800,14 +800,43 @@ if [ "$CLEARED" != "true" ] && [ "$ALLOW_PHASE_4B_SUBSTITUTE" = "true" ]; then
       | group_by(.user.login)
       | map(max_by(.submitted_at))
       | map(select(.state == "APPROVED"))
-      | first
+      | max_by(.submitted_at)
       | if . == null then "" else .user.login + "|" + .submitted_at end
   ')
   if [ -n "$PHASE_4B_APPROVER" ]; then
     PHASE_4B_LOGIN="${PHASE_4B_APPROVER%|*}"
     PHASE_4B_TIME="${PHASE_4B_APPROVER#*|}"
-    CLEARED=true
-    CLEARANCE_REASON="Phase 4b substitute: latest-state APPROVED on HEAD from $PHASE_4B_LOGIN @ $PHASE_4B_TIME (codex.allow_phase_4b_substitute=true)"
+
+    # Latest-signal-wins guard (codex CHANGES_REQUESTED + CodeRabbit ⚠️
+    # Major @ scripts/codex-review-check.sh:811 on PR #225 round 3):
+    # accept the Phase 4b substitute ONLY when its APPROVED is the
+    # newest external clearance signal on HEAD. If a Codex bot review
+    # or 👍 reaction on HEAD is newer than the Phase 4b APPROVED, the
+    # Codex signal carries the verdict — and since the Codex paths
+    # above already failed to clear (CLEARED != true at this point),
+    # that means Codex's newer signal indicated unresolved P0/P1
+    # findings or had no qualifying clearance, and the older Phase 4b
+    # APPROVED must NOT override.
+    #
+    # Edge cases:
+    # - No Codex signals on HEAD (`LATEST_CODEX_SIGNAL_TIME` empty):
+    #   Phase 4b APPROVED is the only external-clearance evidence on
+    #   HEAD; accept it. This is the bare Phase 4b path (Codex App
+    #   not review-ready / timed out / etc.).
+    # - Phase 4b APPROVED newer than Codex review timestamp: the
+    #   reviewer saw Codex's findings and approved anyway (or the
+    #   findings were addressed and Codex's review captured them
+    #   without a 👍). Treat as deliberate; accept.
+    LATEST_CODEX_SIGNAL_TIME="$LATEST_THUMBS_UP_TIME"
+    if [ -n "$CODEX_REVIEW_TIME" ] && { [ -z "$LATEST_CODEX_SIGNAL_TIME" ] || [[ "$CODEX_REVIEW_TIME" > "$LATEST_CODEX_SIGNAL_TIME" ]]; }; then
+      LATEST_CODEX_SIGNAL_TIME="$CODEX_REVIEW_TIME"
+    fi
+    if [ -z "$LATEST_CODEX_SIGNAL_TIME" ] || [[ "$PHASE_4B_TIME" > "$LATEST_CODEX_SIGNAL_TIME" ]]; then
+      CLEARED=true
+      CLEARANCE_REASON="Phase 4b substitute: latest-state APPROVED on HEAD from $PHASE_4B_LOGIN @ $PHASE_4B_TIME (codex.allow_phase_4b_substitute=true; newer than any Codex bot signal on HEAD: ${LATEST_CODEX_SIGNAL_TIME:-none})"
+    else
+      log "gate (c): Phase 4b substitute candidate $PHASE_4B_LOGIN @ $PHASE_4B_TIME is older than newest Codex bot signal @ $LATEST_CODEX_SIGNAL_TIME; latest-signal-wins guard rejects substitute"
+    fi
   fi
 fi
 

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -184,6 +184,27 @@ fi
 REQUIRE_CI_GREEN=$(codex_field require_ci_green)
 REQUIRE_CI_GREEN=${REQUIRE_CI_GREEN:-true}
 
+# Honor codex.allow_phase_4b_substitute. When true (default), gate (c)
+# also accepts an APPROVED review on the current HEAD from an
+# available_reviewers identity != the PR author as a Codex-equivalent
+# clearance signal. This is the merge gate's understanding of Phase 4b
+# clearance per REVIEW_POLICY.md § Phase 4b — without it, PRs that
+# clear via Phase 4b (Codex App not review-ready, App timeout, agent
+# usage limits) leave gate (c) failing forever and the auto-clear
+# workflow stops working until a human removes the
+# `needs-external-review` label by hand. Set to false for repos that
+# genuinely require Codex clearance and not a substitute Phase 4b
+# reviewer. See nathanjohnpayne/mergepath#218.
+ALLOW_PHASE_4B_SUBSTITUTE=$(codex_field allow_phase_4b_substitute)
+ALLOW_PHASE_4B_SUBSTITUTE=${ALLOW_PHASE_4B_SUBSTITUTE:-true}
+case "$ALLOW_PHASE_4B_SUBSTITUTE" in
+  true|false) ;;
+  *)
+    echo "ERROR: codex.allow_phase_4b_substitute must be true|false; got '$ALLOW_PHASE_4B_SUBSTITUTE'" >&2
+    exit 3
+    ;;
+esac
+
 # Read the available_reviewers list (one per line). Same state-machine
 # awk pattern, but collecting list items rather than matching a scalar.
 # Outputs one reviewer login per line to stdout. Handles both quoted
@@ -730,9 +751,51 @@ elif [ -n "$CODEX_REVIEW_TIME" ]; then
   fi
 fi
 
+# Phase 4b substitute (#218): if Codex hasn't cleared via 👍 or a
+# COMMENTED-on-HEAD review, and the knob is on, accept a fresh APPROVED
+# review on the current HEAD from an available_reviewers identity that
+# is NOT the PR author. This is the merge gate's understanding of
+# Phase 4b clearance per REVIEW_POLICY.md § Phase 4b: when the Codex
+# App is unavailable / times out / hits usage limits, an external CLI
+# reviewer (e.g., nathanpayne-cursor or nathanpayne-codex) is the
+# cross-agent signal. The freshness anchor is a strict commit_id ==
+# HEAD_SHA match — no time-window approximation needed since the
+# review API returns the exact SHA the review was submitted on.
+#
+# When this branch fires, the auto-clear-blocking-labels workflow
+# correctly removes `needs-external-review` on the next event-driven
+# trigger or scheduled sweep, instead of stalling on a permanently-
+# failing gate (c) until a human clears the label by hand.
+if [ "$CLEARED" != "true" ] && [ "$ALLOW_PHASE_4B_SUBSTITUTE" = "true" ]; then
+  PHASE_4B_APPROVER=$(echo "$REVIEWS_JSON" | jq -r \
+    --argjson reviewers "$REVIEWERS_JSON" \
+    --arg author "$PR_AUTHOR" \
+    --arg sha "$HEAD_SHA" '
+      [ .[]
+        | select(.state == "APPROVED")
+        | select(.commit_id == $sha)
+        | select(.user.login as $u | $reviewers | index($u))
+        | select(.user.login != $author)
+      ]
+      | sort_by(.submitted_at)
+      | last
+      | if . == null then "" else .user.login + "|" + .submitted_at end
+  ')
+  if [ -n "$PHASE_4B_APPROVER" ]; then
+    PHASE_4B_LOGIN="${PHASE_4B_APPROVER%|*}"
+    PHASE_4B_TIME="${PHASE_4B_APPROVER#*|}"
+    CLEARED=true
+    CLEARANCE_REASON="Phase 4b substitute: APPROVED review from $PHASE_4B_LOGIN @ $PHASE_4B_TIME on $HEAD_SHA (codex.allow_phase_4b_substitute=true)"
+  fi
+fi
+
 if [ "$CLEARED" != "true" ]; then
   if [ -z "$LATEST_THUMBS_UP_TIME" ] && [ -z "$CODEX_REVIEW_TIME" ]; then
-    fail_gate "Codex has not cleared current HEAD (no review on $HEAD_SHA and no +1 reaction from $BOT_LOGIN on or after reaction threshold $REACTION_THRESHOLD: $REACTION_THRESHOLD_SOURCE)"
+    if [ "$ALLOW_PHASE_4B_SUBSTITUTE" = "true" ]; then
+      fail_gate "Codex has not cleared current HEAD and no Phase 4b substitute APPROVED on $HEAD_SHA from a non-author identity in available_reviewers (no review on HEAD, no +1 reaction from $BOT_LOGIN on or after reaction threshold $REACTION_THRESHOLD: $REACTION_THRESHOLD_SOURCE)"
+    else
+      fail_gate "Codex has not cleared current HEAD (no review on $HEAD_SHA and no +1 reaction from $BOT_LOGIN on or after reaction threshold $REACTION_THRESHOLD: $REACTION_THRESHOLD_SOURCE)"
+    fi
   else
     PATHS=$(echo "$UNADDRESSED_P01" | jq -r '[.[] | "\(.path):\(.line)"] | join(", ")')
     fail_gate "latest Codex signal is a review on HEAD with $UNADDRESSED_COUNT unaddressed P0/P1 finding(s): $PATHS"


### PR DESCRIPTION
Authoring-Agent: claude

Closes #218.

## Summary

`scripts/codex-review-check.sh` gate (c) historically required a Codex GitHub App signal — either a `COMMENTED` review on HEAD with no unaddressed P0/P1, or a 👍 reaction within the freshness window. Both are unavailable in Phase 4b. When Phase 4b kicks in (Codex App not review-ready, App timeout, agent usage limits), an external CLI reviewer (e.g., `nathanpayne-cursor`) posts an `APPROVED` review on the current HEAD as the cross-agent clearance signal — exactly what CLAUDE.md step 9 and REVIEW_POLICY.md § Phase 4b describe.

But gate (c) didn't know about that signal, so it stayed failing. The `auto-clear-blocking-labels.yml` workflow correctly didn't fire (gate not met), and a human had to remove `needs-external-review` by hand on every Phase 4b clearance. Observed twice this session: [#215](https://github.com/nathanjohnpayne/mergepath/pull/215) and [#217](https://github.com/nathanjohnpayne/mergepath/pull/217).

This PR adds a Phase 4b substitute branch to gate (c): if the Codex bot signals are absent/stale, accept an `APPROVED` review on the current HEAD (`commit_id == HEAD_SHA`) from a non-author identity in `available_reviewers` as Codex-equivalent clearance. The auto-clear workflow needs no change — it consumes the gate's verdict.

## Implementation

`scripts/codex-review-check.sh`:

1. New config knob `codex.allow_phase_4b_substitute` (default `true`). Validated as `true|false`. Reuses the existing `codex_field` parser.
2. After the existing Codex 👍 / COMMENTED-on-HEAD logic computes `CLEARED`, a new branch checks for an APPROVED review where `commit_id == HEAD_SHA`, `state == \"APPROVED\"`, the user is in `available_reviewers`, and the user != PR author. The freshness anchor is the literal SHA match (no time-window needed — GitHub stores exactly which commit a review was submitted on, so a stale APPROVED from a prior round before a force-push wouldn't pass `commit_id == $sha`).
3. The fail-gate error message branches on whether Phase 4b substitute was enabled, so a `false` repo doesn't see a misleading \"no Phase 4b substitute\" hint.

`.github/review-policy.yml`: documented the new knob inline in the `codex:` block with a pointer to this issue.

`REVIEW_POLICY.md`:
- Phase 4a gate (c) bullet now lists the Phase 4b substitute as an OR-branch.
- Phase 4b section grows a paragraph confirming auto-clear is now first-class for Phase 4b clearances on the happy path — no human-removal step required.

## Verification

Manually verified the script against two reference PRs:

- **PR #215** (Phase 4b cleared via `nathanpayne-cursor` APPROVED): script exits 0 with gate (c) reason \"Phase 4b substitute: APPROVED review from nathanpayne-cursor @ ...\". This is the case the issue specifically calls out as broken before this fix.
- **PR #213** (originally Codex-cleared, now stale 👍 past the 30-min freshness window): falls through to the Phase 4b substitute and clears via `nathanpayne-claude`'s APPROVED on HEAD. Same outcome (CLEARED), broader signal coverage. The freshness behavior of the existing 👍 path is unchanged.

The auto-clear-blocking-labels.yml workflow consumes the gate verdict, so no workflow change is needed.

## Out of scope

- The Phase 4b classifier (`scripts/phase-4b-classifier.sh`) — separate concern per the issue.
- Manual `gh pr edit --remove-label` from agents — still forbidden per CLAUDE.md § 10.6 / `scripts/hooks/label-removal-guard.sh`.

## Net diff

- `.github/review-policy.yml`: +18 lines (knob + comment block).
- `scripts/codex-review-check.sh`: +65 lines (knob read + Phase 4b substitute branch + adjusted fail-gate message).
- `REVIEW_POLICY.md`: +3 lines (gate (c) bullet update + Phase 4b auto-clear paragraph).

## Self-Review

**Correctness.** The `commit_id == \$sha` filter ensures freshness without a time-window approximation — a force-push past an APPROVED review changes the HEAD SHA and the prior approval no longer matches. The non-author check (`user.login != \$author`) preserves the cross-agent intent of gate (b) branch 1 — the same guard that branch already uses, just applied to gate (c). Reuse of `REVIEWERS_JSON` (defined at line 547) keeps the parser identical to gate (b) branch 1.

**Regression risk.** Gate (c) only takes the new branch when the historical Codex paths haven't already cleared (the `if [ \"\$CLEARED\" != \"true\" ]` guard). For Phase 4a happy-path PRs, Codex 👍 within 30 min still wins and the new branch never fires. For repos that want strict Codex-only enforcement, `codex.allow_phase_4b_substitute: false` keeps the prior behavior. The fail-gate message branches on the same flag, so a strict-mode repo doesn't see a misleading \"Phase 4b substitute available\" hint.

**Style.** Followed the file's existing comment density and tone — the Phase 4b substitute block has a heavy comment that mirrors the Branch 2 comment in gate (b). The knob doc in review-policy.yml mirrors the `require_ci_green` doc shape.

**Test coverage.** No automated test fixture for `codex-review-check.sh` exists in the repo (similar to the `coderabbit-wait.sh` situation in PR #224). Manual verification documented above. Building a stub-driven harness is meaningful scope and orthogonal to this fix.

**Security / dependency hygiene.** No new API calls (the script already fetches `\$REVIEWS_JSON`). No secrets touched, no permission scopes broadened, no new dependencies.

## Test plan

- [x] PR #215 (Phase 4b cleared via cursor APPROVED) → script exits 0 via Phase 4b substitute.
- [x] PR #213 (Codex 👍 now stale) → falls through and clears via the Phase 4b substitute (broader signal coverage; same outcome).
- [ ] Once merged, observe the next Phase 4b PR. The auto-clear workflow should remove `needs-external-review` on the next event-driven trigger or scheduled sweep, with no human label removal.
- [ ] Regression check on the next Phase 4a happy-path PR: gate (c) should still clear via the Codex 👍 path first (the Phase 4b substitute is the fallback, not a replacement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)