### PR TITLE
docs(deploy): canonical credential precedence section in DEPLOYMENT.md (#208)

### DIFF
--- a/.ai_context.md
+++ b/.ai_context.md
@@ -45,7 +45,7 @@ chmod +x ~/.local/bin/gcloud ~/.local/bin/op-firebase-deploy ~/.local/bin/op-fir
 - Each project has a dedicated GCP service account: `firebase-deployer@{project-id}.iam.gserviceaccount.com`
 - The default source credential is the per-project Firebase-vault SA key in 1Password — see `DEPLOYMENT.md` § [Deploy credential precedence (canonical)](DEPLOYMENT.md#deploy-credential-precedence-canonical) for the full 5-step resolution order and the impersonation-vs-direct trade-off
 - The 1Password-first deploy-auth model is a deliberate default for repos created from this template and should not be reversed without explicit human approval
-- The local `gcloud` wrapper resolves source credentials through the same canonical precedence so normal `gcloud` commands work without routine browser login prompts
+- The local `gcloud` wrapper resolves source credentials through a narrower 3-step chain (`GOOGLE_APPLICATION_CREDENTIALS` → shared 1Password ADC → local ADC file) so normal `gcloud` commands work without routine browser login prompts. The wrapper does NOT consult per-project Firebase-vault SA keys; that step is specific to `op-firebase-deploy`
 - No deploy service-account key is committed to a repo (the SA key lives in 1Password and is materialized only as a tempfile during a single deploy invocation)
 - Runtime application secrets can still use `op://` references and `op inject` when a repo needs 1Password-managed secrets unrelated to deploy auth
 

--- a/.ai_context.md
+++ b/.ai_context.md
@@ -22,7 +22,7 @@ dist/       build output — never edit manually
 
 ## Deploy Tooling
 
-All Firebase projects in this GitHub account use a standardized keyless deployment system. Human maintainers normally authenticate through a shared 1Password-backed GCP ADC source credential, then deploy through short-lived service account impersonation. CI should prefer Workload Identity Federation or another `external_account` credential as the source credential.
+All Firebase projects in this GitHub account use a standardized 1Password-backed deployment system. The default source credential — interactive and CI/headless — is the per-project Firebase-vault SA key (`op://Firebase/{project-id} — Firebase Deployer SA Key`), resolved via the canonical precedence in `DEPLOYMENT.md` § [Deploy credential precedence (canonical)](DEPLOYMENT.md#deploy-credential-precedence-canonical). The shared 1Password ADC remains a fallback for projects that haven't provisioned the SA key. Service-account impersonation is still used when the resolved source credential is the shared ADC; when it's the project SA key directly, no impersonation wrapper is needed.
 
 ### Scripts
 
@@ -43,11 +43,10 @@ chmod +x ~/.local/bin/gcloud ~/.local/bin/op-firebase-deploy ~/.local/bin/op-fir
 ### Credential Model
 
 - Each project has a dedicated GCP service account: `firebase-deployer@{project-id}.iam.gserviceaccount.com`
-- Humans normally read the shared source credential from `op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential`
+- The default source credential is the per-project Firebase-vault SA key in 1Password — see `DEPLOYMENT.md` § [Deploy credential precedence (canonical)](DEPLOYMENT.md#deploy-credential-precedence-canonical) for the full 5-step resolution order and the impersonation-vs-direct trade-off
 - The 1Password-first deploy-auth model is a deliberate default for repos created from this template and should not be reversed without explicit human approval
-- The local `gcloud` wrapper turns that 1Password-backed or explicit source credential into short-lived access tokens so normal `gcloud` commands work without routine browser login prompts
-- `op-firebase-deploy` converts that same source credential, or a CI-provided `external_account` credential, into a temporary `impersonated_service_account` credential file at deploy time
-- No deploy service-account key is committed to a repo
+- The local `gcloud` wrapper resolves source credentials through the same canonical precedence so normal `gcloud` commands work without routine browser login prompts
+- No deploy service-account key is committed to a repo (the SA key lives in 1Password and is materialized only as a tempfile during a single deploy invocation)
 - Runtime application secrets can still use `op://` references and `op inject` when a repo needs 1Password-managed secrets unrelated to deploy auth
 
 ### Usage

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -149,7 +149,7 @@ For `scripts/deploy.sh` and the underlying `op-firebase-deploy`, the source-cred
 
 `op-firebase-deploy` logs the selected source on stderr: `[op-firebase-deploy] source credential: ...`. Deploy auth debugging is no longer opaque — read the line to know which step won.
 
-This precedence applies to deploy flows ONLY. General `gcloud` commands continue to use the local `gcloud` wrapper's same source-credential resolution chain (so commands like `gcloud auth print-access-token` work under the same precedence) but with quota attribution from explicit flags / `.firebaserc` / active config rather than the deploy script's project pin.
+This precedence applies to deploy flows ONLY. General `gcloud` commands go through the local `gcloud` wrapper at `scripts/gcloud/gcloud`, which uses a narrower 3-step chain — `GOOGLE_APPLICATION_CREDENTIALS` if set, else the shared 1Password ADC (`op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential`), else the local ADC file. The `gcloud` wrapper does NOT consult the per-project Firebase-vault SA key from step 2 above; that step is specific to `op-firebase-deploy`. Quota attribution for `gcloud` commands is resolved separately from explicit flags / `.firebaserc` / active config rather than from the deploy script's project pin.
 
 ### Trade-off
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -134,8 +134,30 @@ If both machines modified the same 1Password item:
 - [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) (`gcloud`) installed
 - [1Password CLI](https://developer.1password.com/docs/cli/) (`op`) installed and signed in
 - `gcloud`, `op-firebase-deploy`, and `op-firebase-setup` on PATH (see Script Installation below)
-- Access to the project SA key in `op://Firebase/{project-id} — Firebase Deployer SA Key` (the **preferred default** for both interactive and CI/headless deploys per #154 — the most stable credential, no daily-reauth churn from #137), with the shared 1Password ADC `op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential` as a fallback, plus support for an explicit `GOOGLE_APPLICATION_CREDENTIALS` file as the highest-priority override
+- Access to the project SA key in `op://Firebase/{project-id} — Firebase Deployer SA Key` (the **preferred default** for both interactive and CI/headless deploys per [Deploy credential precedence (canonical)](#deploy-credential-precedence-canonical)), with the shared 1Password ADC `op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential` as a fallback, plus support for an explicit `GOOGLE_APPLICATION_CREDENTIALS` file as the highest-priority override
 - Permission to create resources in the target Firebase/GCP project and impersonate the deployer service account
+
+## Deploy credential precedence (canonical)
+
+For `scripts/deploy.sh` and the underlying `op-firebase-deploy`, the source-credential resolution order is:
+
+1. **Genuine human-supplied override** — `GOOGLE_APPLICATION_CREDENTIALS` set by the human OUTSIDE preflight (no `OP_PREFLIGHT_ADC_TMPFILE` marker, or its value differs from the marker). Wins. Used for one-off debugging, alternate-account deploys, or CI runners that materialize their own credential.
+2. **Project Firebase-vault SA key** — `op://Firebase/{project-id} — Firebase Deployer SA Key`, when present. **The standard day-to-day credential, both interactive and CI.** Stable (no `firebase login --reauth` churn from RAPT/refresh-token expiry on the shared ADC; see [#137](https://github.com/nathanjohnpayne/mergepath/issues/137)), parity between local and CI flows, no dependence on Firebase CLI local-login state.
+3. **Preflight-injected `GOOGLE_APPLICATION_CREDENTIALS`** — when no project SA key is provisioned, `scripts/op-preflight.sh --mode deploy` (or `--mode all`) materializes the shared 1Password ADC into a tempfile and exports its path. Subject to the same RAPT-expiry surface as the shared ADC.
+4. **Shared 1Password ADC read directly** — `op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential`, read by the script when neither preflight nor an SA key are available. Same RAPT-expiry surface.
+5. **Local ADC file** — `~/.config/gcloud/application_default_credentials.json` from a prior `gcloud auth application-default login`. Last resort.
+
+`op-firebase-deploy` logs the selected source on stderr: `[op-firebase-deploy] source credential: ...`. Deploy auth debugging is no longer opaque — read the line to know which step won.
+
+This precedence applies to deploy flows ONLY. General `gcloud` commands continue to use the local `gcloud` wrapper's same source-credential resolution chain (so commands like `gcloud auth print-access-token` work under the same precedence) but with quota attribution from explicit flags / `.firebaserc` / active config rather than the deploy script's project pin.
+
+### Trade-off
+
+This precedence shifts the day-to-day human deploy path from "impersonation-first via shared ADC" to "stored per-project SA key first." The trade-off is intentional:
+
+- **Why this is acceptable.** The SA key is per-project (blast radius bounded to one Firebase project), stored in 1Password (encryption + access control + audit trail per the org's existing controls), and rotatable on demand without coordination. The stability win — no daily `firebase login --reauth` from RAPT expiry on the shared ADC ([#137](https://github.com/nathanjohnpayne/mergepath/issues/137)) — materially improves deploy reliability across all consumer repos. It also gives interactive and CI/headless flows the same source credential, removing a class of "works in CI, fails locally" deploy bugs.
+- **What we give up.** The strict "no long-lived credentials on disk" property of impersonation-first is weakened for deploys: the SA key sits in 1Password rather than being purely ephemeral. We retain the property for the broader `gcloud` surface (general cloud workflows still use impersonation by default; the SA-key-first precedence only applies under `op-firebase-deploy`).
+- **Rotation.** The SA key is rotated by re-issuing via the Firebase console or `op-firebase-setup`'s key-issuance flow, updating the 1Password item, and invalidating the prior key. The next deploy's source-credential lookup picks up the new key automatically. Detailed rotation steps land alongside [#154 sub-C](https://github.com/nathanjohnpayne/mergepath/issues/210) in `docs/agents/deployment-process.md`.
 
 ## Script Installation
 
@@ -518,18 +540,12 @@ op-firebase-deploy --only functions
 ```
 
 `op-firebase-deploy`:
-1. Auto-detects the Firebase project from `.firebaserc`
-2. Reads source credentials in this order (per #154):
-   1. **Genuinely user-supplied `GOOGLE_APPLICATION_CREDENTIALS`** — when a human explicitly set the env var (debugging, alternate project, one-off flow). The script distinguishes this from preflight-injected ADC by comparing against `OP_PREFLIGHT_ADC_TMPFILE`.
-   2. **Project SA key** from `op://Firebase/{project-id} — Firebase Deployer SA Key` — the **default day-to-day deploy credential**, both interactive and CI. Stable, no RAPT/refresh-token expiry.
-   3. **Preflight-injected `GOOGLE_APPLICATION_CREDENTIALS`** — used when no project SA key is provisioned. The shared 1Password ADC's RAPT-expiry surface (#137) is the cost of this fallback; consumers wanting stable deploys should provision the project SA key.
-   4. **Shared 1Password ADC** read directly from `op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential` — used when neither preflight nor SA key are available.
-   5. **Local ADC file** `~/.config/gcloud/application_default_credentials.json` — last resort.
-3. Logs the selected credential source on stderr (`[op-firebase-deploy] source credential: ...`) so deploy auth debugging is no longer opaque.
-4. If the source credential is a `service_account` key matching the target `firebase-deployer@{project-id}.iam.gserviceaccount.com`, uses it directly (no impersonation wrapper needed — faster, no `serviceAccountTokenCreator` required).
-5. Otherwise, unwraps nested impersonated credentials if needed, stamps the target project into `quota_project_id`, and writes a temporary `impersonated_service_account` credential file.
-6. Runs `firebase deploy --non-interactive`.
-7. Cleans up the temp credentials on exit.
+1. Auto-detects the Firebase project from `.firebaserc`.
+2. Reads source credentials per [Deploy credential precedence (canonical)](#deploy-credential-precedence-canonical) above. Logs the selected source on stderr (`[op-firebase-deploy] source credential: ...`) so deploy auth debugging is no longer opaque.
+3. If the source credential is a `service_account` key matching the target `firebase-deployer@{project-id}.iam.gserviceaccount.com`, uses it directly (no impersonation wrapper needed — faster, no `serviceAccountTokenCreator` required).
+4. Otherwise, unwraps nested impersonated credentials if needed, stamps the target project into `quota_project_id`, and writes a temporary `impersonated_service_account` credential file.
+5. Runs `firebase deploy --non-interactive`.
+6. Cleans up the temp credentials on exit.
 
 No browser prompt is needed for routine use once a valid credential exists in the resolution chain and the 1Password CLI is unlocked.
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ This template includes the canonical Google Cloud and Firebase helper scripts fo
 
 - `scripts/gcloud/gcloud` installs a local wrapper so ordinary `gcloud` commands can use 1Password-backed or explicit source credentials without a routine interactive `gcloud auth login`, while attributing quota to the resolved target project from explicit flags, the repo's `.firebaserc`, or the active `gcloud` config.
 - `scripts/firebase/op-firebase-setup` creates a per-project `firebase-deployer@{project-id}.iam.gserviceaccount.com`, grants deploy roles, and configures impersonation.
-- `scripts/firebase/op-firebase-deploy` turns a 1Password-backed or explicit source credential, or a CI-provided `external_account` credential, into a temporary impersonated credential for `firebase deploy`, with the target project stamped in as the quota project.
+- `scripts/firebase/op-firebase-deploy` resolves a source credential per the canonical precedence (project Firebase-vault SA key first, with shared 1Password ADC and impersonation as fallbacks) and runs `firebase deploy` with the target project stamped in as the quota project.
 
-Human maintainers should use 1Password-backed GCP ADC plus service account impersonation. CI should prefer Workload Identity Federation or another `external_account` source credential instead of stored service-account keys.
+The canonical source-credential precedence is documented in `DEPLOYMENT.md` § [Deploy credential precedence (canonical)](DEPLOYMENT.md#deploy-credential-precedence-canonical). The default day-to-day credential — interactive and CI — is the per-project Firebase-vault SA key (`op://Firebase/{project-id} — Firebase Deployer SA Key`), with the shared 1Password ADC as a fallback and an explicit `GOOGLE_APPLICATION_CREDENTIALS` as the highest-priority override.
 
-This 1Password-first deploy-auth model is intentional. Do not revert template-derived repos to ADC-first or deploy-key-based guidance unless a human explicitly requests that change.
+This 1Password-first deploy-auth model is intentional. Do not revert template-derived repos to deploy-key-on-disk or routine `firebase login`-based guidance unless a human explicitly requests that change.
 
 See `DEPLOYMENT.md` for the full bootstrap and deploy flow.
 

--- a/docs/agents/deployment-process.md
+++ b/docs/agents/deployment-process.md
@@ -6,14 +6,11 @@ If the project uses Firebase or Google Cloud, prefer the canonical
 `scripts/gcloud/gcloud`, `scripts/firebase/op-firebase-setup`, and
 `scripts/firebase/op-firebase-deploy` flow:
 
-- Humans normally authenticate through the shared 1Password-backed GCP ADC source credential
-- The 1Password-first deploy-auth model is a deliberate default. Do not switch template-derived repos back to ADC-first, routine browser-login, `firebase login`, or long-lived deploy-key auth without explicit human approval.
-- Deploys use short-lived service account impersonation
-- CI should prefer Workload Identity Federation or another
-  `external_account` source credential
+- The canonical source-credential precedence — interactive and CI — is documented in `DEPLOYMENT.md` § [Deploy credential precedence (canonical)](../../DEPLOYMENT.md#deploy-credential-precedence-canonical). The default day-to-day credential is the per-project Firebase-vault SA key (`op://Firebase/{project-id} — Firebase Deployer SA Key`); the shared 1Password ADC remains a fallback.
+- The 1Password-first deploy-auth model is a deliberate default. Do not switch template-derived repos back to routine browser-login, `firebase login`, or unmanaged on-disk deploy-key auth without explicit human approval.
+- When the resolved source credential is the project SA key directly, no impersonation wrapper is used (faster, no `serviceAccountTokenCreator` IAM dependency). When it's the shared ADC or another non-matching credential, `op-firebase-deploy` writes a temporary `impersonated_service_account` credential and stamps the target project as the quota project.
 - Do not introduce long-lived service account keys into repo docs,
-  scripts, or secret stores unless a project explicitly requires them
+  scripts, or secret stores unless a project explicitly requires them. The Firebase-vault SA key in 1Password is the supported on-account form; on-disk deploy keys are not.
 - If credential preflight was run at session start (`scripts/op-preflight.sh --mode all`),
-  deploy credentials are already cached in `GOOGLE_APPLICATION_CREDENTIALS`. No additional
-  biometric prompt is needed for deployment.
+  deploy credentials are already cached. No additional biometric prompt is needed for deployment.
 - If an `op` command fails with a sign-in or biometric error during deploy, follow the pause-and-prompt procedure in [operating-rules.md](operating-rules.md#1password-cli-authentication-failures). Do not retry or work around the failure without the human present.


### PR DESCRIPTION
Authoring-Agent: claude

Closes #208 (sub-A of #154).

## Summary

Ship the doctrinal commitment that the parent #154 forced: **the per-project Firebase-vault SA key is the default day-to-day deploy credential, not just the CI/headless path.** The decision is already implemented in code via [PR #181](https://github.com/nathanjohnpayne/mergepath/pull/181) (which closed #137 + #154) and partially documented inline in DEPLOYMENT.md, but had no single named-anchor canonical write-up that downstream docs / consumers could link to.

This PR is intentionally narrow: a doc write-up + four pointer updates. The implementation subs (#209 / #210 / #211) execute against this contract. If reviewer pushback on the policy lands here, the answer is to revise this PR's trade-off section — not to redo the implementation that #181 already shipped.

## Files changed

- **`DEPLOYMENT.md`** — new section `## Deploy credential precedence (canonical)` immediately after `## Prerequisites`. Contains:
  - The 5-step resolution order (genuine `GOOGLE_APPLICATION_CREDENTIALS` override > project Firebase-vault SA key > preflight-injected `GOOGLE_APPLICATION_CREDENTIALS` > shared 1Password ADC read directly > local ADC file), with rationale per step.
  - A `### Trade-off` subsection: why the SA-key-first shift is acceptable (per-project blast radius, 1Password-managed audit trail, no daily `firebase login --reauth` from RAPT expiry on the shared ADC), what we give up vs the prior impersonation-first model (long-lived credential in 1Password, retained for `gcloud` general use), and how rotation works (re-issue, update 1Password item, invalidate prior key — pointer to the bootstrap runbook entry filed in [#210](https://github.com/nathanjohnpayne/mergepath/issues/210)).
  - The pre-existing inline 5-step list under `## Deployment Steps` is collapsed to a pointer at the new canonical section, removing duplicate-content drift risk.
- **`README.md`** — Firebase Auth Template section drops the \"humans normally use ADC + impersonation\" framing in favor of a pointer to the canonical section. The 1Password-first doctrine is preserved; only the default-credential text changes (ADC-first → SA-key-first), which matches the shipped implementation.
- **`.ai_context.md`** — same shift in the Deploy Tooling and Credential Model sections. Both now point at the canonical anchor.
- **`docs/agents/deployment-process.md`** — drops the ADC-first language; references the canonical section via a relative link from the docs/agents/ subdir. Adds a one-line note that the impersonation wrapper is skipped when the resolved source credential is the project SA key directly (faster, no `serviceAccountTokenCreator` IAM dependency).

## Verification

- `scripts/ci/check_duplicate_docs` exits 0 (4 pre-existing warnings about other topics in tool folders; none introduced by this PR).
- All four edited files render correctly; the new \"Deploy credential precedence (canonical)\" anchor resolves to the new section. Cross-file pointers all use the GitHub-slugified anchor `#deploy-credential-precedence-canonical`.

## Out of scope (per #154's sub-issue split)

- **op-firebase-deploy precedence rewrite + source-credential logging** — already shipped in [#181](https://github.com/nathanjohnpayne/mergepath/pull/181); this PR documents what's already there.
- **Doc reconciliation across the wider docs surface** beyond the four named files — see [#210 (#154 sub-C)](https://github.com/nathanjohnpayne/mergepath/issues/210).
- **End-to-end verification on a real consumer repo + smoke test** — see [#211 (#154 sub-D)](https://github.com/nathanjohnpayne/mergepath/issues/211).
- **The bootstrap-runbook.md \"Rotating a Firebase deploy SA key\" entry** referenced from the trade-off section — pointer is to [#210](https://github.com/nathanjohnpayne/mergepath/issues/210).

## Net diff

+41 / -29 across four doc files. No code changes.

## Self-Review

**Correctness.** The 5-step precedence in the new section matches what `op-firebase-deploy` actually does today (verified by reading the script's source-credential resolution chain — same order, same conditions). Step 1 (\"genuine human override\") is distinguished from step 3 (\"preflight-injected GAC\") via the `OP_PREFLIGHT_ADC_TMPFILE` marker, exactly as the script does. The trade-off section is honest about the impersonation-vs-key trade — we don't claim the SA-key-first model is strictly better, only that the rotation/stability win outweighs the on-disk-credential cost for the deploy surface (and impersonation is preserved for the broader `gcloud` surface).

**Regression risk.** Pure docs change. The implementation already shipped under #181, so this PR can't change runtime behavior. The pre-existing inline 5-step list at lines 522-527 of DEPLOYMENT.md is collapsed to a pointer — that's the only structural change to existing content, and it's a deduplication.

**Style.** Followed the existing tone (active voice, concrete reasoning, links to issues for incident references). The new section has its own H2 anchor and is referenced from the four pointer files via the same anchor slug.

**Test coverage.** Doc-only PR; the test surface is `scripts/ci/check_duplicate_docs`, which I verified still passes. No automated test for cross-file anchor consistency exists in this repo (file under follow-up if drift becomes a problem).

**Security / dependency hygiene.** No code changes. The doc references existing 1Password item IDs already documented elsewhere in the repo. No new permission scopes, no new dependencies.

## Test plan

- [x] `scripts/ci/check_duplicate_docs` passes (4 pre-existing warnings, none new).
- [x] DEPLOYMENT.md renders correctly with the new section anchored at `#deploy-credential-precedence-canonical`.
- [x] All four pointer files use the same anchor slug.
- [ ] Reviewer endorsement of the policy decision (this is the explicit one-shot opportunity to revisit it before #209 / #210 / #211 ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)