### PR TITLE
feat(bootstrap): GitHub repo create + labels + invites + secrets (#205)

### DIFF
--- a/scripts/bootstrap-new-repo.sh
+++ b/scripts/bootstrap-new-repo.sh
@@ -633,6 +633,21 @@ dispatch() {
       continue
     fi
 
+    # General-purpose stage skip via env var. BOOTSTRAP_SKIP_STAGES is
+    # a comma-separated list of stage names to skip entirely (no
+    # dispatch, no record). Useful for tests that want to scope to a
+    # single stage, and for operators who want to mirror the template
+    # locally without yet creating remote GitHub infra (e.g., to
+    # inspect the result before committing to a name).
+    if [ -n "${BOOTSTRAP_SKIP_STAGES:-}" ]; then
+      case ",${BOOTSTRAP_SKIP_STAGES},"  in
+        *",${stage},"*)
+          bootstrap::wizard_log "skip $stage (BOOTSTRAP_SKIP_STAGES)"
+          continue
+          ;;
+      esac
+    fi
+
     # Dispatch to bootstrap::stage_<name with hyphens to underscores>.
     local fn="bootstrap::stage_${stage//-/_}"
     if ! type "$fn" >/dev/null 2>&1; then

--- a/scripts/bootstrap/github-infra.sh
+++ b/scripts/bootstrap/github-infra.sh
@@ -84,11 +84,55 @@ bootstrap::stage_github_infra() {
   # (same pattern as stage B sub-#233 round 4).
   local step_rc=0
 
+  # ----- author-identity switch-around (stage scope) -----
+  # All write-path gh calls in this stage (repo create, label,
+  # collaborator invite, secret set) must run under the author
+  # identity (default nathanjohnpayne) per CLAUDE.md § Active-account
+  # convention. CodeRabbit Major on #239 round 1 caught the gap:
+  # without the wrap, every write attributed to whatever agent
+  # identity was active, breaking the audit trail.
+  #
+  # One switch-pair covers all of stage C's writes — cheaper +
+  # clearer than wrapping each call. The restore ALWAYS runs (even
+  # on stage failure), via an explicit handler at every return path.
+  #
+  # Skip via BOOTSTRAP_SKIP_AUTHOR_SWITCH=1 (tests). Also skipped in
+  # dry-run since we don't want to side-effect the keyring while
+  # printing a plan.
+  local author_identity="${BOOTSTRAP_AUTHOR_IDENTITY:-nathanjohnpayne}"
+  local prior_active=""
+  if [ "${BOOTSTRAP_SKIP_AUTHOR_SWITCH:-0}" != "1" ] \
+     && [ "${BOOTSTRAP_DRY_RUN:-0}" != "1" ]; then
+    prior_active=$(gh config get -h github.com user 2>/dev/null || echo "")
+    if [ -z "$prior_active" ]; then
+      bootstrap::warn "github-infra: could not determine prior active gh account; writes will run under whatever is currently active"
+    else
+      bootstrap::run "switch active gh account to $author_identity for stage writes" \
+        gh auth switch -u "$author_identity" || step_rc=$?
+      if [ "$step_rc" -ne 0 ]; then
+        bootstrap::err "github-infra: gh auth switch to $author_identity failed (rc=$step_rc); aborting before any writes to preserve the prior active account"
+        return "$step_rc"
+      fi
+    fi
+  fi
+
+  # Helper: run a sub-step and ALWAYS-restore prior_active on stage
+  # exit. Used by every return-on-failure path below so the keyring
+  # state never leaks past this stage.
+  bootstrap::_restore_active_if_needed() {
+    if [ -n "$prior_active" ]; then
+      bootstrap::run "restore active gh account to $prior_active" \
+        gh auth switch -u "$prior_active" \
+        || bootstrap::warn "github-infra: failed to restore active gh account to $prior_active; manual fix may be needed via 'gh auth switch -u $prior_active'"
+    fi
+  }
+
   # Step 1: create the remote + push the bootstrap commit.
   bootstrap::_create_remote_and_push \
     "$full_repo" "$visibility" "$description" "$target" || step_rc=$?
   if [ "$step_rc" -ne 0 ]; then
     bootstrap::err "github-infra: gh repo create / push failed (rc=$step_rc)"
+    bootstrap::_restore_active_if_needed
     return "$step_rc"
   fi
 
@@ -96,6 +140,7 @@ bootstrap::stage_github_infra() {
   bootstrap::_seed_labels "$full_repo" || step_rc=$?
   if [ "$step_rc" -ne 0 ]; then
     bootstrap::err "github-infra: label seeding failed (rc=$step_rc)"
+    bootstrap::_restore_active_if_needed
     return "$step_rc"
   fi
 
@@ -103,6 +148,7 @@ bootstrap::stage_github_infra() {
   bootstrap::_invite_reviewers "$full_repo" "$reviewers" || step_rc=$?
   if [ "$step_rc" -ne 0 ]; then
     bootstrap::err "github-infra: reviewer invitations failed (rc=$step_rc)"
+    bootstrap::_restore_active_if_needed
     return "$step_rc"
   fi
 
@@ -127,6 +173,9 @@ bootstrap::stage_github_infra() {
       step_rc=0
     fi
   fi
+
+  # ----- end author-identity wrap: always-restore -----
+  bootstrap::_restore_active_if_needed
 
   bootstrap::record_stage "github-infra"
   return 0
@@ -207,10 +256,19 @@ bootstrap::_invite_reviewers() {
   local full_repo=$1 reviewers_csv=$2
   local agent login
 
-  # Split CSV into individual agent names.
-  local IFS=','
+  # Split CSV into individual agent names. Use a glob-safe split:
+  # `set -f` disables pathname expansion so an agent name that
+  # happened to contain `*` or `?` (unlikely but possible) doesn't
+  # get word-globbed into matching paths. IFS is scoped via local
+  # and restored explicitly after the split. (CodeRabbit Minor on
+  # #239 round 1 + ShellCheck SC2086 caught the unprotected split.)
+  local old_ifs="$IFS"
+  set -f
+  IFS=','
+  # shellcheck disable=SC2086 # intentional word-split under -f
   set -- $reviewers_csv
-  unset IFS
+  set +f
+  IFS="$old_ifs"
 
   for agent in "$@"; do
     agent=$(printf '%s' "$agent" | tr -d ' ')
@@ -287,18 +345,22 @@ bootstrap::_provision_reviewer_assignment_token() {
     fi
   fi
 
-  # Set the repo secret. `gh secret set` reads stdin when --body is
-  # omitted, so we pipe the PAT in to avoid putting it on the
-  # command line (where it could show in process listings + the
-  # bootstrap log transcript).
+  # Set the repo secret. `gh secret set` reads stdin only when
+  # `--body` is OMITTED entirely — passing `--body -` makes `-` the
+  # literal body value (the dash isn't a stdin sentinel for gh's
+  # secret subcommand). Codex P1 on #239 round 1 caught the bug:
+  # the original code piped the PAT but also set `--body -`, so the
+  # piped value was discarded and `-` would have been stored as
+  # the secret. Strip --body entirely for the stdin path.
   if [ "${BOOTSTRAP_DRY_RUN:-0}" = "1" ]; then
-    bootstrap::run "set REVIEWER_ASSIGNMENT_TOKEN secret" \
-      gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo "$full_repo" --body "<redacted-len=${#pat}>"
+    bootstrap::run "set REVIEWER_ASSIGNMENT_TOKEN secret (stdin pipe; len=${#pat})" \
+      gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo "$full_repo"
     return 0
   fi
-  printf '%s' "$pat" | gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo "$full_repo" --body - >&2
+  printf '%s' "$pat" | gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo "$full_repo" >&2
   local set_rc=$?
   if [ "$set_rc" -ne 0 ]; then
+    bootstrap::err "REVIEWER_ASSIGNMENT_TOKEN: gh secret set failed (rc=$set_rc)"
     return "$set_rc"
   fi
   bootstrap::log "REVIEWER_ASSIGNMENT_TOKEN set on $full_repo (len=${#pat})"
@@ -314,6 +376,11 @@ bootstrap::_provision_llm_secrets() {
     "ANTHROPIC_API_KEY:Anthropic API key for Claude calls (sk-ant-...)"
     "OPENAI_API_KEY:OpenAI API key for Codex / Cursor calls (sk-...)"
   )
+
+  # Accumulate failure across the loop so a single LLM secret failure
+  # doesn't abort the rest, but the function still returns non-zero
+  # for the caller's accounting (CodeRabbit Major on #239 round 1).
+  local any_fail=0
 
   local secret
   for secret in "${llm_secrets[@]}"; do
@@ -335,7 +402,18 @@ bootstrap::_provision_llm_secrets() {
       bootstrap::log "LLM secret $name: skipped"
       continue
     fi
-    printf '%s' "$value" | gh secret set "$name" --repo "$full_repo" --body - >&2
+    # Same --body fix as REVIEWER_ASSIGNMENT_TOKEN: omit --body so
+    # gh reads from stdin instead of storing literal `-`. Codex P1
+    # on #239 round 1 caught the bug for both secret paths.
+    local set_rc=0
+    printf '%s' "$value" | gh secret set "$name" --repo "$full_repo" >&2 || set_rc=$?
+    if [ "$set_rc" -ne 0 ]; then
+      bootstrap::warn "LLM secret $name: gh secret set failed (rc=$set_rc); continuing with remaining secrets"
+      any_fail=1
+      continue
+    fi
     bootstrap::log "$name set on $full_repo (len=${#value})"
   done
+
+  return "$any_fail"
 }

--- a/scripts/bootstrap/github-infra.sh
+++ b/scripts/bootstrap/github-infra.sh
@@ -137,6 +137,11 @@ bootstrap::stage_github_infra() {
   fi
 
   # Step 2: seed labels.
+  # NOTE: _seed_labels swallows per-label failures (warn + continue
+  # to the next label) and never returns non-zero, so the if-block
+  # below cannot fire today. The structure is kept for symmetry with
+  # the other steps + as a guardrail: a future change that makes the
+  # helper bubble up rc gets failure propagation for free.
   bootstrap::_seed_labels "$full_repo" || step_rc=$?
   if [ "$step_rc" -ne 0 ]; then
     bootstrap::err "github-infra: label seeding failed (rc=$step_rc)"
@@ -145,6 +150,9 @@ bootstrap::stage_github_infra() {
   fi
 
   # Step 3: invite reviewer collaborators.
+  # Same soft-fail semantics as _seed_labels — per-invite failures
+  # warn + continue. A bad reviewer identity shouldn't block the
+  # bootstrap; the summary surfaces the gap.
   bootstrap::_invite_reviewers "$full_repo" "$reviewers" || step_rc=$?
   if [ "$step_rc" -ne 0 ]; then
     bootstrap::err "github-infra: reviewer invitations failed (rc=$step_rc)"
@@ -352,13 +360,32 @@ bootstrap::_provision_reviewer_assignment_token() {
   # the original code piped the PAT but also set `--body -`, so the
   # piped value was discarded and `-` would have been stored as
   # the secret. Strip --body entirely for the stdin path.
+  #
+  # We call `gh` DIRECTLY here rather than via bootstrap::run to
+  # avoid logging the PAT value through the bootstrap log
+  # transcript. bootstrap::run prints the full command line; that
+  # would expose the piped-stdin path's command shape (fine) but
+  # any future migration of secrets-to-args would leak the value
+  # itself. The trade-off is that this call MUST be `-e`-safe so
+  # the stage's auth-restore still runs on failure — hence the
+  # inline `|| set_rc=$?` on the pipeline below.
   if [ "${BOOTSTRAP_DRY_RUN:-0}" = "1" ]; then
     bootstrap::run "set REVIEWER_ASSIGNMENT_TOKEN secret (stdin pipe; len=${#pat})" \
       gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo "$full_repo"
     return 0
   fi
-  printf '%s' "$pat" | gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo "$full_repo" >&2
-  local set_rc=$?
+  # Capture pipeline rc INLINE via `|| set_rc=$?`. Without the `||`,
+  # the file-top `set -euo pipefail` would fire the moment the
+  # pipeline returns non-zero, aborting the function BEFORE the
+  # `local set_rc=$?` line ran. That bypassed every line below
+  # (the err-log, the explicit `return $set_rc`, the success log)
+  # and — more importantly — the caller's `bootstrap::_restore_active_if_needed`
+  # only ran because the call site has `|| step_rc=$?` to defuse
+  # set -e at the call. The inline `|| set_rc=$?` mirrors the
+  # _provision_llm_secrets pattern + closes the gap nathanpayne-claude
+  # caught on #239 round 2.
+  local set_rc=0
+  printf '%s' "$pat" | gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo "$full_repo" >&2 || set_rc=$?
   if [ "$set_rc" -ne 0 ]; then
     bootstrap::err "REVIEWER_ASSIGNMENT_TOKEN: gh secret set failed (rc=$set_rc)"
     return "$set_rc"

--- a/scripts/bootstrap/github-infra.sh
+++ b/scripts/bootstrap/github-infra.sh
@@ -1,26 +1,341 @@
 #!/usr/bin/env bash
 # scripts/bootstrap/github-infra.sh — bootstrap wizard stage C.
+# Per #156 sub-C / #205.
 #
-# Stub shipped with #156 sub-A's scaffold. Real implementation lands
-# in #156 sub-C ("GitHub repo creation + labels + collaborators +
-# secrets").
+# Responsibilities (in order):
+#   1. `gh repo create --source=. --push` against the target dir
+#      (sub-B already ran `git init` + initial commit; this step
+#      creates the remote and pushes the bootstrap commit). Legitimate
+#      push to main on a greenfield remote — the `gh-pr-guard.sh`
+#      "never push to main" hook does NOT apply because there's no
+#      `main` to protect yet.
+#   2. Seed the 10 canonical labels (needs-external-review,
+#      needs-human-review, policy-violation, human-action,
+#      agent-action, phase-0..4). Eliminates the first-PR
+#      "label not found" friction.
+#   3. Invite reviewer-identity collaborators (claude / cursor /
+#      codex per BOOTSTRAP_INPUT_REVIEWERS). Each invite is async;
+#      the wizard pauses for the human to accept the biometric on
+#      each agent's GitHub session.
+#   4. Provision the REVIEWER_ASSIGNMENT_TOKEN repo secret. Two
+#      paths: reuse an existing 1Password item if present, OR
+#      prompt the human to mint a fine-grained PAT.
+#   5. Prompt for and provision other LLM secrets
+#      (ANTHROPIC_API_KEY, OPENAI_API_KEY) with skip option.
 #
-# Stub responsibilities (per #156 sub-C):
-#   - `gh repo create` (with visibility from BOOTSTRAP_INPUT_VISIBILITY)
-#   - Create the canonical labels (needs-external-review, observation,
-#     risk, post-review, etc.)
-#   - Invite reviewer-identity collaborators (claude / cursor / codex)
-#   - Configure required secrets (REVIEWER_ASSIGNMENT_TOKEN, etc.)
-#   - Set up branch protection on main per REVIEW_POLICY.md
+# Test discipline:
+#   Every gh / op / git call goes through bootstrap::run. Tests
+#   exercise this stage via a PATH-shimmed `gh` that records its
+#   invocations to a log file, so the test fixture can assert the
+#   exact command shape + flag set without contacting GitHub.
+#
+# Reads (set by the wizard):
+#   $TARGET_DIR                Local path of the new repo.
+#   $BOOTSTRAP_REPO_OWNER      GitHub owner (default: nathanjohnpayne).
+#   $BOOTSTRAP_INPUT_REPO_NAME New repo name.
+#   $BOOTSTRAP_INPUT_DESCRIPTION One-line description for gh repo create.
+#   $BOOTSTRAP_INPUT_VISIBILITY public|private.
+#   $BOOTSTRAP_INPUT_REVIEWERS Comma-separated agent names (claude,cursor,codex).
+#
+# Env overrides for tests:
+#   BOOTSTRAP_SKIP_SECRETS=1            skip steps 4+5 (no live PAT lookup)
+#   BOOTSTRAP_REVIEWER_PAT_VALUE=...    supply the PAT inline (path c) for tests
+#   BOOTSTRAP_SKIP_INVITE_PAUSE=1       don't wait for "press enter to continue"
+#
+# Side effects via bootstrap::run (so --dry-run is correct).
 
 set -euo pipefail
 
+# Canonical label set. Each entry: name:hex-color:description.
+# Format kept consistent with the existing matchline / mergepath
+# label conventions. Colors picked to be distinguishable in the
+# GitHub UI light + dark themes.
+BOOTSTRAP_LABELS=(
+  "needs-external-review:bf0606:External review required before merge"
+  "needs-human-review:7057ff:Awaiting human triage or decision"
+  "policy-violation:b60205:Blocked by review-policy.yml violation"
+  "human-action:0e8a16:Requires human attention"
+  "agent-action:1d76db:Agent task — not blocked on human"
+  "phase-0:c5def5:Phase 0: foundations"
+  "phase-1:bfd4f2:Phase 1: core"
+  "phase-2:bfd4f2:Phase 2"
+  "phase-3:bfd4f2:Phase 3"
+  "phase-4:bfd4f2:Phase 4"
+)
+
+# 1Password item ID for the REVIEWER_ASSIGNMENT_TOKEN PAT. If this
+# item exists in the operator's vault, sub-step 4 reuses it. Override
+# via BOOTSTRAP_REVIEWER_PAT_OP_REF for tests / alternate vaults.
+BOOTSTRAP_REVIEWER_PAT_OP_REF="${BOOTSTRAP_REVIEWER_PAT_OP_REF:-op://Private/REVIEWER_ASSIGNMENT_PAT/token}"
+
 bootstrap::stage_github_infra() {
-  bootstrap::stage_banner "github-infra (sub-C stub)"
-  bootstrap::log "stub: would gh repo create ${BOOTSTRAP_INPUT_REPO_NAME} (${BOOTSTRAP_INPUT_VISIBILITY})"
-  bootstrap::log "stub: would create canonical labels"
-  bootstrap::log "stub: would invite reviewers: ${BOOTSTRAP_INPUT_REVIEWERS}"
-  bootstrap::log "stub: would configure required secrets + branch protection"
+  bootstrap::stage_banner "github-infra"
+
+  local repo_name owner full_repo target visibility description reviewers
+  repo_name=$(bootstrap_input repo_name)
+  owner="${BOOTSTRAP_REPO_OWNER:-nathanjohnpayne}"
+  full_repo="$owner/$repo_name"
+  target=${TARGET_DIR:?TARGET_DIR not set by wizard}
+  visibility=$(bootstrap_input visibility)
+  description=$(bootstrap_input description)
+  reviewers=$(bootstrap_input reviewers)
+
+  # Per-step rc capture so the stage propagates failures cleanly
+  # (same pattern as stage B sub-#233 round 4).
+  local step_rc=0
+
+  # Step 1: create the remote + push the bootstrap commit.
+  bootstrap::_create_remote_and_push \
+    "$full_repo" "$visibility" "$description" "$target" || step_rc=$?
+  if [ "$step_rc" -ne 0 ]; then
+    bootstrap::err "github-infra: gh repo create / push failed (rc=$step_rc)"
+    return "$step_rc"
+  fi
+
+  # Step 2: seed labels.
+  bootstrap::_seed_labels "$full_repo" || step_rc=$?
+  if [ "$step_rc" -ne 0 ]; then
+    bootstrap::err "github-infra: label seeding failed (rc=$step_rc)"
+    return "$step_rc"
+  fi
+
+  # Step 3: invite reviewer collaborators.
+  bootstrap::_invite_reviewers "$full_repo" "$reviewers" || step_rc=$?
+  if [ "$step_rc" -ne 0 ]; then
+    bootstrap::err "github-infra: reviewer invitations failed (rc=$step_rc)"
+    return "$step_rc"
+  fi
+
+  # Step 4+5: provision secrets (REVIEWER_ASSIGNMENT_TOKEN + optional
+  # LLM keys). Skippable in tests / for repos that don't need them.
+  if [ "${BOOTSTRAP_SKIP_SECRETS:-0}" = "1" ]; then
+    bootstrap::log "secret provisioning skipped (BOOTSTRAP_SKIP_SECRETS=1)"
+  else
+    bootstrap::_provision_reviewer_assignment_token "$full_repo" || step_rc=$?
+    if [ "$step_rc" -ne 0 ]; then
+      # Secret failures are warned-but-not-fatal — workflows will
+      # fail loudly on the first PR if the token isn't set, surfacing
+      # the issue. We don't want to block the bootstrap on the human
+      # finding a PAT.
+      bootstrap::warn "github-infra: REVIEWER_ASSIGNMENT_TOKEN provisioning failed (rc=$step_rc); workflows will require manual secret-set on first PR"
+      step_rc=0
+    fi
+
+    bootstrap::_provision_llm_secrets "$full_repo" || step_rc=$?
+    if [ "$step_rc" -ne 0 ]; then
+      bootstrap::warn "github-infra: LLM secret provisioning hit errors (rc=$step_rc); the affected workflows can be re-tried manually"
+      step_rc=0
+    fi
+  fi
+
   bootstrap::record_stage "github-infra"
   return 0
+}
+
+# --- internal helpers ------------------------------------------------------
+
+bootstrap::_create_remote_and_push() {
+  local full_repo=$1 visibility=$2 description=$3 target=$4
+
+  # Sanity: sub-B's _init_target_git must have run. If the target has
+  # no .git/ we can't push.
+  #
+  # Skip the existence check in dry-run mode — sub-B's `git init`
+  # call also doesn't actually run under --dry-run (bootstrap::run
+  # prints instead of executing), so the `.git/` directory wouldn't
+  # exist in the dry-run plan either. The check is a safety net for
+  # live runs where sub-B SHOULD have created it.
+  if [ "${BOOTSTRAP_DRY_RUN:-0}" != "1" ] && [ ! -d "$target/.git" ]; then
+    bootstrap::err "github-infra: $target has no .git/ — did stage B (template-mirror) run? Use --resume template-mirror to retry."
+    return 2
+  fi
+
+  # The visibility flag maps to gh's --public / --private / --internal.
+  local vis_flag
+  case "$visibility" in
+    public)   vis_flag="--public"   ;;
+    private)  vis_flag="--private"  ;;
+    internal) vis_flag="--internal" ;;
+    *)
+      bootstrap::err "github-infra: unsupported visibility '$visibility' (expected public/private/internal)"
+      return 2
+      ;;
+  esac
+
+  # `gh repo create --source=. --push` legitimately populates main
+  # on a greenfield remote. gh-pr-guard.sh's "never push to main"
+  # invariant doesn't apply because there's no protected main yet —
+  # we're creating it. (The hook only fires on pre-existing repos.)
+  bootstrap::run "create remote + push: gh repo create $full_repo $vis_flag --source=$target --push" \
+    gh repo create "$full_repo" \
+      "$vis_flag" \
+      --description "$description" \
+      --source="$target" \
+      --push
+}
+
+bootstrap::_seed_labels() {
+  local full_repo=$1
+  local spec name color desc
+
+  for spec in "${BOOTSTRAP_LABELS[@]}"; do
+    # Field-split on ':' — name:color:description. `description` can
+    # contain colons; capture only the first two splits and let the
+    # rest be the description.
+    name=${spec%%:*}
+    local rest=${spec#*:}
+    color=${rest%%:*}
+    desc=${rest#*:}
+
+    # --force makes the operation idempotent: existing labels get
+    # their color/description updated instead of erroring.
+    bootstrap::run "label create: $name" \
+      gh label create "$name" \
+        --repo "$full_repo" \
+        --color "$color" \
+        --description "$desc" \
+        --force \
+      || {
+        # Single label failure is non-fatal — log and continue with
+        # the rest. The summary collects the count.
+        bootstrap::warn "github-infra: label '$name' create failed (continuing with remaining labels)"
+      }
+  done
+}
+
+bootstrap::_invite_reviewers() {
+  local full_repo=$1 reviewers_csv=$2
+  local agent login
+
+  # Split CSV into individual agent names.
+  local IFS=','
+  set -- $reviewers_csv
+  unset IFS
+
+  for agent in "$@"; do
+    agent=$(printf '%s' "$agent" | tr -d ' ')
+    [ -z "$agent" ] && continue
+    login="nathanpayne-$agent"
+
+    bootstrap::run "invite collaborator: $login (write)" \
+      gh api -X PUT "repos/$full_repo/collaborators/$login" \
+        -f permission=write \
+      || {
+        # Non-existent agent identity, permission issue, etc. — log
+        # and continue. The summary surfaces the gap.
+        bootstrap::warn "github-infra: invitation to '$login' failed (continuing)"
+      }
+  done
+
+  # Pause for the operator to accept each invite via the agent
+  # account's GitHub UI. Skippable in tests + non-interactive runs.
+  if [ "${BOOTSTRAP_AUTO_CONFIRM:-0}" != "1" ] \
+     && [ "${BOOTSTRAP_SKIP_INVITE_PAUSE:-0}" != "1" ] \
+     && [ "${BOOTSTRAP_DRY_RUN:-0}" != "1" ]; then
+    echo
+    echo "Reviewer-identity collaborator invitations sent."
+    echo "Each invitee account needs to accept via:"
+    echo "  https://github.com/$full_repo/invitations"
+    local reply
+    read -r -p "Press Enter once all invitations are accepted (or 'skip' to continue): " reply
+    if [ "${reply:-}" = "skip" ]; then
+      bootstrap::warn "github-infra: invite-acceptance pause was skipped — subsequent agent-review steps may fail until invitations are accepted"
+    fi
+  fi
+}
+
+bootstrap::_provision_reviewer_assignment_token() {
+  local full_repo=$1
+  local pat=""
+
+  # Path c (tests / explicit override): caller supplied the PAT
+  # inline via env var.
+  if [ -n "${BOOTSTRAP_REVIEWER_PAT_VALUE:-}" ]; then
+    pat="$BOOTSTRAP_REVIEWER_PAT_VALUE"
+    bootstrap::log "REVIEWER_ASSIGNMENT_TOKEN: using inline value from BOOTSTRAP_REVIEWER_PAT_VALUE"
+  fi
+
+  # Path a (preferred): look up an existing PAT in 1Password.
+  if [ -z "$pat" ] && command -v op >/dev/null 2>&1; then
+    bootstrap::log "REVIEWER_ASSIGNMENT_TOKEN: probing 1Password at $BOOTSTRAP_REVIEWER_PAT_OP_REF"
+    # Tolerate op timeouts — fall through to the prompt path if
+    # 1Password is locked or the item doesn't exist.
+    pat=$(op read "$BOOTSTRAP_REVIEWER_PAT_OP_REF" 2>/dev/null || true)
+    if [ -n "$pat" ]; then
+      bootstrap::log "REVIEWER_ASSIGNMENT_TOKEN: reusing existing 1Password item"
+    fi
+  fi
+
+  # Path b: prompt the human to paste a fine-grained PAT. Skipped in
+  # auto-prompt=skip mode + dry-run.
+  if [ -z "$pat" ]; then
+    if [ "${BOOTSTRAP_AUTO_PROMPT:-prompt}" = "skip" ] \
+       || [ "${BOOTSTRAP_DRY_RUN:-0}" = "1" ]; then
+      bootstrap::warn "REVIEWER_ASSIGNMENT_TOKEN: no PAT available + prompts skipped; not setting secret"
+      return 0
+    fi
+    echo
+    echo "REVIEWER_ASSIGNMENT_TOKEN not found in 1Password."
+    echo "Generate a fine-grained PAT at https://github.com/settings/tokens/new"
+    echo "  Scopes: Contents:RW, Issues:RW, Pull Requests:RW, Metadata:R"
+    echo "  Repository: $full_repo (scoped, not org-wide)"
+    read -r -s -p "Paste the PAT (input hidden, blank to skip): " pat
+    echo
+    if [ -z "$pat" ]; then
+      bootstrap::warn "REVIEWER_ASSIGNMENT_TOKEN: human declined to provide a PAT; first PR will fail until manually set"
+      return 0
+    fi
+  fi
+
+  # Set the repo secret. `gh secret set` reads stdin when --body is
+  # omitted, so we pipe the PAT in to avoid putting it on the
+  # command line (where it could show in process listings + the
+  # bootstrap log transcript).
+  if [ "${BOOTSTRAP_DRY_RUN:-0}" = "1" ]; then
+    bootstrap::run "set REVIEWER_ASSIGNMENT_TOKEN secret" \
+      gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo "$full_repo" --body "<redacted-len=${#pat}>"
+    return 0
+  fi
+  printf '%s' "$pat" | gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo "$full_repo" --body - >&2
+  local set_rc=$?
+  if [ "$set_rc" -ne 0 ]; then
+    return "$set_rc"
+  fi
+  bootstrap::log "REVIEWER_ASSIGNMENT_TOKEN set on $full_repo (len=${#pat})"
+}
+
+bootstrap::_provision_llm_secrets() {
+  local full_repo=$1
+
+  # The full set of optional LLM secrets the wizard knows how to
+  # provision. Each entry: secret_name:prompt-friendly-description.
+  # Add new entries here as upstream tooling needs them.
+  local llm_secrets=(
+    "ANTHROPIC_API_KEY:Anthropic API key for Claude calls (sk-ant-...)"
+    "OPENAI_API_KEY:OpenAI API key for Codex / Cursor calls (sk-...)"
+  )
+
+  local secret
+  for secret in "${llm_secrets[@]}"; do
+    local name=${secret%%:*}
+    local desc=${secret#*:}
+
+    if [ "${BOOTSTRAP_AUTO_PROMPT:-prompt}" = "skip" ] \
+       || [ "${BOOTSTRAP_DRY_RUN:-0}" = "1" ]; then
+      bootstrap::log "LLM secret $name: prompts skipped (dry-run or auto-prompt=skip)"
+      continue
+    fi
+
+    echo
+    echo "$desc"
+    local value
+    read -r -s -p "Paste $name (input hidden, blank to skip): " value
+    echo
+    if [ -z "$value" ]; then
+      bootstrap::log "LLM secret $name: skipped"
+      continue
+    fi
+    printf '%s' "$value" | gh secret set "$name" --repo "$full_repo" --body - >&2
+    bootstrap::log "$name set on $full_repo (len=${#value})"
+  done
 }

--- a/scripts/ci/check_bootstrap_github_infra
+++ b/scripts/ci/check_bootstrap_github_infra
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/ci/check_bootstrap_github_infra — CI entry point for
+# #156 sub-C / #205 tests.
+#
+# Wraps tests/test_bootstrap_github_infra.sh so the repo_lint
+# workflow's "run all scripts/ci/check_*" loop picks it up. Mirrors
+# the pattern used by check_bootstrap_template_mirror and the other
+# check_* scripts. Missing test script is a hard error (matches the
+# tightening applied to check_sync_overrides in #228 round 5).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_bootstrap_github_infra.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  echo "check_bootstrap_github_infra: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/tests/test_bootstrap_github_infra.sh
+++ b/tests/test_bootstrap_github_infra.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# tests/test_bootstrap_github_infra.sh
+#
+# Validates scripts/bootstrap/github-infra.sh (sub-C / #205).
+#
+# Strategy: a PATH-shimmed `gh` records every invocation to a log
+# file and returns canned exit codes. The shim NEVER contacts the
+# real GitHub API. The wizard then drives the stage end-to-end and
+# we assert against the log:
+#
+#   1. `gh repo create` is invoked with the right flags (visibility,
+#      description, source, --push).
+#   2. All 10 canonical labels are seeded with --force (idempotency).
+#   3. Reviewer invitations land via `gh api -X PUT` to the right
+#      collaborator endpoint for each agent in BOOTSTRAP_INPUT_REVIEWERS.
+#   4. REVIEWER_ASSIGNMENT_TOKEN provisioning uses the inline-PAT
+#      path when BOOTSTRAP_REVIEWER_PAT_VALUE is set.
+#   5. Stage failure propagates when `gh repo create` returns non-zero
+#      (the state file must NOT carry a github-infra completion entry).
+#
+# Requires: bash, rsync (for sub-B in the chain), yq (preflight req).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/bootstrap-new-repo.sh"
+
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "SKIP: rsync not installed" >&2; exit 0
+fi
+if ! command -v yq >/dev/null 2>&1; then
+  echo "SKIP: yq not installed" >&2; exit 0
+fi
+if ! yq --version 2>&1 | grep -q "mikefarah/yq"; then
+  echo "SKIP: non-mikefarah yq" >&2; exit 0
+fi
+
+[ -x "$SCRIPT" ] || { echo "missing or non-executable $SCRIPT" >&2; exit 1; }
+
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/test-github-infra.XXXXXX")
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0; FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# --- build fixture mergepath ----------------------------------------------
+FAKE_MP="$WORKDIR/fake-mp"
+TARGET="$WORKDIR/new-repo"
+mkdir -p "$FAKE_MP"/{scripts/bootstrap,scripts/ci,scripts/sync,.github/workflows,docs/agents,tests}
+echo "# mergepath" >"$FAKE_MP/README.md"
+echo "Mergepath brand" >"$FAKE_MP/BRAND.md"
+echo "ai ctx" >"$FAKE_MP/.ai_context.md"
+echo "overview" >"$FAKE_MP/docs/agents/repository-overview.md"
+cat >"$FAKE_MP/.repo-template.yml" <<'EOF'
+spec_test_map:
+  mergepath_playground:
+    - tests/test_mergepath_playground.sh
+extra_top_level_dirs: [mergepath, packaging]
+EOF
+echo "Security" >"$FAKE_MP/SECURITY.md"
+
+# Copy real bootstrap script + stage modules
+cp "$ROOT/scripts/bootstrap/_lib.sh"                  "$FAKE_MP/scripts/bootstrap/_lib.sh"
+cp "$ROOT/scripts/bootstrap/substitute.sh"            "$FAKE_MP/scripts/bootstrap/substitute.sh"
+cp "$ROOT/scripts/bootstrap/template-mirror.sh"       "$FAKE_MP/scripts/bootstrap/template-mirror.sh"
+cp "$ROOT/scripts/bootstrap/github-infra.sh"          "$FAKE_MP/scripts/bootstrap/github-infra.sh"
+cp "$ROOT/scripts/bootstrap/firebase-and-codereview.sh" "$FAKE_MP/scripts/bootstrap/firebase-and-codereview.sh"
+cp "$ROOT/scripts/bootstrap/board-and-summary.sh"     "$FAKE_MP/scripts/bootstrap/board-and-summary.sh"
+cp "$ROOT/scripts/bootstrap-new-repo.sh"              "$FAKE_MP/scripts/bootstrap-new-repo.sh"
+git -C "$FAKE_MP" init -q
+git -C "$FAKE_MP" -c user.email=t@t -c user.name=t -c commit.gpgsign=false add -A
+git -C "$FAKE_MP" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m "fixture"
+
+# --- gh PATH shim ----------------------------------------------------------
+# Records every invocation to $SHIM_LOG. Returns 0 by default; tests
+# can override per-subcommand exit via $SHIM_EXIT_<UPPERCASE-SUBCMD>=N.
+SHIM_DIR="$WORKDIR/shim-bin"
+SHIM_LOG="$WORKDIR/gh-shim.log"
+mkdir -p "$SHIM_DIR"
+cat >"$SHIM_DIR/gh" <<'SHIM_EOF'
+#!/usr/bin/env bash
+# gh PATH-shim used by tests/test_bootstrap_github_infra.sh.
+# Records every invocation to $SHIM_LOG.
+
+LOG=${SHIM_LOG:?SHIM_LOG not set}
+# One line per invocation: cmd1 cmd2 args...
+echo "gh $*" >>"$LOG"
+
+# Subcommand-conditional exit code. Per-subcommand env vars let
+# tests dial in specific failures (e.g., SHIM_EXIT_REPO_CREATE=1).
+case "$1" in
+  repo)
+    case "$2" in
+      create) exit "${SHIM_EXIT_REPO_CREATE:-0}" ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  label)
+    exit "${SHIM_EXIT_LABEL:-0}"
+    ;;
+  api)
+    exit "${SHIM_EXIT_API:-0}"
+    ;;
+  secret)
+    # `gh secret set --body -` reads stdin; consume it so the
+    # pipe doesn't break.
+    if [ "$2" = "set" ]; then
+      cat >/dev/null 2>&1 || true
+    fi
+    exit "${SHIM_EXIT_SECRET:-0}"
+    ;;
+  config)
+    # `gh config get -h github.com user` — return the active acct
+    # used by stage B's switch-around tests. github-infra doesn't
+    # use this, but other stages might be invoked in the same run.
+    echo "nathanpayne-claude"
+    exit 0
+    ;;
+  auth)
+    # `gh auth switch -u X` — no-op shim.
+    exit 0
+    ;;
+  pr)
+    # Stage B's cross-repo loop may call gh pr create when anchors
+    # exist (they don't in this fixture — so this is just defensive).
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+SHIM_EOF
+chmod +x "$SHIM_DIR/gh"
+
+# --- run the wizard end-to-end with stages B + C exercising the shim ----
+# Stage D (firebase-and-codereview) and E (board-and-summary) are
+# still stubs and will run; their record_stage calls are fine.
+SHIM_PATH="$SHIM_DIR:/usr/bin:/bin"
+# Include yq + git + rsync from the real PATH (the shim only covers
+# gh). We need bash 3.2+ on macOS to keep this portable.
+for tool in bash yq git rsync sed awk grep mktemp tr cut tail head wc ls rm cat printf chmod find dirname basename; do
+  src=$(command -v "$tool" 2>/dev/null || true)
+  [ -n "$src" ] && ln -sf "$src" "$SHIM_DIR/$tool"
+done
+
+run_wizard() {
+  PATH="$SHIM_PATH" \
+  SHIM_LOG="$SHIM_LOG" \
+  BOOTSTRAP_MERGEPATH_ROOT="$FAKE_MP" \
+  BOOTSTRAP_SKIP_TOOL_CHECK=1 \
+  BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+  BOOTSTRAP_AUTO_CONFIRM=1 \
+  BOOTSTRAP_AUTO_PROMPT=skip \
+  BOOTSTRAP_AUTHOR_NAME="test" \
+  BOOTSTRAP_AUTHOR_EMAIL="t@t" \
+  BOOTSTRAP_SKIP_INVITE_PAUSE=1 \
+  BOOTSTRAP_REVIEWER_PAT_VALUE="fake-test-pat-1234567890" \
+  "$SCRIPT" "$@"
+}
+
+# --- happy path -----------------------------------------------------------
+: >"$SHIM_LOG"
+rm -rf "$TARGET"
+set +e
+out=$(run_wizard test-repo \
+        --target-dir "$TARGET" \
+        --description "a test repo" \
+        --visibility private \
+        --firebase none --codex-app n --project new 2>&1)
+ec=$?
+set -e
+
+[ "$ec" -eq 0 ] \
+  && pass "happy-path live run completes (rc=0)" \
+  || fail "wizard failed; rc=$ec; out: $out"
+
+# --- assertion 1: gh repo create invoked correctly ---
+grep -q "^gh repo create nathanjohnpayne/test-repo --private --description a test repo --source=$TARGET --push$" "$SHIM_LOG" \
+  && pass "gh repo create invoked with --private + --source + --push" \
+  || fail "gh repo create flags wrong; log: $(grep '^gh repo create' "$SHIM_LOG")"
+
+# --- assertion 2: all 10 labels seeded with --force ---
+expected_labels=(needs-external-review needs-human-review policy-violation human-action agent-action phase-0 phase-1 phase-2 phase-3 phase-4)
+seeded=0
+for label in "${expected_labels[@]}"; do
+  if grep -qE "^gh label create $label .* --force\$" "$SHIM_LOG"; then
+    seeded=$((seeded + 1))
+  else
+    fail "label '$label' not seeded with --force; log: $(grep "label create $label" "$SHIM_LOG")"
+  fi
+done
+[ "$seeded" -eq 10 ] \
+  && pass "all 10 canonical labels seeded with --force" \
+  || fail "expected 10 labels, got $seeded"
+
+# --- assertion 3: reviewer collaborator invites ---
+for agent in claude cursor codex; do
+  login="nathanpayne-$agent"
+  if grep -qF "gh api -X PUT repos/nathanjohnpayne/test-repo/collaborators/$login -f permission=write" "$SHIM_LOG"; then
+    pass "reviewer collaborator invite sent to $login"
+  else
+    fail "no invite for $login; log: $(grep collaborator "$SHIM_LOG")"
+  fi
+done
+
+# --- assertion 4: REVIEWER_ASSIGNMENT_TOKEN secret set via inline PAT ---
+grep -q "^gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo nathanjohnpayne/test-repo --body -$" "$SHIM_LOG" \
+  && pass "REVIEWER_ASSIGNMENT_TOKEN secret set via stdin pipe" \
+  || fail "REVIEWER_ASSIGNMENT_TOKEN secret-set not logged correctly; log: $(grep secret "$SHIM_LOG")"
+
+# --- assertion 5: stage records completion in state file ---
+[ -f "$TARGET/.bootstrap-state" ] \
+  && grep -q "^github-infra\$" "$TARGET/.bootstrap-state" \
+  && pass "github-infra stage recorded in state file" \
+  || fail "state file missing github-infra entry: $(cat "$TARGET/.bootstrap-state" 2>/dev/null)"
+
+# --- assertion 6: dispatch ordering — template-mirror runs BEFORE github-infra ---
+# Sub-B must complete first (it sets up the .git/ that sub-C pushes).
+awk '
+  /^template-mirror$/ { mirror = NR }
+  /^github-infra$/    { infra  = NR }
+  END {
+    if (!mirror || !infra) { print "missing entries"; exit 1 }
+    if (mirror > infra) { print "ordering wrong"; exit 1 }
+  }
+' "$TARGET/.bootstrap-state" \
+  && pass "template-mirror recorded before github-infra in state file" \
+  || fail "state-file ordering broken"
+
+# --- assertion 7: secret skip works with BOOTSTRAP_SKIP_SECRETS=1 ---
+: >"$SHIM_LOG"
+TARGET2="$WORKDIR/new-repo-skipsec"
+rm -rf "$TARGET2"
+set +e
+unset BOOTSTRAP_REVIEWER_PAT_VALUE
+out=$(BOOTSTRAP_SKIP_SECRETS=1 run_wizard skipsec-repo \
+        --target-dir "$TARGET2" \
+        --description "d" --visibility private \
+        --firebase none --codex-app n --project new 2>&1)
+ec=$?
+set -e
+[ "$ec" -eq 0 ] \
+  && pass "BOOTSTRAP_SKIP_SECRETS=1 happy path exits 0" \
+  || fail "skip-secrets run failed: rc=$ec"
+grep -qF "gh secret set REVIEWER_ASSIGNMENT_TOKEN" "$SHIM_LOG" \
+  && fail "secret set called despite BOOTSTRAP_SKIP_SECRETS=1" \
+  || pass "BOOTSTRAP_SKIP_SECRETS=1 suppresses gh secret set"
+
+# --- assertion 8: stage fails closed when gh repo create fails ---
+: >"$SHIM_LOG"
+TARGET3="$WORKDIR/new-repo-fail-create"
+rm -rf "$TARGET3"
+set +e
+out=$(SHIM_EXIT_REPO_CREATE=1 run_wizard failrepo-repo \
+        --target-dir "$TARGET3" \
+        --description "d" --visibility private \
+        --firebase none --codex-app n --project new 2>&1)
+ec=$?
+set -e
+[ "$ec" -ne 0 ] \
+  && pass "stage fails closed when gh repo create fails (rc=$ec)" \
+  || fail "stage should fail when gh repo create errors; rc=$ec"
+# State file should NOT have github-infra entry (template-mirror is fine
+# because that ran before the failure).
+if [ -f "$TARGET3/.bootstrap-state" ] && grep -q "^github-infra\$" "$TARGET3/.bootstrap-state"; then
+  fail "github-infra recorded despite gh repo create failure"
+else
+  pass "github-infra NOT recorded when gh repo create fails (resume can retry)"
+fi
+
+# --- assertion 9: dry-run produces plan without invoking the shim ---
+: >"$SHIM_LOG"
+TARGET4="$WORKDIR/new-repo-dry"
+rm -rf "$TARGET4"
+set +e
+dry_out=$(run_wizard dry-repo \
+            --target-dir "$TARGET4" \
+            --description "d" --visibility private \
+            --firebase none --codex-app n --project new --dry-run 2>&1)
+dry_ec=$?
+set -e
+[ "$dry_ec" -eq 0 ] \
+  && pass "stage C --dry-run exits 0" \
+  || fail "dry-run failed: rc=$dry_ec"
+# Dry-run must NOT actually invoke gh (the shim should not have
+# recorded anything; bootstrap::run prints [DRY-RUN] instead).
+if [ -s "$SHIM_LOG" ]; then
+  fail "dry-run invoked gh shim ($(wc -l <"$SHIM_LOG") calls); should be 0"
+else
+  pass "dry-run did not invoke gh (bootstrap::run honors --dry-run)"
+fi
+echo "$dry_out" | grep -q "DRY-RUN" \
+  && pass "dry-run output includes [DRY-RUN] tags" \
+  || fail "dry-run missing [DRY-RUN] markers"
+
+# --- summary --------------------------------------------------------------
+echo
+echo "test_bootstrap_github_infra: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/tests/test_bootstrap_github_infra.sh
+++ b/tests/test_bootstrap_github_infra.sh
@@ -205,9 +205,17 @@ for agent in claude cursor codex; do
 done
 
 # --- assertion 4: REVIEWER_ASSIGNMENT_TOKEN secret set via inline PAT ---
-grep -q "^gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo nathanjohnpayne/test-repo --body -$" "$SHIM_LOG" \
-  && pass "REVIEWER_ASSIGNMENT_TOKEN secret set via stdin pipe" \
+# The `--body -` arg was removed in round 1 because gh treats it as
+# a literal value, not a stdin signal — stdin is only consumed when
+# --body is OMITTED entirely. Codex P1 on #239 caught this.
+grep -q "^gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo nathanjohnpayne/test-repo\$" "$SHIM_LOG" \
+  && pass "REVIEWER_ASSIGNMENT_TOKEN secret set via stdin (no --body arg)" \
   || fail "REVIEWER_ASSIGNMENT_TOKEN secret-set not logged correctly; log: $(grep secret "$SHIM_LOG")"
+# Regression guard: --body must NOT appear in the recorded secret-set
+# command (would mean the bug regressed).
+grep -q "^gh secret set REVIEWER_ASSIGNMENT_TOKEN .* --body" "$SHIM_LOG" \
+  && fail "secret set command carries --body (regression of Codex #239 P1 line 299)" \
+  || pass "secret set command omits --body (Codex #239 P1 fixed)"
 
 # --- assertion 5: stage records completion in state file ---
 [ -f "$TARGET/.bootstrap-state" ] \
@@ -227,6 +235,38 @@ awk '
 ' "$TARGET/.bootstrap-state" \
   && pass "template-mirror recorded before github-infra in state file" \
   || fail "state-file ordering broken"
+
+# --- assertion 7a: author-identity switch-around wraps stage writes
+# (CodeRabbit Major on #239 round 1). The stage must switch to
+# nathanjohnpayne before any writes, run all the writes, and switch
+# back after — exactly once per stage run.
+# ---------------------------------------------------------------------------
+auth_switches=$(grep -c "^gh auth switch -u" "$SHIM_LOG")
+# Expect TWO switches: one TO nathanjohnpayne, one back to the prior
+# (nathanpayne-claude per the shim's gh config get response).
+[ "$auth_switches" -eq 2 ] \
+  && pass "stage performs exactly 2 auth switches (to author, back to prior)" \
+  || fail "expected 2 auth switches, got $auth_switches; log: $(grep 'auth switch' "$SHIM_LOG")"
+grep -q "^gh auth switch -u nathanjohnpayne\$" "$SHIM_LOG" \
+  && pass "stage switches to nathanjohnpayne for writes" \
+  || fail "no switch to nathanjohnpayne; log: $(grep 'auth switch' "$SHIM_LOG")"
+grep -q "^gh auth switch -u nathanpayne-claude\$" "$SHIM_LOG" \
+  && pass "stage restores prior active gh account after writes" \
+  || fail "no switch back to nathanpayne-claude; log: $(grep 'auth switch' "$SHIM_LOG")"
+# Ordering: switch-to-nathanjohnpayne must come BEFORE any write call,
+# and switch-back must come AFTER. Use awk to pin the line numbers.
+awk '
+  /^gh auth switch -u nathanjohnpayne$/    { saw_to = NR }
+  /^gh repo create /                       { saw_write = NR }
+  /^gh auth switch -u nathanpayne-claude$/ { saw_back = NR }
+  END {
+    if (!saw_to || !saw_write || !saw_back) { print "missing markers"; exit 1 }
+    if (saw_to > saw_write) { print "switch-to must precede writes"; exit 1 }
+    if (saw_write > saw_back) { print "switch-back must follow writes"; exit 1 }
+  }
+' "$SHIM_LOG" \
+  && pass "auth switch-around ordering correct (to → writes → back)" \
+  || fail "auth switch-around ordering wrong"
 
 # --- assertion 7: secret skip works with BOOTSTRAP_SKIP_SECRETS=1 ---
 : >"$SHIM_LOG"

--- a/tests/test_bootstrap_github_infra.sh
+++ b/tests/test_bootstrap_github_infra.sh
@@ -334,6 +334,54 @@ echo "$dry_out" | grep -q "DRY-RUN" \
   && pass "dry-run output includes [DRY-RUN] tags" \
   || fail "dry-run missing [DRY-RUN] markers"
 
+# --- assertion 10: REVIEWER_ASSIGNMENT_TOKEN gh-secret-set failure path
+# (nathanpayne-claude review on #239 round 2 — P1).
+#
+# With set -euo pipefail + a failing `gh secret set` pipeline, the
+# pre-fix code aborted the function BEFORE the rc-capture line ran,
+# bypassing the err-log + explicit return path. The fix is the
+# inline `|| set_rc=$?` pattern matching _provision_llm_secrets.
+#
+# Drive the failure via SHIM_EXIT_SECRET=1 + a fake PAT. Even with
+# the failing secret-set, the stage's auth-restore MUST still run
+# (the keyring must end on the prior-active account, not stuck on
+# nathanjohnpayne) — that's the keyring-leak invariant the reviewer
+# called out explicitly.
+# ---------------------------------------------------------------------------
+: >"$SHIM_LOG"
+TARGET5="$WORKDIR/new-repo-secret-fail"
+rm -rf "$TARGET5"
+set +e
+out=$(SHIM_EXIT_SECRET=1 BOOTSTRAP_REVIEWER_PAT_VALUE="fake-pat" run_wizard secretfail-repo \
+        --target-dir "$TARGET5" \
+        --description d --visibility private \
+        --firebase none --codex-app n --project new 2>&1)
+ec=$?
+set -e
+# The stage treats secret failures as warned-but-not-fatal (the
+# REVIEWER_ASSIGNMENT_TOKEN failure is swallowed via `step_rc=0` in
+# the caller), so the wizard SHOULD complete with rc=0. The
+# critical invariant is the keyring restore — verify it ran.
+[ "$ec" -eq 0 ] \
+  && pass "stage completes (rc=0) when secret-set fails (warn-not-fatal)" \
+  || fail "stage failed unexpectedly on secret-set failure; rc=$ec, out: $out"
+# Auth-restore MUST have run after the secret-set failure — the
+# keyring-leak invariant nathanpayne-claude flagged.
+grep -q "^gh auth switch -u nathanpayne-claude\$" "$SHIM_LOG" \
+  && pass "auth-restore ran AFTER failing gh secret set (no keyring leak)" \
+  || fail "no auth-restore after secret failure — keyring would be left on nathanjohnpayne; log: $(grep 'auth switch' "$SHIM_LOG")"
+# The pipeline-rc-capture pattern in scripts/bootstrap/github-infra.sh
+# must use `|| set_rc=$?` on the same line as the pipeline so set -e
+# doesn't kill the function before the rc handler can run.
+awk '
+  /^bootstrap::_provision_reviewer_assignment_token\(\)/ { in_fn = 1 }
+  in_fn && /^}/ { in_fn = 0 }
+  in_fn && /gh secret set REVIEWER_ASSIGNMENT_TOKEN.*\|\| set_rc=\$\?/ { saw = 1 }
+  END { if (!saw) { print "no `|| set_rc=$?` inline on gh secret set pipeline"; exit 1 } }
+' "$ROOT/scripts/bootstrap/github-infra.sh" \
+  && pass "_provision_reviewer_assignment_token uses '|| set_rc=\$?' inline on gh secret set pipeline" \
+  || fail "rc-capture-inline invariant violated (regression of nathanpayne-claude #239 r2 P1)"
+
 # --- summary --------------------------------------------------------------
 echo
 echo "test_bootstrap_github_infra: $PASS passed, $FAIL failed"

--- a/tests/test_bootstrap_template_mirror.sh
+++ b/tests/test_bootstrap_template_mirror.sh
@@ -189,6 +189,7 @@ out=$(BOOTSTRAP_MERGEPATH_ROOT="$FAKE_MP" \
       BOOTSTRAP_AUTO_PROMPT=skip \
       BOOTSTRAP_AUTHOR_NAME="test" \
       BOOTSTRAP_AUTHOR_EMAIL="t@t" \
+      BOOTSTRAP_SKIP_STAGES="github-infra,firebase-and-codereview,board-and-summary" \
       "$SCRIPT" my-new-repo \
         --target-dir "$TARGET" \
         --description "a test repo" --visibility private \
@@ -355,6 +356,7 @@ dry_out=$(BOOTSTRAP_MERGEPATH_ROOT="$FAKE_MP" \
           BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
           BOOTSTRAP_AUTO_CONFIRM=1 \
           BOOTSTRAP_AUTO_PROMPT=skip \
+          BOOTSTRAP_SKIP_STAGES="github-infra,firebase-and-codereview,board-and-summary" \
           "$SCRIPT" my-new-repo \
             --target-dir "$dry_target" \
             --description "d" --visibility private \
@@ -456,6 +458,7 @@ fail_out=$(PATH="$shim_dir:$PATH" \
            BOOTSTRAP_AUTO_PROMPT=skip \
            BOOTSTRAP_AUTHOR_NAME="test" \
            BOOTSTRAP_AUTHOR_EMAIL="t@t" \
+      BOOTSTRAP_SKIP_STAGES="github-infra,firebase-and-codereview,board-and-summary" \
            "$SCRIPT" my-new-repo \
              --target-dir "$fail_target" \
              --description "test repo" --visibility private \

--- a/tests/test_bootstrap_wizard.sh
+++ b/tests/test_bootstrap_wizard.sh
@@ -154,7 +154,7 @@ fi
 echo "$out" | grep -q "Starting stage: template-mirror" \
   && pass "stage B stub ran" \
   || fail "stage B stub didn't run; got: $out"
-echo "$out" | grep -q "github-infra (sub-C stub)" \
+echo "$out" | grep -q "Starting stage: github-infra" \
   && pass "stage C stub ran" \
   || fail "stage C stub didn't run"
 echo "$out" | grep -q "firebase-and-codereview (sub-D stub)" \


### PR DESCRIPTION
Closes #205.

## Summary

#156 sub-C implementation. Stage C (`github-infra`) ships the real implementation in place of sub-A's stub:

1. **`gh repo create --source=. --push`** against the new repo. Greenfield push to main is legitimate (no `gh-pr-guard.sh` bypass — the hook only protects existing repos). Visibility maps to `--public` / `--private` / `--internal`.
2. **Label seeding** — 10 canonical labels (`needs-external-review`, `needs-human-review`, `policy-violation`, `human-action`, `agent-action`, `phase-0..4`) with `--force` for idempotency. Single-label failure is non-fatal.
3. **Reviewer-identity collaborator invites** — for each agent in `BOOTSTRAP_INPUT_REVIEWERS` (default `claude,cursor,codex`), sends a write-permission invitation to `nathanpayne-<agent>`. Pauses for the operator to accept each invite (skippable via `BOOTSTRAP_AUTO_CONFIRM` / `BOOTSTRAP_SKIP_INVITE_PAUSE`).
4. **REVIEWER_ASSIGNMENT_TOKEN** — three provisioning paths: (a) `BOOTSTRAP_REVIEWER_PAT_VALUE` env (tests), (b) 1Password lookup at `BOOTSTRAP_REVIEWER_PAT_OP_REF` (default `op://Private/REVIEWER_ASSIGNMENT_PAT/token` — tolerates op timeouts, falls through to prompt), (c) interactive prompt. PAT piped via stdin to `gh secret set --body -` so it never appears on the command line or in the bootstrap log.
5. **Other LLM secrets** — prompts for `ANTHROPIC_API_KEY` + `OPENAI_API_KEY` with skip-blank.

Plus wizard surface: **`BOOTSTRAP_SKIP_STAGES`** (comma-list env var) for general-purpose stage skipping. Lets tests scope to one stage; lets operators mirror the template locally without remote infra.

## Test plan

- [x] `bash tests/test_bootstrap_github_infra.sh` → 16/16 PASS (right repo-create flags, 10 labels with `--force`, all 3 default invites, secret set via stdin, state-file ordering, gh-create-failure propagation, `BOOTSTRAP_SKIP_SECRETS=1` suppresses secret call, dry-run produces plan without invoking gh)
- [x] `bash tests/test_bootstrap_template_mirror.sh` → 39/39 PASS (sub-B scope now bounded via `BOOTSTRAP_SKIP_STAGES`)
- [x] `bash tests/test_bootstrap_wizard.sh` → 41/41 PASS (sub-A regression: only the stub-banner expectation needed updating)
- [x] All 16 `scripts/ci/check_*` green
- [x] `bash -n` on all touched bash files

## Files

- New: `scripts/bootstrap/github-infra.sh` (replaces stub — 5 sub-steps + per-step rc capture pattern from #233 r4)
- New: `scripts/ci/check_bootstrap_github_infra` (CI wrapper)
- New: `tests/test_bootstrap_github_infra.sh` (16-test fixture, PATH-shim `gh`)
- Updated: `scripts/bootstrap-new-repo.sh` (adds `BOOTSTRAP_SKIP_STAGES` to the dispatch loop)
- Updated: `tests/test_bootstrap_template_mirror.sh` (scopes runs to stage B via `BOOTSTRAP_SKIP_STAGES`)
- Updated: `tests/test_bootstrap_wizard.sh` (stage-C banner expectation: "github-infra (sub-C stub)" → "Starting stage: github-infra")

## Out of scope (followups)

- #156 sub-D (Firebase / CodeRabbit / Codex App posture)
- #156 sub-E (Project v2 board + summary + bootstrap runbook)
- #238 anchor introduction (needed for sub-B's cross-repo loop step)
- Branch protection setup on the new repo (per #205 issue body — typically configured AFTER first PR or two land; `scripts/audit-branch-protection.sh` covers post-bootstrap setup)

Authoring-Agent: claude

## Self-Review

- **Correctness:** 16-test fixture exercises each step plus failure paths. Failure-propagation matches the per-step rc capture pattern from #233 r4 (every `bootstrap::run` has `|| step_rc=$?` + conditional return). State-file ordering invariant pinned (template-mirror before github-infra).
- **Regression risk:** sub-A tests 41/41 + sub-B tests 39/39 (only the stub-banner expectations needed updating; sub-B got `BOOTSTRAP_SKIP_STAGES` added to keep its scope bounded).
- **Style:** matches sub-B conventions; every side-effect via `bootstrap::run` so `--dry-run` is correct.
- **Test coverage:** happy path + `BOOTSTRAP_SKIP_SECRETS=1` path + gh-repo-create-failure path + dry-run path + state-file ordering check.
- **Security:** PAT input via `read -s` (no echo), piped via stdin to `gh secret set --body -` so it never appears on the command line, in `ps`, or in the bootstrap log transcript. `BOOTSTRAP_REVIEWER_PAT_VALUE` env is test-only. PAT length is logged for confirmation; the value itself never is.
