### PR TITLE
fix(codex-review-check): bind .label before $required_names sub-pipeline

### DIFF
--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -520,9 +520,16 @@ BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq --argjson required_names "${REQUIRED_JSON:
     # checks block the gate. When the list is empty (no branch
     # protection configured or query failed), fall back to the
     # prior behavior of treating all checks as required.
+    #
+    # Bind `.label` to a variable BEFORE the `$required_names | ...`
+    # sub-pipeline, because inside that sub-pipeline `.` rebinds to
+    # `$required_names` (the array) and `.label` would then try to
+    # index the array, producing the jq error
+    # "Cannot index array with string \"label\"".
+    | (.label) as $label_name
     | select(
         ($required_names | length) == 0
-        or ($required_names | index(.label)) != null
+        or ($required_names | index($label_name)) != null
       )
     # A check passes the gate iff its result is SUCCESS, SKIPPED, or
     # NEUTRAL. Everything else — FAILURE, CANCELLED, TIMED_OUT,


### PR DESCRIPTION
Closes #244

## Summary

Gate (a) of `scripts/codex-review-check.sh` crashed on every merge-gate run against repos that have branch-protection-listed required checks with:

```
jq: error (at <stdin>:1): Cannot index array with string "label"
```

Root cause: the BAD_CHECKS jq expression contained `$required_names | index(.label)`. Inside the `$required_names | ...` sub-pipeline, jq's `.` rebinds to `$required_names` (the array), so `.label` then tries to index the array with a string and errors.

The bug only triggered when GitHub's branch-protection `required_status_checks` endpoint returned a non-empty list (the empty-list path short-circuited via `length == 0`). Matchline hit this on every merge-gate run against `main` and back-ported the identical fix yesterday in [matchline#221](https://github.com/nathanjohnpayne/matchline/pull/221); this PR brings the same fix upstream so future template syncs don't reintroduce the bug.

**Fix:** bind `.label` to a `$label_name` variable BEFORE entering the `$required_names | ...` sub-pipeline. Same patch as matchline#221.

Authoring-Agent: claude

## Self-Review

- **Correctness.** Same fix that already shipped in matchline#221 and was verified live against [matchline#218](https://github.com/nathanjohnpayne/matchline/pull/218) — gate (a) crashed pre-fix, passed post-fix. The mergepath copy of `scripts/codex-review-check.sh` still has the buggy form at line 525; this PR back-ports the matchline patch byte-for-byte (including the explanatory comment).
- **Regression risk.** Low. The change only moves the binding scope of `.label` to a named variable; the filter semantics (required-check membership) are identical.
- **Style.** Added an inline comment documenting why the binding moves out — same shape and tone as the surrounding comments in the script.
- **Test coverage.** No unit harness exists in mergepath for this script (`scripts/hooks/__tests__/` doesn't exist upstream yet; matchline has only `gh-pr-guard.test.sh`). Manual verification path is identical to matchline#221: run `bash scripts/codex-review-check.sh <PR#> <repo>` against any PR on a repo with branch-protection required checks → gate (a) reaches gate (b) without crashing.
- **Security / dep hygiene.** No deps added. No secrets touched. Read-only script.

## Test plan

- [x] Same diff as matchline#221, which was repro-verified pre/post on matchline#218.
- [ ] CI green on this PR.
