### PR TITLE
fix(pr-audit): exempt mergepath-sync/* propagation PRs from external-review check (#229)

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -149,18 +149,51 @@ jobs:
 
               // Exemption (#229): PRs opened by `scripts/sync-to-downstream.sh`
               // propagate already-reviewed mergepath commits to downstream
-              // consumers. The head branch namespace `mergepath-sync/*` is
-              // owned by the sync script and never used for human-authored
-              // work; the PR title carries `(mergepath@<sha>)` as a second
-              // confirming signal. Re-reviewing a propagation PR on each
-              // consumer is redundant (the upstream commit was reviewed in
-              // mergepath itself), so the audit's external-review violation
-              // check is skipped for these PRs. Dependabot's separate rule
+              // consumers. Re-reviewing a propagation PR on each consumer
+              // is redundant (the upstream commit was reviewed in mergepath
+              // itself), so the audit's external-review violation check is
+              // skipped for these PRs. Dependabot's separate rule
               // (cliApprovedReviews) is unaffected.
-              const isMergepathSyncPR =
+              //
+              // Four guards, all required, defending against spoofing
+              // (CodeRabbit ⚠️ Major on PR #230 round 1 — naming alone is
+              // not a trusted-provenance signal):
+              //
+              //   1. PR author == author_identity from review-policy.yml
+              //      (typically `nathanjohnpayne`). The propagation script
+              //      runs under that identity per CLAUDE.md's active-account
+              //      convention; a PR from any other login isn't from the
+              //      sync flow.
+              //   2. Head ref comes from the same repo (not a fork). Forks
+              //      can't impersonate the propagation flow because the
+              //      sync script pushes directly to the consumer repo's
+              //      own `mergepath-sync/*` namespace.
+              //   3. Head branch namespace `mergepath-sync/*` — owned by
+              //      the sync script's branch-naming convention
+              //      (`mergepath-sync/<short-sha>`) and never used for
+              //      hand-authored work.
+              //   4. PR title matches `(mergepath@[0-9a-f]{7,40})` — the
+              //      canonical title format the sync script emits,
+              //      identifying the upstream commit.
+              //
+              // Hand-creating all four signals at once is possible but is
+              // an explicit, traceable action that would surface during
+              // self-review.
+              const isTrustedSyncAuthor =
+                pr.user && pr.user.login === authorIdentity;
+              const isSameRepoHead =
+                pr.head && pr.head.repo &&
+                pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+              const hasSyncBranchName =
                 pr.head && pr.head.ref &&
-                pr.head.ref.startsWith('mergepath-sync/') &&
+                pr.head.ref.startsWith('mergepath-sync/');
+              const hasMergepathMarker =
                 /\(mergepath@[0-9a-f]{7,40}\)/.test(pr.title || '');
+              const isMergepathSyncPR =
+                isTrustedSyncAuthor &&
+                isSameRepoHead &&
+                hasSyncBranchName &&
+                hasMergepathMarker;
 
               if (hadExternalLabel || dependabotNeedsApproval) {
                 // For the external-review path we accept either:

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -147,6 +147,21 @@ jobs:
               );
               const dependabotNeedsApproval = isDependabot;
 
+              // Exemption (#229): PRs opened by `scripts/sync-to-downstream.sh`
+              // propagate already-reviewed mergepath commits to downstream
+              // consumers. The head branch namespace `mergepath-sync/*` is
+              // owned by the sync script and never used for human-authored
+              // work; the PR title carries `(mergepath@<sha>)` as a second
+              // confirming signal. Re-reviewing a propagation PR on each
+              // consumer is redundant (the upstream commit was reviewed in
+              // mergepath itself), so the audit's external-review violation
+              // check is skipped for these PRs. Dependabot's separate rule
+              // (cliApprovedReviews) is unaffected.
+              const isMergepathSyncPR =
+                pr.head && pr.head.ref &&
+                pr.head.ref.startsWith('mergepath-sync/') &&
+                /\(mergepath@[0-9a-f]{7,40}\)/.test(pr.title || '');
+
               if (hadExternalLabel || dependabotNeedsApproval) {
                 // For the external-review path we accept either:
                 //   - an APPROVED review from a CLI reviewer identity
@@ -178,7 +193,8 @@ jobs:
 
                 if (hadExternalLabel &&
                     cliApprovedReviews.length === 0 &&
-                    codexBotReviews.length === 0) {
+                    codexBotReviews.length === 0 &&
+                    !isMergepathSyncPR) {
                   prViolations.push(
                     'External-review PR merged with no APPROVED review from a CLI reviewer identity and no review from the Codex bot'
                   );


### PR DESCRIPTION
Authoring-Agent: claude

Closes #229. Option 1 from the issue's three-option list (recommended): audit-side exemption keyed on the `mergepath-sync/*` head-branch namespace, double-gated by the PR title's `(mergepath@<sha>)` signature.

## Why

Every PR opened by `scripts/sync-to-downstream.sh` propagates an already-reviewed mergepath commit to each downstream consumer. When that commit touches `.github/workflows/*.yml` (the most common propagation case), each downstream's `external_review_paths: '.github/**'` auto-applies `needs-external-review`. The human then merges without re-reviewing on each consumer — it's already reviewed in mergepath — and `pr-audit.yml` flags the merge as a policy violation.

Last week's audit caught the pattern across 7 of 8 consumer repos on the same propagation PR. The list of consumer-side audit issues is in #229. It's not a real review gap: propagation is verbatim file copy + documented substitution, and re-reviewing per-repo wouldn't catch anything fresh.

## What the patch does

Inside `pr-audit.yml`'s Check 2 (external-review approval), add a two-condition guard that exempts propagation PRs:

```javascript
const isMergepathSyncPR =
  pr.head && pr.head.ref &&
  pr.head.ref.startsWith('mergepath-sync/') &&
  /\(mergepath@[0-9a-f]{7,40}\)/.test(pr.title || '');
```

The external-review violation push is guarded with `&& !isMergepathSyncPR`. Both conditions must hold:

1. **`pr.head.ref` starts with `mergepath-sync/`** — the namespace is owned by `sync-to-downstream.sh`'s branch-naming convention (`mergepath-sync/<short-sha>`) and is never used for hand-authored work.
2. **PR title matches `(mergepath@[0-9a-f]{7,40})`** — the canonical title format the sync script emits, identifying the upstream commit. A second confirming signal that this is a propagation PR, not a hand-crafted branch in the namespace.

One alone isn't enough — a manually-created branch named `mergepath-sync/foo` without the title signature still gets flagged.

## Scope

Narrowly the Check 2 external-review violation. Unaffected:

- **Check 1 (Self-Review)** — propagation PRs already include the required `## Self-Review` section in their template body, so this check passes for them naturally.
- **Check 2 Dependabot rule** (cliApprovedReviews requirement at lines 193–197 of pr-audit.yml) — Dependabot PRs use `dependabot/*` head refs, not `mergepath-sync/*`, and the sync script doesn't open Dependabot-style PRs.
- **Check 3 (bot self-approval)** — doesn't gate on the external-review label.
- **Real audit gaps** — `audit-violation` issues still file for any merged external-review PR with no Codex / CLI review where the branch isn't in the sync namespace.

## Out of scope (per #229)

- **Option 2 (propagation label)** — more moving parts (label on sync-to-downstream.sh + Label Gate exemption). Not chosen because the head-branch namespace already provides a sharper exemption criterion than a label that humans could add by accident.
- **Option 3 (full Codex review on each downstream PR)** — most defensible audit-trail-wise but adds a per-repo Codex round (cost + flake risk). Not chosen because the upstream commit was already reviewed in mergepath; re-reviewing is redundant.

## Verification

- `yq eval '.' .github/workflows/pr-audit.yml` parses clean (workflow YAML still valid).
- The exemption is read-only on the audit side — it cannot create false positives (it just stops one specific false flag), and the namespace-plus-title double-guard prevents spoofing.

The propagation gap closes once this lands in mergepath; consumer repos pick up the new pr-audit.yml on the next sync propagation cycle (the audit workflow itself is canonical-mirrored to all consumers per `.mergepath-sync.yml`).

## Net diff

+17 / -1 lines in `.github/workflows/pr-audit.yml`. Single file, no test changes needed (the workflow runs against real PRs; the exemption logic is small and the guard conditions are both verifiable from the PR object the audit already fetches).

## Self-Review

**Correctness.** The two guards are independently necessary:
- Head-branch check alone could be spoofed by a human pushing a branch named `mergepath-sync/something`. The title-format regex is a second signal because the sync script explicitly emits `(mergepath@<sha>)` in titles.
- Title-format check alone could be spoofed by a human putting that string in any PR title. The branch namespace is owned by the sync script's branch convention.

Together they form a tight exemption: hand-creating both is possible but explicit, and would show up as an unusual diff during the standard self-review. The SHA in the title is also unverified at audit time (per the issue's spec, the optional `git rev-parse` cross-repo check is not included — head-branch + title-format are the documented sufficient pair).

**Regression risk.** The exemption only suppresses Check 2 (external-review violation). It does not:
- Affect Self-Review check (Check 1)
- Affect bot-self-approval check (Check 3)
- Affect human-review-label check (Check 4 at line 220)
- Affect Dependabot's separate approval rule (still gates on cliApprovedReviews)
- Affect the violation surfacing for any other PR

Worst case if the exemption misfires: a real audit gap goes unflagged on one specific class of PR (sync propagation). Best case: the legitimate noise the audit was generating last week stops.

**Style.** Followed the existing pattern (`const` + JSDoc-style comment block explaining why). Comment cross-references #229 for the audit-side context.

**Test coverage.** No automated test for pr-audit.yml exists in the repo. The next weekly audit run is the live verification — if any of the 8 consumer repos' last-week propagation PRs are filed under audit-issues again, the exemption isn't firing; if zero are, the exemption is doing its job.

**Security / dependency hygiene.** No new dependencies. Read-only against the PR object the script already fetches. No new permissions on the workflow.

## Test plan

- [x] YAML parses.
- [ ] Once merged, the next propagation cycle picks up the new pr-audit.yml across all 8 consumers via `sync-to-downstream.sh`.
- [ ] Next weekly audit run (2026-05-18 by the workflow's `schedule:`) should not flag any of the upcoming propagation PRs.
- [ ] Spot-check: a hand-authored PR with `mergepath-sync/test` head branch and a non-conforming title (no `(mergepath@<sha>)`) is still flagged by the audit if it merges with `needs-external-review` set and no APPROVED — i.e., the exemption can't be trivially spoofed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)