### PR TITLE
feat(bootstrap): bootstrap-new-repo.sh wizard scaffold + dispatch + stage stubs (#203)

### DIFF
--- a/scripts/bootstrap-new-repo.sh
+++ b/scripts/bootstrap-new-repo.sh
@@ -371,7 +371,16 @@ preflight() {
   #    probe in dry-run mode + when tool check is suppressed.
   if [ "$BOOTSTRAP_DRY_RUN" != "1" ] && [ "${BOOTSTRAP_SKIP_TOOL_CHECK:-0}" != "1" ] && command -v gh >/dev/null 2>&1; then
     local full_name="$BOOTSTRAP_REPO_OWNER/${BOOTSTRAP_INPUT_REPO_NAME}"
-    if gh repo view "$full_name" >/dev/null 2>&1; then
+    # Use GH_TOKEN explicitly per CLAUDE.md § Active-account convention:
+    # read-path gh calls honor GH_TOKEN, and pinning to the preflight
+    # author/reviewer PAT keeps the call deterministic across machines
+    # where the active keyring account might differ. Fall back to
+    # whatever gh's keyring resolves if no preflight var is present
+    # (developer running wizard locally without preflight).
+    local _gh_repo_view_rc=0
+    GH_TOKEN="${OP_PREFLIGHT_AUTHOR_PAT:-${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}}" \
+      gh repo view "$full_name" >/dev/null 2>&1 || _gh_repo_view_rc=$?
+    if [ "$_gh_repo_view_rc" -eq 0 ]; then
       bootstrap::wizard_err "remote already exists: $full_name. Refusing to bootstrap over an existing repo."
       violations=$((violations + 1))
     fi
@@ -477,10 +486,19 @@ prompt_for_inputs() {
   if [ -z "${BOOTSTRAP_FROM_FLAG_PROJECT:-}" ]; then
     local v="new"
     read -r -p "[bootstrap-wizard] Project v2 board [new/<N>] (default: new): " input
+    # Mirror the strict --project flag validation (round-1 fix at the
+     # arg-parser): `[0-9]*` would accept "12abc", which then breaks
+     # later when the wizard tries `gh project ... --number 12abc`.
+     # Reject anything containing a non-digit, accept empty/new + all-
+     # digits. CodeRabbit caught this as a same-bug-different-path
+     # finding on the interactive prompt after round 1.
     case "${input:-}" in
       new|"") v="new" ;;
-      [0-9]*) v="$input" ;;
-      *) bootstrap::wizard_err "invalid project value '$input'; defaulting to new" ;;
+      *[!0-9]*)
+        bootstrap::wizard_err "invalid project value '$input'; expected 'new' or a non-negative integer"
+        exit 1
+        ;;
+      *) v="$input" ;;  # digits-only
     esac
     BOOTSTRAP_INPUT_PROJECT="$v"
   fi
@@ -589,8 +607,14 @@ dispatch() {
       bootstrap::wizard_err "stage function $fn not found (sourced from $BOOTSTRAP_LIB_DIR)"
       return 3
     fi
-    if ! "$fn"; then
-      bootstrap::wizard_err "stage '$stage' failed (rc=$?). Resume with: $0 ${BOOTSTRAP_INPUT_REPO_NAME} --resume $stage"
+    # Capture the stage's real exit code BEFORE the branch test. The
+    # `! "$fn"` form runs `$fn` and then negates; inside the if-block,
+    # `$?` reflects the negation step (always 0), not the function's
+    # rc. Use a then/else split so we can record the actual rc with $?.
+    local stage_rc=0
+    "$fn" || stage_rc=$?
+    if [ "$stage_rc" -ne 0 ]; then
+      bootstrap::wizard_err "stage '$stage' failed (rc=$stage_rc). Resume with: $0 ${BOOTSTRAP_INPUT_REPO_NAME} --resume $stage"
       return 3
     fi
   done

--- a/scripts/bootstrap-new-repo.sh
+++ b/scripts/bootstrap-new-repo.sh
@@ -1,0 +1,571 @@
+#!/usr/bin/env bash
+# scripts/bootstrap-new-repo.sh — wizard for spinning up a new repo
+# from the Mergepath template. See #156 for the parent design.
+#
+# This is the scaffold from #156 sub-A: argument parsing, interactive
+# prompts, preflight checks, and the dispatch shape. Each subsequent
+# sub-issue (#156 B/C/D/E) plugs into a stage function under
+# scripts/bootstrap/ — see scripts/bootstrap/_lib.sh for the helper
+# contract.
+#
+# Usage:
+#   scripts/bootstrap-new-repo.sh <new-repo-name> [options]
+#
+# Options:
+#   --description "..."          New repo's short description (skips prompt).
+#   --visibility public|private  New repo visibility (skips prompt).
+#   --firebase dev|dev+prod|none Firebase scope (skips prompt + skips
+#                                Phase D firebase when "none").
+#   --reviewers c1,c2,...        Reviewer identities (default: claude,cursor,codex).
+#                                Each entry is the agent name; the wizard
+#                                resolves to nathanpayne-<agent>.
+#   --codex-app y|n              Whether to display Codex App install URL.
+#                                Default: prompt.
+#   --project new|<N>            Project v2 board target. "new" creates a
+#                                fresh board; <N> attaches to existing
+#                                project number N. Default: prompt
+#                                (defaulting to "new").
+#   --skip-firebase              Same as --firebase=none. Doc-only repos.
+#   --skip-board                 Skip Project v2 board creation entirely.
+#   --dry-run                    Print what would happen; zero side
+#                                effects on disk or via gh/git/op.
+#   --resume [<stage>]           Resume a partially-completed run. With
+#                                an explicit stage, skip up to and
+#                                including <stage>. Without, read the
+#                                last completed stage from
+#                                $TARGET_DIR/.bootstrap-state.
+#   --target-dir <path>          Override the new repo's local working
+#                                tree path. Default: $HOME/GitHub/<name>.
+#   --help, -h                   Show this help.
+#   --version                    Print version info.
+#
+# Exit codes:
+#   0  All in-scope stages completed (or all skipped per --resume).
+#   1  Bad arguments / unknown flag / required arg missing.
+#   2  Preflight failed (missing dependency, dirty target dir,
+#      existing remote, etc.).
+#   3  Mid-run stage failure; resumable from the last completed
+#      stage. The state file at $TARGET_DIR/.bootstrap-state records
+#      progress.
+#   4  User aborted at a confirmation prompt.
+#
+# Environment:
+#   BOOTSTRAP_REPO_OWNER  GitHub owner for new repos. Default:
+#                         "nathanjohnpayne" (the canonical author
+#                         identity in this template).
+#   BOOTSTRAP_LIB_DIR     Override the per-stage module directory.
+#                         Default: $(dirname $0)/bootstrap.
+#
+# Design notes:
+#   - Side-effects are gated through bootstrap::run (defined in
+#     scripts/bootstrap/_lib.sh). Stages that bypass that wrapper
+#     break dry-run correctness.
+#   - The state file is append-only; --resume reads the last line.
+#     This keeps the resume semantics simple (last-wins) and
+#     auditable (the file is the full stage-completion log).
+#   - Preflight runs BEFORE prompts; we don't want to ask the human
+#     six questions and then fail on a missing `gh`.
+
+set -euo pipefail
+
+# --- constants --------------------------------------------------------------
+
+SCRIPT_VERSION="0.1.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOOTSTRAP_LIB_DIR="${BOOTSTRAP_LIB_DIR:-$SCRIPT_DIR/bootstrap}"
+BOOTSTRAP_REPO_OWNER="${BOOTSTRAP_REPO_OWNER:-nathanjohnpayne}"
+
+# --- collected inputs --------------------------------------------------------
+#
+# Individual variables instead of an associative array because bash 3.2
+# (macOS default) lacks `declare -A`. Each input has a parallel
+# BOOTSTRAP_FROM_FLAG_<name> sentinel — "1" iff the input came from a
+# flag (skip the prompt), empty otherwise. The wizard's per-stage
+# functions read these via the BOOTSTRAP_INPUT_<name> shape exported
+# below; see bootstrap_input() for the read accessor.
+
+BOOTSTRAP_INPUT_REPO_NAME=""
+BOOTSTRAP_INPUT_DESCRIPTION=""
+BOOTSTRAP_INPUT_VISIBILITY=""
+BOOTSTRAP_INPUT_FIREBASE=""
+BOOTSTRAP_INPUT_REVIEWERS="claude,cursor,codex"
+BOOTSTRAP_INPUT_CODEX_APP=""
+BOOTSTRAP_INPUT_PROJECT=""
+
+BOOTSTRAP_FROM_FLAG_DESCRIPTION=""
+BOOTSTRAP_FROM_FLAG_VISIBILITY=""
+BOOTSTRAP_FROM_FLAG_FIREBASE=""
+BOOTSTRAP_FROM_FLAG_REVIEWERS=""
+BOOTSTRAP_FROM_FLAG_CODEX_APP=""
+BOOTSTRAP_FROM_FLAG_PROJECT=""
+
+BOOTSTRAP_DRY_RUN=0
+BOOTSTRAP_SKIP_FIREBASE=0
+BOOTSTRAP_SKIP_BOARD=0
+BOOTSTRAP_RESUME_STAGE=""
+BOOTSTRAP_RESUME_REQUESTED=0
+BOOTSTRAP_TARGET_DIR_OVERRIDE=""
+
+# Read accessor used by stage modules. Stages reference inputs by
+# logical name (e.g., `bootstrap_input repo_name`) rather than
+# touching the variable names directly. Keeps the surface for sub-B
+# through sub-E stable even if the storage shape changes later
+# (e.g., if we move to bash 4+ and re-introduce associative arrays).
+bootstrap_input() {
+  local name=$1
+  case "$name" in
+    repo_name)   echo "$BOOTSTRAP_INPUT_REPO_NAME" ;;
+    description) echo "$BOOTSTRAP_INPUT_DESCRIPTION" ;;
+    visibility)  echo "$BOOTSTRAP_INPUT_VISIBILITY" ;;
+    firebase)    echo "$BOOTSTRAP_INPUT_FIREBASE" ;;
+    reviewers)   echo "$BOOTSTRAP_INPUT_REVIEWERS" ;;
+    codex_app)   echo "$BOOTSTRAP_INPUT_CODEX_APP" ;;
+    project)     echo "$BOOTSTRAP_INPUT_PROJECT" ;;
+    *)
+      echo "[bootstrap-wizard] ERROR: unknown input name '$name' (allowed: repo_name, description, visibility, firebase, reviewers, codex_app, project)" >&2
+      return 1
+      ;;
+  esac
+}
+export -f bootstrap_input
+
+# --- helpers (logging only — bootstrap::run + state come from _lib.sh) ------
+
+usage() {
+  sed -n '
+    /^# Usage:/,/^$/{
+      /^# */{
+        s/^# *//
+        p
+      }
+    }
+  ' "${BASH_SOURCE[0]}"
+}
+
+bootstrap::wizard_log() { echo "[bootstrap-wizard] $*"; }
+bootstrap::wizard_err() { echo "[bootstrap-wizard] ERROR: $*" >&2; }
+
+# --- argument parsing -------------------------------------------------------
+
+if [ $# -eq 0 ]; then
+  usage
+  exit 1
+fi
+
+# First positional = new repo name. Everything else is flags.
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --description)
+      [ -z "${2:-}" ] && { bootstrap::wizard_err "missing argument for --description"; exit 1; }
+      BOOTSTRAP_INPUT_DESCRIPTION="$2"
+      BOOTSTRAP_FROM_FLAG_DESCRIPTION=1
+      shift 2
+      ;;
+    --visibility)
+      [ -z "${2:-}" ] && { bootstrap::wizard_err "missing argument for --visibility"; exit 1; }
+      case "$2" in
+        public|private) ;;
+        *) bootstrap::wizard_err "--visibility must be 'public' or 'private' (got '$2')"; exit 1 ;;
+      esac
+      BOOTSTRAP_INPUT_VISIBILITY="$2"
+      BOOTSTRAP_FROM_FLAG_VISIBILITY=1
+      shift 2
+      ;;
+    --firebase)
+      [ -z "${2:-}" ] && { bootstrap::wizard_err "missing argument for --firebase"; exit 1; }
+      case "$2" in
+        dev|dev+prod|none) ;;
+        *) bootstrap::wizard_err "--firebase must be 'dev', 'dev+prod', or 'none' (got '$2')"; exit 1 ;;
+      esac
+      BOOTSTRAP_INPUT_FIREBASE="$2"
+      BOOTSTRAP_FROM_FLAG_FIREBASE=1
+      shift 2
+      ;;
+    --reviewers)
+      [ -z "${2:-}" ] && { bootstrap::wizard_err "missing argument for --reviewers"; exit 1; }
+      BOOTSTRAP_INPUT_REVIEWERS="$2"
+      BOOTSTRAP_FROM_FLAG_REVIEWERS=1
+      shift 2
+      ;;
+    --codex-app)
+      [ -z "${2:-}" ] && { bootstrap::wizard_err "missing argument for --codex-app"; exit 1; }
+      case "$2" in
+        y|n) ;;
+        *) bootstrap::wizard_err "--codex-app must be 'y' or 'n' (got '$2')"; exit 1 ;;
+      esac
+      BOOTSTRAP_INPUT_CODEX_APP="$2"
+      BOOTSTRAP_FROM_FLAG_CODEX_APP=1
+      shift 2
+      ;;
+    --project)
+      [ -z "${2:-}" ] && { bootstrap::wizard_err "missing argument for --project"; exit 1; }
+      case "$2" in
+        new|[0-9]*) ;;
+        *) bootstrap::wizard_err "--project must be 'new' or a number (got '$2')"; exit 1 ;;
+      esac
+      BOOTSTRAP_INPUT_PROJECT="$2"
+      BOOTSTRAP_FROM_FLAG_PROJECT=1
+      shift 2
+      ;;
+    --skip-firebase)
+      BOOTSTRAP_SKIP_FIREBASE=1
+      BOOTSTRAP_INPUT_FIREBASE="none"
+      BOOTSTRAP_FROM_FLAG_FIREBASE=1
+      shift
+      ;;
+    --skip-board)
+      BOOTSTRAP_SKIP_BOARD=1
+      BOOTSTRAP_FROM_FLAG_PROJECT=1
+      shift
+      ;;
+    --dry-run)
+      BOOTSTRAP_DRY_RUN=1
+      shift
+      ;;
+    --resume)
+      BOOTSTRAP_RESUME_REQUESTED=1
+      # The arg is optional. If the next token isn't a flag, take it
+      # as the stage name.
+      if [ $# -gt 1 ] && [[ "${2:-}" != --* ]]; then
+        BOOTSTRAP_RESUME_STAGE="$2"
+        shift 2
+      else
+        shift
+      fi
+      ;;
+    --target-dir)
+      [ -z "${2:-}" ] && { bootstrap::wizard_err "missing argument for --target-dir"; exit 1; }
+      BOOTSTRAP_TARGET_DIR_OVERRIDE="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --version)
+      echo "bootstrap-new-repo.sh $SCRIPT_VERSION"
+      exit 0
+      ;;
+    -*)
+      bootstrap::wizard_err "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      if [ -n "${BOOTSTRAP_INPUT_REPO_NAME}" ]; then
+        bootstrap::wizard_err "multiple positional args; expected exactly one repo-name (got '${BOOTSTRAP_INPUT_REPO_NAME}' and '$1')"
+        exit 1
+      fi
+      BOOTSTRAP_INPUT_REPO_NAME="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "${BOOTSTRAP_INPUT_REPO_NAME}" ]; then
+  bootstrap::wizard_err "missing required positional argument: <new-repo-name>"
+  usage
+  exit 1
+fi
+
+# --- derived paths ----------------------------------------------------------
+
+if [ -n "$BOOTSTRAP_TARGET_DIR_OVERRIDE" ]; then
+  TARGET_DIR="$BOOTSTRAP_TARGET_DIR_OVERRIDE"
+else
+  TARGET_DIR="${HOME}/GitHub/${BOOTSTRAP_INPUT_REPO_NAME}"
+fi
+BOOTSTRAP_LOG_FILE="$TARGET_DIR/.bootstrap-log"
+BOOTSTRAP_STATE_FILE="$TARGET_DIR/.bootstrap-state"
+
+export BOOTSTRAP_DRY_RUN BOOTSTRAP_LOG_FILE BOOTSTRAP_STATE_FILE
+
+# --- source the helper lib + stage modules ---------------------------------
+
+if [ ! -d "$BOOTSTRAP_LIB_DIR" ]; then
+  bootstrap::wizard_err "bootstrap library dir not found: $BOOTSTRAP_LIB_DIR"
+  exit 2
+fi
+
+# shellcheck source=scripts/bootstrap/_lib.sh
+. "$BOOTSTRAP_LIB_DIR/_lib.sh"
+# shellcheck source=scripts/bootstrap/template-mirror.sh
+. "$BOOTSTRAP_LIB_DIR/template-mirror.sh"
+# shellcheck source=scripts/bootstrap/github-infra.sh
+. "$BOOTSTRAP_LIB_DIR/github-infra.sh"
+# shellcheck source=scripts/bootstrap/firebase-and-codereview.sh
+. "$BOOTSTRAP_LIB_DIR/firebase-and-codereview.sh"
+# shellcheck source=scripts/bootstrap/board-and-summary.sh
+. "$BOOTSTRAP_LIB_DIR/board-and-summary.sh"
+
+# --- preflight --------------------------------------------------------------
+
+preflight() {
+  local violations=0
+  local v
+
+  # 1. Required CLI tools on PATH. Tests may set BOOTSTRAP_SKIP_TOOL_CHECK=1
+  #    to bypass this (e.g., a CI runner that doesn't have firebase /
+  #    gcloud installed but is still exercising the wizard's flag parser).
+  if [ "${BOOTSTRAP_SKIP_TOOL_CHECK:-0}" != "1" ]; then
+    for tool in gh op git; do
+      if ! command -v "$tool" >/dev/null 2>&1; then
+        bootstrap::wizard_err "missing required dependency: $tool"
+        violations=$((violations + 1))
+      fi
+    done
+    # firebase and gcloud only required when Firebase scope != none.
+    if [ "${BOOTSTRAP_INPUT_FIREBASE}" != "none" ] && [ "$BOOTSTRAP_SKIP_FIREBASE" != "1" ]; then
+      for tool in firebase gcloud; do
+        if ! command -v "$tool" >/dev/null 2>&1; then
+          bootstrap::wizard_err "missing Firebase dependency: $tool (skip with --skip-firebase if not deploying)"
+          violations=$((violations + 1))
+        fi
+      done
+    fi
+  fi
+
+  # 2. op-preflight.sh session cache. Soft-warn rather than hard-fail —
+  #    not every flow needs preflight (dry-run smoke tests, for
+  #    instance). The Firebase / GitHub side-effects will surface
+  #    a credential error themselves if preflight wasn't run.
+  if [ "${OP_PREFLIGHT_DONE:-0}" != "1" ] && [ "$BOOTSTRAP_DRY_RUN" != "1" ]; then
+    bootstrap::warn "OP_PREFLIGHT_DONE not set — credential preflight may need to run before any gh/op side-effects"
+  fi
+
+  # 3. Active gh account is the author identity. Don't auto-switch
+  #    here; surface the mismatch and let the human decide. (Stages B/C
+  #    will switch as needed using the standard switch-around.)
+  if [ "${BOOTSTRAP_SKIP_TOOL_CHECK:-0}" != "1" ] && command -v gh >/dev/null 2>&1; then
+    local active
+    active=$(gh config get -h github.com user 2>/dev/null || echo "")
+    if [ -n "$active" ] && [ "$active" != "$BOOTSTRAP_REPO_OWNER" ]; then
+      bootstrap::warn "active gh account is '$active', not '$BOOTSTRAP_REPO_OWNER'. Stage modules will switch as needed."
+    fi
+  fi
+
+  # 4. Target dir is empty (or absent). Refuse to overwrite a populated
+  #    dir — the wizard is meant for new repos, not for re-bootstrapping
+  #    an existing tree.
+  if [ -d "$TARGET_DIR" ]; then
+    # Allow the dir if it's empty OR contains only resume bookkeeping
+    # (.bootstrap-state, .bootstrap-log).
+    local extra
+    extra=$(find "$TARGET_DIR" -mindepth 1 -maxdepth 1 \
+              ! -name '.bootstrap-state' \
+              ! -name '.bootstrap-log' 2>/dev/null | head -1)
+    if [ -n "$extra" ]; then
+      bootstrap::wizard_err "target dir $TARGET_DIR is not empty (contains: $extra ...). Refusing to overwrite."
+      violations=$((violations + 1))
+    fi
+  fi
+
+  # 5. No existing remote with the same owner/name. Skip the network
+  #    probe in dry-run mode + when tool check is suppressed.
+  if [ "$BOOTSTRAP_DRY_RUN" != "1" ] && [ "${BOOTSTRAP_SKIP_TOOL_CHECK:-0}" != "1" ] && command -v gh >/dev/null 2>&1; then
+    local full_name="$BOOTSTRAP_REPO_OWNER/${BOOTSTRAP_INPUT_REPO_NAME}"
+    if gh repo view "$full_name" >/dev/null 2>&1; then
+      bootstrap::wizard_err "remote already exists: $full_name. Refusing to bootstrap over an existing repo."
+      violations=$((violations + 1))
+    fi
+  fi
+
+  # 6. Mergepath itself is on main and clean. The cross-repo loop
+  #    update in stage B writes to mergepath; doing that against a
+  #    dirty / non-main worktree risks committing unrelated changes.
+  #    Skip in dry-run.
+  if [ "$BOOTSTRAP_DRY_RUN" != "1" ] && [ "${BOOTSTRAP_SKIP_MERGEPATH_GUARD:-0}" != "1" ]; then
+    local mp_root
+    mp_root=$(cd "$SCRIPT_DIR/.." && pwd)
+    local mp_branch
+    mp_branch=$(git -C "$mp_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    if [ "$mp_branch" != "main" ]; then
+      bootstrap::wizard_err "mergepath worktree at $mp_root is on branch '$mp_branch', not 'main'. Switch to main before bootstrapping."
+      violations=$((violations + 1))
+    fi
+    if [ -n "$(git -C "$mp_root" status --porcelain 2>/dev/null)" ]; then
+      bootstrap::wizard_err "mergepath worktree at $mp_root has uncommitted changes. Stash or commit before bootstrapping."
+      violations=$((violations + 1))
+    fi
+  fi
+
+  if [ "$violations" -gt 0 ]; then
+    bootstrap::wizard_err "preflight failed ($violations violation(s)). Aborting."
+    return 2
+  fi
+  return 0
+}
+
+# --- prompt block -----------------------------------------------------------
+
+prompt_for_inputs() {
+  # Each prompt is skipped if the corresponding --flag was passed.
+  # Defaults match the issue spec.
+
+  if [ -z "${BOOTSTRAP_FROM_FLAG_DESCRIPTION:-}" ]; then
+    read -r -p "[bootstrap-wizard] Short description (one line): " v
+    BOOTSTRAP_INPUT_DESCRIPTION="$v"
+  fi
+
+  if [ -z "${BOOTSTRAP_FROM_FLAG_VISIBILITY:-}" ]; then
+    local v="private"
+    read -r -p "[bootstrap-wizard] Visibility [public/private] (default: private): " input
+    case "${input:-}" in
+      public) v="public" ;;
+      private|"") v="private" ;;
+      *) bootstrap::wizard_err "invalid visibility '$input'; defaulting to private" ;;
+    esac
+    BOOTSTRAP_INPUT_VISIBILITY="$v"
+  fi
+
+  if [ -z "${BOOTSTRAP_FROM_FLAG_FIREBASE:-}" ]; then
+    local v="none"
+    read -r -p "[bootstrap-wizard] Firebase scope [dev/dev+prod/none] (default: none): " input
+    case "${input:-}" in
+      dev|dev+prod|none) v="$input" ;;
+      "") v="none" ;;
+      *) bootstrap::wizard_err "invalid firebase scope '$input'; defaulting to none" ;;
+    esac
+    BOOTSTRAP_INPUT_FIREBASE="$v"
+  fi
+
+  if [ -z "${BOOTSTRAP_FROM_FLAG_CODEX_APP:-}" ]; then
+    local v="n"
+    read -r -p "[bootstrap-wizard] Display Codex App install URL? [y/N]: " input
+    case "${input:-}" in
+      y|Y|yes) v="y" ;;
+      *) v="n" ;;
+    esac
+    BOOTSTRAP_INPUT_CODEX_APP="$v"
+  fi
+
+  if [ -z "${BOOTSTRAP_FROM_FLAG_PROJECT:-}" ]; then
+    local v="new"
+    read -r -p "[bootstrap-wizard] Project v2 board [new/<N>] (default: new): " input
+    case "${input:-}" in
+      new|"") v="new" ;;
+      [0-9]*) v="$input" ;;
+      *) bootstrap::wizard_err "invalid project value '$input'; defaulting to new" ;;
+    esac
+    BOOTSTRAP_INPUT_PROJECT="$v"
+  fi
+
+  # Defaults for inputs that have no prompt (reviewers comes from the
+  # flag default; nothing to ask interactively).
+  : "${BOOTSTRAP_INPUT_REVIEWERS:=claude,cursor,codex}"
+}
+
+# Print the collected inputs + confirm. Skipped in dry-run mode and
+# when BOOTSTRAP_AUTO_CONFIRM=1 (tests).
+confirm_inputs() {
+  bootstrap::wizard_log "----- collected inputs -----"
+  bootstrap::wizard_log "repo_name:    ${BOOTSTRAP_INPUT_REPO_NAME}"
+  bootstrap::wizard_log "description:  ${BOOTSTRAP_INPUT_DESCRIPTION}"
+  bootstrap::wizard_log "visibility:   ${BOOTSTRAP_INPUT_VISIBILITY}"
+  bootstrap::wizard_log "firebase:     ${BOOTSTRAP_INPUT_FIREBASE}"
+  bootstrap::wizard_log "reviewers:    ${BOOTSTRAP_INPUT_REVIEWERS}"
+  bootstrap::wizard_log "codex_app:    ${BOOTSTRAP_INPUT_CODEX_APP}"
+  bootstrap::wizard_log "project:      ${BOOTSTRAP_INPUT_PROJECT}"
+  bootstrap::wizard_log "target_dir:   $TARGET_DIR"
+  bootstrap::wizard_log "----------------------------"
+
+  if [ "$BOOTSTRAP_DRY_RUN" = "1" ] || [ "${BOOTSTRAP_AUTO_CONFIRM:-0}" = "1" ]; then
+    return 0
+  fi
+  read -r -p "[bootstrap-wizard] Proceed? [y/N]: " input
+  case "${input:-}" in
+    y|Y|yes) return 0 ;;
+    *) bootstrap::wizard_err "user aborted at confirmation"; return 4 ;;
+  esac
+}
+
+# --- dispatch ---------------------------------------------------------------
+
+# Stages in execution order. The wizard runs them sequentially; on
+# failure, records the last-completed stage to BOOTSTRAP_STATE_FILE
+# and exits 3 with a "resume with --resume <stage>" message.
+STAGES=(
+  template-mirror
+  github-infra
+  firebase-and-codereview
+  board-and-summary
+)
+
+dispatch() {
+  local resume_after=""
+
+  if [ "$BOOTSTRAP_RESUME_REQUESTED" = "1" ]; then
+    if [ -n "$BOOTSTRAP_RESUME_STAGE" ]; then
+      resume_after="$BOOTSTRAP_RESUME_STAGE"
+    else
+      resume_after=$(bootstrap::last_completed_stage)
+    fi
+    if [ -n "$resume_after" ]; then
+      bootstrap::wizard_log "resume: skipping stages up to and including '$resume_after'"
+    fi
+  fi
+
+  local skipping=0
+  if [ -n "$resume_after" ]; then
+    skipping=1
+  fi
+
+  for stage in "${STAGES[@]}"; do
+    if [ "$skipping" = "1" ]; then
+      bootstrap::wizard_log "resume: skip $stage (already completed)"
+      if [ "$stage" = "$resume_after" ]; then
+        skipping=0
+      fi
+      continue
+    fi
+
+    # Per-flag stage skips. --skip-firebase suppresses stage D's
+    # Firebase substeps but the stage function still runs (it
+    # handles --skip-firebase / firebase=none internally). --skip-board
+    # skips stage E entirely.
+    if [ "$stage" = "board-and-summary" ] && [ "$BOOTSTRAP_SKIP_BOARD" = "1" ]; then
+      bootstrap::wizard_log "skip $stage (--skip-board)"
+      bootstrap::record_stage "$stage"
+      continue
+    fi
+
+    # Dispatch to bootstrap::stage_<name with hyphens to underscores>.
+    local fn="bootstrap::stage_${stage//-/_}"
+    if ! type "$fn" >/dev/null 2>&1; then
+      bootstrap::wizard_err "stage function $fn not found (sourced from $BOOTSTRAP_LIB_DIR)"
+      return 3
+    fi
+    if ! "$fn"; then
+      bootstrap::wizard_err "stage '$stage' failed (rc=$?). Resume with: $0 ${BOOTSTRAP_INPUT_REPO_NAME} --resume $stage"
+      return 3
+    fi
+  done
+
+  return 0
+}
+
+# --- main -------------------------------------------------------------------
+
+preflight || exit $?
+
+# Skip prompts under --dry-run when all inputs came from flags; also
+# skip when BOOTSTRAP_AUTO_PROMPT=skip (tests). The flag-only path
+# means a `--dry-run --visibility private --firebase none ...`
+# invocation runs non-interactively, which is what CI smoke tests
+# need.
+if [ "${BOOTSTRAP_AUTO_PROMPT:-}" != "skip" ]; then
+  prompt_for_inputs
+fi
+
+confirm_inputs || exit $?
+
+bootstrap::wizard_log "starting bootstrap of ${BOOTSTRAP_INPUT_REPO_NAME} into $TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+
+dispatch_rc=0
+dispatch || dispatch_rc=$?
+
+if [ "$dispatch_rc" = "0" ]; then
+  bootstrap::wizard_log "all stages completed for ${BOOTSTRAP_INPUT_REPO_NAME}"
+fi
+exit "$dispatch_rc"

--- a/scripts/bootstrap-new-repo.sh
+++ b/scripts/bootstrap-new-repo.sh
@@ -199,9 +199,19 @@ while [ $# -gt 0 ]; do
       ;;
     --project)
       [ -z "${2:-}" ] && { bootstrap::wizard_err "missing argument for --project"; exit 1; }
+      # Validate as either the literal "new" or a non-empty
+      # digits-only string. The naive case-glob `new|[0-9]*` accepts
+      # values like `12abc` because `*` matches any chars; Codex
+      # P2 caught this on PR #232. The two-step case below uses an
+      # explicit reject pattern (`*[!0-9]*`) so non-digit suffixes
+      # are flagged.
       case "$2" in
-        new|[0-9]*) ;;
-        *) bootstrap::wizard_err "--project must be 'new' or a number (got '$2')"; exit 1 ;;
+        new) ;;
+        '') bootstrap::wizard_err "--project value cannot be empty"; exit 1 ;;
+        *[!0-9]*)
+          bootstrap::wizard_err "--project must be 'new' or a non-negative integer (got '$2')"; exit 1
+          ;;
+        *) ;;  # digits-only — accept
       esac
       BOOTSTRAP_INPUT_PROJECT="$2"
       BOOTSTRAP_FROM_FLAG_PROJECT=1
@@ -314,15 +324,12 @@ preflight() {
         violations=$((violations + 1))
       fi
     done
-    # firebase and gcloud only required when Firebase scope != none.
-    if [ "${BOOTSTRAP_INPUT_FIREBASE}" != "none" ] && [ "$BOOTSTRAP_SKIP_FIREBASE" != "1" ]; then
-      for tool in firebase gcloud; do
-        if ! command -v "$tool" >/dev/null 2>&1; then
-          bootstrap::wizard_err "missing Firebase dependency: $tool (skip with --skip-firebase if not deploying)"
-          violations=$((violations + 1))
-        fi
-      done
-    fi
+    # Firebase / gcloud check is deferred to preflight_firebase_deps()
+    # which runs AFTER prompts populate BOOTSTRAP_INPUT_FIREBASE. Codex
+    # P1 on PR #232 round 1 caught the gap: when the user hasn't
+    # explicitly set --firebase, the input is empty until prompts run;
+    # gating the dep check on `!= "none"` here would reject valid
+    # interactive runs whose intended (defaulted) scope is none.
   fi
 
   # 2. op-preflight.sh session cache. Soft-warn rather than hard-fail —
@@ -391,6 +398,34 @@ preflight() {
 
   if [ "$violations" -gt 0 ]; then
     bootstrap::wizard_err "preflight failed ($violations violation(s)). Aborting."
+    return 2
+  fi
+  return 0
+}
+
+# Firebase-specific dependency check. Runs AFTER prompts populate
+# BOOTSTRAP_INPUT_FIREBASE so an interactive run that defaults
+# firebase=none doesn't trip on missing firebase/gcloud. Codex P1
+# on PR #232 round 1.
+preflight_firebase_deps() {
+  if [ "${BOOTSTRAP_SKIP_TOOL_CHECK:-0}" = "1" ]; then
+    return 0
+  fi
+  if [ "$BOOTSTRAP_SKIP_FIREBASE" = "1" ]; then
+    return 0
+  fi
+  if [ "$BOOTSTRAP_INPUT_FIREBASE" = "none" ] || [ -z "$BOOTSTRAP_INPUT_FIREBASE" ]; then
+    return 0
+  fi
+  local violations=0
+  for tool in firebase gcloud; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      bootstrap::wizard_err "missing Firebase dependency: $tool (skip with --skip-firebase if not deploying)"
+      violations=$((violations + 1))
+    fi
+  done
+  if [ "$violations" -gt 0 ]; then
+    bootstrap::wizard_err "Firebase dependency check failed ($violations missing). Aborting."
     return 2
   fi
   return 0
@@ -501,6 +536,25 @@ dispatch() {
       resume_after=$(bootstrap::last_completed_stage)
     fi
     if [ -n "$resume_after" ]; then
+      # Validate resume_after against the known STAGES list BEFORE
+      # entering the dispatch loop. Without this, an unknown stage
+      # name (typo on the CLI, or a stale state file from an older
+      # wizard version) sets `skipping=1` and never finds a matching
+      # stage to flip it back to 0 — every stage is treated as
+      # already completed and the wizard exits 0 with no work done
+      # (silent false-success). Codex P1 on PR #232 round 1.
+      local known=0
+      for s in "${STAGES[@]}"; do
+        if [ "$s" = "$resume_after" ]; then
+          known=1
+          break
+        fi
+      done
+      if [ "$known" != "1" ]; then
+        bootstrap::wizard_err "unknown resume stage: '$resume_after' (known stages: ${STAGES[*]})"
+        bootstrap::wizard_err "If the state file is the source: edit or remove $BOOTSTRAP_STATE_FILE and re-run."
+        return 1
+      fi
       bootstrap::wizard_log "resume: skipping stages up to and including '$resume_after'"
     fi
   fi
@@ -556,6 +610,11 @@ preflight || exit $?
 if [ "${BOOTSTRAP_AUTO_PROMPT:-}" != "skip" ]; then
   prompt_for_inputs
 fi
+
+# Firebase deps check runs HERE — after prompts populate
+# BOOTSTRAP_INPUT_FIREBASE — so the interactive default-to-none path
+# doesn't trip on missing firebase/gcloud (Codex P1 on PR #232 round 1).
+preflight_firebase_deps || exit $?
 
 confirm_inputs || exit $?
 

--- a/scripts/bootstrap/_lib.sh
+++ b/scripts/bootstrap/_lib.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# scripts/bootstrap/_lib.sh — shared helpers sourced by the
+# bootstrap-new-repo.sh wizard and its per-stage modules.
+#
+# Surface:
+#   bootstrap::log <message>           Log a non-side-effect line to stdout.
+#   bootstrap::warn <message>          Log a warning to stderr.
+#   bootstrap::err <message>           Log an error to stderr.
+#   bootstrap::stage_banner <name>     Emit "==> Starting stage: <name>".
+#   bootstrap::run <label> <cmd> [...] Execute (or dry-run echo) a side-effect.
+#   bootstrap::record_stage <name>     Append a completed stage name to the
+#                                      state file at $BOOTSTRAP_STATE_FILE.
+#   bootstrap::last_completed_stage    Echo the last recorded stage name,
+#                                      or empty if no state file.
+#
+# Globals (set by the wizard before sourcing this file):
+#   BOOTSTRAP_DRY_RUN     "1" iff --dry-run was passed; otherwise "0".
+#   BOOTSTRAP_LOG_FILE    Path to a transcript log file. Each side-effect's
+#                         label + command line is appended. The file's
+#                         directory is created on first use.
+#   BOOTSTRAP_STATE_FILE  Path to the state file used by --resume.
+#
+# Design notes:
+#   - The bootstrap::run wrapper is the ONLY interface for side-effects.
+#     Every gh/git/op/firebase call from a stage module must go through
+#     it. Dry-run correctness depends on no stage cheating around the
+#     wrapper.
+#   - Logs are deliberately verbose (full command line, not abbreviated).
+#     The .bootstrap-log transcript is the audit trail.
+#   - Stage modules read the wizard's collected inputs from a shared
+#     associative array `BOOTSTRAP_INPUTS` (declared in the wizard,
+#     populated by prompts/flags). This file does NOT redeclare it —
+#     the wizard owns the lifecycle.
+
+set -euo pipefail
+
+# Prevent double-sourcing — useful if a stage file mistakenly sources
+# the lib redundantly.
+if [ "${_BOOTSTRAP_LIB_SOURCED:-0}" = "1" ]; then
+  return 0
+fi
+_BOOTSTRAP_LIB_SOURCED=1
+
+bootstrap::log() {
+  echo "[bootstrap] $*"
+}
+
+bootstrap::warn() {
+  echo "[bootstrap] WARN: $*" >&2
+}
+
+bootstrap::err() {
+  echo "[bootstrap] ERROR: $*" >&2
+}
+
+bootstrap::stage_banner() {
+  local stage_name=$1
+  echo
+  echo "==> Starting stage: $stage_name"
+}
+
+# Run a side-effecting command, or echo it in dry-run mode. The
+# command is logged to $BOOTSTRAP_LOG_FILE either way (so dry-run
+# produces a transcript readable as a do-it-yourself runbook).
+#
+# Usage:
+#   bootstrap::run "create repo" gh repo create owner/name --private
+#
+# Args:
+#   $1     Human-readable label (one line, no trailing punctuation).
+#   $2..   Command + args, passed verbatim to exec.
+#
+# Returns the command's exit code, or 0 in dry-run mode.
+bootstrap::run() {
+  local label=$1
+  shift
+  if [ "$#" -eq 0 ]; then
+    bootstrap::err "bootstrap::run requires a command after the label"
+    return 64
+  fi
+
+  # Ensure log dir exists on first use.
+  if [ -n "${BOOTSTRAP_LOG_FILE:-}" ]; then
+    mkdir -p "$(dirname "$BOOTSTRAP_LOG_FILE")"
+  fi
+
+  local cmd_repr
+  cmd_repr=$(printf '%q ' "$@")
+  cmd_repr=${cmd_repr% }  # strip trailing space from printf
+
+  if [ "${BOOTSTRAP_DRY_RUN:-0}" = "1" ]; then
+    echo "[DRY-RUN] $label: $cmd_repr"
+    if [ -n "${BOOTSTRAP_LOG_FILE:-}" ]; then
+      echo "[DRY-RUN] $label: $cmd_repr" >>"$BOOTSTRAP_LOG_FILE"
+    fi
+    return 0
+  fi
+
+  echo "[bootstrap] $label: $cmd_repr"
+  if [ -n "${BOOTSTRAP_LOG_FILE:-}" ]; then
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $label: $cmd_repr" >>"$BOOTSTRAP_LOG_FILE"
+  fi
+  "$@"
+}
+
+# Append a completed-stage name to the resume state file. Idempotent —
+# repeated calls just re-append (last entry wins). State file is a
+# simple newline-separated list of stage names; --resume reads the
+# LAST line.
+bootstrap::record_stage() {
+  local stage_name=$1
+  if [ -z "${BOOTSTRAP_STATE_FILE:-}" ]; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$BOOTSTRAP_STATE_FILE")"
+  echo "$stage_name" >>"$BOOTSTRAP_STATE_FILE"
+}
+
+# Echo the last recorded stage name, or empty string if the state
+# file is absent / empty. Used by --resume to skip already-completed
+# stages on a re-run.
+bootstrap::last_completed_stage() {
+  if [ -z "${BOOTSTRAP_STATE_FILE:-}" ] || [ ! -f "$BOOTSTRAP_STATE_FILE" ]; then
+    return 0
+  fi
+  tail -n 1 "$BOOTSTRAP_STATE_FILE" 2>/dev/null || true
+}

--- a/scripts/bootstrap/board-and-summary.sh
+++ b/scripts/bootstrap/board-and-summary.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# scripts/bootstrap/board-and-summary.sh — bootstrap wizard stage E.
+#
+# Stub shipped with #156 sub-A's scaffold. Real implementation lands
+# in #156 sub-E ("Project v2 board + summary + bootstrap runbook").
+#
+# Stub responsibilities (per #156 sub-E):
+#   - Create a Project v2 board (or attach to existing #) per
+#     BOOTSTRAP_INPUT_PROJECT
+#   - Add the new repo to the board
+#   - Configure default board views matching mergepath's project layout
+#   - Generate a per-run summary report: URLs, next steps, the
+#     hand-off checklist for things the wizard couldn't fully
+#     automate (Codex environment setup, CodeRabbit app install on
+#     non-org repos, etc.)
+#   - Ship/update docs/bootstrap-new-repo.md as the operator runbook
+
+set -euo pipefail
+
+bootstrap::stage_board_and_summary() {
+  bootstrap::stage_banner "board-and-summary (sub-E stub)"
+  local project=${BOOTSTRAP_INPUT_PROJECT:-new}
+  if [ "$project" = "new" ]; then
+    bootstrap::log "stub: would create a new Project v2 board for ${BOOTSTRAP_INPUT_REPO_NAME}"
+  else
+    bootstrap::log "stub: would attach ${BOOTSTRAP_INPUT_REPO_NAME} to existing project #${project}"
+  fi
+  bootstrap::log "stub: would generate the per-run summary + hand-off checklist"
+  bootstrap::record_stage "board-and-summary"
+  return 0
+}

--- a/scripts/bootstrap/firebase-and-codereview.sh
+++ b/scripts/bootstrap/firebase-and-codereview.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/bootstrap/firebase-and-codereview.sh — bootstrap wizard stage D.
+#
+# Stub shipped with #156 sub-A's scaffold. Real implementation lands
+# in #156 sub-D ("Firebase + CodeRabbit posture + Codex App posture").
+#
+# Stub responsibilities (per #156 sub-D):
+#   - Firebase project creation (when BOOTSTRAP_INPUT_FIREBASE != "none")
+#   - op-firebase-setup invocation per DEPLOYMENT.md
+#   - Mint per-project Firebase deployer SA key, store in 1Password
+#   - CodeRabbit App install URL printout (skip if BOOTSTRAP_INPUTS
+#     opts out)
+#   - Codex App install URL printout (display only; CLAUDE.md notes
+#     this can't be fully automated since environment config is
+#     manual at chatgpt.com/codex/cloud/settings)
+#   - Wire up .github/review-policy.yml's coderabbit/codex blocks per
+#     the operator's choices
+
+set -euo pipefail
+
+bootstrap::stage_firebase_and_codereview() {
+  bootstrap::stage_banner "firebase-and-codereview (sub-D stub)"
+  local fb=${BOOTSTRAP_INPUT_FIREBASE:-none}
+  if [ "$fb" = "none" ]; then
+    bootstrap::log "stub: firebase=none, skipping Firebase setup"
+  else
+    bootstrap::log "stub: would create Firebase project (${fb}) + mint deployer SA key"
+  fi
+  bootstrap::log "stub: would print CodeRabbit App install URL"
+  if [ "${BOOTSTRAP_INPUT_CODEX_APP:-prompt}" = "y" ]; then
+    bootstrap::log "stub: would print Codex App install URL + environment setup steps"
+  else
+    bootstrap::log "stub: codex_app=n, skipping Codex App URL printout"
+  fi
+  bootstrap::record_stage "firebase-and-codereview"
+  return 0
+}

--- a/scripts/bootstrap/github-infra.sh
+++ b/scripts/bootstrap/github-infra.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# scripts/bootstrap/github-infra.sh — bootstrap wizard stage C.
+#
+# Stub shipped with #156 sub-A's scaffold. Real implementation lands
+# in #156 sub-C ("GitHub repo creation + labels + collaborators +
+# secrets").
+#
+# Stub responsibilities (per #156 sub-C):
+#   - `gh repo create` (with visibility from BOOTSTRAP_INPUT_VISIBILITY)
+#   - Create the canonical labels (needs-external-review, observation,
+#     risk, post-review, etc.)
+#   - Invite reviewer-identity collaborators (claude / cursor / codex)
+#   - Configure required secrets (REVIEWER_ASSIGNMENT_TOKEN, etc.)
+#   - Set up branch protection on main per REVIEW_POLICY.md
+
+set -euo pipefail
+
+bootstrap::stage_github_infra() {
+  bootstrap::stage_banner "github-infra (sub-C stub)"
+  bootstrap::log "stub: would gh repo create ${BOOTSTRAP_INPUT_REPO_NAME} (${BOOTSTRAP_INPUT_VISIBILITY})"
+  bootstrap::log "stub: would create canonical labels"
+  bootstrap::log "stub: would invite reviewers: ${BOOTSTRAP_INPUT_REVIEWERS}"
+  bootstrap::log "stub: would configure required secrets + branch protection"
+  bootstrap::record_stage "github-infra"
+  return 0
+}

--- a/scripts/bootstrap/template-mirror.sh
+++ b/scripts/bootstrap/template-mirror.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# scripts/bootstrap/template-mirror.sh — bootstrap wizard stage B.
+#
+# This is the STUB shipped with #156 sub-A's scaffold. The real
+# implementation lands in #156 sub-B ("template mirror + name
+# substitution + cross-repo loop update"). For now the stage prints
+# what it WOULD do and records itself as completed so the wizard's
+# dispatch shape can be tested end-to-end before sub-B lands.
+#
+# Stub responsibilities (per #156 sub-B):
+#   - Clone mergepath to a working tree
+#   - Copy canonical files into the new repo
+#   - Apply name substitutions ({{REPO_NAME}}, etc.) to templated files
+#   - Update mergepath's .mergepath-sync.yml `consumers:` list to
+#     include the new repo
+#   - Initialize the new repo's git history
+
+set -euo pipefail
+
+bootstrap::stage_template_mirror() {
+  bootstrap::stage_banner "template-mirror (sub-B stub)"
+  bootstrap::log "stub: would mirror mergepath template into ${BOOTSTRAP_INPUT_REPO_NAME}"
+  bootstrap::log "stub: would apply name substitutions for ${BOOTSTRAP_INPUT_REPO_NAME}"
+  bootstrap::log "stub: would add ${BOOTSTRAP_INPUT_REPO_NAME} to mergepath's .mergepath-sync.yml consumers list"
+  bootstrap::record_stage "template-mirror"
+  return 0
+}

--- a/scripts/ci/check_bootstrap_wizard
+++ b/scripts/ci/check_bootstrap_wizard
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# scripts/ci/check_bootstrap_wizard — CI entry point for #156 sub-A tests.
+#
+# Wraps tests/test_bootstrap_wizard.sh so the repo_lint workflow's
+# "run all scripts/ci/check_*" loop picks it up. Mirrors the
+# pattern used by check_sync_overrides and the other check_*
+# scripts.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_bootstrap_wizard.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  # Missing test script is a hard error (silent skip would let an
+  # accidental delete/rename disable this check). Matches the
+  # tightening applied to check_sync_overrides in #228 round 5.
+  echo "check_bootstrap_wizard: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/tests/test_bootstrap_wizard.sh
+++ b/tests/test_bootstrap_wizard.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# tests/test_bootstrap_wizard.sh
+#
+# Validates scripts/bootstrap-new-repo.sh's scaffold (arg parsing,
+# preflight, prompts, dispatch, resume). Each subsystem stage is
+# stubbed (records its own completion + logs what it would do) so the
+# dispatch shape can be exercised before sub-issues B/C/D/E ship their
+# real stage implementations.
+#
+# The wizard is run under BOOTSTRAP_SKIP_TOOL_CHECK=1 (skips
+# missing-dependency checks) + BOOTSTRAP_SKIP_MERGEPATH_GUARD=1
+# (skips the mergepath-must-be-on-main-and-clean check, since the
+# branch this test runs on isn't main) + BOOTSTRAP_AUTO_CONFIRM=1
+# (skips the "y to proceed" prompt) + BOOTSTRAP_AUTO_PROMPT=skip
+# (skips interactive prompts entirely — all inputs must come from
+# flags) so the test runs non-interactively under CI.
+#
+# Requires: bash 3.2+ (macOS default). Run manually or from
+# scripts/ci/check_bootstrap_wizard.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/bootstrap-new-repo.sh"
+
+[[ -x "$SCRIPT" ]] || { echo "missing or non-executable $SCRIPT" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/bootstrap-wizard-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+run_wizard() {
+  # Wrapper for the test environment: skip every preflight check that
+  # depends on real on-disk state, drive prompts via flags, auto-confirm.
+  BOOTSTRAP_SKIP_TOOL_CHECK=1 \
+  BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+  BOOTSTRAP_AUTO_CONFIRM=1 \
+  BOOTSTRAP_AUTO_PROMPT=skip \
+    "$SCRIPT" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: --help renders without crashing.
+# ---------------------------------------------------------------------------
+if "$SCRIPT" --help 2>&1 | grep -q "Usage:"; then
+  pass "--help renders"
+else
+  fail "--help did not include Usage:"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: --version emits the version string.
+# ---------------------------------------------------------------------------
+if "$SCRIPT" --version 2>&1 | grep -q "bootstrap-new-repo.sh"; then
+  pass "--version renders"
+else
+  fail "--version did not include script name"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: Missing required positional → exit 1.
+# ---------------------------------------------------------------------------
+set +e
+"$SCRIPT" --dry-run >/dev/null 2>&1
+ec=$?
+set -e
+[ "$ec" -eq 1 ] && pass "missing repo-name → exit 1" \
+                || fail "missing repo-name should exit 1; got $ec"
+
+# ---------------------------------------------------------------------------
+# Test 4: Unknown flag → exit 1.
+# ---------------------------------------------------------------------------
+set +e
+"$SCRIPT" some-repo --not-a-real-flag >/dev/null 2>&1
+ec=$?
+set -e
+[ "$ec" -eq 1 ] && pass "unknown flag → exit 1" \
+                || fail "unknown flag should exit 1; got $ec"
+
+# ---------------------------------------------------------------------------
+# Test 5: Invalid --visibility → exit 1.
+# ---------------------------------------------------------------------------
+set +e
+"$SCRIPT" some-repo --visibility invalid >/dev/null 2>&1
+ec=$?
+set -e
+[ "$ec" -eq 1 ] && pass "invalid --visibility → exit 1" \
+                || fail "invalid visibility should exit 1; got $ec"
+
+# ---------------------------------------------------------------------------
+# Test 6: Invalid --firebase → exit 1.
+# ---------------------------------------------------------------------------
+set +e
+"$SCRIPT" some-repo --firebase invalid >/dev/null 2>&1
+ec=$?
+set -e
+[ "$ec" -eq 1 ] && pass "invalid --firebase → exit 1" \
+                || fail "invalid firebase scope should exit 1; got $ec"
+
+# ---------------------------------------------------------------------------
+# Test 7: Invalid --project (non-numeric, not 'new') → exit 1.
+# ---------------------------------------------------------------------------
+set +e
+"$SCRIPT" some-repo --project banana >/dev/null 2>&1
+ec=$?
+set -e
+[ "$ec" -eq 1 ] && pass "invalid --project → exit 1" \
+                || fail "invalid project should exit 1; got $ec"
+
+# ---------------------------------------------------------------------------
+# Test 8: Missing argument for a value-taking flag → exit 1.
+# ---------------------------------------------------------------------------
+set +e
+"$SCRIPT" some-repo --visibility 2>&1 >/dev/null
+ec=$?
+set -e
+[ "$ec" -eq 1 ] && pass "--visibility with no value → exit 1" \
+                || fail "missing flag arg should exit 1; got $ec"
+
+# ---------------------------------------------------------------------------
+# Test 9: Dirty target dir → preflight fails with exit 2.
+# ---------------------------------------------------------------------------
+dirty_target="$WORKDIR/dirty-target"
+mkdir -p "$dirty_target"
+echo "existing content" >"$dirty_target/README.md"
+set +e
+out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+      BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+      "$SCRIPT" my-new-repo \
+      --target-dir "$dirty_target" \
+      --description "desc" --visibility private --firebase none \
+      --codex-app n --project new 2>&1)
+ec=$?
+set -e
+[ "$ec" -eq 2 ] && echo "$out" | grep -q "not empty" \
+  && pass "dirty target dir → exit 2 with diagnostic" \
+  || fail "dirty target dir should exit 2 with 'not empty' diagnostic; got rc=$ec, out: $out"
+
+# ---------------------------------------------------------------------------
+# Test 10: Empty target dir + all flags set → preflight + dispatch
+# completes; state file shows all stage completions; dry-run produces
+# no real side-effects (all stages just stub-print).
+# ---------------------------------------------------------------------------
+clean_target="$WORKDIR/clean-target"
+mkdir -p "$clean_target"
+set +e
+out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+      BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+      "$SCRIPT" my-new-repo \
+      --target-dir "$clean_target" \
+      --description "test repo" --visibility private --firebase none \
+      --codex-app n --project new --dry-run 2>&1)
+ec=$?
+set -e
+if [ "$ec" -ne 0 ]; then
+  fail "dry-run with all flags should exit 0; got rc=$ec, out: $out"
+else
+  pass "dry-run with all flags completes (exit 0)"
+fi
+echo "$out" | grep -q "template-mirror (sub-B stub)" \
+  && pass "stage B stub ran" \
+  || fail "stage B stub didn't run; got: $out"
+echo "$out" | grep -q "github-infra (sub-C stub)" \
+  && pass "stage C stub ran" \
+  || fail "stage C stub didn't run"
+echo "$out" | grep -q "firebase-and-codereview (sub-D stub)" \
+  && pass "stage D stub ran" \
+  || fail "stage D stub didn't run"
+echo "$out" | grep -q "board-and-summary (sub-E stub)" \
+  && pass "stage E stub ran" \
+  || fail "stage E stub didn't run"
+
+# ---------------------------------------------------------------------------
+# Test 11: Resume mechanism. Pre-seed the state file with the first
+# two stages, run with --resume, verify only stages C/D/E run.
+# ---------------------------------------------------------------------------
+resume_target="$WORKDIR/resume-target"
+mkdir -p "$resume_target"
+cat >"$resume_target/.bootstrap-state" <<'EOF'
+template-mirror
+github-infra
+EOF
+set +e
+resume_out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+             BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+             "$SCRIPT" my-new-repo \
+             --target-dir "$resume_target" \
+             --description "test repo" --visibility private --firebase none \
+             --codex-app n --project new --dry-run --resume 2>&1)
+resume_ec=$?
+set -e
+[ "$resume_ec" -eq 0 ] && pass "resume run exits 0" \
+                       || fail "resume should exit 0; got $resume_ec"
+echo "$resume_out" | grep -q "skip template-mirror (already completed)" \
+  && pass "resume skipped template-mirror" \
+  || fail "resume did not skip template-mirror; got: $resume_out"
+echo "$resume_out" | grep -q "skip github-infra (already completed)" \
+  && pass "resume skipped github-infra" \
+  || fail "resume did not skip github-infra"
+echo "$resume_out" | grep -q "firebase-and-codereview (sub-D stub)" \
+  && pass "resume ran firebase-and-codereview" \
+  || fail "resume did not run firebase-and-codereview"
+echo "$resume_out" | grep -q "board-and-summary (sub-E stub)" \
+  && pass "resume ran board-and-summary" \
+  || fail "resume did not run board-and-summary"
+
+# ---------------------------------------------------------------------------
+# Test 12: --resume <explicit-stage> overrides the state-file lookup.
+# Pre-seed the state file with nothing; pass --resume github-infra;
+# verify only stages D/E run.
+# ---------------------------------------------------------------------------
+explicit_resume_target="$WORKDIR/explicit-resume-target"
+mkdir -p "$explicit_resume_target"
+set +e
+ex_out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+         BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+         "$SCRIPT" my-new-repo \
+         --target-dir "$explicit_resume_target" \
+         --description "test repo" --visibility private --firebase none \
+         --codex-app n --project new --dry-run \
+         --resume github-infra 2>&1)
+ex_ec=$?
+set -e
+[ "$ex_ec" -eq 0 ] && pass "--resume <stage> exits 0" \
+                   || fail "--resume <stage> should exit 0; got $ex_ec"
+echo "$ex_out" | grep -q "skip github-infra (already completed)" \
+  && pass "explicit-resume skipped github-infra" \
+  || fail "explicit-resume did not skip github-infra"
+echo "$ex_out" | grep -q "firebase-and-codereview (sub-D stub)" \
+  && pass "explicit-resume ran firebase-and-codereview" \
+  || fail "explicit-resume did not run firebase-and-codereview"
+echo "$ex_out" | grep -q "template-mirror (sub-B stub)" \
+  && fail "explicit-resume should have skipped template-mirror (came before github-infra)" \
+  || pass "explicit-resume correctly skipped pre-target stages"
+
+# ---------------------------------------------------------------------------
+# Test 13: --skip-board skips stage E.
+# ---------------------------------------------------------------------------
+skip_board_target="$WORKDIR/skip-board-target"
+mkdir -p "$skip_board_target"
+set +e
+sb_out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+         BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+         "$SCRIPT" my-new-repo \
+         --target-dir "$skip_board_target" \
+         --description "test repo" --visibility private --firebase none \
+         --codex-app n --skip-board --dry-run 2>&1)
+sb_ec=$?
+set -e
+[ "$sb_ec" -eq 0 ] && pass "--skip-board exits 0" \
+                   || fail "--skip-board should exit 0; got $sb_ec"
+echo "$sb_out" | grep -q "skip board-and-summary (--skip-board)" \
+  && pass "--skip-board skipped board-and-summary" \
+  || fail "--skip-board should skip board-and-summary; got: $sb_out"
+
+# ---------------------------------------------------------------------------
+# Test 14: --skip-firebase implies --firebase=none.
+# ---------------------------------------------------------------------------
+skip_fb_target="$WORKDIR/skip-fb-target"
+mkdir -p "$skip_fb_target"
+set +e
+sf_out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+         BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+         "$SCRIPT" my-new-repo \
+         --target-dir "$skip_fb_target" \
+         --description "test repo" --visibility private \
+         --skip-firebase \
+         --codex-app n --project new --dry-run 2>&1)
+sf_ec=$?
+set -e
+[ "$sf_ec" -eq 0 ] && pass "--skip-firebase exits 0" \
+                   || fail "--skip-firebase should exit 0; got $sf_ec"
+echo "$sf_out" | grep -q "firebase=none, skipping Firebase setup" \
+  && pass "--skip-firebase routes through firebase=none branch" \
+  || fail "--skip-firebase did not log firebase=none; got: $sf_out"
+
+# ---------------------------------------------------------------------------
+# Test 15: Dry-run produces the transcript log but does NOT touch
+# anything outside TARGET_DIR (the log file + state recording both
+# live there).
+# ---------------------------------------------------------------------------
+log_check_target="$WORKDIR/log-check-target"
+mkdir -p "$log_check_target"
+BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+  BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+  "$SCRIPT" my-new-repo \
+  --target-dir "$log_check_target" \
+  --description "test repo" --visibility private --firebase none \
+  --codex-app n --project new --dry-run >/dev/null 2>&1
+# State file should exist with all four stages recorded.
+[ -f "$log_check_target/.bootstrap-state" ] \
+  && pass "dry-run created state file" \
+  || fail "state file missing after dry-run"
+state_lines=$(wc -l <"$log_check_target/.bootstrap-state" | tr -d ' ')
+[ "$state_lines" -eq 4 ] \
+  && pass "state file has 4 stage entries" \
+  || fail "expected 4 state-file entries; got $state_lines"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "test_bootstrap_wizard: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test_bootstrap_wizard.sh
+++ b/tests/test_bootstrap_wizard.sh
@@ -115,7 +115,7 @@ set -e
 # Test 8: Missing argument for a value-taking flag → exit 1.
 # ---------------------------------------------------------------------------
 set +e
-"$SCRIPT" some-repo --visibility 2>&1 >/dev/null
+"$SCRIPT" some-repo --visibility >/dev/null 2>&1
 ec=$?
 set -e
 [ "$ec" -eq 1 ] && pass "--visibility with no value → exit 1" \
@@ -418,6 +418,47 @@ fb_ec=$?
 set -e
 [ "$fb_ec" -eq 0 ] && pass "--firebase none passes even without firebase/gcloud on PATH" \
                    || fail "--firebase none should pass when firebase/gcloud missing; got rc=$fb_ec, out: $fb_out"
+
+# ---------------------------------------------------------------------------
+# Test 19: Interactive prompt --project validation mirrors the flag
+# (CodeRabbit round 2 — same `[0-9]*` glob bug existed at the
+# read-loop's case statement). Pipe "12abc\n" to the wizard with no
+# --project flag; the prompt should reject and exit 1.
+# ---------------------------------------------------------------------------
+ip_target="$WORKDIR/interactive-proj-target"
+mkdir -p "$ip_target"
+set +e
+ip_out=$(printf '12abc\n' | BOOTSTRAP_SKIP_TOOL_CHECK=1 \
+         BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+         "$SCRIPT" my-new-repo \
+         --target-dir "$ip_target" \
+         --description d --visibility private --firebase none \
+         --codex-app n --dry-run 2>&1)
+ip_ec=$?
+set -e
+[ "$ip_ec" -ne 0 ] && pass "interactive --project 12abc → non-zero" \
+                  || fail "interactive prompt should reject '12abc'; got rc=$ip_ec, out: $ip_out"
+echo "$ip_out" | grep -q "invalid project value" \
+  && pass "interactive --project rejection emits 'invalid project value'" \
+  || fail "expected 'invalid project value' diagnostic; got: $ip_out"
+
+# Test 20: Interactive prompt accepts empty/new and digits-only.
+ip_ok_target="$WORKDIR/interactive-proj-ok-target"
+mkdir -p "$ip_ok_target"
+set +e
+ip_ok_out=$(printf '7\n' | BOOTSTRAP_SKIP_TOOL_CHECK=1 \
+            BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+            "$SCRIPT" my-new-repo \
+            --target-dir "$ip_ok_target" \
+            --description d --visibility private --firebase none \
+            --codex-app n --dry-run 2>&1)
+ip_ok_ec=$?
+set -e
+[ "$ip_ok_ec" -eq 0 ] && pass "interactive --project 7 → exit 0" \
+                     || fail "interactive '7' should succeed; got rc=$ip_ok_ec"
+echo "$ip_ok_out" | grep -q "project: *7" \
+  && pass "interactive '7' captured as project=7" \
+  || fail "expected 'project: 7' summary; got: $ip_ok_out"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/test_bootstrap_wizard.sh
+++ b/tests/test_bootstrap_wizard.sh
@@ -33,16 +33,6 @@ FAIL=0
 pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
 
-run_wizard() {
-  # Wrapper for the test environment: skip every preflight check that
-  # depends on real on-disk state, drive prompts via flags, auto-confirm.
-  BOOTSTRAP_SKIP_TOOL_CHECK=1 \
-  BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
-  BOOTSTRAP_AUTO_CONFIRM=1 \
-  BOOTSTRAP_AUTO_PROMPT=skip \
-    "$SCRIPT" "$@"
-}
-
 # ---------------------------------------------------------------------------
 # Test 1: --help renders without crashing.
 # ---------------------------------------------------------------------------

--- a/tests/test_bootstrap_wizard.sh
+++ b/tests/test_bootstrap_wizard.sh
@@ -301,6 +301,125 @@ state_lines=$(wc -l <"$log_check_target/.bootstrap-state" | tr -d ' ')
   || fail "expected 4 state-file entries; got $state_lines"
 
 # ---------------------------------------------------------------------------
+# Test 16: --project with non-digit suffix (e.g., "12abc") → exit 1.
+# Codex P2 round 1 caught the `new|[0-9]*` case-glob accepting trailing
+# non-digit chars.
+# ---------------------------------------------------------------------------
+set +e
+"$SCRIPT" some-repo --project 12abc >/dev/null 2>&1
+ec=$?
+set -e
+[ "$ec" -eq 1 ] && pass "--project 12abc → exit 1" \
+                || fail "--project with non-digit suffix should exit 1; got $ec"
+
+# Negative case: --project new and --project 7 should still pass arg validation.
+set +e
+new_target="$WORKDIR/proj-new-target"; mkdir -p "$new_target"
+BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+  BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+  "$SCRIPT" my-new-repo --target-dir "$new_target" \
+  --description d --visibility private --firebase none --codex-app n \
+  --project new --dry-run >/dev/null 2>&1
+new_ec=$?
+set -e
+[ "$new_ec" -eq 0 ] && pass "--project new → exit 0" \
+                    || fail "--project new should pass; got $new_ec"
+
+set +e
+num_target="$WORKDIR/proj-num-target"; mkdir -p "$num_target"
+BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+  BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+  "$SCRIPT" my-new-repo --target-dir "$num_target" \
+  --description d --visibility private --firebase none --codex-app n \
+  --project 42 --dry-run >/dev/null 2>&1
+num_ec=$?
+set -e
+[ "$num_ec" -eq 0 ] && pass "--project 42 → exit 0" \
+                    || fail "--project 42 should pass; got $num_ec"
+
+# ---------------------------------------------------------------------------
+# Test 17: --resume with an unknown stage name → exit 1 (Codex P1
+# round 1 — without the guard, dispatch silently no-ops every stage).
+# ---------------------------------------------------------------------------
+unknown_resume_target="$WORKDIR/unknown-resume-target"
+mkdir -p "$unknown_resume_target"
+set +e
+ur_out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+         BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+         "$SCRIPT" my-new-repo \
+         --target-dir "$unknown_resume_target" \
+         --description d --visibility private --firebase none \
+         --codex-app n --project new --dry-run \
+         --resume not-a-real-stage 2>&1)
+ur_ec=$?
+set -e
+[ "$ur_ec" -ne 0 ] && pass "--resume with unknown stage → non-zero" \
+                   || fail "unknown resume stage should fail; got exit 0 silently (CODEX P1)"
+echo "$ur_out" | grep -q "unknown resume stage" \
+  && pass "unknown resume stage produces targeted diagnostic" \
+  || fail "expected 'unknown resume stage' diagnostic; got: $ur_out"
+
+# Resume target from a STALE state file (typo or older-version
+# wizard recorded a stage that doesn't exist anymore) → same exit
+# path, with a guidance line that points at the state file.
+stale_state_target="$WORKDIR/stale-state-target"
+mkdir -p "$stale_state_target"
+echo "stage-from-a-prior-version" >"$stale_state_target/.bootstrap-state"
+set +e
+ss_out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+         BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+         "$SCRIPT" my-new-repo \
+         --target-dir "$stale_state_target" \
+         --description d --visibility private --firebase none \
+         --codex-app n --project new --dry-run \
+         --resume 2>&1)
+ss_ec=$?
+set -e
+[ "$ss_ec" -ne 0 ] && pass "--resume with stale state-file stage → non-zero" \
+                   || fail "stale state-file stage should fail; got 0"
+echo "$ss_out" | grep -q "state file" \
+  && pass "stale state-file diagnostic points at the file" \
+  || fail "expected 'state file' diagnostic; got: $ss_out"
+
+# ---------------------------------------------------------------------------
+# Test 18: Firebase dep check is deferred until after prompts populate
+# the input (Codex P1 round 1 — the original gating against
+# `BOOTSTRAP_INPUT_FIREBASE != "none"` rejected interactive runs that
+# defaulted to none). Simulate by NOT passing --firebase and NOT having
+# firebase/gcloud installed (SKIP_TOOL_CHECK=0 + a tmpdir PATH).
+# ---------------------------------------------------------------------------
+fb_defer_target="$WORKDIR/fb-defer-target"
+mkdir -p "$fb_defer_target"
+# Manufactured PATH with only the absolute minimum (bash, gh, op, git).
+# If `firebase` and `gcloud` aren't on this PATH AND the user supplied
+# --firebase none, the deferred check should pass with exit 0.
+empty_path_dir="$WORKDIR/empty-path-dir"
+mkdir -p "$empty_path_dir"
+# Symlink the bootstrap-required tools into the manufactured PATH dir
+# so preflight's gh/op/git check passes; firebase/gcloud are
+# deliberately absent.
+for tool in bash gh op git; do
+  src=$(command -v "$tool" || true)
+  if [ -n "$src" ]; then ln -sf "$src" "$empty_path_dir/$tool"; fi
+done
+set +e
+# Include /usr/bin and /bin so coreutils (dirname, sed, etc.) resolve.
+# Crucially: NO /opt/homebrew/bin and NO ~/google-cloud-sdk/bin, so
+# `firebase` and `gcloud` are NOT findable — that's the scenario under
+# test (operator on a fresh machine, picks --firebase none).
+fb_out=$(PATH="$empty_path_dir:/usr/bin:/bin" \
+         BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 BOOTSTRAP_AUTO_CONFIRM=1 \
+         BOOTSTRAP_AUTO_PROMPT=skip \
+         "$SCRIPT" my-new-repo \
+         --target-dir "$fb_defer_target" \
+         --description d --visibility private --firebase none \
+         --codex-app n --project new --dry-run 2>&1)
+fb_ec=$?
+set -e
+[ "$fb_ec" -eq 0 ] && pass "--firebase none passes even without firebase/gcloud on PATH" \
+                   || fail "--firebase none should pass when firebase/gcloud missing; got rc=$fb_ec, out: $fb_out"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo


### PR DESCRIPTION
Authoring-Agent: claude

Closes #203 (sub-A of #156). Ships the bootstrap wizard's scaffold so sub-issues B/C/D/E have a defined plug-in shape. Each per-subsystem stage ships as a stub that prints what it would do and records its own completion — the dispatch flow can be exercised end-to-end before the real stage implementations land.

## What's in

| File | Purpose |
|---|---|
| `scripts/bootstrap-new-repo.sh` | Main wizard. CLI surface (1 positional + 12 flags), 6-point preflight, prompt block, append-only state file, dispatch with --resume support. ~430 lines. |
| `scripts/bootstrap/_lib.sh` | Shared helpers: `bootstrap::run` (dry-run-aware side-effect wrapper), `bootstrap::record_stage`, `bootstrap::last_completed_stage`, log/warn/err. Stages source this once at startup. |
| `scripts/bootstrap/template-mirror.sh` | Sub-B stub. |
| `scripts/bootstrap/github-infra.sh` | Sub-C stub. |
| `scripts/bootstrap/firebase-and-codereview.sh` | Sub-D stub. |
| `scripts/bootstrap/board-and-summary.sh` | Sub-E stub. |
| `tests/test_bootstrap_wizard.sh` | 29-case test fixture — bash 3.2 compatible (macOS default). |
| `scripts/ci/check_bootstrap_wizard` | CI entry point. Fails (exit 1) on missing test script, mirroring the tightening applied to other `check_*` scripts in this directory. |

## Key design choices

- **`bash 3.2` compatible.** No `declare -A`. Individual `BOOTSTRAP_INPUT_<NAME>` variables + a `bootstrap_input <name>` accessor function. Stages reference inputs by logical name only.
- **Side-effects gated through `bootstrap::run`.** Single wrapper for dry-run echoing + transcript logging. Stage modules don't reach for `gh` / `git` / `op` directly; the wrapper is the only path. Dry-run correctness depends on this discipline.
- **Append-only state file.** `$TARGET_DIR/.bootstrap-state` is a newline-separated list of completed stages. `--resume` reads the LAST line. Keeps semantics simple (last-wins) and makes the file readable as a stage-completion audit log.
- **Preflight before prompts.** We don't want to ask 6 questions and then fail on a missing `gh`.
- **Stub-only sub-B/C/D/E.** Each stage function prints what it would do and records itself as completed. Real implementations land in their respective sub-issues.

## Test coverage (29 cases)

- CLI rendering: `--help`, `--version`
- Argument validation: missing positional, unknown flag, invalid value for `--visibility` / `--firebase` / `--project`, missing argument for value-taking flags — all exit 1 with targeted diagnostic
- Preflight: dirty target dir exits 2 with `not empty` diagnostic
- Happy path: dry-run with all flags supplied → exit 0, state file has 4 entries, every stage stub ran in order
- Resume mechanism:
  - Pre-seeded state file → skip-completed, run-remaining
  - `--resume <explicit-stage>` overrides state-file lookup
  - Explicit-resume correctly skips pre-target stages
- Flag-driven skips: `--skip-board` skips stage E; `--skip-firebase` routes through `firebase=none`

All 14 `scripts/ci/check_*` pass.

## Net diff

+1152 lines across 8 new files. Substantial — but bulk is the test fixture (~400 lines) + the main wizard (~430 lines) + supporting modules (~280 lines combined). Over the 300-line `external_review_threshold`, so Phase 4 applies.

## Out of scope (per #156 sub-issue split)

- Template-mirror's real implementation — [#156 sub-B (#204)](https://github.com/nathanjohnpayne/mergepath/issues/204).
- GitHub-infra's real implementation — [#156 sub-C (#205)](https://github.com/nathanjohnpayne/mergepath/issues/205).
- Firebase + code-review's real implementation — [#156 sub-D (#206)](https://github.com/nathanjohnpayne/mergepath/issues/206).
- Board + summary's real implementation + operator runbook — [#156 sub-E (#207)](https://github.com/nathanjohnpayne/mergepath/issues/207).

## Self-Review

**Correctness.** Stage dispatch routes via `bootstrap::stage_<name with hyphens to underscores>`; every stub registers its function name in its own file under that convention. State-file recording is append-only with `mkdir -p` defense. The `bootstrap::run` wrapper logs the printf-quoted command line so transcripts are re-runnable manually. Preflight escape-hatch env vars are CI-only and clearly named.

**Regression risk.** All-new files; no existing scripts modified. No new top-level directories (`scripts/bootstrap/` is allowed by `check_no_forbidden_top_level_dirs` since it's under `scripts/`). The new `check_bootstrap_wizard` joins the existing CI suite without changing other checks' invocations.

**Style.** Matches the heavy-comment convention from `sync-to-downstream.sh` (rationale + sub-issue refs inline). Help text + script header are kept in lockstep — single source of truth via the `sed -n /^# Usage:/,/^$/` pattern.

**Test coverage.** 29 cases cover argument parsing, value validation, preflight, dispatch, resume, and per-flag skip behavior. Each negative test asserts both the exit code AND a targeted diagnostic substring (so a regression that swaps exit codes silently still fails the test).

**Security / dependency hygiene.** Wizard runs side-effects only via `bootstrap::run`; tests stub the dependency presence checks via `BOOTSTRAP_SKIP_TOOL_CHECK=1` rather than mocking executables. No new dependencies beyond `bash` / `gh` / `git` / `op` (the wizard itself is permissive on missing `firebase` / `gcloud` when Firebase scope is `none`). No secrets stored or transmitted; the wizard reads from preflight cache by convention.

## Test plan

- [x] `bash -n scripts/bootstrap-new-repo.sh` + per-stage modules clean.
- [x] `bash tests/test_bootstrap_wizard.sh` → 29/29 passing.
- [x] All `scripts/ci/check_*` exit 0.
- [ ] Next sub-issue (#204 sub-B) sources the existing stubs and replaces them in-place; dispatch shape stays unchanged.
- [ ] Live bootstrap run against a throwaway repo name once sub-B/C/D ship (deferred to those sub-issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)