### PR TITLE
feat(sync): .sync-overrides.yml schema + validator + apply lib + tests (#200)

### DIFF
--- a/docs/sync-overrides.md
+++ b/docs/sync-overrides.md
@@ -1,0 +1,142 @@
+# Per-repo sync overrides
+
+Each downstream consumer of the Mergepath template can carry a `.sync-overrides.yml` at its repo root declaring **intentional divergences** from the canonical mirror. The propagation script (`scripts/sync-to-downstream.sh`) reads this file when computing what to write to a consumer, so legitimate per-repo divergence stays put while everything else syncs cleanly.
+
+This is the third leg of the propagation system. The other two:
+
+- **The manifest** — `.mergepath-sync.yml` in mergepath's repo root. Declares which paths are canonical / kit / templated, and which consumers opt in to each. Single source of truth for **what** propagates.
+- **The propagation script** — `scripts/sync-to-downstream.sh`. Reads the manifest + a target commit, computes per-consumer file diffs, opens a PR per consumer.
+
+Without the override mechanism the script would either silently overwrite legitimate per-repo divergence (data loss) or have to abort whenever it detected a difference (which makes the script useless on any non-trivial consumer). The override file resolves that by giving each repo a documented escape hatch — every divergence carries a `reason`, so drift without a paper trail is the failure mode the schema exists to prevent.
+
+## File location and lifecycle
+
+- **Location.** `.sync-overrides.yml` at the consumer repo's root, alongside `.mergepath-sync.yml`-managed canonical paths.
+- **Absence is allowed.** A consumer with no documented divergences should not have the file at all. The validator treats an absent file as "no overrides" (pass).
+- **Schema validation.** `scripts/sync/validate-overrides.sh` runs on every PR in the downstream repo via the `repo_lint.yml` workflow. A malformed override blocks merge.
+- **Application.** `scripts/sync/apply-overrides.sh` exposes two helpers (`override_should_skip_path`, `override_substitution_for`) that the propagation script calls per-path. The library is read-only and has no side effects beyond setting one global (`OVERRIDE_SKIP_REASON`) for caller logging.
+
+## Schema
+
+```yaml
+# Schema version. Bumped on incompatible schema changes.
+version: 1
+
+# Paths the propagation script must NOT overwrite for this repo.
+# Each entry references a `paths[].path` value declared by the
+# manifest at .mergepath-sync.yml.
+skip_paths:
+  - path: <path-from-manifest>
+    reason: <non-empty rationale; multi-line allowed>
+
+# Override values for templated-path substitution markers. Manifest
+# defaults apply where this map is silent. Keys must match a
+# substitution marker declared by a `type: templated` path in the
+# manifest.
+substitutions:
+  <marker-name>: <override-value>
+```
+
+### Validation rules
+
+`scripts/sync/validate-overrides.sh` enforces:
+
+| Rule | Behavior on violation |
+|---|---|
+| File parses as YAML | Exit 1 |
+| Top-level keys ⊆ {`version`, `skip_paths`, `substitutions`} | Exit 1 |
+| `version`, when present, == 1 | Exit 1 |
+| Every `skip_paths[].path` is declared by the manifest | Exit 1 |
+| Every `skip_paths[].reason` is non-empty (whitespace counts as empty) | Exit 1 |
+| Every `substitutions.<key>` matches a marker declared by a `type: templated` manifest path | Exit 1 |
+
+Absence of the file → exit 0. Empty file → exit 0 (no entries means no constraints to validate).
+
+The "every marker is declared" rule is the strictest of these and is intentional. The v1 manifest currently has no `type: templated` paths, so any non-empty `substitutions:` content fails validation — that's correct: the validator picks up new templated paths automatically once they land in the manifest, without a code change here.
+
+## Worked examples
+
+### A consumer that never diverges
+
+The recommended starting state for new repos created from the Mergepath template. Either omit the file entirely, or commit an explicit empty version copied from `examples/.sync-overrides.yml`:
+
+```yaml
+version: 1
+skip_paths: []
+substitutions: {}
+```
+
+### A consumer that legitimately uses Cloud Run instead of Firebase Hosting
+
+```yaml
+version: 1
+skip_paths:
+  - path: .github/workflows/deploy.yml
+    reason: |
+      This repo's deploy workflow targets Cloud Run, not Firebase
+      Hosting (which the canonical workflow assumes). Tracked in
+      <repo>#42 for eventual canonical convergence once Mergepath
+      ships a Cloud Run variant.
+```
+
+The propagation script logs the skip + reason on every run for that repo. The reason is the audit trail: a future maintainer reading this can decide whether the divergence still applies, file the convergence work, or remove the override when canonical catches up.
+
+### A high-deploy-frequency repo overriding a Phase-4b knob
+
+```yaml
+version: 1
+substitutions:
+  phase_4b_default: fallback-only
+  # Reason: deploy frequency is high (~5 PRs/day), and the latency
+  # cost of always-on phase-4b proactive routing outweighs the safety
+  # benefit. Re-evaluate after 90 days (target review: 2026-08-01).
+```
+
+(This example assumes a future templated path in the manifest declares `phase_4b_default` as a substitution marker. v1 manifest doesn't yet.)
+
+## Workflow: adding an override
+
+1. Open a PR in the downstream repo that includes:
+   - The new `.sync-overrides.yml` entry (skip_paths / substitutions, with `reason`).
+   - The corresponding file change (the actual divergence in the repo content).
+2. The reviewer flags any `reason` field that's missing or vague. "Required for this repo" is not a reason; "uses Cloud Run instead of Firebase Hosting (issue #42)" is.
+3. Merge.
+
+## Workflow: removing an override (re-converge with canonical)
+
+1. Remove the entry from `.sync-overrides.yml`.
+2. From a Mergepath checkout, run a dry-run sync to confirm the next propagation will write the canonical version:
+   ```bash
+   scripts/sync-to-downstream.sh HEAD --repos <consumer-name> --dry-run
+   ```
+3. Merge in the consumer repo.
+4. The next live propagation run picks up the removed override and writes the canonical content.
+
+## Helper API (for `sync-to-downstream.sh` integration)
+
+```bash
+. "$MERGEPATH_ROOT/scripts/sync/apply-overrides.sh"
+
+# Per-consumer, per-path:
+if override_should_skip_path "$consumer_overrides_file" "$path"; then
+  log "skip $path on $consumer_name: $OVERRIDE_SKIP_REASON"
+  continue
+fi
+
+# For templated paths' substitution markers:
+if override_value=$(override_substitution_for "$consumer_overrides_file" "$marker"); then
+  rendered_value="$override_value"
+else
+  rendered_value="$manifest_default"
+fi
+```
+
+The helpers are read-only, treat any error or absent file as "no override" (conservative — over-propagation is safer than silent skips), and never abort the caller. They assume a previously-validated overrides file (downstream CI runs `validate-overrides.sh` on every PR).
+
+## References
+
+- [#168](https://github.com/nathanjohnpayne/mergepath/issues/168) — parent: `sync-to-downstream.sh` propagation tool design.
+- [#198](https://github.com/nathanjohnpayne/mergepath/issues/198) — sub-A: manifest spec (closed; landed via PR #215).
+- [#199](https://github.com/nathanjohnpayne/mergepath/issues/199) — sub-B: main propagation script (in progress).
+- [#200](https://github.com/nathanjohnpayne/mergepath/issues/200) — sub-C: this override mechanism.
+- [#201](https://github.com/nathanjohnpayne/mergepath/issues/201) — sub-D: `--audit` drift detection (closed; landed via PR #215).

--- a/docs/sync-overrides.md
+++ b/docs/sync-overrides.md
@@ -32,9 +32,13 @@ skip_paths:
 # Override values for templated-path substitution markers. Manifest
 # defaults apply where this map is silent. Keys must match a
 # substitution marker declared by a `type: templated` path in the
-# manifest.
+# manifest. Each entry is a structured `{value, reason}` map — bare-
+# scalar overrides are explicitly rejected so substitutions carry
+# the same audit-trail discipline as `skip_paths`.
 substitutions:
-  <marker-name>: <override-value>
+  <marker-name>:
+    value: <override-value>
+    reason: <non-empty rationale; multi-line allowed>
 ```
 
 ### Validation rules
@@ -49,6 +53,7 @@ substitutions:
 | Every `skip_paths[].path` is declared by the manifest | Exit 1 |
 | Every `skip_paths[].reason` is non-empty (whitespace counts as empty) | Exit 1 |
 | Every `substitutions.<key>` matches a marker declared by a `type: templated` manifest path | Exit 1 |
+| Every `substitutions.<key>` is a map with `value` and non-empty `reason` fields | Exit 1 |
 
 Absence of the file → exit 0. Empty file → exit 0 (no entries means no constraints to validate).
 
@@ -86,13 +91,17 @@ The propagation script logs the skip + reason on every run for that repo. The re
 ```yaml
 version: 1
 substitutions:
-  phase_4b_default: fallback-only
-  # Reason: deploy frequency is high (~5 PRs/day), and the latency
-  # cost of always-on phase-4b proactive routing outweighs the safety
-  # benefit. Re-evaluate after 90 days (target review: 2026-08-01).
+  phase_4b_default:
+    value: fallback-only
+    reason: |
+      Deploy frequency is high (~5 PRs/day), and the latency cost of
+      always-on phase-4b proactive routing outweighs the safety
+      benefit. Re-evaluate after 90 days (target review: 2026-08-01).
 ```
 
 (This example assumes a future templated path in the manifest declares `phase_4b_default` as a substitution marker. v1 manifest doesn't yet.)
+
+The `reason` field is part of the substitution map, not a YAML comment — the validator's Rule 7 enforces it the same way `skip_paths[].reason` is enforced. A bare-scalar override (`phase_4b_default: fallback-only`) fails validation explicitly.
 
 ## Workflow: adding an override
 

--- a/docs/sync-overrides.md
+++ b/docs/sync-overrides.md
@@ -19,7 +19,8 @@ Without the override mechanism the script would either silently overwrite legiti
 ## Schema
 
 ```yaml
-# Schema version. Bumped on incompatible schema changes.
+# Schema version. Required on any non-empty document; must equal 1
+# (bumped on incompatible schema changes).
 version: 1
 
 # Paths the propagation script must NOT overwrite for this repo.
@@ -32,12 +33,13 @@ skip_paths:
 # Override values for templated-path substitution markers. Manifest
 # defaults apply where this map is silent. Keys must match a
 # substitution marker declared by a `type: templated` path in the
-# manifest. Each entry is a structured `{value, reason}` map — bare-
+# manifest. Each entry is a structured `{value, reason}` map — both
+# fields required and non-empty (whitespace counts as empty). Bare-
 # scalar overrides are explicitly rejected so substitutions carry
 # the same audit-trail discipline as `skip_paths`.
 substitutions:
   <marker-name>:
-    value: <override-value>
+    value: <non-empty override-value>
     reason: <non-empty rationale; multi-line allowed>
 ```
 
@@ -49,11 +51,11 @@ substitutions:
 |---|---|
 | File parses as YAML | Exit 1 |
 | Top-level keys ⊆ {`version`, `skip_paths`, `substitutions`} | Exit 1 |
-| `version`, when present, == 1 | Exit 1 |
+| `version` is required on non-empty documents and must equal 1 | Exit 1 |
 | Every `skip_paths[].path` is declared by the manifest | Exit 1 |
 | Every `skip_paths[].reason` is non-empty (whitespace counts as empty) | Exit 1 |
 | Every `substitutions.<key>` matches a marker declared by a `type: templated` manifest path | Exit 1 |
-| Every `substitutions.<key>` is a map with `value` and non-empty `reason` fields | Exit 1 |
+| Every `substitutions.<key>` is a map with non-empty `value` and non-empty `reason` fields (whitespace counts as empty for both) | Exit 1 |
 
 Absence of the file → exit 0. Empty file → exit 0 (no entries means no constraints to validate).
 

--- a/docs/sync-overrides.md
+++ b/docs/sync-overrides.md
@@ -106,9 +106,11 @@ substitutions:
 
 1. Remove the entry from `.sync-overrides.yml`.
 2. From a Mergepath checkout, run a dry-run sync to confirm the next propagation will write the canonical version:
+
    ```bash
    scripts/sync-to-downstream.sh HEAD --repos <consumer-name> --dry-run
    ```
+
 3. Merge in the consumer repo.
 4. The next live propagation run picks up the removed override and writes the canonical content.
 

--- a/examples/.sync-overrides.yml
+++ b/examples/.sync-overrides.yml
@@ -47,9 +47,17 @@ skip_paths: []
 # v1 manifest has no templated paths yet, so non-empty content in this
 # section currently fails validation. Once templated paths land in the
 # manifest with declared substitution markers, matching keys are allowed.
+#
+# Each entry is a structured `{value, reason}` map. Both fields are
+# required and non-empty — the `reason` is the audit-trail (same
+# posture as `skip_paths`), and a bare-scalar override like
+# `phase_4b_default: fallback-only` is explicitly rejected by the
+# validator to prevent undocumented divergence.
 substitutions: {}
 # substitutions:
-#   phase_4b_default: fallback-only
-#   # Reason: deploy frequency is high (~5 PRs/day), and the latency
-#   # cost of always-on phase-4b proactive routing outweighs the safety
-#   # benefit. Re-evaluate after 90 days (target review: <date>).
+#   phase_4b_default:
+#     value: fallback-only
+#     reason: |
+#       Deploy frequency is high (~5 PRs/day), and the latency cost
+#       of always-on phase-4b proactive routing outweighs the safety
+#       benefit. Re-evaluate after 90 days (target review: <date>).

--- a/examples/.sync-overrides.yml
+++ b/examples/.sync-overrides.yml
@@ -1,0 +1,55 @@
+# .sync-overrides.yml — sync-to-downstream divergence registry.
+#
+# Declares paths and substitution values that this repo intentionally
+# diverges from the Mergepath canonical mirror. The propagation script
+# (scripts/sync-to-downstream.sh in mergepath) reads this file to know
+# what to skip or override.
+#
+# Every entry needs a `reason` field for audit-trail. Drift without a
+# documented reason is the failure mode this file exists to prevent;
+# scripts/sync/validate-overrides.sh enforces that on every PR.
+#
+# This is the EXAMPLE template. To use it:
+#   1. Copy to the repo root as `.sync-overrides.yml`
+#   2. Add entries as needed; an empty file (or absent file) means
+#      "no overrides" and is the recommended starting state for new
+#      repos created from the Mergepath template.
+#
+# Schema details + worked examples: docs/sync-overrides.md in mergepath.
+
+# Schema version. Bumped on incompatible schema changes; the
+# validator refuses to run against an unknown version so old
+# scripts can't silently misinterpret a newer overrides file.
+version: 1
+
+# Paths the canonical-mirror script should NOT overwrite. Each entry
+# must reference a `paths[].path` value declared by the manifest at
+# .mergepath-sync.yml — skipping a path the manifest doesn't declare
+# is a no-op and gets caught as a validation error.
+#
+# Uncomment and edit these examples; remove them entirely if this
+# repo has no skip-overrides.
+skip_paths: []
+# skip_paths:
+#   - path: .github/workflows/deploy.yml
+#     reason: |
+#       This repo's deploy workflow uses Cloud Run, not Firebase Hosting
+#       (which the canonical workflow assumes). Tracked in <repo>#42 for
+#       eventual canonical convergence once Mergepath ships a Cloud Run
+#       variant.
+
+# Override values for templated paths' substitution markers. Manifest
+# defaults apply where this file is silent. Each key must match a
+# substitution marker declared by a `type: templated` path in the
+# manifest — overriding a marker the manifest doesn't declare gets
+# caught as a validation error.
+#
+# v1 manifest has no templated paths yet; this section will start
+# rejecting non-empty content once templated paths land in the
+# manifest with their own substitution markers.
+substitutions: {}
+# substitutions:
+#   phase_4b_default: fallback-only
+#   # Reason: deploy frequency is high (~5 PRs/day), and the latency
+#   # cost of always-on phase-4b proactive routing outweighs the safety
+#   # benefit. Re-evaluate after 90 days (target review: <date>).

--- a/examples/.sync-overrides.yml
+++ b/examples/.sync-overrides.yml
@@ -44,9 +44,9 @@ skip_paths: []
 # manifest — overriding a marker the manifest doesn't declare gets
 # caught as a validation error.
 #
-# v1 manifest has no templated paths yet; this section will start
-# rejecting non-empty content once templated paths land in the
-# manifest with their own substitution markers.
+# v1 manifest has no templated paths yet, so non-empty content in this
+# section currently fails validation. Once templated paths land in the
+# manifest with declared substitution markers, matching keys are allowed.
 substitutions: {}
 # substitutions:
 #   phase_4b_default: fallback-only

--- a/examples/.sync-overrides.yml
+++ b/examples/.sync-overrides.yml
@@ -17,9 +17,11 @@
 #
 # Schema details + worked examples: docs/sync-overrides.md in mergepath.
 
-# Schema version. Bumped on incompatible schema changes; the
-# validator refuses to run against an unknown version so old
-# scripts can't silently misinterpret a newer overrides file.
+# Schema version. REQUIRED on any non-empty overrides document —
+# the validator emits "missing required top-level key: version" if
+# omitted. Bumped on incompatible schema changes; the validator
+# refuses to run against an unknown version so old scripts can't
+# silently misinterpret a newer overrides file.
 version: 1
 
 # Paths the canonical-mirror script should NOT overwrite. Each entry
@@ -49,10 +51,11 @@ skip_paths: []
 # manifest with declared substitution markers, matching keys are allowed.
 #
 # Each entry is a structured `{value, reason}` map. Both fields are
-# required and non-empty — the `reason` is the audit-trail (same
-# posture as `skip_paths`), and a bare-scalar override like
-# `phase_4b_default: fallback-only` is explicitly rejected by the
-# validator to prevent undocumented divergence.
+# required and non-empty (whitespace counts as empty for either) —
+# the `reason` is the audit-trail (same posture as `skip_paths`),
+# and a bare-scalar override like `phase_4b_default: fallback-only`
+# is explicitly rejected by the validator to prevent undocumented
+# divergence.
 substitutions: {}
 # substitutions:
 #   phase_4b_default:

--- a/scripts/ci/check_sync_overrides
+++ b/scripts/ci/check_sync_overrides
@@ -11,8 +11,11 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEST_SCRIPT="$REPO_ROOT/tests/test_sync_overrides.sh"
 
 if [ ! -f "$TEST_SCRIPT" ]; then
-  echo "check_sync_overrides: SKIP (no $TEST_SCRIPT)"
-  exit 0
+  # Missing test script is a hard error, not a skip — silent-skip
+  # would let an accidental delete/rename disable this check
+  # without surfacing in CI. CodeRabbit ⚠️ Major on PR #228 round 4.
+  echo "check_sync_overrides: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
 fi
 
 bash "$TEST_SCRIPT"

--- a/scripts/ci/check_sync_overrides
+++ b/scripts/ci/check_sync_overrides
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# scripts/ci/check_sync_overrides — CI entry point for #200 tests.
+#
+# Wraps tests/test_sync_overrides.sh so the repo_lint workflow's
+# "run all scripts/ci/check_*" loop picks it up. Mirrors the
+# pattern used by the other check_* scripts in this directory.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_sync_overrides.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  echo "check_sync_overrides: SKIP (no $TEST_SCRIPT)"
+  exit 0
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/sync/apply-overrides.sh
+++ b/scripts/sync/apply-overrides.sh
@@ -114,6 +114,12 @@ override_substitution_for() {
     return 1
   fi
 
-  YQ_MARKER="$marker" yq eval '.substitutions[strenv(YQ_MARKER)]' "$overrides_file" 2>/dev/null
+  # Substitution entries are structured `{value, reason}` maps per the
+  # round 2 schema change (#228; nathanpayne-codex CHANGES_REQUESTED
+  # caught that bare-scalar overrides bypassed the audit-trail reason
+  # contract). Return only the `.value` field — the `.reason` is for
+  # audit / human-readers and is enforced by validate-overrides.sh, not
+  # consumed at propagation time.
+  YQ_MARKER="$marker" yq eval '.substitutions[strenv(YQ_MARKER)].value' "$overrides_file" 2>/dev/null
   return 0
 }

--- a/scripts/sync/apply-overrides.sh
+++ b/scripts/sync/apply-overrides.sh
@@ -65,8 +65,13 @@ override_should_skip_path() {
     return 1
   fi
 
+  # Use strenv() bracket-lookup rather than string-interpolating $path
+  # into a yq filter. CodeRabbit ⚠️ Major on PR #228: a path containing
+  # quotes or other yq metacharacters would otherwise break the filter
+  # or, worse, alter its semantics. strenv reads the value safely from
+  # the environment.
   local reason
-  reason=$(yq eval ".skip_paths[]? | select(.path == \"$path\") | .reason" "$overrides_file" 2>/dev/null | head -n 1)
+  reason=$(YQ_PATH="$path" yq eval '.skip_paths[]? | select(.path == strenv(YQ_PATH)) | .reason' "$overrides_file" 2>/dev/null | head -n 1)
   if [ -n "$reason" ] && [ "$reason" != "null" ]; then
     OVERRIDE_SKIP_REASON="$reason"
     return 0
@@ -98,12 +103,17 @@ override_substitution_for() {
     return 1
   fi
 
+  # Bracket-lookup with strenv() rather than dot-string-interpolation —
+  # marker names can legitimately contain `-`, `.`, or other characters
+  # that break yq's dot-path syntax (e.g., `phase-4b.default`). CodeRabbit
+  # ⚠️ Major on PR #228 caught this. strenv() reads the marker name from
+  # the environment and treats it as a literal map key.
   local has_key
-  has_key=$(yq eval ".substitutions | has(\"$marker\")" "$overrides_file" 2>/dev/null || echo "false")
+  has_key=$(YQ_MARKER="$marker" yq eval '.substitutions | has(strenv(YQ_MARKER))' "$overrides_file" 2>/dev/null || echo "false")
   if [ "$has_key" != "true" ]; then
     return 1
   fi
 
-  yq eval ".substitutions.$marker" "$overrides_file" 2>/dev/null
+  YQ_MARKER="$marker" yq eval '.substitutions[strenv(YQ_MARKER)]' "$overrides_file" 2>/dev/null
   return 0
 }

--- a/scripts/sync/apply-overrides.sh
+++ b/scripts/sync/apply-overrides.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# scripts/sync/apply-overrides.sh — override-application library
+#
+# Sourced by sync-to-downstream.sh's main propagation flow (#168 sub-B).
+# Defines two helpers for the per-path decision points where the
+# override mechanism feeds into propagation:
+#
+#   override_should_skip_path  Tests whether a downstream's overrides
+#                              file says to skip a given canonical/kit
+#                              path. Returns 0 (skip) when matched,
+#                              non-zero otherwise. Stores the matched
+#                              `reason` in OVERRIDE_SKIP_REASON for
+#                              the caller to log.
+#
+#   override_substitution_for  Looks up an override value for a
+#                              templated-path substitution marker.
+#                              Returns 0 when an override exists and
+#                              writes the value to stdout; non-zero
+#                              when the manifest default should win.
+#
+# Both helpers are read-only against the overrides file. They do NOT
+# validate schema (call validate-overrides.sh for that, which is what
+# downstream CI does on every PR per #200's design). The contract:
+# helpers assume a previously-validated overrides file, treat parse
+# errors as "no override" (conservative — safer to over-propagate
+# than to silently skip), and never abort the caller.
+#
+# Sourcing convention:
+#
+#   # In sync-to-downstream.sh's main script:
+#   . "$MERGEPATH_ROOT/scripts/sync/apply-overrides.sh"
+#
+#   # Then per-consumer, per-path:
+#   if override_should_skip_path "$consumer_overrides_file" "$path"; then
+#     log "skip $path on $consumer_name: $OVERRIDE_SKIP_REASON"
+#     continue
+#   fi
+#
+#   value=$(override_substitution_for "$consumer_overrides_file" "$marker") \
+#     && rendered_value="$value" \
+#     || rendered_value="$manifest_default"
+#
+# Globals: OVERRIDE_SKIP_REASON is set to the matched reason when
+# override_should_skip_path returns 0.
+
+# --- override_should_skip_path -------------------------------------
+#
+# Args:
+#   $1  Path to the consumer's .sync-overrides.yml. May be empty
+#       string or a missing file — both are handled as "no override."
+#   $2  The path being propagated (from manifest `paths[].path`).
+#
+# Returns 0 if the overrides file's skip_paths declares this path,
+# non-zero otherwise.
+
+override_should_skip_path() {
+  local overrides_file=$1
+  local path=$2
+  OVERRIDE_SKIP_REASON=""
+
+  if [ -z "$overrides_file" ] || [ ! -f "$overrides_file" ]; then
+    return 1
+  fi
+  if ! command -v yq >/dev/null 2>&1; then
+    return 1
+  fi
+
+  local reason
+  reason=$(yq eval ".skip_paths[]? | select(.path == \"$path\") | .reason" "$overrides_file" 2>/dev/null | head -n 1)
+  if [ -n "$reason" ] && [ "$reason" != "null" ]; then
+    OVERRIDE_SKIP_REASON="$reason"
+    return 0
+  fi
+  return 1
+}
+
+# --- override_substitution_for -------------------------------------
+#
+# Args:
+#   $1  Path to the consumer's .sync-overrides.yml.
+#   $2  Substitution marker name (the key under `substitutions:`).
+#
+# Returns 0 when an override exists; writes the override value to
+# stdout. Returns non-zero when no override is present (caller falls
+# back to the manifest default).
+#
+# Multi-line override values are passed through verbatim. The caller
+# is responsible for any escaping required by the templating engine.
+
+override_substitution_for() {
+  local overrides_file=$1
+  local marker=$2
+
+  if [ -z "$overrides_file" ] || [ ! -f "$overrides_file" ]; then
+    return 1
+  fi
+  if ! command -v yq >/dev/null 2>&1; then
+    return 1
+  fi
+
+  local has_key
+  has_key=$(yq eval ".substitutions | has(\"$marker\")" "$overrides_file" 2>/dev/null || echo "false")
+  if [ "$has_key" != "true" ]; then
+    return 1
+  fi
+
+  yq eval ".substitutions.$marker" "$overrides_file" 2>/dev/null
+  return 0
+}

--- a/scripts/sync/apply-overrides.sh
+++ b/scripts/sync/apply-overrides.sh
@@ -120,6 +120,19 @@ override_substitution_for() {
   # contract). Return only the `.value` field — the `.reason` is for
   # audit / human-readers and is enforced by validate-overrides.sh, not
   # consumed at propagation time.
-  YQ_MARKER="$marker" yq eval '.substitutions[strenv(YQ_MARKER)].value' "$overrides_file" 2>/dev/null
+  #
+  # Treat null / empty / missing `.value` as "no override" (return
+  # non-zero so the caller falls back to the manifest default).
+  # Without this guard, a malformed entry would propagate a literal
+  # `null` or empty string into rendered output. The validator
+  # rejects such entries on every PR (Rule 7), but this is defensive
+  # belt-and-suspenders for already-merged or pre-validated cases.
+  # CodeRabbit ⚠️ Major on PR #228 round 4.
+  local value
+  value=$(YQ_MARKER="$marker" yq eval '.substitutions[strenv(YQ_MARKER)].value' "$overrides_file" 2>/dev/null || true)
+  if [ -z "$value" ] || [ "$value" = "null" ]; then
+    return 1
+  fi
+  printf '%s\n' "$value"
   return 0
 }

--- a/scripts/sync/validate-overrides.sh
+++ b/scripts/sync/validate-overrides.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# scripts/sync/validate-overrides.sh — schema validator for .sync-overrides.yml
+#
+# Each downstream consumer carries a `.sync-overrides.yml` at its repo
+# root declaring intentional divergence from the Mergepath canonical
+# mirror. This validator enforces the override schema BEFORE the
+# propagation script (sync-to-downstream.sh) honors any entry — drift
+# without a documented `reason` is the failure mode the override
+# system exists to prevent.
+#
+# Usage:
+#   scripts/sync/validate-overrides.sh [overrides-file] [manifest-file]
+#
+# Arguments:
+#   overrides-file  Optional. Path to the .sync-overrides.yml. Defaults
+#                   to ./.sync-overrides.yml relative to the cwd.
+#   manifest-file   Optional. Path to the .mergepath-sync.yml manifest.
+#                   Defaults to MERGEPATH_ROOT/.mergepath-sync.yml,
+#                   resolved via env var MERGEPATH_ROOT_OVERRIDE (used
+#                   in tests) or, if unset, the parent of the directory
+#                   containing this script (i.e., scripts/sync/.. → repo
+#                   root for an in-mergepath-checkout invocation).
+#
+# Validation rules:
+#   1. Overrides file (if it exists) parses as YAML.
+#   2. Top-level keys are limited to `version`, `skip_paths`, `substitutions`.
+#      Unknown top-level keys exit non-zero.
+#   3. `version`, when present, equals SUPPORTED_OVERRIDE_VERSION (currently 1).
+#   4. Every `skip_paths[].path` exists in the manifest's `paths[].path`.
+#      Skip-of-nonexistent-file exits non-zero.
+#   5. Every `skip_paths[]` has a non-empty `reason` field.
+#   6. Every `substitutions.<key>` matches a marker declared by a
+#      manifest path with `type: templated`. (No templated paths in v1
+#      means any `substitutions:` content fails validation. This is the
+#      correct strict default — when templated paths land, the
+#      validator picks them up automatically without a code change.)
+#
+# Exit codes:
+#   0   Overrides file is absent OR all rules pass. Both cases are
+#       valid for downstream CI: a repo with no divergences is fine.
+#   1   Validation failure. One or more diagnostics on stderr.
+#   2   Usage error / missing prerequisite (no `yq`, manifest absent
+#       and not provided, etc.).
+#
+# Design notes:
+#   - Read-only. Never writes to disk except diagnostics on stderr.
+#   - Uses `yq` (mikefarah/yq v4+) for YAML parsing. Same dependency
+#     the existing sync-to-downstream.sh uses.
+#   - Absent overrides file is intentionally a pass — most consumers
+#     won't have any divergences to document.
+
+set -euo pipefail
+
+SUPPORTED_OVERRIDE_VERSION=1
+
+OVERRIDES_FILE="${1:-.sync-overrides.yml}"
+
+if [ -n "${2:-}" ]; then
+  MANIFEST_FILE="$2"
+else
+  MERGEPATH_ROOT="${MERGEPATH_ROOT_OVERRIDE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+  MANIFEST_FILE="$MERGEPATH_ROOT/.mergepath-sync.yml"
+fi
+
+err() { echo "validate-overrides: ERROR: $*" >&2; }
+fail() { err "$@"; exit 1; }
+usage() { err "$@"; exit 2; }
+
+if ! command -v yq >/dev/null 2>&1; then
+  usage "yq (mikefarah/yq v4+) is required. Install via 'brew install yq'."
+fi
+if ! yq --version 2>&1 | grep -q "mikefarah/yq"; then
+  usage "Detected non-mikefarah yq. Install mikefarah/yq v4+ from https://github.com/mikefarah/yq."
+fi
+
+# Absent overrides file = no divergences = pass. This is intentional;
+# most consumers should not have any documented overrides on day one.
+if [ ! -f "$OVERRIDES_FILE" ]; then
+  echo "validate-overrides: OK — no overrides file at $OVERRIDES_FILE"
+  exit 0
+fi
+
+if [ ! -f "$MANIFEST_FILE" ]; then
+  usage "manifest not found at $MANIFEST_FILE (set MERGEPATH_ROOT_OVERRIDE or pass as 2nd arg)"
+fi
+
+# --- Rule 1: overrides file parses as YAML --------------------------
+if ! yq eval '.' "$OVERRIDES_FILE" >/dev/null 2>&1; then
+  fail "$OVERRIDES_FILE is not valid YAML"
+fi
+
+# --- Rule 2: top-level keys are restricted --------------------------
+ALLOWED_KEYS=(version skip_paths substitutions)
+# Portable replacement for `mapfile -t` (not available in bash 3.2 on
+# macOS). Read each yq output line into an array element, preserving
+# the count via ${#TOP_KEYS[@]}.
+TOP_KEYS=()
+while IFS= read -r _line; do
+  TOP_KEYS+=("$_line")
+done < <(yq eval 'keys | .[]' "$OVERRIDES_FILE" 2>/dev/null || true)
+VIOLATIONS=0
+for k in "${TOP_KEYS[@]:-}"; do
+  [ -z "$k" ] && continue
+  found=0
+  for allowed in "${ALLOWED_KEYS[@]}"; do
+    if [ "$k" = "$allowed" ]; then
+      found=1
+      break
+    fi
+  done
+  if [ "$found" -eq 0 ]; then
+    err "unknown top-level key: $k (allowed: ${ALLOWED_KEYS[*]})"
+    VIOLATIONS=$((VIOLATIONS + 1))
+  fi
+done
+
+# --- Rule 3: version, if present, must match -----------------------
+HAS_VERSION=$(yq eval 'has("version")' "$OVERRIDES_FILE" 2>/dev/null || echo "false")
+if [ "$HAS_VERSION" = "true" ]; then
+  V=$(yq eval '.version' "$OVERRIDES_FILE" 2>/dev/null)
+  if [ "$V" != "$SUPPORTED_OVERRIDE_VERSION" ]; then
+    err "version $V not supported by this validator (expected $SUPPORTED_OVERRIDE_VERSION)"
+    VIOLATIONS=$((VIOLATIONS + 1))
+  fi
+fi
+
+# --- Rules 4 + 5: skip_paths validation ----------------------------
+SKIP_COUNT=$(yq eval '.skip_paths | length // 0' "$OVERRIDES_FILE" 2>/dev/null || echo "0")
+if [ "$SKIP_COUNT" -gt 0 ]; then
+  # Snapshot the manifest's set of declared paths once, for fast lookup.
+  MANIFEST_PATHS=()
+  while IFS= read -r _line; do
+    MANIFEST_PATHS+=("$_line")
+  done < <(yq eval '.paths[].path' "$MANIFEST_FILE" 2>/dev/null || true)
+  if [ "${#MANIFEST_PATHS[@]}" -eq 0 ]; then
+    fail "manifest at $MANIFEST_FILE has no paths declared (cannot validate skip_paths)"
+  fi
+
+  for ((i = 0; i < SKIP_COUNT; i++)); do
+    P=$(yq eval ".skip_paths[$i].path // \"\"" "$OVERRIDES_FILE")
+    R=$(yq eval ".skip_paths[$i].reason // \"\"" "$OVERRIDES_FILE")
+
+    if [ -z "$P" ]; then
+      err "skip_paths[$i]: missing 'path' field"
+      VIOLATIONS=$((VIOLATIONS + 1))
+      continue
+    fi
+    # Strip surrounding whitespace from reason; treat trim-empty as missing.
+    R_TRIMMED=$(printf '%s' "$R" | tr -d '[:space:]')
+    if [ -z "$R_TRIMMED" ]; then
+      err "skip_paths[$i] (path=$P): missing or empty 'reason' field — drift without a reason is the failure mode this file exists to prevent"
+      VIOLATIONS=$((VIOLATIONS + 1))
+    fi
+
+    # Match the path against the manifest. Manifest paths can be exact
+    # files (e.g., scripts/keep-in-sync.sh) or directories ending in `/`
+    # (e.g., scripts/ci/). For skip_paths, the override path must equal
+    # a manifest entry exactly; partial-prefix skips would be ambiguous.
+    found=0
+    for mp in "${MANIFEST_PATHS[@]}"; do
+      if [ "$mp" = "$P" ]; then
+        found=1
+        break
+      fi
+    done
+    if [ "$found" -eq 0 ]; then
+      err "skip_paths[$i] (path=$P): not found in manifest's paths[].path — cannot skip a path the manifest doesn't declare"
+      VIOLATIONS=$((VIOLATIONS + 1))
+    fi
+  done
+fi
+
+# --- Rule 6: substitutions validation -------------------------------
+HAS_SUBS=$(yq eval 'has("substitutions")' "$OVERRIDES_FILE" 2>/dev/null || echo "false")
+if [ "$HAS_SUBS" = "true" ]; then
+  SUBS_COUNT=$(yq eval '.substitutions | length // 0' "$OVERRIDES_FILE" 2>/dev/null || echo "0")
+  if [ "$SUBS_COUNT" -gt 0 ]; then
+    # Collect the set of substitution markers declared by the manifest's
+    # templated paths. v1 manifest has only canonical + kit types so
+    # this set is empty until templated lands; the validator then
+    # rejects any substitution entries (correct strict default).
+    TEMPLATED_MARKERS=()
+    while IFS= read -r _line; do
+      TEMPLATED_MARKERS+=("$_line")
+    done < <(yq eval '.paths[] | select(.type == "templated") | .substitutions // {} | keys | .[]' "$MANIFEST_FILE" 2>/dev/null | sort -u || true)
+
+    SUB_KEYS=()
+    while IFS= read -r _line; do
+      SUB_KEYS+=("$_line")
+    done < <(yq eval '.substitutions | keys | .[]' "$OVERRIDES_FILE" 2>/dev/null || true)
+    for k in "${SUB_KEYS[@]:-}"; do
+      [ -z "$k" ] && continue
+      found=0
+      for marker in "${TEMPLATED_MARKERS[@]}"; do
+        if [ "$marker" = "$k" ]; then
+          found=1
+          break
+        fi
+      done
+      if [ "$found" -eq 0 ]; then
+        if [ "${#TEMPLATED_MARKERS[@]}" -eq 0 ]; then
+          err "substitutions.$k: manifest has no templated paths declared yet, so no substitution markers exist to override"
+        else
+          err "substitutions.$k: not declared as a substitution marker by any templated path in manifest (declared markers: ${TEMPLATED_MARKERS[*]})"
+        fi
+        VIOLATIONS=$((VIOLATIONS + 1))
+      fi
+    done
+  fi
+fi
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  err "$VIOLATIONS validation error(s) in $OVERRIDES_FILE"
+  exit 1
+fi
+
+echo "validate-overrides: OK — $OVERRIDES_FILE matches schema"
+exit 0

--- a/scripts/sync/validate-overrides.sh
+++ b/scripts/sync/validate-overrides.sh
@@ -34,6 +34,12 @@
 #      means any `substitutions:` content fails validation. This is the
 #      correct strict default — when templated paths land, the
 #      validator picks them up automatically without a code change.)
+#   7. Every `substitutions.<key>` entry is a map with non-empty
+#      `value` and `reason` fields. Bare scalar substitutions
+#      (`marker: just-a-value`) fail validation — every override
+#      must carry an audit-trail reason, matching the same posture
+#      enforced on `skip_paths`. Closes a schema-contract gap caught
+#      by nathanpayne-codex CHANGES_REQUESTED on PR #228.
 #
 # Exit codes:
 #   0   Overrides file is absent OR all rules pass. Both cases are
@@ -262,6 +268,32 @@ if [ "$HAS_SUBS" = "true" ]; then
         else
           err "substitutions.$k: not declared as a substitution marker by any templated path in manifest (declared markers: ${TEMPLATED_MARKERS[*]})"
         fi
+        VIOLATIONS=$((VIOLATIONS + 1))
+      fi
+
+      # --- Rule 7: substitution entries must be {value, reason} -----
+      # nathanpayne-codex CHANGES_REQUESTED on PR #228 caught the
+      # schema-contract gap: the docs/issue claim every divergence
+      # carries an audit-trail reason, but the original schema let
+      # substitutions ship as a bare scalar (`marker: value`) with
+      # no reason at all. Require a structured map with both fields
+      # present and non-empty — matches the posture skip_paths
+      # already enforces.
+      ENTRY_TYPE=$(YQ_K="$k" yq eval '.substitutions[strenv(YQ_K)] | type' "$OVERRIDES_FILE" 2>/dev/null || echo "!!unknown")
+      if [ "$ENTRY_TYPE" != "!!map" ]; then
+        err "substitutions.$k: must be a map with 'value' and 'reason' fields (got $ENTRY_TYPE — bare scalar substitutions are not allowed; every override must carry an audit-trail reason)"
+        VIOLATIONS=$((VIOLATIONS + 1))
+        continue
+      fi
+      ENTRY_VALUE_PRESENT=$(YQ_K="$k" yq eval '.substitutions[strenv(YQ_K)] | has("value")' "$OVERRIDES_FILE" 2>/dev/null || echo "false")
+      ENTRY_REASON_RAW=$(YQ_K="$k" yq eval '.substitutions[strenv(YQ_K)].reason // ""' "$OVERRIDES_FILE" 2>/dev/null || echo "")
+      ENTRY_REASON_TRIMMED=$(printf '%s' "$ENTRY_REASON_RAW" | tr -d '[:space:]')
+      if [ "$ENTRY_VALUE_PRESENT" != "true" ]; then
+        err "substitutions.$k: missing 'value' field"
+        VIOLATIONS=$((VIOLATIONS + 1))
+      fi
+      if [ -z "$ENTRY_REASON_TRIMMED" ]; then
+        err "substitutions.$k: missing or empty 'reason' field — every override must carry an audit-trail reason"
         VIOLATIONS=$((VIOLATIONS + 1))
       fi
     done

--- a/scripts/sync/validate-overrides.sh
+++ b/scripts/sync/validate-overrides.sh
@@ -89,6 +89,27 @@ if ! yq eval '.' "$OVERRIDES_FILE" >/dev/null 2>&1; then
   fail "$OVERRIDES_FILE is not valid YAML"
 fi
 
+# --- Rule 1b: document root must be a map ---------------------------
+# Without this guard, a top-level scalar (e.g., the file contents are
+# just `"not-a-map"`) or sequence (`- foo\n- bar`) would pass rules
+# 2-6 silently — yq's `keys | .[]` returns nothing on non-map roots,
+# so all the per-key checks no-op without complaint. CodeRabbit ⚠️
+# Major on PR #228 round 2 caught this. `!!null` (empty document)
+# round-trips as no overrides, same as an absent file.
+ROOT_TYPE=$(yq eval '. | type' "$OVERRIDES_FILE" 2>/dev/null || echo "!!unknown")
+case "$ROOT_TYPE" in
+  "!!map")
+    ;;
+  "!!null")
+    # Empty / `~` / `null` document — treat as no overrides.
+    echo "validate-overrides: OK — $OVERRIDES_FILE is empty (no overrides)"
+    exit 0
+    ;;
+  *)
+    fail "$OVERRIDES_FILE document root must be a map (got $ROOT_TYPE)"
+    ;;
+esac
+
 # --- Rule 2: top-level keys are restricted --------------------------
 ALLOWED_KEYS=(version skip_paths substitutions)
 # Portable replacement for `mapfile -t` (not available in bash 3.2 on

--- a/scripts/sync/validate-overrides.sh
+++ b/scripts/sync/validate-overrides.sh
@@ -25,7 +25,9 @@
 #   1. Overrides file (if it exists) parses as YAML.
 #   2. Top-level keys are limited to `version`, `skip_paths`, `substitutions`.
 #      Unknown top-level keys exit non-zero.
-#   3. `version`, when present, equals SUPPORTED_OVERRIDE_VERSION (currently 1).
+#   3. `version` is required on any non-empty document and must equal
+#      SUPPORTED_OVERRIDE_VERSION (currently 1). Empty / null-root
+#      documents bypass at Rule 1b before this rule runs.
 #   4. Every `skip_paths[].path` exists in the manifest's `paths[].path`.
 #      Skip-of-nonexistent-file exits non-zero.
 #   5. Every `skip_paths[]` has a non-empty `reason` field.

--- a/scripts/sync/validate-overrides.sh
+++ b/scripts/sync/validate-overrides.sh
@@ -125,7 +125,28 @@ if [ "$HAS_VERSION" = "true" ]; then
 fi
 
 # --- Rules 4 + 5: skip_paths validation ----------------------------
-SKIP_COUNT=$(yq eval '.skip_paths | length // 0' "$OVERRIDES_FILE" 2>/dev/null || echo "0")
+# Type-check skip_paths first — same defense as the substitutions block
+# below. yq's `length` aborts on scalar values, which would otherwise
+# produce a confusing diagnostic rather than a clean "skip_paths must
+# be a sequence" violation. `null` round-trips as empty (no-op).
+HAS_SKIP=$(yq eval 'has("skip_paths")' "$OVERRIDES_FILE" 2>/dev/null || echo "false")
+SKIP_TYPE="!!null"
+if [ "$HAS_SKIP" = "true" ]; then
+  SKIP_TYPE=$(yq eval '.skip_paths | type' "$OVERRIDES_FILE" 2>/dev/null || echo "!!unknown")
+  case "$SKIP_TYPE" in
+    "!!seq"|"!!null")
+      ;;
+    *)
+      err "skip_paths: must be a sequence (got $SKIP_TYPE)"
+      VIOLATIONS=$((VIOLATIONS + 1))
+      SKIP_TYPE="!!null"
+      ;;
+  esac
+fi
+SKIP_COUNT=0
+if [ "$SKIP_TYPE" = "!!seq" ]; then
+  SKIP_COUNT=$(yq eval '.skip_paths | length' "$OVERRIDES_FILE" 2>/dev/null || echo "0")
+fi
 if [ "$SKIP_COUNT" -gt 0 ]; then
   # Snapshot the manifest's set of declared paths once, for fast lookup.
   MANIFEST_PATHS=()
@@ -173,8 +194,25 @@ fi
 # --- Rule 6: substitutions validation -------------------------------
 HAS_SUBS=$(yq eval 'has("substitutions")' "$OVERRIDES_FILE" 2>/dev/null || echo "false")
 if [ "$HAS_SUBS" = "true" ]; then
+  # Type-check substitutions before traversing keys (CodeRabbit ⚠️ Major
+  # on PR #228). yq's `keys | .[]` aborts non-zero on a scalar value
+  # (e.g., `substitutions: foo` where foo isn't a map), so without the
+  # type check the validator would crash with `set -u`-unfriendly
+  # diagnostics rather than emitting a clear "substitutions must be a
+  # map" violation. `null` is allowed (treated as no-op, like an empty
+  # map) so `substitutions: ~` round-trips cleanly.
+  SUBS_TYPE=$(yq eval '.substitutions | type' "$OVERRIDES_FILE" 2>/dev/null || echo "!!unknown")
+  case "$SUBS_TYPE" in
+    "!!map"|"!!null")
+      ;;
+    *)
+      err "substitutions: must be a map (got $SUBS_TYPE)"
+      VIOLATIONS=$((VIOLATIONS + 1))
+      SUBS_TYPE="!!null"
+      ;;
+  esac
   SUBS_COUNT=$(yq eval '.substitutions | length // 0' "$OVERRIDES_FILE" 2>/dev/null || echo "0")
-  if [ "$SUBS_COUNT" -gt 0 ]; then
+  if [ "$SUBS_TYPE" = "!!map" ] && [ "$SUBS_COUNT" -gt 0 ]; then
     # Collect the set of substitution markers declared by the manifest's
     # templated paths. v1 manifest has only canonical + kit types so
     # this set is empty until templated lands; the validator then

--- a/scripts/sync/validate-overrides.sh
+++ b/scripts/sync/validate-overrides.sh
@@ -141,9 +141,18 @@ for k in "${TOP_KEYS[@]:-}"; do
   fi
 done
 
-# --- Rule 3: version, if present, must match -----------------------
+# --- Rule 3: version is required and must match -----------------------
+# Schema-version is required on any non-empty overrides document so a
+# downstream consumer's file declares an unambiguous schema contract
+# from the start. (Empty/null-root documents already exited at Rule 1b.)
+# CodeRabbit ⚠️ Major on PR #228 round 4 caught the gap — previously
+# version was only validated WHEN present, so a non-empty file omitting
+# it would silently pass.
 HAS_VERSION=$(yq eval 'has("version")' "$OVERRIDES_FILE" 2>/dev/null || echo "false")
-if [ "$HAS_VERSION" = "true" ]; then
+if [ "$HAS_VERSION" != "true" ]; then
+  err "missing required top-level key: version (expected $SUPPORTED_OVERRIDE_VERSION)"
+  VIOLATIONS=$((VIOLATIONS + 1))
+else
   V=$(yq eval '.version' "$OVERRIDES_FILE" 2>/dev/null)
   if [ "$V" != "$SUPPORTED_OVERRIDE_VERSION" ]; then
     err "version $V not supported by this validator (expected $SUPPORTED_OVERRIDE_VERSION)"
@@ -286,10 +295,19 @@ if [ "$HAS_SUBS" = "true" ]; then
         continue
       fi
       ENTRY_VALUE_PRESENT=$(YQ_K="$k" yq eval '.substitutions[strenv(YQ_K)] | has("value")' "$OVERRIDES_FILE" 2>/dev/null || echo "false")
+      ENTRY_VALUE_RAW=$(YQ_K="$k" yq eval '.substitutions[strenv(YQ_K)].value // ""' "$OVERRIDES_FILE" 2>/dev/null || echo "")
+      ENTRY_VALUE_TRIMMED=$(printf '%s' "$ENTRY_VALUE_RAW" | tr -d '[:space:]')
       ENTRY_REASON_RAW=$(YQ_K="$k" yq eval '.substitutions[strenv(YQ_K)].reason // ""' "$OVERRIDES_FILE" 2>/dev/null || echo "")
       ENTRY_REASON_TRIMMED=$(printf '%s' "$ENTRY_REASON_RAW" | tr -d '[:space:]')
       if [ "$ENTRY_VALUE_PRESENT" != "true" ]; then
         err "substitutions.$k: missing 'value' field"
+        VIOLATIONS=$((VIOLATIONS + 1))
+      elif [ -z "$ENTRY_VALUE_TRIMMED" ]; then
+        # Present-but-empty value (null, "", or whitespace) — the
+        # `{value, reason}` contract requires non-empty value. CodeRabbit
+        # ⚠️ Major on PR #228 round 4 caught the gap; the prior shape
+        # accepted `value: null` / `value: ""`.
+        err "substitutions.$k: missing or empty 'value' field"
         VIOLATIONS=$((VIOLATIONS + 1))
       fi
       if [ -z "$ENTRY_REASON_TRIMMED" ]; then

--- a/tests/test_sync_overrides.sh
+++ b/tests/test_sync_overrides.sh
@@ -412,6 +412,100 @@ else
   fail "substitution without value should be rejected; got: $out"
 fi
 
+# Test 26: substitution entry with `value: null` → fail (Rule 7
+# extension; CodeRabbit ⚠️ Major round 4 caught that null/empty
+# values were allowed even though the {value, reason} contract says
+# non-empty).
+null_value_sub="$WORKDIR/null-value-sub.yml"
+cat >"$null_value_sub" <<'YAML'
+version: 1
+substitutions:
+  phase_4b_default:
+    value: null
+    reason: oops, forgot the actual value
+YAML
+out=$("$VALIDATOR" "$null_value_sub" "$MANIFEST" 2>&1 || true)
+if echo "$out" | grep -q "missing or empty 'value' field"; then
+  pass "substitution with value: null → rejected"
+else
+  fail "substitution with null value should be rejected; got: $out"
+fi
+
+# Test 27: substitution entry with `value: ""` → fail.
+empty_value_sub="$WORKDIR/empty-value-sub.yml"
+cat >"$empty_value_sub" <<'YAML'
+version: 1
+substitutions:
+  phase_4b_default:
+    value: ""
+    reason: ditto, but with explicit empty string
+YAML
+out=$("$VALIDATOR" "$empty_value_sub" "$MANIFEST" 2>&1 || true)
+if echo "$out" | grep -q "missing or empty 'value' field"; then
+  pass "substitution with value: \"\" → rejected"
+else
+  fail "substitution with empty value should be rejected; got: $out"
+fi
+
+# Test 28: substitution entry with whitespace-only `value` → fail.
+ws_value_sub="$WORKDIR/ws-value-sub.yml"
+cat >"$ws_value_sub" <<'YAML'
+version: 1
+substitutions:
+  phase_4b_default:
+    value: "   "
+    reason: whitespace value
+YAML
+out=$("$VALIDATOR" "$ws_value_sub" "$MANIFEST" 2>&1 || true)
+if echo "$out" | grep -q "missing or empty 'value' field"; then
+  pass "substitution with whitespace-only value → rejected"
+else
+  fail "substitution with whitespace value should be rejected; got: $out"
+fi
+
+# Test 29: non-empty overrides file missing `version` → fail (Rule 3
+# now requires version on any non-empty document; CodeRabbit ⚠️ Major
+# round 4).
+no_version="$WORKDIR/no-version.yml"
+cat >"$no_version" <<'YAML'
+skip_paths: []
+YAML
+out=$("$VALIDATOR" "$no_version" "$MANIFEST" 2>&1 || true)
+if echo "$out" | grep -q "missing required top-level key: version"; then
+  pass "non-empty file without version → rejected"
+else
+  fail "missing version should be rejected; got: $out"
+fi
+
+# Test 30: apply-overrides.sh treats null/empty .value as "no override"
+# (returns non-zero), so callers fall back to the manifest default
+# rather than propagating a literal null. CodeRabbit ⚠️ Major round 4.
+null_value_apply="$WORKDIR/null-value-apply.yml"
+cat >"$null_value_apply" <<'YAML'
+substitutions:
+  phase_4b_default:
+    value: null
+    reason: shouldn't propagate
+YAML
+if override_substitution_for "$null_value_apply" "phase_4b_default" >/dev/null 2>&1; then
+  fail "override_substitution_for should return non-zero for null value"
+else
+  pass "override_substitution_for treats null .value as no override"
+fi
+
+empty_value_apply="$WORKDIR/empty-value-apply.yml"
+cat >"$empty_value_apply" <<'YAML'
+substitutions:
+  phase_4b_default:
+    value: ""
+    reason: empty string shouldn't propagate either
+YAML
+if override_substitution_for "$empty_value_apply" "phase_4b_default" >/dev/null 2>&1; then
+  fail "override_substitution_for should return non-zero for empty value"
+else
+  pass "override_substitution_for treats empty .value as no override"
+fi
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_overrides.sh
+++ b/tests/test_sync_overrides.sh
@@ -86,7 +86,11 @@ skip_paths:
       This repo replaced keep-in-sync with a custom variant.
       Tracked in repo#42 for eventual convergence.
 substitutions:
-  phase_4b_default: fallback-only
+  phase_4b_default:
+    value: fallback-only
+    reason: |
+      Deploy frequency is high (~5 PRs/day); always-on phase-4b
+      routing latency outweighs the safety benefit on this repo.
 YAML
 if "$VALIDATOR" "$good" "$MANIFEST" >/dev/null 2>&1; then
   pass "well-formed overrides → exits 0"
@@ -232,10 +236,14 @@ else
 fi
 
 # Test 11: override_substitution_for returns 0 + value when key exists.
+# Structured shape per the round 2 schema change (#228) — entries are
+# `{value, reason}` maps, helper returns the .value field only.
 sub_override="$WORKDIR/helper-sub.yml"
 cat >"$sub_override" <<'YAML'
 substitutions:
-  phase_4b_default: fallback-only
+  phase_4b_default:
+    value: fallback-only
+    reason: test fixture
 YAML
 if val=$(override_substitution_for "$sub_override" "phase_4b_default") \
    && [ "$val" = "fallback-only" ]; then
@@ -335,13 +343,73 @@ fi
 specialchar_subs="$WORKDIR/specialchar.yml"
 cat >"$specialchar_subs" <<'YAML'
 substitutions:
-  phase-4b.default: fallback-only
+  phase-4b.default:
+    value: fallback-only
+    reason: test
 YAML
 if val=$(override_substitution_for "$specialchar_subs" "phase-4b.default") \
    && [ "$val" = "fallback-only" ]; then
   pass "override_substitution_for handles special-char marker name (-, .)"
 else
   fail "override_substitution_for failed on special-char marker (got '$val')"
+fi
+
+# Test 22: bare-scalar substitution → fail validation (the schema-contract
+# fix from #228 round 2; nathanpayne-codex caught that the old shape
+# `marker: value` shipped without an audit-trail reason).
+bare_sub="$WORKDIR/bare-sub.yml"
+cat >"$bare_sub" <<'YAML'
+substitutions:
+  phase_4b_default: fallback-only
+YAML
+out=$("$VALIDATOR" "$bare_sub" "$MANIFEST" 2>&1 || true)
+if echo "$out" | grep -q "must be a map with 'value' and 'reason'"; then
+  pass "bare-scalar substitution → rejected with clear diagnostic"
+else
+  fail "bare-scalar substitution should be rejected; got: $out"
+fi
+
+# Test 23: substitution entry with `value` but no `reason` → fail.
+no_reason_sub="$WORKDIR/no-reason-sub.yml"
+cat >"$no_reason_sub" <<'YAML'
+substitutions:
+  phase_4b_default:
+    value: fallback-only
+YAML
+out=$("$VALIDATOR" "$no_reason_sub" "$MANIFEST" 2>&1 || true)
+if echo "$out" | grep -q "missing or empty 'reason' field"; then
+  pass "substitution without reason → rejected"
+else
+  fail "substitution without reason should be rejected; got: $out"
+fi
+
+# Test 24: substitution entry with empty (whitespace) reason → fail.
+ws_reason_sub="$WORKDIR/ws-reason-sub.yml"
+cat >"$ws_reason_sub" <<'YAML'
+substitutions:
+  phase_4b_default:
+    value: fallback-only
+    reason: "   "
+YAML
+out=$("$VALIDATOR" "$ws_reason_sub" "$MANIFEST" 2>&1 || true)
+if echo "$out" | grep -q "missing or empty 'reason' field"; then
+  pass "substitution with whitespace-only reason → rejected"
+else
+  fail "substitution with whitespace reason should be rejected; got: $out"
+fi
+
+# Test 25: substitution entry with `reason` but no `value` → fail.
+no_value_sub="$WORKDIR/no-value-sub.yml"
+cat >"$no_value_sub" <<'YAML'
+substitutions:
+  phase_4b_default:
+    reason: forgot the value field
+YAML
+out=$("$VALIDATOR" "$no_value_sub" "$MANIFEST" 2>&1 || true)
+if echo "$out" | grep -q "missing 'value' field"; then
+  pass "substitution without value → rejected"
+else
+  fail "substitution without value should be rejected; got: $out"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_overrides.sh
+++ b/tests/test_sync_overrides.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# tests/test_sync_overrides.sh
+#
+# Unit tests for scripts/sync/validate-overrides.sh and
+# scripts/sync/apply-overrides.sh. Builds a synthetic manifest +
+# overrides files in a tempdir, exercises each rule + helper.
+#
+# Requires: yq (mikefarah/yq v4+), bash 4+. Run manually or from
+# scripts/ci/check_sync_overrides.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATOR="$ROOT/scripts/sync/validate-overrides.sh"
+APPLY_LIB="$ROOT/scripts/sync/apply-overrides.sh"
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "SKIP: yq not installed (brew install yq)" >&2
+  exit 0
+fi
+if ! yq --version 2>&1 | grep -q "mikefarah/yq"; then
+  echo "SKIP: detected non-mikefarah yq" >&2
+  exit 0
+fi
+
+[[ -x "$VALIDATOR" ]] || { echo "missing or non-executable $VALIDATOR" >&2; exit 1; }
+[[ -f "$APPLY_LIB" ]] || { echo "missing $APPLY_LIB" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d -t sync-overrides-test)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+
+# ---------------------------------------------------------------------------
+# Synthetic manifest with two canonical paths, one kit, and one templated
+# path with two substitution markers (the templated entry exercises the
+# substitutions validation; v1 manifest doesn't yet declare templated
+# paths but the validator must support them when they land).
+# ---------------------------------------------------------------------------
+MANIFEST="$WORKDIR/.mergepath-sync.yml"
+cat >"$MANIFEST" <<'YAML'
+version: 1
+consumers:
+  - {name: alpha, repo: example/alpha}
+paths:
+  - {path: scripts/keep-in-sync.sh,    type: canonical, consumers: all}
+  - {path: scripts/hooks/the-hook.sh,  type: canonical, consumers: all}
+  - {path: scripts/ci/,                type: kit,       consumers: all}
+  - path: AGENTS.md
+    type: templated
+    consumers: all
+    substitutions:
+      phase_4b_default: complex-changes
+      author_identity: nathanjohnpayne
+YAML
+
+# ---------------------------------------------------------------------------
+# Test 1: absent overrides file → pass (the "no divergences" common case).
+# ---------------------------------------------------------------------------
+absent_dir="$WORKDIR/absent"
+mkdir -p "$absent_dir"
+cd "$absent_dir"
+if "$VALIDATOR" "$absent_dir/.sync-overrides.yml" "$MANIFEST" >/dev/null 2>&1; then
+  pass "absent overrides file → exits 0"
+else
+  fail "absent overrides file should pass; validator returned non-zero"
+fi
+cd "$ROOT"
+
+# ---------------------------------------------------------------------------
+# Test 2: well-formed overrides with skip + substitution → pass.
+# ---------------------------------------------------------------------------
+good="$WORKDIR/good.yml"
+cat >"$good" <<'YAML'
+version: 1
+skip_paths:
+  - path: scripts/keep-in-sync.sh
+    reason: |
+      This repo replaced keep-in-sync with a custom variant.
+      Tracked in repo#42 for eventual convergence.
+substitutions:
+  phase_4b_default: fallback-only
+YAML
+if "$VALIDATOR" "$good" "$MANIFEST" >/dev/null 2>&1; then
+  pass "well-formed overrides → exits 0"
+else
+  out=$("$VALIDATOR" "$good" "$MANIFEST" 2>&1 || true)
+  fail "well-formed overrides should pass; got: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: skip_paths entry with empty reason → fail (audit-trail).
+# ---------------------------------------------------------------------------
+empty_reason="$WORKDIR/empty-reason.yml"
+cat >"$empty_reason" <<'YAML'
+skip_paths:
+  - path: scripts/keep-in-sync.sh
+    reason: ""
+YAML
+if "$VALIDATOR" "$empty_reason" "$MANIFEST" >/dev/null 2>&1; then
+  fail "empty reason should fail validation; validator passed"
+else
+  pass "empty reason → exits non-zero"
+fi
+
+# Whitespace-only reason — should also fail.
+ws_reason="$WORKDIR/ws-reason.yml"
+cat >"$ws_reason" <<'YAML'
+skip_paths:
+  - path: scripts/keep-in-sync.sh
+    reason: "   "
+YAML
+if "$VALIDATOR" "$ws_reason" "$MANIFEST" >/dev/null 2>&1; then
+  fail "whitespace-only reason should fail; validator passed"
+else
+  pass "whitespace-only reason → exits non-zero"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: skip_paths references nonexistent manifest path → fail.
+# ---------------------------------------------------------------------------
+bad_path="$WORKDIR/bad-path.yml"
+cat >"$bad_path" <<'YAML'
+skip_paths:
+  - path: scripts/does-not-exist.sh
+    reason: legitimate-looking reason
+YAML
+if "$VALIDATOR" "$bad_path" "$MANIFEST" >/dev/null 2>&1; then
+  fail "nonexistent skip path should fail; validator passed"
+else
+  pass "nonexistent skip path → exits non-zero"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: substitution references nonexistent marker → fail.
+# ---------------------------------------------------------------------------
+bad_sub="$WORKDIR/bad-sub.yml"
+cat >"$bad_sub" <<'YAML'
+substitutions:
+  marker_that_isnt_in_manifest: any-value
+YAML
+if "$VALIDATOR" "$bad_sub" "$MANIFEST" >/dev/null 2>&1; then
+  fail "nonexistent substitution marker should fail; validator passed"
+else
+  pass "nonexistent substitution marker → exits non-zero"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: unknown top-level key → fail.
+# ---------------------------------------------------------------------------
+unknown_key="$WORKDIR/unknown-key.yml"
+cat >"$unknown_key" <<'YAML'
+skip_paths: []
+unknown_field: oops
+YAML
+if "$VALIDATOR" "$unknown_key" "$MANIFEST" >/dev/null 2>&1; then
+  fail "unknown top-level key should fail; validator passed"
+else
+  pass "unknown top-level key → exits non-zero"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: malformed YAML → fail.
+# ---------------------------------------------------------------------------
+malformed="$WORKDIR/malformed.yml"
+cat >"$malformed" <<'YAML'
+skip_paths:
+  - path: scripts/keep-in-sync.sh
+   reason: bad indentation
+   extra: -
+YAML
+if "$VALIDATOR" "$malformed" "$MANIFEST" >/dev/null 2>&1; then
+  fail "malformed YAML should fail; validator passed"
+else
+  pass "malformed YAML → exits non-zero"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: unsupported version → fail.
+# ---------------------------------------------------------------------------
+bad_version="$WORKDIR/bad-version.yml"
+cat >"$bad_version" <<'YAML'
+version: 999
+skip_paths: []
+YAML
+if "$VALIDATOR" "$bad_version" "$MANIFEST" >/dev/null 2>&1; then
+  fail "unsupported version should fail; validator passed"
+else
+  pass "unsupported version → exits non-zero"
+fi
+
+# ---------------------------------------------------------------------------
+# apply-overrides.sh helper tests
+# ---------------------------------------------------------------------------
+# shellcheck source=../scripts/sync/apply-overrides.sh
+. "$APPLY_LIB"
+
+# Test 9: override_should_skip_path on a matching entry returns 0 with
+# OVERRIDE_SKIP_REASON populated.
+helper_override="$WORKDIR/helper-good.yml"
+cat >"$helper_override" <<'YAML'
+skip_paths:
+  - path: scripts/keep-in-sync.sh
+    reason: example skip
+YAML
+OVERRIDE_SKIP_REASON=""
+if override_should_skip_path "$helper_override" "scripts/keep-in-sync.sh" \
+   && [ "$OVERRIDE_SKIP_REASON" = "example skip" ]; then
+  pass "override_should_skip_path matches and stores reason"
+else
+  fail "override_should_skip_path failed to match (reason=$OVERRIDE_SKIP_REASON)"
+fi
+
+# Test 10: override_should_skip_path on a non-matching path returns
+# non-zero and clears OVERRIDE_SKIP_REASON.
+OVERRIDE_SKIP_REASON="lingering"
+if override_should_skip_path "$helper_override" "scripts/some-other.sh"; then
+  fail "override_should_skip_path matched on non-listed path"
+else
+  if [ -z "$OVERRIDE_SKIP_REASON" ]; then
+    pass "override_should_skip_path clears reason on miss"
+  else
+    fail "override_should_skip_path did not clear OVERRIDE_SKIP_REASON on miss"
+  fi
+fi
+
+# Test 11: override_substitution_for returns 0 + value when key exists.
+sub_override="$WORKDIR/helper-sub.yml"
+cat >"$sub_override" <<'YAML'
+substitutions:
+  phase_4b_default: fallback-only
+YAML
+val=$(override_substitution_for "$sub_override" "phase_4b_default") \
+  && [ "$val" = "fallback-only" ] \
+  && pass "override_substitution_for returns override value" \
+  || fail "override_substitution_for didn't return expected value (got '$val')"
+
+# Test 12: override_substitution_for returns non-zero when key absent
+# (caller falls back to manifest default).
+if override_substitution_for "$sub_override" "missing_marker" >/dev/null 2>&1; then
+  fail "override_substitution_for returned 0 for missing marker"
+else
+  pass "override_substitution_for returns non-zero for missing marker"
+fi
+
+# Test 13: helpers tolerate absent overrides file (return non-zero,
+# don't abort the caller).
+if override_should_skip_path "" "scripts/keep-in-sync.sh"; then
+  fail "override_should_skip_path matched against empty file path"
+else
+  pass "override_should_skip_path tolerates empty file path"
+fi
+if override_substitution_for "/nonexistent/.sync-overrides.yml" "phase_4b_default" >/dev/null 2>&1; then
+  fail "override_substitution_for matched against absent file"
+else
+  pass "override_substitution_for tolerates absent file"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "test_sync_overrides: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test_sync_overrides.sh
+++ b/tests/test_sync_overrides.sh
@@ -289,9 +289,47 @@ else
   fail "scalar skip_paths did not produce expected diagnostic; got: $out"
 fi
 
-# Test 16: marker name with special characters (`-`, `.`) — the
-# apply-overrides.sh helpers must look it up via strenv-bracket, not
-# yq's dot-path syntax. Round 1 CodeRabbit ⚠️ Major caught the bug.
+# Test 18: scalar at document root → fail validation cleanly.
+# CodeRabbit ⚠️ Major round 2 caught: without a root-type guard,
+# a top-level scalar passes silently because yq's `keys | .[]`
+# returns nothing on non-map roots and rules 2-6 no-op.
+scalar_root="$WORKDIR/scalar-root.yml"
+cat >"$scalar_root" <<'YAML'
+"not-a-map"
+YAML
+out=$("$VALIDATOR" "$scalar_root" "$MANIFEST" 2>&1 || true)
+if echo "$out" | grep -q "document root must be a map"; then
+  pass "scalar root → clean diagnostic, not a silent pass"
+else
+  fail "scalar root did not produce expected diagnostic; got: $out"
+fi
+
+# Sequence at document root → also fail.
+seq_root="$WORKDIR/seq-root.yml"
+cat >"$seq_root" <<'YAML'
+- entry-one
+- entry-two
+YAML
+out=$("$VALIDATOR" "$seq_root" "$MANIFEST" 2>&1 || true)
+if echo "$out" | grep -q "document root must be a map"; then
+  pass "sequence root → clean diagnostic"
+else
+  fail "sequence root did not produce expected diagnostic; got: $out"
+fi
+
+# Empty / null root → pass (empty file is the "no overrides" case).
+null_root="$WORKDIR/null-root.yml"
+echo "" >"$null_root"
+if "$VALIDATOR" "$null_root" "$MANIFEST" >/dev/null 2>&1; then
+  pass "empty document root → exits 0 (no overrides)"
+else
+  fail "empty document root should pass; validator returned non-zero"
+fi
+
+# Test 16 (renumbered to keep stable counts): marker name with special
+# characters (`-`, `.`) — the apply-overrides.sh helpers must look it
+# up via strenv-bracket, not yq's dot-path syntax. Round 1 CodeRabbit
+# ⚠️ Major caught the bug.
 specialchar_subs="$WORKDIR/specialchar.yml"
 cat >"$specialchar_subs" <<'YAML'
 substitutions:

--- a/tests/test_sync_overrides.sh
+++ b/tests/test_sync_overrides.sh
@@ -26,7 +26,11 @@ fi
 [[ -x "$VALIDATOR" ]] || { echo "missing or non-executable $VALIDATOR" >&2; exit 1; }
 [[ -f "$APPLY_LIB" ]] || { echo "missing $APPLY_LIB" >&2; exit 1; }
 
-WORKDIR="$(mktemp -d -t sync-overrides-test)"
+# Use the explicit `$TMPDIR/<prefix>.XXXXXX` form for cross-platform
+# portability — `mktemp -d -t literal-prefix` is BSD-specific and
+# behaves differently on GNU/Linux (CodeRabbit ⚠️ Major on PR #228;
+# same defense matchline applied to test_sync_to_downstream.sh in #217).
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/sync-overrides-test.XXXXXX")"
 trap 'rm -rf "$WORKDIR"' EXIT
 
 PASS=0
@@ -258,6 +262,45 @@ if override_substitution_for "/nonexistent/.sync-overrides.yml" "phase_4b_defaul
 else
   pass "override_substitution_for tolerates absent file"
 fi
+
+# Test 14: substitutions as a scalar (not a map) → fail validation,
+# don't crash. CodeRabbit ⚠️ Major round 1 caught the underlying
+# bug — yq's `length` aborts on scalar values.
+scalar_subs="$WORKDIR/scalar-subs.yml"
+cat >"$scalar_subs" <<'YAML'
+substitutions: "this is a scalar, not a map"
+YAML
+out=$("$VALIDATOR" "$scalar_subs" "$MANIFEST" 2>&1 || true)
+if echo "$out" | grep -q "must be a map"; then
+  pass "scalar substitutions → clean diagnostic, not a crash"
+else
+  fail "scalar substitutions did not produce expected diagnostic; got: $out"
+fi
+
+# Test 15: skip_paths as a scalar → fail validation cleanly.
+scalar_skip="$WORKDIR/scalar-skip.yml"
+cat >"$scalar_skip" <<'YAML'
+skip_paths: "scalar instead of sequence"
+YAML
+out=$("$VALIDATOR" "$scalar_skip" "$MANIFEST" 2>&1 || true)
+if echo "$out" | grep -q "must be a sequence"; then
+  pass "scalar skip_paths → clean diagnostic, not a crash"
+else
+  fail "scalar skip_paths did not produce expected diagnostic; got: $out"
+fi
+
+# Test 16: marker name with special characters (`-`, `.`) — the
+# apply-overrides.sh helpers must look it up via strenv-bracket, not
+# yq's dot-path syntax. Round 1 CodeRabbit ⚠️ Major caught the bug.
+specialchar_subs="$WORKDIR/specialchar.yml"
+cat >"$specialchar_subs" <<'YAML'
+substitutions:
+  phase-4b.default: fallback-only
+YAML
+val=$(override_substitution_for "$specialchar_subs" "phase-4b.default") \
+  && [ "$val" = "fallback-only" ] \
+  && pass "override_substitution_for handles special-char marker name (-, .)" \
+  || fail "override_substitution_for failed on special-char marker (got '$val')"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/test_sync_overrides.sh
+++ b/tests/test_sync_overrides.sh
@@ -237,10 +237,12 @@ cat >"$sub_override" <<'YAML'
 substitutions:
   phase_4b_default: fallback-only
 YAML
-val=$(override_substitution_for "$sub_override" "phase_4b_default") \
-  && [ "$val" = "fallback-only" ] \
-  && pass "override_substitution_for returns override value" \
-  || fail "override_substitution_for didn't return expected value (got '$val')"
+if val=$(override_substitution_for "$sub_override" "phase_4b_default") \
+   && [ "$val" = "fallback-only" ]; then
+  pass "override_substitution_for returns override value"
+else
+  fail "override_substitution_for didn't return expected value (got '$val')"
+fi
 
 # Test 12: override_substitution_for returns non-zero when key absent
 # (caller falls back to manifest default).
@@ -335,10 +337,12 @@ cat >"$specialchar_subs" <<'YAML'
 substitutions:
   phase-4b.default: fallback-only
 YAML
-val=$(override_substitution_for "$specialchar_subs" "phase-4b.default") \
-  && [ "$val" = "fallback-only" ] \
-  && pass "override_substitution_for handles special-char marker name (-, .)" \
-  || fail "override_substitution_for failed on special-char marker (got '$val')"
+if val=$(override_substitution_for "$specialchar_subs" "phase-4b.default") \
+   && [ "$val" = "fallback-only" ]; then
+  pass "override_substitution_for handles special-char marker name (-, .)"
+else
+  fail "override_substitution_for failed on special-char marker (got '$val')"
+fi
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
Authoring-Agent: claude

Closes #200 (sub-C of #168). Ships the per-repo override mechanism — the third leg of the sync-to-downstream propagation system after the manifest (#198, landed via PR #215) and the main script (#199, in progress).

## Why this exists

Without an override mechanism, the propagation script either silently overwrites legitimate per-repo divergence (data loss) or has to abort whenever it detects a difference (which makes the script useless on any non-trivial consumer). `.sync-overrides.yml` resolves that by giving each consumer a documented escape hatch — every override carries a `reason` field, so drift without a paper trail is the failure mode the schema exists to prevent.

## What's in this PR

| File | Purpose |
|---|---|
| `scripts/sync/validate-overrides.sh` | Schema validator. Six rules (YAML well-formed, allowed top-level keys, version match, manifest-declared skip paths, non-empty `reason`, manifest-declared substitution markers). Absent file → pass. Bash 3.2 compatible. |
| `scripts/sync/apply-overrides.sh` | Application library sourced by #199 sub-B's main propagation flow. Two helpers: `override_should_skip_path` (sets `OVERRIDE_SKIP_REASON` for caller logging when matched) and `override_substitution_for` (writes override value to stdout when key exists; non-zero return tells caller to use manifest default). Both read-only, tolerant of absent / malformed files. |
| `examples/.sync-overrides.yml` | Annotated empty template. Copied into new repos by the bootstrap wizard (#156, when it ships) or manually by maintainers introducing their first divergence. |
| `docs/sync-overrides.md` | Per-repo overrides documentation. Schema, validation rules, three worked examples (no-divergence baseline, Cloud-Run-vs-Firebase skip, Phase-4b knob override), add/remove workflow, helper API. |
| `tests/test_sync_overrides.sh` | 15 test cases covering validator paths (well-formed, empty/whitespace reason, nonexistent skip path, nonexistent substitution marker, unknown top-level key, malformed YAML, unsupported version, absent file) plus apply-overrides helper paths (matching/non-matching skip, substitution hit/miss, absent-file tolerance). All 15 pass. |
| `scripts/ci/check_sync_overrides` | repo_lint entry point wrapping the test fixture, mirroring the existing `check_*` pattern. |

## Schema (recap)

```yaml
version: 1

skip_paths:
  - path: <path-from-manifest>   # must match a paths[].path in .mergepath-sync.yml
    reason: <non-empty rationale; multi-line allowed>

substitutions:
  <marker-name>: <override-value>  # must match a marker declared by a templated manifest path
```

## Verification

- `bash tests/test_sync_overrides.sh` → **15 passed, 0 failed.**
- All `scripts/ci/check_*` (13 total) pass against the new state.
- `bash -n` clean on all new scripts.

## Out of scope (per #168 sub-issue split)

- **Manifest spec** — already shipped via #198 / PR #215.
- **Main propagation script integration** — see #168 sub-B / [#199](https://github.com/nathanjohnpayne/mergepath/issues/199); this PR ships the library that sub-B will source via `. \"$MERGEPATH_ROOT/scripts/sync/apply-overrides.sh\"`.
- **`--audit` drift detection** — already shipped via #201 / PR #215.
- **Initial `.sync-overrides.yml` for the 7 existing downstream consumers** — #200 calls these out as separate follow-up PRs filed against each consumer repo; not in this PR.

## Net diff

+812 / -0 across 6 new files. Substantial — but the bulk is the test fixture (340 lines), the validator (170 lines), and the doc (180 lines). The library + entry point + example are short. PR exceeds `external_review_threshold` (300) so Phase 4 external review applies.

## Self-Review

**Correctness.** The validator's six rules map 1:1 to the issue's acceptance criteria. The substitutions rule is intentionally strict — v1 manifest has no `type: templated` paths, so any non-empty `substitutions:` content fails validation today. That's correct: the validator picks up new templated paths automatically once they land in the manifest, with no code change needed here. Apply-helper return codes are designed for the natural `if override_value=$(override_substitution_for ...); then ...; else ...; fi` pattern in sub-B's main flow.

**Regression risk.** All-new files. No existing scripts are modified. The new `examples/` and `scripts/sync/` directories are checked against `check_no_forbidden_top_level_dirs` — passes (existing allowlist already permits these patterns). Bash 3.2 compatibility is verified locally on macOS's default bash; the original `mapfile` calls were replaced with portable `while IFS= read -r ... done < <(...)` so the validator runs on every consumer regardless of bash version.

**Style.** Followed the heavy-comment convention from existing `scripts/sync-to-downstream.sh` (rationale + design notes + issue refs inline). The validator and library each have a clear top-of-file usage block. The test fixture mirrors the structure of `tests/test_sync_to_downstream.sh` (synthetic fixtures in tempdirs, per-test pass/fail tally).

**Test coverage.** 15 cases ≥ the issue's ≥5 requirement. Each validation rule has at least one positive (passes) and one negative (fails) test. Helper API has matched/unmatched cases plus absent-file tolerance. Edge cases covered: whitespace-only `reason`, malformed YAML, unsupported version, empty file path.

**Security / dependency hygiene.** No new dependencies (yq is already required by `sync-to-downstream.sh`). Validator + library are read-only. The library defensively returns non-zero on parse errors rather than crashing the caller — over-propagation is safer than silent skips on a malformed override file.

## Test plan

- [x] `bash tests/test_sync_overrides.sh` → 15/15 pass.
- [x] All `scripts/ci/check_*` pass.
- [x] Validator handles bash 3.2 (macOS default).
- [ ] Once merged, the bootstrap wizard (#156) and #199 sub-B can consume the library + example template without further changes here. Real consumers add their own `.sync-overrides.yml` as separate follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)