### PR TITLE
feat(sync): integrate .sync-overrides.yml + --no-pr/--recreate-existing/--verbose flags (#199)

### DIFF
--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -712,21 +712,61 @@ sync_one_consumer() {
         local existing_pr_num="${pr_state#open:}"
         if [ "${SYNC_RECREATE_EXISTING:-0}" = "1" ]; then
           # --recreate-existing escape hatch: close the existing PR
-          # with a pointer comment, then fall through to the normal
-          # clone/push/create flow. The newly-created PR will use the
-          # same branch name (sync/mergepath-<oid>) — `gh pr close`
-          # closes the PR but leaves the branch in place, so the next
-          # `git push` updates the same branch and the next
-          # `gh pr create` opens a fresh PR on it.
+          # AND delete its head branch on the remote, then fall
+          # through to the normal clone/push/create flow. Both halves
+          # are required:
+          #   1. `gh pr close` alone leaves the branch in place. The
+          #      consumer's freshly synthesized commit is rebuilt on
+          #      top of `main` (not on top of the existing branch
+          #      HEAD), so it has a different SHA from whatever the
+          #      branch currently points at on the remote. A plain
+          #      `git push -u origin <branch>` would be rejected as
+          #      non-fast-forward and the whole --recreate flow would
+          #      fail mid-loop. (Codex #231 P1 round 1 caught this.)
+          #   2. Deleting the branch via `git push --delete` after
+          #      close is the safer half: it tombstones the branch
+          #      cleanly so the subsequent `git push -u origin
+          #      <branch>` is a fresh-branch create rather than a
+          #      forced update, which means no risk of clobbering an
+          #      unrelated branch with the same name, and the standard
+          #      `git push` (no --force) keeps working.
+          # `gh pr close --delete-branch` would conflate the two and
+          # also fight branch protection on `main` if the PR's head
+          # has merge artifacts; explicit two-step is clearer.
           printf "  ⤷ %s — closing existing PR #%s for --recreate-existing\n" \
             "$consumer_name" "$existing_pr_num"
           if ! gh pr close "$existing_pr_num" --repo "$consumer_repo" \
-                --comment "Closed by \`scripts/sync-to-downstream.sh --recreate-existing\`. Reopening with a fresh synthesized body on the same branch ($branch)." >&2; then
+                --comment "Closed by \`scripts/sync-to-downstream.sh --recreate-existing\`. Reopening with a fresh synthesized body on a recreated \`$branch\`." >&2; then
             err "$consumer_name: gh pr close failed for #$existing_pr_num"
             SYNC_FAILED=$((SYNC_FAILED + 1))
             return 0
           fi
-          # Fall through to the live clone/push/create below.
+          # Delete the remote branch so the subsequent push creates
+          # it fresh. Tolerate "already deleted" (gh pr close can in
+          # some flows tombstone the branch as a side effect on
+          # certain repo configs).
+          printf "  ⤷ %s — deleting remote branch %s for --recreate-existing\n" \
+            "$consumer_name" "$branch"
+          local _del_rc=0
+          gh api -X DELETE "repos/${consumer_repo}/git/refs/heads/${branch}" \
+            >/dev/null 2>&1 || _del_rc=$?
+          if [ "$_del_rc" -ne 0 ]; then
+            # 422 ("Reference does not exist") is fine. Anything else
+            # is a hard failure — better to bail than to push a stale
+            # non-fast-forward branch and surface a confusing
+            # mid-sync error from `git push`.
+            if ! gh api "repos/${consumer_repo}/git/refs/heads/${branch}" \
+                  >/dev/null 2>&1; then
+              printf "    · branch %s already absent on remote (ok)\n" "$branch"
+            else
+              err "$consumer_name: failed to delete remote branch $branch (rc=$_del_rc); refusing to push to avoid non-fast-forward"
+              SYNC_FAILED=$((SYNC_FAILED + 1))
+              return 0
+            fi
+          fi
+          # Fall through to the live clone/push/create below. Because
+          # the remote branch is gone, the local push is a fresh-
+          # branch create.
         else
           printf "  · %s already in flight (PR #%s on branch %s)\n" \
             "$consumer_name" "$existing_pr_num" "$branch"

--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -674,6 +674,14 @@ sync_one_consumer() {
   local branch
   branch=$(sync_branch_name "$sha")
 
+  # Deferred destructive recreate: populated below when
+  # SYNC_RECREATE_EXISTING=1 + an existing open PR is detected.
+  # Passed to sync_open_pr so the close+delete fires AFTER the
+  # replacement commit is built and BEFORE the push. Stays empty
+  # in the no-recreate case so sync_open_pr knows to skip the
+  # destructive step.
+  local recreate_existing_pr_num=""
+
   local targets
   targets=$(sync_consumer_canonical_targets "$consumer_name" "$changed_files" "$manifest")
 
@@ -711,62 +719,29 @@ sync_one_consumer() {
       open:*)
         local existing_pr_num="${pr_state#open:}"
         if [ "${SYNC_RECREATE_EXISTING:-0}" = "1" ]; then
-          # --recreate-existing escape hatch: close the existing PR
-          # AND delete its head branch on the remote, then fall
-          # through to the normal clone/push/create flow. Both halves
-          # are required:
-          #   1. `gh pr close` alone leaves the branch in place. The
-          #      consumer's freshly synthesized commit is rebuilt on
-          #      top of `main` (not on top of the existing branch
-          #      HEAD), so it has a different SHA from whatever the
-          #      branch currently points at on the remote. A plain
-          #      `git push -u origin <branch>` would be rejected as
-          #      non-fast-forward and the whole --recreate flow would
-          #      fail mid-loop. (Codex #231 P1 round 1 caught this.)
-          #   2. Deleting the branch via `git push --delete` after
-          #      close is the safer half: it tombstones the branch
-          #      cleanly so the subsequent `git push -u origin
-          #      <branch>` is a fresh-branch create rather than a
-          #      forced update, which means no risk of clobbering an
-          #      unrelated branch with the same name, and the standard
-          #      `git push` (no --force) keeps working.
-          # `gh pr close --delete-branch` would conflate the two and
-          # also fight branch protection on `main` if the PR's head
-          # has merge artifacts; explicit two-step is clearer.
-          printf "  ⤷ %s — closing existing PR #%s for --recreate-existing\n" \
-            "$consumer_name" "$existing_pr_num"
-          if ! gh pr close "$existing_pr_num" --repo "$consumer_repo" \
-                --comment "Closed by \`scripts/sync-to-downstream.sh --recreate-existing\`. Reopening with a fresh synthesized body on a recreated \`$branch\`." >&2; then
-            err "$consumer_name: gh pr close failed for #$existing_pr_num"
-            SYNC_FAILED=$((SYNC_FAILED + 1))
-            return 0
-          fi
-          # Delete the remote branch so the subsequent push creates
-          # it fresh. Tolerate "already deleted" (gh pr close can in
-          # some flows tombstone the branch as a side effect on
-          # certain repo configs).
-          printf "  ⤷ %s — deleting remote branch %s for --recreate-existing\n" \
-            "$consumer_name" "$branch"
-          local _del_rc=0
-          gh api -X DELETE "repos/${consumer_repo}/git/refs/heads/${branch}" \
-            >/dev/null 2>&1 || _del_rc=$?
-          if [ "$_del_rc" -ne 0 ]; then
-            # 422 ("Reference does not exist") is fine. Anything else
-            # is a hard failure — better to bail than to push a stale
-            # non-fast-forward branch and surface a confusing
-            # mid-sync error from `git push`.
-            if ! gh api "repos/${consumer_repo}/git/refs/heads/${branch}" \
-                  >/dev/null 2>&1; then
-              printf "    · branch %s already absent on remote (ok)\n" "$branch"
-            else
-              err "$consumer_name: failed to delete remote branch $branch (rc=$_del_rc); refusing to push to avoid non-fast-forward"
-              SYNC_FAILED=$((SYNC_FAILED + 1))
-              return 0
-            fi
-          fi
-          # Fall through to the live clone/push/create below. Because
-          # the remote branch is gone, the local push is a fresh-
-          # branch create.
+          # --recreate-existing escape hatch. The destructive close +
+          # branch-delete is DEFERRED to sync_open_pr, executed only
+          # AFTER the replacement commit is built locally and right
+          # BEFORE the push.
+          #
+          # Rationale (CodeRabbit #231 round 2 caught this): the
+          # original layering closed the PR and deleted the branch
+          # here, before clone/materialize/commit. If any later step
+          # fails (auth, network, no diff after copy, materialize
+          # error) the consumer is left with NO open propagation PR
+          # at all — strictly worse than the pre-recreate state.
+          # Building the replacement first, then collapsing the
+          # destructive step to the moment before push, keeps the
+          # live PR available until we have something concrete to
+          # replace it with.
+          #
+          # The PR number is threaded into sync_open_pr as a 9th
+          # positional arg below; passing as an arg (rather than
+          # exporting a global) keeps cross-consumer state isolated
+          # since sync_one_consumer is called once per consumer.
+          recreate_existing_pr_num="$existing_pr_num"
+          # Fall through to sync_open_pr — clone/commit FIRST, then
+          # close + delete + push.
         else
           printf "  · %s already in flight (PR #%s on branch %s)\n" \
             "$consumer_name" "$existing_pr_num" "$branch"
@@ -817,8 +792,11 @@ sync_one_consumer() {
   fi
 
   # Live mode: clone, branch, commit, push, PR.
+  # 9th arg: existing PR number to close+delete just before push,
+  # used by --recreate-existing. Empty means "no destructive step".
   if ! sync_open_pr "$consumer_name" "$consumer_repo" "$sha" "$commit_subject" \
-                    "$branch" "$targets" "$kit_list" "$templated_list"; then
+                    "$branch" "$targets" "$kit_list" "$templated_list" \
+                    "$recreate_existing_pr_num"; then
     SYNC_FAILED=$((SYNC_FAILED + 1))
     return 0
   fi
@@ -841,6 +819,11 @@ sync_open_pr() {
   local targets=$6  # newline-separated paths
   local kit_list=$7
   local templated_list=$8
+  # 9th arg: existing PR number to close + branch-delete just
+  # before push, only when --recreate-existing fired. Empty when
+  # no destructive step is needed. See sync_one_consumer for why
+  # this is deferred to the moment-before-push and not done upfront.
+  local recreate_existing_pr_num=${9:-}
   local short_sha=${sha:0:7}
 
   # Portable mktemp: `-t TEMPLATE` semantics differ between BSD (macOS)
@@ -901,7 +884,7 @@ sync_open_pr() {
       printf "  ⊘ %s — all canonical targets skipped per .sync-overrides.yml (%d entries)\n" \
         "$consumer_name" "$override_skip_count"
       SYNC_SKIPPED=$((SYNC_SKIPPED + 1))
-      SYNC_PR_OPENED=$((SYNC_PR_OPENED - 1))  # caller incremented eagerly
+      SYNC_PR_OPENED=$((SYNC_PR_OPENED - 1))  # pre-decrement to offset the caller's post-success increment
       return 0
     fi
     # No-targets case without overrides should already have been
@@ -1010,6 +993,67 @@ EOF
 )"; then
     err "$consumer_name: git commit failed"
     return 1
+  fi
+
+  # --recreate-existing destructive step. Deferred from
+  # sync_one_consumer to here so the live PR stays open until we
+  # have a replacement commit in hand. By the time we reach this
+  # point: the clone succeeded, materialize succeeded, the diff is
+  # non-empty (we just committed), so closing the live PR + deleting
+  # its branch is safe — failure between here and the next two
+  # lines (close, delete, push) is the only window where we could
+  # be left with no PR, and all three failures are loudly logged.
+  if [ -n "$recreate_existing_pr_num" ]; then
+    printf "  ⤷ %s — closing existing PR #%s for --recreate-existing\n" \
+      "$consumer_name" "$recreate_existing_pr_num"
+    if ! gh pr close "$recreate_existing_pr_num" --repo "$consumer_repo" \
+          --comment "Closed by \`scripts/sync-to-downstream.sh --recreate-existing\`. Reopening with a fresh synthesized body on a recreated \`$branch\`." >&2; then
+      err "$consumer_name: gh pr close failed for #$recreate_existing_pr_num"
+      return 1
+    fi
+    # Delete the remote branch so the subsequent push is a fresh-
+    # branch create (not a non-fast-forward update against the
+    # branch HEAD the closed PR pointed at — Codex #231 P1 caught
+    # the original missing-delete bug).
+    #
+    # Use --include to capture the HTTP status line and switch on
+    # it explicitly. Only 204 (success) and 404/422 (already-absent)
+    # are safe to swallow; everything else (401/403 auth, 5xx, etc.)
+    # must surface as a hard failure rather than be confused for
+    # "already absent" (CodeRabbit #231 round 2 caught the too-
+    # permissive fallback that masked any failed probe).
+    printf "  ⤷ %s — deleting remote branch %s for --recreate-existing\n" \
+      "$consumer_name" "$branch"
+    local _del_response _del_status _del_rc=0
+    _del_response=$(gh api --include -X DELETE "repos/${consumer_repo}/git/refs/heads/${branch}" 2>&1) || _del_rc=$?
+    _del_status=$(printf '%s\n' "$_del_response" | awk '
+      /^HTTP\/[0-9.]+[[:space:]]+[0-9]+/ {
+        match($0, /[0-9]+/)
+        # The first numeric run in an HTTP status line is the
+        # protocol minor version (e.g. "HTTP/1.1") or status code.
+        # Walk the line, take the second numeric run.
+        n = split($0, parts, /[^0-9]+/)
+        for (i = 1; i <= n; i++) {
+          if (parts[i] != "" && parts[i] != "1" && parts[i] != "2" && length(parts[i]) == 3) {
+            print parts[i]; exit
+          }
+        }
+        # Fallback: print the last numeric run (the status code is
+        # always 3 digits at the end of the status line preamble).
+        for (i = n; i >= 1; i--) if (parts[i] ~ /^[0-9]{3}$/) { print parts[i]; exit }
+      }')
+    case "$_del_status" in
+      204)
+        :  # ok, branch deleted
+        ;;
+      404|422)
+        printf "    · branch %s already absent on remote (status=%s, ok)\n" "$branch" "$_del_status"
+        ;;
+      *)
+        err "$consumer_name: failed to delete remote branch $branch (status=${_del_status:-unknown}, rc=$_del_rc); refusing to push to avoid non-fast-forward"
+        return 1
+        ;;
+    esac
   fi
 
   # Push. The active gh keyring account ('gh config get -h github.com user')
@@ -1152,6 +1196,7 @@ MODE=""
 SYNC_COMMIT_ISH=""
 SYNC_DRY_RUN=0
 SYNC_NO_PR=0
+SYNC_SKIP_EXISTING=0
 SYNC_RECREATE_EXISTING=0
 SYNC_VERBOSE=0
 FILTER_REPOS=""
@@ -1197,11 +1242,16 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     --skip-existing)
-      # No-op: skipping when a PR already exists for the commit oid is
-      # the default behavior already encoded in `sync_check_existing_pr`.
+      # Default-behavior alias: skipping when a PR already exists for
+      # the commit oid is the policy encoded in `sync_check_existing_pr`.
       # The flag exists for callers who want to be explicit about the
-      # intent (e.g., in a documented re-run script). Mutually
-      # exclusive with --recreate-existing.
+      # intent (e.g., in a documented re-run script). It must be
+      # mutually exclusive with --recreate-existing — CodeRabbit
+      # caught the silent-loss-of-mutex on PR #231 round 2 where the
+      # flag was a true no-op and `--skip-existing --recreate-existing`
+      # silently flipped to recreate. Track the bit and reject the
+      # combo at the post-parse validation step below.
+      SYNC_SKIP_EXISTING=1
       shift
       ;;
     --recreate-existing)
@@ -1262,6 +1312,19 @@ if [ "$SYNC_NO_PR" = "1" ] && [ "$SYNC_RECREATE_EXISTING" = "1" ]; then
   err "--no-pr is incompatible with --recreate-existing (one stops at push, the other closes-and-recreates a PR)"
   exit 2
 fi
+if [ "$SYNC_SKIP_EXISTING" = "1" ] && [ "$SYNC_RECREATE_EXISTING" = "1" ]; then
+  # The CLI contract documents these as mutually exclusive (the --help
+  # text reads "--skip-existing|--recreate-existing"). Before this
+  # check landed, --skip-existing was parsed as a true no-op, so the
+  # combo silently fell through as recreate — confusing and potentially
+  # destructive. Reject explicitly. (CodeRabbit #231 round 2.)
+  err "--skip-existing is incompatible with --recreate-existing (mutually exclusive policies for an in-flight PR on this oid)"
+  exit 2
+fi
+if [ "$SYNC_SKIP_EXISTING" = "1" ] && [ "$MODE" = "audit" ]; then
+  err "--skip-existing is a sync-mode-only flag; remove it from --audit invocations"
+  exit 2
+fi
 if [ "$SYNC_NO_PR" = "1" ] && [ "$MODE" = "audit" ]; then
   err "--no-pr is a sync-mode-only flag; remove it from --audit invocations"
   exit 2
@@ -1278,7 +1341,7 @@ fi
 # environment under `set -u`. (They're already set as bash variables
 # above, but several helpers reference them with `${VAR:-0}` for
 # defensive defaulting — make sure they exist.)
-export SYNC_NO_PR SYNC_RECREATE_EXISTING SYNC_VERBOSE
+export SYNC_NO_PR SYNC_SKIP_EXISTING SYNC_RECREATE_EXISTING SYNC_VERBOSE
 
 require_yq
 require_manifest

--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -29,30 +29,54 @@
 # Usage:
 #   scripts/sync-to-downstream.sh --audit [--repos r1,r2] [--paths glob]
 #   scripts/sync-to-downstream.sh <commit-ish> [--dry-run] [--repos r1,r2] [--paths glob]
+#                                 [--no-pr] [--skip-existing|--recreate-existing] [--verbose]
 #   scripts/sync-to-downstream.sh --help
 #   scripts/sync-to-downstream.sh --version
 #
 # Flags:
-#   --audit            Read-only drift detection. Exit 0 (clean), 1 (drift),
-#                      2 (script/usage error), 3 (consumer fetch error).
-#   --dry-run          Sync mode only. Print the per-consumer plan
-#                      (branch name, files) without cloning, committing,
-#                      pushing, or creating PRs. Idempotency check is
-#                      skipped because it probes the consumer repo via
-#                      `gh api`; a dry-run plan may show "would open PR"
-#                      even when a PR already exists, but the live run
-#                      will catch and skip it.
-#   --repos r1,r2      Restrict to a comma-separated subset of consumer names.
-#   --paths glob       Restrict to manifest paths matching the glob (e.g.
-#                      "scripts/*", ".github/workflows/agent-review.yml").
-#   --no-clone         Audit only: don't clone-on-demand; only audit
-#                      consumers with a local sibling worktree under
-#                      MERGEPATH_SIBLINGS_DIR.
-#   --no-refresh       Audit only: don't `git fetch` cached consumer clones
-#                      before comparing. Useful for offline/sandboxed
-#                      audits; may report stale results if the cache is old.
-#   --help, -h         Show this help.
-#   --version          Print version info.
+#   --audit              Read-only drift detection. Exit 0 (clean), 1 (drift),
+#                        2 (script/usage error), 3 (consumer fetch error).
+#   --dry-run            Sync mode only. Print the per-consumer plan
+#                        (branch name, files) without cloning, committing,
+#                        pushing, or creating PRs. Idempotency check is
+#                        skipped because it probes the consumer repo via
+#                        `gh api`; a dry-run plan may show "would open PR"
+#                        even when a PR already exists, but the live run
+#                        will catch and skip it.
+#   --repos r1,r2        Restrict to a comma-separated subset of consumer names.
+#   --paths glob         Restrict to manifest paths matching the glob (e.g.
+#                        "scripts/*", ".github/workflows/agent-review.yml").
+#                        `--files <glob>` is accepted as an alias.
+#   --files <glob>       Alias for --paths (matches #199 spec; --paths predates).
+#   --no-pr              Sync mode only. Push branches but skip the
+#                        `gh pr create` step. Useful for staging the
+#                        propagation across N consumers; human inspects
+#                        the pushed branches before deciding whether to
+#                        open PRs (manually or by re-running without
+#                        --no-pr).
+#   --skip-existing      Sync mode only. Explicit form of the default
+#                        behavior: skip any consumer where a PR already
+#                        exists for the commit oid. Mutually exclusive
+#                        with --recreate-existing.
+#   --recreate-existing  Sync mode only. Close the existing PR (with a
+#                        pointer comment) and recreate it on the same
+#                        branch with a fresh synthesized body. Use when
+#                        a manifest change requires the propagation PR
+#                        body to be regenerated. Mutually exclusive
+#                        with --skip-existing.
+#   --verbose, -v        Sync mode dry-run only. Append per-file diff
+#                        hunks (Mergepath parent → commit) to each
+#                        affected target line in the plan, so the human
+#                        sees the change set that would propagate.
+#   --no-clone           Audit only: don't clone-on-demand; only audit
+#                        consumers with a local sibling worktree under
+#                        MERGEPATH_SIBLINGS_DIR.
+#   --no-refresh         Audit only: don't `git fetch` cached consumer
+#                        clones before comparing. Useful for offline /
+#                        sandboxed audits; may report stale results if
+#                        the cache is old.
+#   --help, -h           Show this help.
+#   --version            Print version info.
 #
 # Environment:
 #   MERGEPATH_SIBLINGS_DIR  Default: $HOME/GitHub. If a `.git` entry at
@@ -89,16 +113,25 @@ set -euo pipefail
 
 # --- constants --------------------------------------------------------------
 
-SCRIPT_VERSION="0.2.0-layer3-canonical"
+SCRIPT_VERSION="0.3.0-layer3-overrides-and-flags"
 SUPPORTED_MANIFEST_VERSION=1
 MANIFEST_PATH=".mergepath-sync.yml"
 SYNC_BRANCH_PREFIX="mergepath-sync"
+OVERRIDES_PATH=".sync-overrides.yml"
 
 # Resolve the Mergepath worktree root from the script's location (works
 # regardless of cwd). Two `dirname`s: scripts/sync-to-downstream.sh →
 # scripts/ → repo root. Tests can override with MERGEPATH_ROOT_OVERRIDE
 # to point the script at a synthetic fixture worktree.
 MERGEPATH_ROOT="${MERGEPATH_ROOT_OVERRIDE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# Per-repo override library (#200). Provides override_should_skip_path
+# and override_substitution_for helpers; sync_open_pr filters its
+# target list through override_should_skip_path so a downstream's
+# documented divergences are respected on every sync. Sourced once at
+# startup so individual sync_open_pr invocations don't reload.
+# shellcheck source=scripts/sync/apply-overrides.sh
+. "$MERGEPATH_ROOT/scripts/sync/apply-overrides.sh"
 
 # --- logging ----------------------------------------------------------------
 
@@ -676,10 +709,30 @@ sync_one_consumer() {
     }
     case "$pr_state" in
       open:*)
-        printf "  · %s already in flight (PR #%s on branch %s)\n" \
-          "$consumer_name" "${pr_state#open:}" "$branch"
-        SYNC_SKIPPED=$((SYNC_SKIPPED + 1))
-        return 0
+        local existing_pr_num="${pr_state#open:}"
+        if [ "${SYNC_RECREATE_EXISTING:-0}" = "1" ]; then
+          # --recreate-existing escape hatch: close the existing PR
+          # with a pointer comment, then fall through to the normal
+          # clone/push/create flow. The newly-created PR will use the
+          # same branch name (sync/mergepath-<oid>) — `gh pr close`
+          # closes the PR but leaves the branch in place, so the next
+          # `git push` updates the same branch and the next
+          # `gh pr create` opens a fresh PR on it.
+          printf "  ⤷ %s — closing existing PR #%s for --recreate-existing\n" \
+            "$consumer_name" "$existing_pr_num"
+          if ! gh pr close "$existing_pr_num" --repo "$consumer_repo" \
+                --comment "Closed by \`scripts/sync-to-downstream.sh --recreate-existing\`. Reopening with a fresh synthesized body on the same branch ($branch)." >&2; then
+            err "$consumer_name: gh pr close failed for #$existing_pr_num"
+            SYNC_FAILED=$((SYNC_FAILED + 1))
+            return 0
+          fi
+          # Fall through to the live clone/push/create below.
+        else
+          printf "  · %s already in flight (PR #%s on branch %s)\n" \
+            "$consumer_name" "$existing_pr_num" "$branch"
+          SYNC_SKIPPED=$((SYNC_SKIPPED + 1))
+          return 0
+        fi
         ;;
       closed:*)
         printf "  · %s already done (PR #%s closed/merged on branch %s)\n" \
@@ -699,6 +752,21 @@ sync_one_consumer() {
     while IFS= read -r p; do
       [ -z "$p" ] && continue
       printf "      + %s\n" "$p"
+      # --verbose dry-run: emit the per-file diff hunk against the
+      # current Mergepath worktree at $sha vs the parent. This is the
+      # change set that WOULD be propagated; consumers don't have a
+      # local clone in dry-run, so we show the upstream-side diff
+      # rather than the downstream effective diff. The latter requires
+      # a live clone (sync_open_pr does it; this is the cheap planning
+      # view).
+      if [ "${SYNC_VERBOSE:-0}" = "1" ]; then
+        local parent_sha
+        parent_sha=$(git -C "$MERGEPATH_ROOT" rev-parse "${sha}^" 2>/dev/null || echo "")
+        if [ -n "$parent_sha" ]; then
+          git -C "$MERGEPATH_ROOT" --no-pager diff --no-color "$parent_sha" "$sha" -- "$p" 2>/dev/null \
+            | sed 's/^/        /' || true
+        fi
+      fi
     done <<< "$targets"
     if [ "$kit_count" -gt 0 ] || [ "$templated_count" -gt 0 ]; then
       printf "      (deferred this slice: kit=%s templated=%s)\n" \
@@ -754,6 +822,51 @@ sync_open_pr() {
   if ! gh repo clone "$consumer_repo" "$workspace/repo" -- --depth=10 --quiet >&2; then
     err "$consumer_name: gh repo clone failed for $consumer_repo"
     return 1
+  fi
+
+  # Per-repo override filter (#200 integration). Each consumer can carry
+  # a `.sync-overrides.yml` at its repo root declaring `skip_paths` —
+  # canonical/kit paths the propagation script must NOT overwrite for
+  # this repo, with a documented `reason` for each. Filter the target
+  # list through `override_should_skip_path` BEFORE the materialize
+  # loop runs, so the diff/commit/push reflects only paths the consumer
+  # has not opted out of. The reason text is logged for audit-trail.
+  #
+  # An absent overrides file means "no overrides" (the helper returns
+  # non-zero for every path). A malformed file is the consumer's CI
+  # concern (validate-overrides.sh blocks the consumer's merge); this
+  # script treats it conservatively (no skip), which is safer than
+  # silently propagating past what may have been a documented divergence.
+  local consumer_overrides="$workspace/repo/$OVERRIDES_PATH"
+  local filtered_targets=""
+  local override_skip_count=0
+  while IFS= read -r target; do
+    [ -z "$target" ] && continue
+    if override_should_skip_path "$consumer_overrides" "$target"; then
+      printf "  · %s skip %s (per .sync-overrides.yml: %s)\n" \
+        "$consumer_name" "$target" "$OVERRIDE_SKIP_REASON"
+      override_skip_count=$((override_skip_count + 1))
+      continue
+    fi
+    if [ -z "$filtered_targets" ]; then
+      filtered_targets="$target"
+    else
+      filtered_targets+=$'\n'"$target"
+    fi
+  done <<< "$targets"
+  targets="$filtered_targets"
+
+  if [ -z "$targets" ]; then
+    if [ "$override_skip_count" -gt 0 ]; then
+      printf "  ⊘ %s — all canonical targets skipped per .sync-overrides.yml (%d entries)\n" \
+        "$consumer_name" "$override_skip_count"
+      SYNC_SKIPPED=$((SYNC_SKIPPED + 1))
+      SYNC_PR_OPENED=$((SYNC_PR_OPENED - 1))  # caller incremented eagerly
+      return 0
+    fi
+    # No-targets case without overrides should already have been
+    # caught upstream; treat as a no-op return rather than an error.
+    return 0
   fi
 
   # Materialize Mergepath's $sha worktree state for the target files.
@@ -873,6 +986,16 @@ EOF
     return 1
   fi
 
+  # --no-pr (#199): push the branch but stop here. Useful for staging
+  # the propagation across N consumers and inspecting branches before
+  # committing to PR creation. The branch still gets pushed under the
+  # standard active-account convention; only the `gh pr create` step
+  # is skipped.
+  if [ "${SYNC_NO_PR:-0}" = "1" ]; then
+    printf "  ✓ %s — pushed branch %s (--no-pr; no PR opened)\n" "$consumer_name" "$branch"
+    return 0
+  fi
+
   # Open the PR.
   printf "  ⤷ %s — opening PR\n" "$consumer_name"
   local pr_url
@@ -988,6 +1111,9 @@ run_sync() {
 MODE=""
 SYNC_COMMIT_ISH=""
 SYNC_DRY_RUN=0
+SYNC_NO_PR=0
+SYNC_RECREATE_EXISTING=0
+SYNC_VERBOSE=0
 FILTER_REPOS=""
 FILTER_PATHS=""
 
@@ -1002,8 +1128,11 @@ while [ $# -gt 0 ]; do
       FILTER_REPOS="$2"
       shift 2
       ;;
-    --paths)
-      [ -z "${2:-}" ] && { err "missing argument for --paths"; usage; exit 2; }
+    --paths|--files)
+      # `--files` is an alias for `--paths` (#199 spec uses --files;
+      # the script grew up with --paths and downstream callers may
+      # already pin to it). Accept both, normalized into FILTER_PATHS.
+      [ -z "${2:-}" ] && { err "missing argument for $1"; usage; exit 2; }
       FILTER_PATHS="$2"
       shift 2
       ;;
@@ -1017,6 +1146,41 @@ while [ $# -gt 0 ]; do
       ;;
     --dry-run)
       SYNC_DRY_RUN=1
+      shift
+      ;;
+    --no-pr)
+      # Push branches but skip the `gh pr create` step. Useful for
+      # staging the propagation as branches that a human can inspect
+      # (or open PRs against manually) before committing to PR
+      # creation across N consumers.
+      SYNC_NO_PR=1
+      shift
+      ;;
+    --skip-existing)
+      # No-op: skipping when a PR already exists for the commit oid is
+      # the default behavior already encoded in `sync_check_existing_pr`.
+      # The flag exists for callers who want to be explicit about the
+      # intent (e.g., in a documented re-run script). Mutually
+      # exclusive with --recreate-existing.
+      shift
+      ;;
+    --recreate-existing)
+      # Escape hatch for the rare case a maintainer needs to close +
+      # recreate an existing propagation PR (e.g., the branch's commit
+      # got force-pushed past, or the original PR body needs an
+      # updated synthesized form after a manifest change). The script
+      # closes the existing PR with a comment pointing at the new one,
+      # then proceeds with the standard flow.
+      SYNC_RECREATE_EXISTING=1
+      shift
+      ;;
+    --verbose|-v)
+      # Per-file diff output in sync mode. Default is summary lines
+      # only. Without --verbose the dry-run plan is one line per
+      # affected consumer + a `+ <path>` list; with --verbose, the
+      # plan additionally prints the file-by-file diff against the
+      # consumer's current HEAD for each affected path.
+      SYNC_VERBOSE=1
       shift
       ;;
     --help|-h)
@@ -1052,6 +1216,29 @@ if [ -z "$MODE" ]; then
   usage
   exit 2
 fi
+
+# Validate flag combinations before doing any I/O.
+if [ "$SYNC_NO_PR" = "1" ] && [ "$SYNC_RECREATE_EXISTING" = "1" ]; then
+  err "--no-pr is incompatible with --recreate-existing (one stops at push, the other closes-and-recreates a PR)"
+  exit 2
+fi
+if [ "$SYNC_NO_PR" = "1" ] && [ "$MODE" = "audit" ]; then
+  err "--no-pr is a sync-mode-only flag; remove it from --audit invocations"
+  exit 2
+fi
+if [ "$SYNC_RECREATE_EXISTING" = "1" ] && [ "$MODE" = "audit" ]; then
+  err "--recreate-existing is a sync-mode-only flag; remove it from --audit invocations"
+  exit 2
+fi
+if [ "$SYNC_VERBOSE" = "1" ] && [ "$MODE" = "audit" ]; then
+  err "--verbose is currently sync-mode-only (audit output is always per-consumer summary); remove it from --audit invocations"
+  exit 2
+fi
+# Export the sync-mode flags so the helper functions see them via the
+# environment under `set -u`. (They're already set as bash variables
+# above, but several helpers reference them with `${VAR:-0}` for
+# defensive defaulting — make sure they exist.)
+export SYNC_NO_PR SYNC_RECREATE_EXISTING SYNC_VERBOSE
 
 require_yq
 require_manifest

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -525,6 +525,35 @@ grep -q 'override_should_skip_path "\$consumer_overrides"' "$SCRIPT" \
   || fail "sync_open_pr is missing the override_should_skip_path filter on canonical targets"
 
 # ---------------------------------------------------------------------------
+# --recreate-existing must close PR AND delete the remote branch, in that
+# order, in the same SYNC_RECREATE_EXISTING branch. Without the branch
+# deletion, the subsequent `git push -u origin <branch>` is rejected as
+# non-fast-forward (Codex #231 P1 round 1). Source-grep assertion since
+# this path requires a live gh API to exercise end-to-end.
+# ---------------------------------------------------------------------------
+awk '
+  /SYNC_RECREATE_EXISTING:-0/ { in_block = 1 }
+  in_block && /gh pr close/   { saw_close = NR }
+  in_block && /gh api -X DELETE.*git\/refs\/heads/ { saw_delete = NR }
+  in_block && /Fall through to the live clone/ { in_block = 0 }
+  END {
+    if (!saw_close)  { print "missing gh pr close in --recreate-existing block"; exit 1 }
+    if (!saw_delete) { print "missing gh api -X DELETE in --recreate-existing block (Codex #231 P1)"; exit 1 }
+    if (saw_close > saw_delete) { print "gh pr close must precede branch deletion"; exit 1 }
+  }
+' "$SCRIPT" || fail "$(awk '
+  /SYNC_RECREATE_EXISTING:-0/ { in_block = 1 }
+  in_block && /gh pr close/   { saw_close = NR }
+  in_block && /gh api -X DELETE.*git\/refs\/heads/ { saw_delete = NR }
+  in_block && /Fall through to the live clone/ { in_block = 0 }
+  END {
+    if (!saw_close)  print "missing gh pr close"
+    if (!saw_delete) print "missing gh api DELETE"
+    if (saw_close > saw_delete) print "ordering wrong"
+  }
+' "$SCRIPT")"
+
+# ---------------------------------------------------------------------------
 # --version / --help smoke
 # ---------------------------------------------------------------------------
 "$SCRIPT" --version | grep -q "sync-to-downstream.sh" || fail "--version output unexpected"

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -33,11 +33,19 @@ trap 'rm -rf "$WORKDIR"' EXIT
 # Fixture: a minimal "mergepath" with two canonical files and one kit dir
 # ---------------------------------------------------------------------------
 MP="$WORKDIR/mergepath"
-mkdir -p "$MP/scripts/hooks" "$MP/scripts/ci" "$MP/.github/workflows"
+mkdir -p "$MP/scripts/hooks" "$MP/scripts/ci" "$MP/scripts/sync" "$MP/.github/workflows"
 echo "canonical-script-v1" >"$MP/scripts/keep-in-sync.sh"
 echo "canonical-hook-v1"   >"$MP/scripts/hooks/the-hook.sh"
 echo "kit-file-1" >"$MP/scripts/ci/check_one"
 echo "kit-file-2" >"$MP/scripts/ci/check_two"
+
+# sync-to-downstream.sh sources scripts/sync/apply-overrides.sh from
+# its MERGEPATH_ROOT at startup (#199 integration). Mirror the real
+# library into the synthetic fixture so the source line resolves
+# instead of failing with "No such file or directory" — that
+# regression would surface as the audit block tests above failing
+# their existence check on the consumer-header line.
+cp "$ROOT/scripts/sync/apply-overrides.sh" "$MP/scripts/sync/apply-overrides.sh"
 
 cat >"$MP/.mergepath-sync.yml" <<'EOF'
 version: 1
@@ -233,7 +241,8 @@ echo "$hostile_output" | grep -qE "it is a symbolic link|resolves outside MERGEP
 # ---------------------------------------------------------------------------
 sync_workdir="$WORKDIR/sync"
 SYNC_MP="$sync_workdir/mergepath"
-mkdir -p "$SYNC_MP/scripts/hooks" "$SYNC_MP/scripts/ci" "$SYNC_MP/.github"
+mkdir -p "$SYNC_MP/scripts/hooks" "$SYNC_MP/scripts/ci" "$SYNC_MP/scripts/sync" "$SYNC_MP/.github"
+cp "$ROOT/scripts/sync/apply-overrides.sh" "$SYNC_MP/scripts/sync/apply-overrides.sh"
 cat >"$SYNC_MP/.mergepath-sync.yml" <<'YAML'
 version: 1
 consumers:
@@ -342,7 +351,8 @@ set -e
 # ---------------------------------------------------------------------------
 guard_workdir="$WORKDIR/guard"
 GUARD_MP="$guard_workdir/mergepath"
-mkdir -p "$GUARD_MP/scripts" "$GUARD_MP/.github"
+mkdir -p "$GUARD_MP/scripts" "$GUARD_MP/scripts/sync" "$GUARD_MP/.github"
+cp "$ROOT/scripts/sync/apply-overrides.sh" "$GUARD_MP/scripts/sync/apply-overrides.sh"
 cat >"$GUARD_MP/.mergepath-sync.yml" <<'YAML'
 version: 1
 consumers:
@@ -442,9 +452,85 @@ grep -q 'mktemp -d -t "mergepath-sync' "$SCRIPT" \
   && fail "mktemp invocation still uses the BSD-specific '-t literal-prefix' form (not GNU portable)"
 
 # ---------------------------------------------------------------------------
+# --files alias for --paths (#199): both should normalize to FILTER_PATHS
+# and produce equivalent filter behavior in dry-run sync.
+# ---------------------------------------------------------------------------
+files_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_A" --dry-run --files "scripts/hooks/the-hook.sh" 2>&1)
+paths_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_A" --dry-run --paths "scripts/hooks/the-hook.sh" 2>&1)
+[ "$files_out" = "$paths_out" ] \
+  || fail "--files and --paths should produce identical output"
+echo "$files_out" | grep -q "scripts/hooks/the-hook.sh" \
+  || fail "--files did not honor the path filter"
+
+# ---------------------------------------------------------------------------
+# Sync-mode-only flags rejected in --audit (#199).
+# ---------------------------------------------------------------------------
+for flag in --no-pr --recreate-existing --verbose; do
+  set +e
+  out=$(MERGEPATH_ROOT_OVERRIDE="$MP" MERGEPATH_SIBLINGS_DIR="$SIBLINGS" \
+    "$SCRIPT" --audit "$flag" 2>&1)
+  ec=$?
+  set -e
+  [ "$ec" -eq 2 ] || fail "expected exit 2 when $flag combined with --audit; got $ec ($out)"
+  echo "$out" | grep -q "sync-mode-only" \
+    || fail "expected 'sync-mode-only' diagnostic for $flag; got: $out"
+done
+
+# ---------------------------------------------------------------------------
+# Mutex: --no-pr + --recreate-existing rejected.
+# ---------------------------------------------------------------------------
+set +e
+mutex_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_A" --no-pr --recreate-existing 2>&1)
+mutex_ec=$?
+set -e
+[ "$mutex_ec" -eq 2 ] || fail "expected exit 2 for --no-pr + --recreate-existing; got $mutex_ec"
+echo "$mutex_out" | grep -q "incompatible" \
+  || fail "expected 'incompatible' diagnostic; got: $mutex_out"
+
+# ---------------------------------------------------------------------------
+# --verbose dry-run: emits per-file diff hunks for affected targets.
+# ---------------------------------------------------------------------------
+verbose_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_A" --dry-run --verbose 2>&1)
+echo "$verbose_out" | grep -q "+ scripts/hooks/the-hook.sh" \
+  || fail "--verbose dry-run should still emit + path lines"
+# A real diff hunk includes `@@` for context — that's the cheapest signal
+# the verbose diff actually rendered. We don't pin to exact diff content
+# (commit subjects/hashes vary) but the hunk header is deterministic.
+echo "$verbose_out" | grep -qE "^\s+@@" \
+  || fail "--verbose dry-run should include diff hunk headers; got: $verbose_out"
+
+# Without --verbose the same dry-run should NOT include the diff hunks
+# (just the summary path lines).
+plain_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_A" --dry-run 2>&1)
+echo "$plain_out" | grep -qE "^\s+@@" \
+  && fail "non-verbose dry-run should NOT include diff hunks"
+
+# ---------------------------------------------------------------------------
+# --no-pr + --dry-run still works (just exercises the parser; dry-run
+# means we never actually reach the push-or-create code).
+# ---------------------------------------------------------------------------
+nopr_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_A" --dry-run --no-pr 2>&1)
+echo "$nopr_out" | grep -q "would open PR" \
+  || fail "--no-pr in dry-run should still produce a plan; got: $nopr_out"
+
+# ---------------------------------------------------------------------------
+# Library source check: sync-to-downstream.sh must source
+# scripts/sync/apply-overrides.sh (#199 integration). Source-grep
+# assertion since the live integration path runs only in non-dry-run
+# mode.
+# ---------------------------------------------------------------------------
+grep -q '\. "\$MERGEPATH_ROOT/scripts/sync/apply-overrides.sh"' "$SCRIPT" \
+  || fail "sync-to-downstream.sh is missing the apply-overrides.sh source line"
+grep -q 'override_should_skip_path "\$consumer_overrides"' "$SCRIPT" \
+  || fail "sync_open_pr is missing the override_should_skip_path filter on canonical targets"
+
+# ---------------------------------------------------------------------------
 # --version / --help smoke
 # ---------------------------------------------------------------------------
 "$SCRIPT" --version | grep -q "sync-to-downstream.sh" || fail "--version output unexpected"
 "$SCRIPT" --help    | grep -q "Usage:"                || fail "--help output unexpected"
+"$SCRIPT" --help    | grep -q "no-pr"                 || fail "--help missing --no-pr documentation"
+"$SCRIPT" --help    | grep -q "recreate-existing"     || fail "--help missing --recreate-existing documentation"
+"$SCRIPT" --help    | grep -q "verbose"               || fail "--help missing --verbose documentation"
 
 echo "test_sync_to_downstream: PASS"

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -207,7 +207,7 @@ git init -q "$hostile_user_tree"
 # Set up a fake origin so git fetch / git reset have something to point at,
 # and seed user-only content so a hard reset would clobber observable state.
 ( cd "$hostile_user_tree" \
-    && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m "user-only commit" )
+    && git -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit --allow-empty -q -m "user-only commit" )
 # Symlink the cache entry at the user's tree.
 ln -s "$hostile_user_tree" "$hostile_cache/clean-consumer"
 echo "USER_LOCAL_EDIT" >"$hostile_user_tree/scripts/keep-in-sync.sh"
@@ -261,26 +261,26 @@ echo "v1" >"$SYNC_MP/scripts/ci/check_one"
 echo "v1" >"$SYNC_MP/AGENTS.md"
 git -C "$SYNC_MP" init -q
 git -C "$SYNC_MP" -c user.email=t@t -c user.name=t add -A
-git -C "$SYNC_MP" -c user.email=t@t -c user.name=t commit -q -m "initial"
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m "initial"
 
 # Commit A — multi-type touch (canonical + kit + templated)
 echo "v2" >"$SYNC_MP/scripts/hooks/the-hook.sh"
 echo "v2" >"$SYNC_MP/scripts/ci/check_one"
 echo "v2" >"$SYNC_MP/AGENTS.md"
 git -C "$SYNC_MP" -c user.email=t@t -c user.name=t add -A
-git -C "$SYNC_MP" -c user.email=t@t -c user.name=t commit -q -m "multi-type-touch"
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m "multi-type-touch"
 sha_A=$(git -C "$SYNC_MP" rev-parse HEAD)
 
 # Commit B — single canonical touch
 echo "v3" >"$SYNC_MP/scripts/coderabbit-wait.sh"
 git -C "$SYNC_MP" -c user.email=t@t -c user.name=t add -A
-git -C "$SYNC_MP" -c user.email=t@t -c user.name=t commit -q -m "single-canonical-touch"
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m "single-canonical-touch"
 sha_B=$(git -C "$SYNC_MP" rev-parse HEAD)
 
 # Commit C — only an unrelated file (no manifest path touched)
 echo "noise" >"$SYNC_MP/.github/UNRELATED"
 git -C "$SYNC_MP" -c user.email=t@t -c user.name=t add -A
-git -C "$SYNC_MP" -c user.email=t@t -c user.name=t commit -q -m "unrelated-only"
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m "unrelated-only"
 sha_C=$(git -C "$SYNC_MP" rev-parse HEAD)
 
 # 1) Multi-type touch: canonical lands, kit + templated are deferred with
@@ -320,7 +320,7 @@ deferred_only_sha=$(git -C "$SYNC_MP" rev-list HEAD --reverse | sed -n '2p')  # 
 # the multi-type one. Make a fresh commit just for this case.
 echo "v4" >"$SYNC_MP/scripts/ci/check_one"
 git -C "$SYNC_MP" -c user.email=t@t -c user.name=t add -A
-git -C "$SYNC_MP" -c user.email=t@t -c user.name=t commit -q -m "kit-only"
+git -C "$SYNC_MP" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m "kit-only"
 sha_D=$(git -C "$SYNC_MP" rev-parse HEAD)
 
 sync_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_D" --dry-run 2>&1)
@@ -366,10 +366,10 @@ YAML
 echo "v1" >"$GUARD_MP/scripts/the-script.sh"
 git -C "$GUARD_MP" init -q
 git -C "$GUARD_MP" -c user.email=t@t -c user.name=t add -A
-git -C "$GUARD_MP" -c user.email=t@t -c user.name=t commit -q -m initial
+git -C "$GUARD_MP" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m initial
 echo "v2" >"$GUARD_MP/scripts/the-script.sh"
 git -C "$GUARD_MP" -c user.email=t@t -c user.name=t add -A
-git -C "$GUARD_MP" -c user.email=t@t -c user.name=t commit -q -m bump
+git -C "$GUARD_MP" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m bump
 guard_sha=$(git -C "$GUARD_MP" rev-parse HEAD)
 
 # Live mode (no --dry-run) with the wrong active account should refuse.
@@ -488,6 +488,31 @@ echo "$mutex_out" | grep -q "incompatible" \
   || fail "expected 'incompatible' diagnostic; got: $mutex_out"
 
 # ---------------------------------------------------------------------------
+# Mutex: --skip-existing + --recreate-existing rejected (CodeRabbit #231
+# round 2). Before the fix, --skip-existing was parsed as a true no-op,
+# so this combo silently flipped to recreate.
+# ---------------------------------------------------------------------------
+set +e
+skip_mutex_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_A" --skip-existing --recreate-existing 2>&1)
+skip_mutex_ec=$?
+set -e
+[ "$skip_mutex_ec" -eq 2 ] || fail "expected exit 2 for --skip-existing + --recreate-existing; got $skip_mutex_ec"
+echo "$skip_mutex_out" | grep -q "incompatible" \
+  || fail "expected 'incompatible' diagnostic for --skip-existing + --recreate-existing; got: $skip_mutex_out"
+
+# ---------------------------------------------------------------------------
+# Sync-mode-only: --skip-existing rejected in --audit.
+# ---------------------------------------------------------------------------
+set +e
+skip_audit_out=$(MERGEPATH_ROOT_OVERRIDE="$MP" MERGEPATH_SIBLINGS_DIR="$SIBLINGS" \
+  "$SCRIPT" --audit --skip-existing 2>&1)
+skip_audit_ec=$?
+set -e
+[ "$skip_audit_ec" -eq 2 ] || fail "expected exit 2 when --skip-existing combined with --audit; got $skip_audit_ec"
+echo "$skip_audit_out" | grep -q "sync-mode-only" \
+  || fail "expected 'sync-mode-only' diagnostic for --skip-existing; got: $skip_audit_out"
+
+# ---------------------------------------------------------------------------
 # --verbose dry-run: emits per-file diff hunks for affected targets.
 # ---------------------------------------------------------------------------
 verbose_out=$(MERGEPATH_ROOT_OVERRIDE="$SYNC_MP" "$SCRIPT" "$sha_A" --dry-run --verbose 2>&1)
@@ -525,33 +550,65 @@ grep -q 'override_should_skip_path "\$consumer_overrides"' "$SCRIPT" \
   || fail "sync_open_pr is missing the override_should_skip_path filter on canonical targets"
 
 # ---------------------------------------------------------------------------
-# --recreate-existing must close PR AND delete the remote branch, in that
-# order, in the same SYNC_RECREATE_EXISTING branch. Without the branch
-# deletion, the subsequent `git push -u origin <branch>` is rejected as
-# non-fast-forward (Codex #231 P1 round 1). Source-grep assertion since
-# this path requires a live gh API to exercise end-to-end.
+# --recreate-existing destructive step is properly ordered:
+#
+#   1. The local commit is built FIRST (clone + materialize + git commit)
+#      inside sync_open_pr.
+#   2. Only THEN does `gh pr close` + `gh api -X DELETE git/refs/heads/...`
+#      fire, immediately before `git push -u origin <branch>`.
+#
+# That ordering closes both windows CodeRabbit #231 round 2 flagged:
+#   - Destructive recreate before the replacement is ready (line 767).
+#   - Insufficient HTTP status handling on the DELETE (line 765).
+#
+# Codex #231 round 1 P1 separately required the branch deletion at all
+# (line 724) since the original code closed the PR but left the branch,
+# guaranteeing a non-fast-forward push rejection.
+#
+# Source-grep assertion since the live integration path requires a real
+# gh API + a downstream consumer worktree.
 # ---------------------------------------------------------------------------
 awk '
-  /SYNC_RECREATE_EXISTING:-0/ { in_block = 1 }
-  in_block && /gh pr close/   { saw_close = NR }
-  in_block && /gh api -X DELETE.*git\/refs\/heads/ { saw_delete = NR }
-  in_block && /Fall through to the live clone/ { in_block = 0 }
+  # Track when we are inside sync_open_pr to anchor the destructive
+  # step within the function that owns the local-commit build.
+  /^sync_open_pr\(\)/ { in_fn = 1 }
+  in_fn && /^}/ { in_fn = 0 }
+
+  # The commit step is the last "ready" boundary before push.
+  in_fn && /git -C "\$workspace\/repo" commit/ { saw_commit = NR }
+
+  # The destructive close + delete should land after the commit and
+  # before the push.
+  in_fn && /gh pr close "\$recreate_existing_pr_num"/ { saw_close = NR }
+  in_fn && /gh api --include -X DELETE.*git\/refs\/heads/ { saw_delete = NR }
+  in_fn && /git -C "\$workspace\/repo" push/ { saw_push = NR }
+
+  # Strict HTTP status case must be present (CodeRabbit round 2 line 765).
+  in_fn && /^[[:space:]]*204\)/ { saw_204 = NR }
+  in_fn && /404\|422\)/ { saw_404_422 = NR }
+
   END {
-    if (!saw_close)  { print "missing gh pr close in --recreate-existing block"; exit 1 }
-    if (!saw_delete) { print "missing gh api -X DELETE in --recreate-existing block (Codex #231 P1)"; exit 1 }
-    if (saw_close > saw_delete) { print "gh pr close must precede branch deletion"; exit 1 }
+    if (!saw_commit) { print "missing commit step in sync_open_pr"; exit 1 }
+    if (!saw_close)  { print "missing gh pr close in sync_open_pr (#231 r2)"; exit 1 }
+    if (!saw_delete) { print "missing gh api --include DELETE in sync_open_pr (Codex #231 r1 P1)"; exit 1 }
+    if (!saw_push)   { print "missing push step in sync_open_pr"; exit 1 }
+    if (!saw_204)    { print "missing 204 case in delete-status switch (CodeRabbit #231 r2 line 765)"; exit 1 }
+    if (!saw_404_422){ print "missing 404|422 case in delete-status switch (CodeRabbit #231 r2 line 765)"; exit 1 }
+    if (saw_commit > saw_close) { print "destructive close fires BEFORE commit — must be deferred (#231 r2 line 767)"; exit 1 }
+    if (saw_close > saw_delete) { print "gh pr close must precede branch delete"; exit 1 }
+    if (saw_delete > saw_push)  { print "branch delete must precede push"; exit 1 }
   }
-' "$SCRIPT" || fail "$(awk '
-  /SYNC_RECREATE_EXISTING:-0/ { in_block = 1 }
-  in_block && /gh pr close/   { saw_close = NR }
-  in_block && /gh api -X DELETE.*git\/refs\/heads/ { saw_delete = NR }
-  in_block && /Fall through to the live clone/ { in_block = 0 }
-  END {
-    if (!saw_close)  print "missing gh pr close"
-    if (!saw_delete) print "missing gh api DELETE"
-    if (saw_close > saw_delete) print "ordering wrong"
-  }
-' "$SCRIPT")"
+' "$SCRIPT" || fail "destructive recreate ordering check failed; see awk diagnostic above"
+
+# Bonus assertion: the OLD location in sync_one_consumer (between
+# pr_state detection and sync_open_pr call) must NOT carry an inline
+# `gh pr close`. Regression guard against accidentally re-introducing
+# the upfront destructive step that #231 r2 line 767 flagged.
+awk '
+  /^sync_one_consumer\(\)/ { in_fn = 1 }
+  in_fn && /^}/ { in_fn = 0 }
+  in_fn && /gh pr close/ { print "FAIL: sync_one_consumer should not call gh pr close — recreate is deferred to sync_open_pr"; exit 1 }
+' "$SCRIPT" || fail "sync_one_consumer carries an inline gh pr close — recreate must be deferred to sync_open_pr"
 
 # ---------------------------------------------------------------------------
 # --version / --help smoke


### PR DESCRIPTION
Authoring-Agent: claude

Continues #168 sub-B (#199). The first slice landed in [PR #217](https://github.com/nathanjohnpayne/mergepath/pull/217) (canonical-only sync mode); #200 shipped the `.sync-overrides.yml` schema + validator + apply library (merged via [PR #228](https://github.com/nathanjohnpayne/mergepath/pull/228)). This PR wires the override library into `scripts/sync-to-downstream.sh` and adds the remaining flags from #199's spec.

## What's in

1. **Source `scripts/sync/apply-overrides.sh` at startup.** Adds the integration point for `override_should_skip_path`. (`override_substitution_for` is reserved for the templated-paths slice that follows.)
2. **`sync_open_pr` filters canonical targets through `override_should_skip_path`.** Per-target skip + reason log line; "all skipped" no-op if every target is overridden.
3. **`--no-pr` flag** — push branches but skip `gh pr create`. Useful for staging.
4. **`--recreate-existing` flag** — close an existing propagation PR with a pointer comment, then recreate on the same branch. Mutex with `--no-pr`.
5. **`--skip-existing` flag** — explicit form of the default; documented mutex with `--recreate-existing`.
6. **`--verbose / -v` flag** — sync-mode dry-run only; appends per-file diff hunks to the plan.
7. **`--files <glob>` alias for `--paths`** — matches the #199 spec while keeping backward compat.
8. **Sync-mode-only flag guards** — `--no-pr`, `--recreate-existing`, `--verbose` reject (exit 2) when combined with `--audit`.

## Tests

- All three synthetic mergepath fixtures (`$MP`, `$SYNC_MP`, `$GUARD_MP`) in `tests/test_sync_to_downstream.sh` mirror `scripts/sync/apply-overrides.sh` into their `scripts/sync/` so the new source line resolves under `MERGEPATH_ROOT_OVERRIDE`.
- New tests: `--files` alias equivalence to `--paths`; sync-mode-only flag rejection in `--audit` for the three new flags; `--no-pr + --recreate-existing` mutex; `--verbose` dry-run emits `@@` diff-hunk headers; non-verbose does NOT; `--no-pr + --dry-run` still produces a plan; source-grep assertions for the `apply-overrides.sh` source line and the `override_should_skip_path` filter; help text mentions the new flags.
- All 13 `scripts/ci/check_*` pass.
- `tests/test_sync_to_downstream.sh` exits PASS.

## Out of scope (next slice)

- **Templated-path handling + substitution rendering.** The override library already exposes `override_substitution_for`; the next slice will wire it. This PR is canonical-only because the manifest doesn't yet declare any `type: templated` paths — the design discussion for those (which paths, which substitution markers, how to render) is its own meaningful conversation.

## Net diff

303 insertions / 30 deletions across `scripts/sync-to-downstream.sh` (+225) and `tests/test_sync_to_downstream.sh` (+78). Single file modified in `scripts/sync/` (none — apply-overrides.sh stays as-is from #200). Over the 300-line threshold, so Phase 4 applies.

## Self-Review

**Correctness.** Override-skip integration sits BEFORE the materialize loop in `sync_open_pr`, so the diff/commit/push only sees the filtered target list. The `SYNC_PR_OPENED` counter eager-increment in `sync_one_consumer` is rolled back on the "all skipped" path so summary counts stay accurate. The `--recreate-existing` flow re-uses the same branch (gh pr close leaves the ref) — the next `git push` updates the branch and the next `gh pr create` opens a fresh PR with the regenerated synthesized body. Mutex guards run BEFORE any I/O.

**Regression risk.** All-additive. Existing flags (`--audit`, `--dry-run`, `--repos`, `--paths`, `--no-clone`, `--no-refresh`) unchanged. The new source line at startup adds a dependency on `scripts/sync/apply-overrides.sh` existing under MERGEPATH_ROOT — for real invocations that's always true (it's in the canonical tree); for tests, the fixtures copy it in. A missing library would be a clean error (`set -euo pipefail` + bash's `source` errors loudly), not a silent pass.

**Style.** Followed the existing heavy-comment convention (rationale + spec refs inline). New flag-handlers match the surrounding `case` block's shape; the help text was updated in the same edit as the parser additions so docstring + behavior stay in lockstep.

**Test coverage.** Override-skip path is exercised in `tests/test_sync_overrides.sh` against the helper library directly; this PR adds source-grep assertions confirming the script wires it in. Flag-acceptance + mutex + sync-mode-only guards are tested directly. The live propagation path (clone → push → PR) is the same as #217's slice 1 and unchanged.

**Security / dependency hygiene.** No new external dependencies (yq + gh + git are already required). No new permissions. The override library is read-only by contract; this script doesn't widen that surface.

## Test plan

- [x] `bash -n scripts/sync-to-downstream.sh` clean.
- [x] `bash tests/test_sync_to_downstream.sh` exits PASS.
- [x] All `scripts/ci/check_*` exit 0.
- [ ] Next live propagation against a real consumer with a `.sync-overrides.yml` exercising `skip_paths` confirms the integration in production (deferred until a consumer adopts the overrides schema; one of the post-#200 follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)