### PR TITLE
fix(automation): gh-as-author wrapper + identity verification + recovery docs (#241)

### DIFF
--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -57,6 +57,9 @@ jobs:
       - name: check_resolve_pr_threads
         run: ./scripts/ci/check_resolve_pr_threads
 
+      - name: check_gh_as_author
+        run: ./scripts/ci/check_gh_as_author
+
       - name: check_auto_clear_workflow
         run: ./scripts/ci/check_auto_clear_workflow
 

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -81,6 +81,12 @@ paths:
   - path: scripts/request-label-removal.sh
     type: canonical
     consumers: all
+  - path: scripts/gh-as-author.sh
+    type: canonical
+    consumers: all
+  - path: scripts/gh-as-reviewer.sh
+    type: canonical
+    consumers: all
   - path: scripts/hooks/gh-pr-guard.sh
     type: canonical
     consumers: all

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,15 @@ This repository uses a multi-identity AI agent code review system. The full poli
    machine: `gh auth switch -u nathanpayne-{your-agent}`. Then use
    `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"` (or `$OP_PREFLIGHT_AUTHOR_PAT`)
    only for read-path API calls and helper scripts. For author-identity
-   writes (PR create/merge/label edits), wrap the call in a temporary
-   `gh auth switch -u nathanjohnpayne && ... && gh auth switch -u nathanpayne-{your-agent}`.
-   See REVIEW_POLICY.md § Reviewer PAT Quick Start for the full convention.
+   writes (PR create/merge/label edits), MUST wrap the call in
+   `scripts/gh-as-author.sh -- gh pr create ...` — a single bash process
+   that switches, runs, and switches back via `trap EXIT`. Splitting the
+   sequence across two Bash tool calls lands the PR under the wrong
+   identity (#241). The `gh-pr-guard.sh` PreToolUse hook now blocks
+   `gh pr create` when the keyring's active is not `nathanjohnpayne`.
+   See REVIEW_POLICY.md § Reviewer PAT Quick Start for the full convention
+   and § Recovery: PR created under the wrong identity for what to do
+   if a PR already landed under the wrong account.
    Run `scripts/op-preflight.sh --agent {your-agent} --purge` (or
    `--purge-all`) at end of session to delete the cached PATs.
 1. Author code as nathanjohnpayne. File a PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,11 +330,14 @@ keyring active is your agent identity. No switch needed for commits.
       condition before coming back to merge. If `fallback-only`, skip
       directly to merge.
    h. With the gate passing AND the 4b checkpoint cleared, merge as
-      nathanjohnpayne with the switch-around per the active-account
-      convention:
-      `gh auth switch -u nathanjohnpayne && \
-       gh pr merge <PR#> --squash --delete-branch && \
-       gh auth switch -u nathanpayne-claude`
+      nathanjohnpayne via `scripts/gh-as-author.sh` per the active-
+      account convention above (HARD RULE — splitting the switch +
+      merge + switch-back across Bash tool calls has been observed
+      to leave the keyring on the wrong identity, see #241):
+
+      ```
+      scripts/gh-as-author.sh -- gh pr merge <PR#> --squash --delete-branch
+      ```
 
    **Phase 4b — Manual CLI fallback.** Applies when Phase 4a is
    unavailable (`codex.enabled: false`, either helper script missing,
@@ -349,9 +352,9 @@ keyring active is your agent identity. No switch needed for commits.
    d. Wait for the external reviewer identity to post an `APPROVED` review.
    e. If the external reviewer flags observations or risks, file the
       post-merge GitHub Issues per step 11 below.
-   f. Merge as nathanjohnpayne via the switch-around per the
-      active-account convention (`gh auth switch -u nathanjohnpayne &&
-      gh pr merge ... && gh auth switch -u nathanpayne-claude`).
+   f. Merge as nathanjohnpayne via `scripts/gh-as-author.sh` per the
+      active-account convention above (HARD RULE per #241):
+      `scripts/gh-as-author.sh -- gh pr merge <PR#> --squash --delete-branch`.
 
 10. Never use `--admin` to merge unless the human explicitly authorizes it
     in chat as a break-glass exception. The hook will block it otherwise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,11 +41,31 @@ time `gh auth login` per identity per machine). With this convention:
 - Reviewer-identity writes (`gh pr review --comment` from your agent
   identity) just work — no `GH_TOKEN` switch, no `gh auth switch`.
 - Author-identity writes (`gh pr create`, `gh pr merge`, `gh pr edit`
-  for label changes) need a temporary switch-around so the byline is
-  the author identity, paired with a switch-back so the active state
-  never lingers wrong:
+  for label changes) **MUST** use `scripts/gh-as-author.sh` — a single
+  bash process that switches to the author identity, runs the wrapped
+  command, then restores the prior active account via `trap EXIT`:
 
   ```bash
+  scripts/gh-as-author.sh -- gh pr create --title "..." --body "..."
+  scripts/gh-as-author.sh -- gh pr merge <PR#> --squash --delete-branch
+  ```
+
+  Bundling the switch + write + switch-back into one wrapper process
+  is a HARD RULE, not a soft recommendation. Splitting the three
+  steps across two or more Bash tool calls has been observed to land
+  the PR under the wrong identity — see #241 (and the concrete
+  incident on `friends-and-family-billing#262`) for the failure
+  mechanism and consequences (self-approval blocked, policy
+  fingerprint inversion, destructive recovery). The `gh-pr-guard.sh`
+  PreToolUse hook now enforces this: a `gh pr create` while the
+  keyring's active account is not `nathanjohnpayne` is blocked with
+  a diagnostic pointing at `gh-as-author.sh`. The wrapper also runs
+  a post-create `gh pr view --json author` verification to catch the
+  failure within seconds if it slips through. If you ever need the
+  unwrapped form, do it in one bash invocation:
+
+  ```bash
+  # Equivalent, only acceptable if gh-as-author.sh is unavailable for some reason:
   gh auth switch -u nathanjohnpayne && \
     gh pr merge <PR#> --squash --delete-branch && \
     gh auth switch -u nathanpayne-claude

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -88,9 +88,15 @@ GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
 # for the byline. Just run the command.
 gh pr review <PR#> --repo <owner/repo> --comment --body "Review comment"
 
-# Author-identity write: switch around the call so the byline is the
-# author identity, then switch back so the active state is correct
-# for subsequent reviewer-identity writes.
+# Author-identity write: MUST use scripts/gh-as-author.sh, which
+# switches + runs + restores inside ONE bash process via trap EXIT.
+# Splitting the switch and the write across two Bash invocations has
+# been observed to land the PR under the wrong identity (#241). The
+# gh-pr-guard.sh PreToolUse hook now enforces this for gh pr create.
+scripts/gh-as-author.sh -- gh pr create --title "..." --body "..."
+
+# Only when gh-as-author.sh is unavailable, the equivalent inline
+# form is acceptable — but it MUST stay inside one bash invocation:
 gh auth switch -u nathanjohnpayne && \
   gh pr create --title "..." --body "..." && \
   gh auth switch -u nathanpayne-claude
@@ -157,7 +163,7 @@ Replace `claude` with `cursor` or `codex` depending on which agent is running. T
 
 After preflight, these environment variables are set:
 - `OP_PREFLIGHT_REVIEWER_PAT` — use with `GH_TOKEN=` for reviewer-identity **read-path** API calls and helper scripts (`coderabbit-wait.sh`, `codex-review-request.sh`, `codex-review-check.sh`). Write paths (`gh pr review` / `create` / `merge` / `edit`) use the active keyring account regardless of `GH_TOKEN` — see [Reviewer PAT Quick Start](#reviewer-pat-quick-start).
-- `OP_PREFLIGHT_AUTHOR_PAT` — use with `GH_TOKEN=` for author-identity read-path API calls. For author-identity writes (PR create / merge / label edit), use the `gh auth switch -u nathanjohnpayne && ... && gh auth switch -u nathanpayne-<agent>` switch-around pattern.
+- `OP_PREFLIGHT_AUTHOR_PAT` — use with `GH_TOKEN=` for author-identity read-path API calls. For author-identity **writes** (PR create / merge / label edit), wrap the call in `scripts/gh-as-author.sh` — the wrapper switches the gh keyring to the author identity, runs the wrapped command, and restores the prior active account via `trap EXIT`, all in a single bash process. This is the canonical pattern (the `gh-pr-guard.sh` PreToolUse hook enforces it for `gh pr create`). The inline `gh auth switch -u nathanjohnpayne && ... && gh auth switch -u nathanpayne-<agent>` switch-around pattern remains acceptable as a fallback only when the wrapper is unavailable, and only when it stays inside one bash invocation — see [Recovery: PR created under the wrong identity](#recovery-pr-created-under-the-wrong-identity) for the #241 failure mode that motivates the wrapper-first rule.
 - `GOOGLE_APPLICATION_CREDENTIALS` — used automatically by gcloud/Firebase scripts
 - `OP_PREFLIGHT_DONE=1` — flag indicating preflight has been run
 

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -696,9 +696,16 @@ GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-request.sh <PR#>
 # Reviewer-identity write (your agent identity is active by default):
 gh pr review <PR#> --repo <owner/repo> --comment --body "Review comment"
 
-# Author-identity write: temporary switch-around so the byline is
-# nathanjohnpayne, paired with switch-back so active state never lingers
-# wrong for subsequent reviewer-identity writes:
+# Author-identity write: MUST use scripts/gh-as-author.sh, which
+# switches + runs + restores inside ONE bash process via trap EXIT.
+# Splitting the switch and the write across two Bash invocations has
+# been observed to land the PR under the wrong identity (#241). The
+# gh-pr-guard.sh PreToolUse hook now enforces this.
+scripts/gh-as-author.sh -- gh pr merge <PR#> --squash --delete-branch
+scripts/gh-as-author.sh -- gh pr create --title "..." --body "..."
+
+# Only when gh-as-author.sh is unavailable, the equivalent inline form
+# is acceptable — but it MUST stay inside one bash invocation:
 gh auth switch -u nathanjohnpayne && \
   gh pr merge <PR#> --squash --delete-branch && \
   gh auth switch -u nathanpayne-<agent>
@@ -769,6 +776,99 @@ for repo in mergepath swipewatch nathanpaynedotcom \
   fi
 done
 ```
+
+## Recovery: PR created under the wrong identity
+
+If `gh pr create` lands a PR under the wrong account — typically because the
+`gh auth switch -u nathanjohnpayne` and the `gh pr create` were split across
+two Bash tool calls and the gh keyring's active state drifted between them —
+the PR is unrecoverable in place: any review attempt under the same account
+that authored the PR returns `Can not approve your own pull request`, and the
+`Authoring-Agent:` fingerprint in the body now disagrees with `author.login`,
+breaking downstream audit. See #241 for the bug history and
+`nathanjohnpayne/friends-and-family-billing#262` for the canonical incident.
+
+### Prevention (the primary path)
+
+Always wrap author-identity writes in `scripts/gh-as-author.sh`:
+
+```bash
+scripts/gh-as-author.sh -- gh pr create --title "..." --body "..."
+```
+
+The wrapper switches to `nathanjohnpayne`, runs the wrapped command, and
+restores the prior active account via `trap EXIT` — all inside one bash
+process so the switch and the write can't drift apart. For `gh pr create`
+specifically, it also runs a post-create `gh pr view --json author`
+verification and exits non-zero (code 5) if `author.login` does not match
+the expected identity. The `gh-pr-guard.sh` PreToolUse hook independently
+blocks `gh pr create` when the keyring's active account is not the author
+identity.
+
+### Detection
+
+If you suspect the wrong-identity failure (e.g., the PR was just created
+and review attempts return `Can not approve your own pull request`), confirm
+with:
+
+```bash
+gh pr view <PR#> --repo <owner>/<repo> --json author --jq .author.login
+```
+
+Expected: `nathanjohnpayne`. If the output is your agent identity (e.g.
+`nathanpayne-claude`), you hit the #241 footgun.
+
+### Recovery procedure
+
+Close the wrong PR and recreate from the same branch. The commits and the
+branch survive the close — what's lost is the PR's review thread history,
+prior CI results, and any `chatgpt-codex-connector[bot]` / CodeRabbit
+comments. There is no in-place fix: GitHub does not expose an API to change
+`author.login` on an existing PR.
+
+```bash
+# 1. Close the wrong-author PR with a comment explaining the recreate.
+gh pr close <PR#> --repo <owner>/<repo> \
+  --comment "Wrong author identity (see #241). Recreating from the same branch."
+
+# 2. Recreate from a fresh shell so any stale gh-state shell vars are gone,
+#    and route through gh-as-author.sh so the new PR can't repeat the
+#    failure mode.
+scripts/gh-as-author.sh -- gh pr create \
+  --repo <owner>/<repo> \
+  --base main --head <same-branch> \
+  --title "..." \
+  --body "..."
+
+# 3. Verify the new PR landed under the right identity (the wrapper also
+#    does this automatically, but it's worth checking once by hand if you
+#    bypassed the wrapper):
+gh pr view <NEW_PR#> --repo <owner>/<repo> --json author --jq .author.login
+# expected: nathanjohnpayne
+```
+
+The fresh shell in step 2 is belt-and-suspenders: any `GH_TOKEN` /
+`GH_HOST` / `GITHUB_TOKEN` env vars exported earlier in the session that
+might have contributed to the drift are cleared by the new process. The
+wrapper script itself does not depend on those env vars, but a fresh shell
+removes ambiguity about which version of the state any helper is reading.
+
+### What's lost vs. what survives
+
+| Item | After recreate |
+|------|----------------|
+| Commits on the branch | survive (`git push` is unaffected) |
+| Branch ref | survives |
+| PR review threads | LOST (closed-PR threads do not carry over) |
+| CodeRabbit comments | LOST (will re-run on the new PR if enabled) |
+| Codex Connector review | LOST (will re-trigger on the new PR if review-ready) |
+| CI run history | LOST (jobs re-run on the new PR) |
+| PR number | new one assigned |
+| Authoring-Agent fingerprint | regenerated (now matches `author.login`) |
+
+Filing a post-merge issue noting the recreated-PR situation is optional but
+helpful for audit trails — link both the closed PR and the new one so a
+later reader can follow the thread.
 
 ## Adding a New Agent
 

--- a/rules/repo_rules.md
+++ b/rules/repo_rules.md
@@ -44,3 +44,4 @@ All checks must pass before merge.
 - check_duplicate_docs
 - check_review_policy_exists (inline in repo_lint.yml): .github/review-policy.yml and REVIEW_POLICY.md must both exist
 - check_codex_scripts: `scripts/codex-review-request.sh` and `scripts/codex-review-check.sh` must exist and be executable in every repo. Required for `CLAUDE.md` step 8 Phase 4a (automated external review via the OpenAI Codex GitHub App) — missing either script silently forces callers to Phase 4b fallback.
+- check_gh_as_author: `tests/test_gh_as_author.sh` and `tests/test_gh_pr_guard.sh` must exist and pass. Covers the #241 wrapper (`scripts/gh-as-author.sh`) and the identity-check addition to `scripts/hooks/gh-pr-guard.sh` that prevent the gh keyring active-identity glitch from landing a PR under the wrong account.

--- a/scripts/ci/check_gh_as_author
+++ b/scripts/ci/check_gh_as_author
@@ -16,6 +16,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 TESTS=(
   "tests/test_gh_as_author.sh"
+  "tests/test_gh_as_reviewer.sh"
   "tests/test_gh_pr_guard.sh"
 )
 

--- a/scripts/ci/check_gh_as_author
+++ b/scripts/ci/check_gh_as_author
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# scripts/ci/check_gh_as_author — CI entry point for #241 tests.
+#
+# Runs the unit tests for scripts/gh-as-author.sh AND for the
+# identity-check addition to scripts/hooks/gh-pr-guard.sh. Both test
+# files are under tests/; this wrapper invokes them in sequence and
+# fails on the first failure. Hard-fails (exit 1, not skip) when
+# either test script is missing, so an accidental delete/rename
+# can't silently disable this check.
+#
+# Mirrors the pattern used by scripts/ci/check_sync_overrides.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+TESTS=(
+  "tests/test_gh_as_author.sh"
+  "tests/test_gh_pr_guard.sh"
+)
+
+FAILED=0
+for rel in "${TESTS[@]}"; do
+  full="$REPO_ROOT/$rel"
+  if [ ! -f "$full" ]; then
+    echo "check_gh_as_author: ERROR (missing $rel)" >&2
+    FAILED=1
+    continue
+  fi
+  echo "check_gh_as_author: running $rel"
+  if ! bash "$full"; then
+    echo "check_gh_as_author: FAIL ($rel)" >&2
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "check_gh_as_author: FAIL"
+  exit 1
+fi
+
+echo "check_gh_as_author: PASS"
+exit 0

--- a/scripts/gh-as-author.sh
+++ b/scripts/gh-as-author.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# scripts/gh-as-author.sh
+#
+# Run a `gh` command (typically a write — pr create, pr merge, pr
+# edit) under the AUTHOR identity (nathanjohnpayne by default), then
+# restore the previously-active gh keyring account. Switches and
+# switch-back all happen inside one bash process via `trap EXIT`, so
+# even a crash or interrupt between the switch and the wrapped command
+# leaves the keyring in a known-good state.
+#
+# Usage:
+#   scripts/gh-as-author.sh -- gh pr create --title ...
+#   scripts/gh-as-author.sh -- gh pr merge 123 --squash --delete-branch
+#   scripts/gh-as-author.sh -- gh pr edit 123 --add-label foo
+#
+# The leading `--` is conventional but optional; the script strips it
+# before exec-ing the wrapped command.
+#
+# Why this exists (#241):
+#
+#   The canonical pattern `gh auth switch -u <author> && gh pr create
+#   && gh auth switch -u <reviewer>` is correct only when all three
+#   commands run inside ONE bash invocation. When an agent splits it
+#   across two Bash tool calls (switch in call A; pr create + switch-
+#   back in call B), the gh keyring's active account can drift between
+#   calls — observed concretely on friends-and-family-billing#262
+#   where a `gh pr create` landed under `nathanpayne-claude` despite
+#   a preceding `gh auth switch -u nathanjohnpayne` in the prior
+#   Bash call. Wrapping the whole sequence in a single script process
+#   eliminates the split-invocation failure mode.
+#
+#   This wrapper is the canonical pattern referenced from CLAUDE.md
+#   and REVIEW_POLICY.md.
+#
+# Verification (#241 mitigation 2):
+#
+#   When the wrapped command is `gh pr create`, the script also runs
+#   a post-create `gh pr view --json author` check on the created PR
+#   and exits non-zero if `author.login` does not match the expected
+#   author identity. This catches the "PR landed under the wrong
+#   identity" failure mode immediately, instead of at the reviewer-
+#   approval step ~10 min later.
+#
+# Environment:
+#   GH_AS_AUTHOR_IDENTITY   author identity to switch to.
+#                           Default: nathanjohnpayne
+#
+# Exit codes:
+#   0    success (wrapped command exited 0 AND, for gh pr create,
+#        author verification passed)
+#   1    setup error (could not determine prior active account, etc.)
+#   2    switch-to-author failed
+#   5    post-create author verification failed (PR landed under
+#        wrong identity)
+#   *    propagated from the wrapped command otherwise
+#
+# Bash 3.2 compatible (macOS default).
+
+set -euo pipefail
+
+AUTHOR="${GH_AS_AUTHOR_IDENTITY:-nathanjohnpayne}"
+
+# Capture prior active via `gh config get -h github.com user`, NOT
+# `gh auth status`. `gh auth status` is GH_TOKEN-poisonable — when
+# GH_TOKEN is set it reports the GH_TOKEN entry as Active even though
+# writes still attribute to the keyring entry. CLAUDE.md § Active-
+# account convention is explicit about this.
+PRIOR=$(gh config get -h github.com user 2>/dev/null || echo "")
+if [ -z "$PRIOR" ]; then
+  echo "gh-as-author: could not determine prior active gh account (gh config get -h github.com user returned empty)" >&2
+  echo "gh-as-author: refusing to proceed; running the wrapped command without a recorded prior account would leave the keyring in an unknown state on switch-back." >&2
+  exit 1
+fi
+
+# Install the switch-back trap BEFORE the switch-to-author. That way
+# if the switch-to-author itself partial-fails, we still attempt to
+# restore the prior account. The trap is tolerant of restore failure
+# — a stuck-on-author keyring is a louder problem than the wrapped
+# command's exit code, so we emit a clear diagnostic but don't
+# clobber the exit code.
+restore_prior() {
+  if ! gh auth switch -u "$PRIOR" >/dev/null 2>&1; then
+    echo "gh-as-author: WARNING failed to restore prior active account ($PRIOR). Run 'gh auth switch -u $PRIOR' manually to recover." >&2
+  fi
+}
+trap 'restore_prior' EXIT
+
+if ! gh auth switch -u "$AUTHOR" >/dev/null 2>&1; then
+  echo "gh-as-author: gh auth switch -u $AUTHOR failed. Is $AUTHOR in the keyring? Run 'gh auth login' once for that identity." >&2
+  exit 2
+fi
+
+# Strip leading `--` if present so callers can use the conventional
+# disambiguator `scripts/gh-as-author.sh -- gh pr create ...`.
+[ "${1:-}" = "--" ] && shift
+
+# Detect whether the wrapped command is `gh pr create`. argv[0] must
+# be `gh` and argv[1] must be `pr` and argv[2] must be `create`. We
+# don't try to handle `gh -R foo/bar pr create ...` here — agents
+# should use the subcommand-scoped `--repo` flag with this wrapper
+# (the gh CLI accepts both forms equivalently). Worst case: a global
+# -R/--repo before `pr` slips past the detector, the wrapped command
+# still runs correctly, and we just skip the post-create verification.
+IS_PR_CREATE=0
+if [ "${1:-}" = "gh" ] && [ "${2:-}" = "pr" ] && [ "${3:-}" = "create" ]; then
+  IS_PR_CREATE=1
+fi
+
+if [ "$IS_PR_CREATE" -eq 1 ]; then
+  # Capture stdout so we can extract the PR URL for verification, but
+  # also tee it to the operator's terminal so they see the URL gh
+  # prints. Stderr is left alone (gh emits progress + errors there).
+  TMP_OUT=$(mktemp)
+  # `trap` chains — append to the existing EXIT trap (the restore)
+  # so the tempfile is cleaned up too.
+  trap 'rm -f "$TMP_OUT"; restore_prior' EXIT
+  set +e
+  "$@" | tee "$TMP_OUT"
+  # PIPESTATUS[0] is the wrapped gh's exit code; tee almost always
+  # returns 0 so we ignore PIPESTATUS[1].
+  WRAPPED_RC=${PIPESTATUS[0]}
+  set -e
+  if [ "$WRAPPED_RC" -ne 0 ]; then
+    exit "$WRAPPED_RC"
+  fi
+
+  # Extract the PR URL from the captured output. gh pr create's last
+  # line is the URL (https://github.com/owner/repo/pull/N). `basename`
+  # on the URL yields the PR number. Use `grep -oE` to find the URL
+  # rather than `tail -1` because gh sometimes appends `--web` open
+  # diagnostics or other trailing lines.
+  PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' "$TMP_OUT" | tail -1 || true)
+  if [ -z "$PR_URL" ]; then
+    echo "gh-as-author: WARNING could not extract PR URL from gh pr create output; skipping post-create author verification." >&2
+    exit 0
+  fi
+  PR_NUM=$(basename "$PR_URL")
+  # Repo slug is the path component between github.com/ and /pull/N.
+  PR_REPO=$(echo "$PR_URL" | sed -E 's|https://github\.com/([^/]+/[^/]+)/pull/[0-9]+|\1|')
+
+  # Use the active keyring (currently $AUTHOR) for the verification
+  # read. We don't pin GH_TOKEN here — the read works under either
+  # identity and avoiding the env-var dependency keeps the wrapper
+  # standalone.
+  ACTUAL_AUTHOR=$(gh pr view "$PR_NUM" --repo "$PR_REPO" --json author --jq .author.login 2>/dev/null || echo "")
+  if [ -z "$ACTUAL_AUTHOR" ]; then
+    echo "gh-as-author: WARNING could not read PR author from gh pr view $PR_NUM --repo $PR_REPO (network? permissions?). Skipping post-create author verification." >&2
+    exit 0
+  fi
+
+  if [ "$ACTUAL_AUTHOR" != "$AUTHOR" ]; then
+    echo "gh-as-author: ERROR PR #$PR_NUM on $PR_REPO landed under '$ACTUAL_AUTHOR', expected '$AUTHOR'." >&2
+    echo "gh-as-author: This is the #241 footgun — gh keyring active-identity glitch." >&2
+    echo "gh-as-author: Recovery: close the PR and recreate from the same branch." >&2
+    echo "gh-as-author:   gh pr close $PR_NUM --repo $PR_REPO --comment 'Wrong author identity (see #241). Recreating.'" >&2
+    echo "gh-as-author:   scripts/gh-as-author.sh -- gh pr create --repo $PR_REPO --title '...' --body '...'" >&2
+    echo "gh-as-author: See REVIEW_POLICY.md § Recovery: PR created under the wrong identity." >&2
+    exit 5
+  fi
+
+  echo "gh-as-author: verified PR #$PR_NUM author=$ACTUAL_AUTHOR (matches expected $AUTHOR)" >&2
+  exit 0
+fi
+
+# Non-gh-pr-create path: just exec the wrapped command. The EXIT trap
+# handles switch-back. No verification overhead.
+exec "$@"

--- a/scripts/gh-as-author.sh
+++ b/scripts/gh-as-author.sh
@@ -14,7 +14,7 @@
 #   scripts/gh-as-author.sh -- gh pr edit 123 --add-label foo
 #
 # The leading `--` is conventional but optional; the script strips it
-# before exec-ing the wrapped command.
+# before running the wrapped command.
 #
 # Why this exists (#241):
 #
@@ -51,7 +51,11 @@
 #   1    setup error (could not determine prior active account, etc.)
 #   2    switch-to-author failed
 #   5    post-create author verification failed (PR landed under
-#        wrong identity)
+#        wrong identity) OR verification could not complete (PR URL
+#        not extractable from gh pr create output / gh pr view failed
+#        / empty author.login). Fail-closed: an unverified create
+#        is NOT treated as success, so downstream automation can
+#        distinguish "verified clean" from "verification skipped".
 #   *    propagated from the wrapped command otherwise
 #
 # Bash 3.2 compatible (macOS default).
@@ -131,8 +135,15 @@ if [ "$IS_PR_CREATE" -eq 1 ]; then
   # diagnostics or other trailing lines.
   PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' "$TMP_OUT" | tail -1 || true)
   if [ -z "$PR_URL" ]; then
-    echo "gh-as-author: WARNING could not extract PR URL from gh pr create output; skipping post-create author verification." >&2
-    exit 0
+    # Fail closed: a successful `gh pr create` whose URL we cannot
+    # extract is NOT verified. Treating it as verified would let
+    # downstream automation proceed after the safety check was
+    # silently skipped — exactly the #241 footgun this wrapper
+    # exists to close. Operator recovery: verify the new PR's
+    # author.login manually (`gh pr list --author nathanjohnpayne`).
+    echo "gh-as-author: ERROR could not extract PR URL from gh pr create output; refusing to treat the create as verified." >&2
+    echo "gh-as-author: The PR may still have been created — check 'gh pr list --author $AUTHOR' and verify manually." >&2
+    exit 5
   fi
   PR_NUM=$(basename "$PR_URL")
   # Repo slug is the path component between github.com/ and /pull/N.
@@ -144,8 +155,12 @@ if [ "$IS_PR_CREATE" -eq 1 ]; then
   # standalone.
   ACTUAL_AUTHOR=$(gh pr view "$PR_NUM" --repo "$PR_REPO" --json author --jq .author.login 2>/dev/null || echo "")
   if [ -z "$ACTUAL_AUTHOR" ]; then
-    echo "gh-as-author: WARNING could not read PR author from gh pr view $PR_NUM --repo $PR_REPO (network? permissions?). Skipping post-create author verification." >&2
-    exit 0
+    # Fail closed: see PR-URL branch above. Network blips and
+    # transient gh errors must NOT be confused with a verified clean
+    # create.
+    echo "gh-as-author: ERROR could not read PR author from gh pr view $PR_NUM --repo $PR_REPO (network? permissions?); refusing to treat the create as verified." >&2
+    echo "gh-as-author: Verify manually: gh pr view $PR_NUM --repo $PR_REPO --json author" >&2
+    exit 5
   fi
 
   if [ "$ACTUAL_AUTHOR" != "$AUTHOR" ]; then
@@ -162,6 +177,15 @@ if [ "$IS_PR_CREATE" -eq 1 ]; then
   exit 0
 fi
 
-# Non-gh-pr-create path: just exec the wrapped command. The EXIT trap
-# handles switch-back. No verification overhead.
-exec "$@"
+# Non-gh-pr-create path: run the wrapped command in this shell (NOT
+# exec) so the EXIT trap still fires and restores $PRIOR. Using exec
+# would replace the bash process with the wrapped command, dropping
+# the trap and leaving the keyring stuck on $AUTHOR — the exact
+# state the wrapper exists to prevent. Capture the wrapped command's
+# exit code and propagate it so callers see the same rc they would
+# from running the command directly.
+set +e
+"$@"
+WRAPPED_RC=$?
+set -e
+exit "$WRAPPED_RC"

--- a/scripts/gh-as-reviewer.sh
+++ b/scripts/gh-as-reviewer.sh
@@ -54,4 +54,15 @@ fi
 
 [ "${1:-}" = "--" ] && shift
 
-exec "$@"
+# Run the wrapped command in THIS shell (NOT exec) so the EXIT trap
+# still fires and restores $PRIOR. `exec "$@"` would replace the
+# bash process with the wrapped command, dropping the trap and
+# leaving the keyring stuck on $REVIEWER. Capture and propagate the
+# wrapped command's exit code so callers see the same rc they would
+# from running the command directly. Same fix shape as
+# scripts/gh-as-author.sh.
+set +e
+"$@"
+WRAPPED_RC=$?
+set -e
+exit "$WRAPPED_RC"

--- a/scripts/gh-as-reviewer.sh
+++ b/scripts/gh-as-reviewer.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/gh-as-reviewer.sh
+#
+# Run a `gh` command under the REVIEWER identity (the agent identity,
+# e.g. nathanpayne-claude), then restore the previously-active gh
+# keyring account. Companion to scripts/gh-as-author.sh — same trap-
+# EXIT pattern, same prior-active detection via `gh config get`, but
+# switches to the reviewer identity instead.
+#
+# Usage:
+#   GH_AS_REVIEWER_IDENTITY=nathanpayne-claude \
+#     scripts/gh-as-reviewer.sh -- gh pr review 123 --comment --body "..."
+#
+# Environment:
+#   GH_AS_REVIEWER_IDENTITY   reviewer identity to switch to.
+#                             Default: nathanpayne-claude
+#
+# On most agent machines the reviewer identity is ALREADY the active
+# account per the CLAUDE.md convention, so this wrapper is mostly a
+# no-op (switches to itself, runs the command, switches back to
+# itself). The value is for the inverse case — an agent in the
+# middle of an author-identity flow (e.g. just finished a wrapped
+# `gh pr create`) who needs to post a reviewer comment WITHOUT
+# leaving the keyring in a wrong state on return.
+#
+# Exit codes mirror gh-as-author.sh except there is no post-create
+# verification (the reviewer wrapper is not the canonical path for
+# pr create).
+#
+# Bash 3.2 compatible (macOS default).
+
+set -euo pipefail
+
+REVIEWER="${GH_AS_REVIEWER_IDENTITY:-nathanpayne-claude}"
+
+PRIOR=$(gh config get -h github.com user 2>/dev/null || echo "")
+if [ -z "$PRIOR" ]; then
+  echo "gh-as-reviewer: could not determine prior active gh account (gh config get -h github.com user returned empty)" >&2
+  echo "gh-as-reviewer: refusing to proceed; running the wrapped command without a recorded prior account would leave the keyring in an unknown state on switch-back." >&2
+  exit 1
+fi
+
+restore_prior() {
+  if ! gh auth switch -u "$PRIOR" >/dev/null 2>&1; then
+    echo "gh-as-reviewer: WARNING failed to restore prior active account ($PRIOR). Run 'gh auth switch -u $PRIOR' manually to recover." >&2
+  fi
+}
+trap 'restore_prior' EXIT
+
+if ! gh auth switch -u "$REVIEWER" >/dev/null 2>&1; then
+  echo "gh-as-reviewer: gh auth switch -u $REVIEWER failed. Is $REVIEWER in the keyring? Run 'gh auth login' once for that identity." >&2
+  exit 2
+fi
+
+[ "${1:-}" = "--" ] && shift
+
+exec "$@"

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # gh-pr-guard.sh — PreToolUse hook for Claude Code
 #
-# Gates three operations:
-#   1. gh pr create — blocks unless the command text includes
-#      "Authoring-Agent:" and "## Self-Review"
+# Gates four operations:
+#   1. gh pr create — blocks unless (a) the keyring's active gh
+#      account is the AUTHOR identity (nathanjohnpayne by default;
+#      override via GH_PR_GUARD_EXPECTED_AUTHOR), AND (b) the command
+#      text includes "Authoring-Agent:" and "## Self-Review". The
+#      identity check (#241) prevents the split-invocation footgun
+#      where a `gh auth switch` in one Bash tool call drifts before
+#      the `gh pr create` in a subsequent call, landing the PR under
+#      the wrong account. Canonical fix is to use
+#      scripts/gh-as-author.sh which wraps switch + create + switch-
+#      back in one bash process.
 #   2. gh pr merge --admin — blocks unless BREAK_GLASS_ADMIN=1
 #      (human must explicitly authorize in chat)
 #   3. gh pr merge (non-admin) — blocks when the target PR carries
@@ -13,6 +21,13 @@
 #      merge gate at the hook layer so an agent can't accidentally
 #      merge past Label Gate by removing the label without running
 #      the gate check first.
+#
+# The identity check (1a) honors a
+# BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK=1 escape hatch for tests
+# that PATH-shim gh and have no real keyring. Production code should
+# never set this — the wrapper script gh-as-author.sh switches to the
+# author identity BEFORE the gh pr create call lands, so the check
+# passes naturally without the bypass.
 #
 # Exit codes:
 #   0 = allow
@@ -512,6 +527,58 @@ fi
 # structural ones, and they don't depend on argument positions or
 # global flags.
 if [ "$PR_SUBCOMMAND" = "create" ]; then
+  # Identity check (#241): the keyring's active account must be the
+  # AUTHOR identity (nathanjohnpayne) at the moment of `gh pr create`,
+  # otherwise the PR is authored by whatever identity IS active —
+  # observed concretely on friends-and-family-billing#262 where a
+  # split switch / pr-create across two Bash tool calls landed a PR
+  # under the wrong identity. The canonical fix is to wrap the entire
+  # sequence in `scripts/gh-as-author.sh` so the switch and the create
+  # share one bash process.
+  #
+  # The check uses `gh config get -h github.com user`, NOT `gh auth
+  # status`. The latter is GH_TOKEN-poisonable: when GH_TOKEN is set
+  # it reports the GH_TOKEN entry as Active, but the keyring entry is
+  # still the one that signs writes. `gh config get` reads the
+  # keyring config file directly and is the authoritative read for
+  # "who will this write attribute to".
+  #
+  # Escape hatch: `BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK=1` lets
+  # tests and edge cases bypass this check. The check is additive
+  # defense-in-depth on top of gh-as-author.sh — when an agent runs
+  # `scripts/gh-as-author.sh -- gh pr create ...` correctly, the
+  # wrapper has already switched to the author identity by the time
+  # this hook fires, so the check passes naturally without the
+  # escape. The escape exists for test harnesses that PATH-shim `gh`
+  # and have no real keyring to read.
+  EXPECTED_AUTHOR="${GH_PR_GUARD_EXPECTED_AUTHOR:-nathanjohnpayne}"
+  if [ "${BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK:-0}" != "1" ]; then
+    ACTIVE_GH_USER=$(gh config get -h github.com user 2>/dev/null || echo "")
+    if [ -z "$ACTIVE_GH_USER" ]; then
+      echo "BLOCKED: gh-pr-guard could not read the active gh account from 'gh config get -h github.com user'." >&2
+      echo "  Either gh is not installed/authenticated, or the keyring config is corrupt." >&2
+      echo "  Run 'gh auth login' for the $EXPECTED_AUTHOR identity, then retry via scripts/gh-as-author.sh." >&2
+      exit 2
+    fi
+    if [ "$ACTIVE_GH_USER" != "$EXPECTED_AUTHOR" ]; then
+      echo "BLOCKED: gh pr create is about to run under active account '$ACTIVE_GH_USER', not the expected author identity '$EXPECTED_AUTHOR'." >&2
+      echo "" >&2
+      echo "  This is the #241 footgun. A PR created right now would be authored by '$ACTIVE_GH_USER'," >&2
+      echo "  which breaks self-approval (Can not approve your own pull request) and inverts the" >&2
+      echo "  Authoring-Agent: fingerprint in the PR body." >&2
+      echo "" >&2
+      echo "  Canonical fix: wrap the call in scripts/gh-as-author.sh, which switches to" >&2
+      echo "  $EXPECTED_AUTHOR, runs gh pr create, then restores the prior active account via" >&2
+      echo "  trap EXIT — all inside one bash process so the switch and the create can't drift apart:" >&2
+      echo "" >&2
+      echo "    scripts/gh-as-author.sh -- gh pr create --title '...' --body '...'" >&2
+      echo "" >&2
+      echo "  See REVIEW_POLICY.md § Recovery: PR created under the wrong identity for the case" >&2
+      echo "  where a PR already landed under the wrong account." >&2
+      exit 2
+    fi
+  fi
+
   MISSING=""
 
   if ! echo "$COMMAND" | grep -qi 'Authoring-Agent:'; then

--- a/tests/test_gh_as_author.sh
+++ b/tests/test_gh_as_author.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# tests/test_gh_as_author.sh
+#
+# Unit tests for scripts/gh-as-author.sh — the #241 wrapper that
+# atomically switches the gh keyring's active account to the AUTHOR
+# identity, runs a wrapped gh command, then restores the prior active
+# account via trap EXIT.
+#
+# Strategy: PATH-shim `gh` with a stub that records every invocation
+# in $GH_CALLS_LOG and simulates `gh auth switch` / `gh config get` /
+# `gh pr create` / `gh pr view` so the script can run end-to-end
+# without touching the real keyring or the network. Each test asserts
+# on the contents of the call log and the script's exit code.
+#
+# Bash 3.2 portable. Runs from `scripts/ci/check_gh_as_author`.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$ROOT/scripts/gh-as-author.sh"
+
+[[ -x "$WRAPPER" ]] || { echo "missing or non-executable $WRAPPER" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/gh-as-author-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Build a PATH-shim `gh` stub. Driven by env vars set per test:
+#
+#   GH_CALLS_LOG          path to a file the stub appends each call to
+#   GH_INITIAL_ACTIVE     value `gh config get -h github.com user` returns
+#   GH_CREATE_PR_URL      URL `gh pr create` prints on stdout
+#   GH_CREATE_PR_RC       exit code for `gh pr create` (default 0)
+#   GH_VIEW_AUTHOR        author.login `gh pr view` returns (default
+#                         GH_INITIAL_ACTIVE — typical happy path)
+#   GH_VIEW_RC            exit code for `gh pr view` (default 0)
+#   GH_SWITCH_RC          exit code for `gh auth switch` (default 0)
+#
+# The stub also UPDATES the file backing GH_INITIAL_ACTIVE on a
+# `gh auth switch -u <user>` so subsequent `gh config get` calls
+# reflect the switch — important for verifying the trap-EXIT switch-
+# back actually restores prior.
+# ---------------------------------------------------------------------------
+STUB_DIR="$WORKDIR/stub-bin"
+mkdir -p "$STUB_DIR"
+ACTIVE_STATE_FILE="$WORKDIR/active-state"
+
+cat >"$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+# Record the call. NUL-delimited args so embedded spaces / quotes
+# can't confuse the test assertions.
+LOG="${GH_CALLS_LOG:-/dev/null}"
+printf 'gh' >> "$LOG"
+for a in "$@"; do
+  printf '\t%s' "$a" >> "$LOG"
+done
+printf '\n' >> "$LOG"
+
+# Dispatch on the subcommand grammar this wrapper exercises.
+case "$1 $2" in
+  "config get")
+    # Args: config get -h github.com user
+    if [ -f "${ACTIVE_STATE_FILE:-/nonexistent}" ]; then
+      cat "$ACTIVE_STATE_FILE"
+    elif [ -n "${GH_INITIAL_ACTIVE:-}" ]; then
+      echo "$GH_INITIAL_ACTIVE"
+    fi
+    exit 0
+    ;;
+  "auth switch")
+    # Args: auth switch -u <user>
+    rc="${GH_SWITCH_RC:-0}"
+    if [ "$rc" -ne 0 ]; then exit "$rc"; fi
+    # Find -u value
+    shift; shift # consume `auth switch`
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "-u" ]; then
+        shift
+        echo "$1" > "$ACTIVE_STATE_FILE"
+        exit 0
+      fi
+      shift
+    done
+    exit 0
+    ;;
+  "pr create")
+    echo "${GH_CREATE_PR_URL:-https://github.com/example/repo/pull/999}"
+    exit "${GH_CREATE_PR_RC:-0}"
+    ;;
+  "pr view")
+    rc="${GH_VIEW_RC:-0}"
+    if [ "$rc" -ne 0 ]; then exit "$rc"; fi
+    # Args: pr view <PR#> --repo <repo> --json author --jq .author.login
+    echo "${GH_VIEW_AUTHOR:-${GH_INITIAL_ACTIVE:-nathanjohnpayne}}"
+    exit 0
+    ;;
+  *)
+    # Unknown command — succeed quietly so tests can pass arbitrary
+    # commands through the wrapper without orchestration overhead.
+    exit 0
+    ;;
+esac
+STUB
+chmod +x "$STUB_DIR/gh"
+
+reset_state() {
+  : > "$WORKDIR/calls.log"
+  echo "${GH_INITIAL_ACTIVE:-nathanpayne-claude}" > "$ACTIVE_STATE_FILE"
+}
+
+# Run the wrapper with the stubbed PATH. Args are passed verbatim.
+# Returns the wrapper's exit code via the outer shell ($?).
+run_wrapper() {
+  PATH="$STUB_DIR:$PATH" \
+  GH_CALLS_LOG="$WORKDIR/calls.log" \
+  ACTIVE_STATE_FILE="$ACTIVE_STATE_FILE" \
+    "$WRAPPER" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Happy path — gh pr create switches to author, runs create,
+# verifies author, switches back to prior. Five gh calls expected:
+#   1. gh config get -h github.com user        (capture prior)
+#   2. gh auth switch -u nathanjohnpayne       (switch to author)
+#   3. gh pr create ...                        (the wrapped command)
+#   4. gh pr view 999 --repo ... ...           (verification)
+#   5. gh auth switch -u nathanpayne-claude    (trap EXIT switch-back)
+# ---------------------------------------------------------------------------
+GH_INITIAL_ACTIVE="nathanpayne-claude" \
+GH_CREATE_PR_URL="https://github.com/example/repo/pull/42" \
+GH_VIEW_AUTHOR="nathanjohnpayne" \
+reset_state
+
+GH_INITIAL_ACTIVE="nathanpayne-claude" \
+GH_CREATE_PR_URL="https://github.com/example/repo/pull/42" \
+GH_VIEW_AUTHOR="nathanjohnpayne" \
+  run_wrapper -- gh pr create --title "t" --body "b" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "happy path: wrapper exited $rc, expected 0"
+else
+  # Verify switch-to-author happened.
+  if grep -qP '^gh\tauth\tswitch\t-u\tnathanjohnpayne$' "$WORKDIR/calls.log" 2>/dev/null \
+    || grep -qE $'^gh\tauth\tswitch\t-u\tnathanjohnpayne$' "$WORKDIR/calls.log"; then
+    pass "happy path: switched to nathanjohnpayne"
+  else
+    fail "happy path: did NOT switch to nathanjohnpayne"
+    cat "$WORKDIR/calls.log" >&2
+  fi
+  # Verify pr create happened.
+  if grep -qE $'^gh\tpr\tcreate\t' "$WORKDIR/calls.log"; then
+    pass "happy path: ran gh pr create"
+  else
+    fail "happy path: did NOT run gh pr create"
+  fi
+  # Verify post-create verification happened.
+  if grep -qE $'^gh\tpr\tview\t42\t' "$WORKDIR/calls.log"; then
+    pass "happy path: ran post-create gh pr view"
+  else
+    fail "happy path: did NOT run post-create gh pr view"
+    cat "$WORKDIR/calls.log" >&2
+  fi
+  # Verify switch-back to prior happened.
+  if grep -qE $'^gh\tauth\tswitch\t-u\tnathanpayne-claude$' "$WORKDIR/calls.log"; then
+    pass "happy path: switched back to nathanpayne-claude (trap EXIT)"
+  else
+    fail "happy path: did NOT switch back to nathanpayne-claude"
+    cat "$WORKDIR/calls.log" >&2
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: Switch-back happens on wrapped command failure (trap EXIT).
+# ---------------------------------------------------------------------------
+GH_INITIAL_ACTIVE="nathanpayne-claude" \
+GH_CREATE_PR_RC=1 \
+reset_state
+
+set +e
+GH_INITIAL_ACTIVE="nathanpayne-claude" \
+GH_CREATE_PR_RC=1 \
+  run_wrapper -- gh pr create --title "t" --body "b" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  fail "failure path: wrapper exited 0, expected non-zero (gh pr create failed with rc=1)"
+elif grep -qE $'^gh\tauth\tswitch\t-u\tnathanpayne-claude$' "$WORKDIR/calls.log"; then
+  pass "failure path: switch-back to nathanpayne-claude happened despite gh pr create failure"
+else
+  fail "failure path: switch-back did NOT happen on gh pr create failure"
+  cat "$WORKDIR/calls.log" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: Post-create author verification mismatch → exit 5 with
+# diagnostic. Stub returns GH_VIEW_AUTHOR != GH_AS_AUTHOR_IDENTITY.
+# ---------------------------------------------------------------------------
+GH_INITIAL_ACTIVE="nathanpayne-claude" \
+GH_CREATE_PR_URL="https://github.com/example/repo/pull/77" \
+GH_VIEW_AUTHOR="nathanpayne-claude" \
+reset_state
+
+set +e
+stderr_capture=$(
+  GH_INITIAL_ACTIVE="nathanpayne-claude" \
+  GH_CREATE_PR_URL="https://github.com/example/repo/pull/77" \
+  GH_VIEW_AUTHOR="nathanpayne-claude" \
+    run_wrapper -- gh pr create --title "t" --body "b" 2>&1 1>/dev/null
+)
+rc=$?
+set -e
+if [ "$rc" -ne 5 ]; then
+  fail "verification mismatch: wrapper exited $rc, expected 5"
+elif ! echo "$stderr_capture" | grep -qi "ERROR PR #77.*landed under 'nathanpayne-claude'"; then
+  fail "verification mismatch: missing diagnostic in stderr"
+  echo "stderr was: $stderr_capture" >&2
+elif ! echo "$stderr_capture" | grep -qi "#241"; then
+  fail "verification mismatch: diagnostic does not reference #241"
+else
+  pass "verification mismatch: exit 5 with #241 diagnostic"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: Non-gh-pr-create commands skip the verification path.
+# Wrapping a `gh pr merge` (or anything else) should NOT trigger
+# the extra gh pr view call.
+# ---------------------------------------------------------------------------
+GH_INITIAL_ACTIVE="nathanpayne-claude" \
+reset_state
+
+GH_INITIAL_ACTIVE="nathanpayne-claude" \
+  run_wrapper -- gh pr merge 123 --squash --delete-branch >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "non-create path: wrapper exited $rc, expected 0"
+elif grep -qE $'^gh\tpr\tview\t' "$WORKDIR/calls.log"; then
+  fail "non-create path: post-create verification SHOULD NOT run for gh pr merge"
+  cat "$WORKDIR/calls.log" >&2
+else
+  pass "non-create path: no post-create verification ran for gh pr merge"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: Empty prior-active fails fast with exit 1, no switch, no
+# wrapped command.
+# ---------------------------------------------------------------------------
+GH_INITIAL_ACTIVE="" \
+reset_state
+# Override the active state file to be empty
+: > "$ACTIVE_STATE_FILE"
+
+set +e
+PATH="$STUB_DIR:$PATH" \
+GH_CALLS_LOG="$WORKDIR/calls.log" \
+ACTIVE_STATE_FILE="$ACTIVE_STATE_FILE" \
+GH_INITIAL_ACTIVE="" \
+  "$WRAPPER" -- gh pr merge 123 --squash --delete-branch >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -ne 1 ]; then
+  fail "empty prior: wrapper exited $rc, expected 1"
+elif grep -qE $'^gh\tauth\tswitch\t' "$WORKDIR/calls.log"; then
+  fail "empty prior: gh auth switch SHOULD NOT have run when prior is empty"
+  cat "$WORKDIR/calls.log" >&2
+else
+  pass "empty prior: failed fast without switching"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: GH_AS_AUTHOR_IDENTITY env var overrides default.
+# ---------------------------------------------------------------------------
+GH_INITIAL_ACTIVE="nathanpayne-claude" \
+reset_state
+
+GH_INITIAL_ACTIVE="nathanpayne-claude" \
+GH_AS_AUTHOR_IDENTITY="custom-author" \
+  run_wrapper -- gh pr merge 1 --squash >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "custom identity: wrapper exited $rc, expected 0"
+elif ! grep -qE $'^gh\tauth\tswitch\t-u\tcustom-author$' "$WORKDIR/calls.log"; then
+  fail "custom identity: did not switch to custom-author"
+  cat "$WORKDIR/calls.log" >&2
+else
+  pass "custom identity: GH_AS_AUTHOR_IDENTITY override switched to custom-author"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "test_gh_as_author: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test_gh_as_author.sh
+++ b/tests/test_gh_as_author.sh
@@ -245,6 +245,17 @@ else
   pass "non-create path: no post-create verification ran for gh pr merge"
 fi
 
+# Same call must also have fired the trap to switch back. Without
+# the fix in this round, `exec "$@"` on the non-create path would
+# replace the shell process and skip the EXIT trap — see CodeRabbit
+# round-1 review id 3237851481.
+if grep -qE $'^gh\tauth\tswitch\t-u\tnathanpayne-claude$' "$WORKDIR/calls.log"; then
+  pass "non-create path: trap EXIT switch-back fired (no exec)"
+else
+  fail "non-create path: trap EXIT switch-back did NOT fire — exec \"\$@\" regression?"
+  cat "$WORKDIR/calls.log" >&2
+fi
+
 # ---------------------------------------------------------------------------
 # Test 5: Empty prior-active fails fast with exit 1, no switch, no
 # wrapped command.
@@ -288,6 +299,78 @@ elif ! grep -qE $'^gh\tauth\tswitch\t-u\tcustom-author$' "$WORKDIR/calls.log"; t
   cat "$WORKDIR/calls.log" >&2
 else
   pass "custom identity: GH_AS_AUTHOR_IDENTITY override switched to custom-author"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7 (CodeRabbit round-1 id 3237851475 + 3237851481): fail-closed
+# when the PR URL cannot be extracted from gh pr create output. Prior
+# to this round the wrapper silently exited 0 when `grep -oE ... |
+# tail -1` returned empty, letting downstream automation treat an
+# unverified create as verified. Set GH_CREATE_PR_URL to a string the
+# regex can't match and assert the wrapper exits 5 with an ERROR (not
+# WARNING) diagnostic mentioning the manual verification command.
+# ---------------------------------------------------------------------------
+GH_INITIAL_ACTIVE="nathanpayne-claude" \
+GH_CREATE_PR_URL="created PR but no URL in output" \
+reset_state
+
+set +e
+stderr_capture=$(
+  GH_INITIAL_ACTIVE="nathanpayne-claude" \
+  GH_CREATE_PR_URL="created PR but no URL in output" \
+    run_wrapper -- gh pr create --title "t" --body "b" 2>&1 1>/dev/null
+)
+rc=$?
+set -e
+if [ "$rc" -ne 5 ]; then
+  fail "fail-closed (no PR URL): wrapper exited $rc, expected 5"
+elif ! echo "$stderr_capture" | grep -qi "ERROR could not extract PR URL"; then
+  fail "fail-closed (no PR URL): missing ERROR diagnostic; stderr: $stderr_capture"
+elif echo "$stderr_capture" | grep -qi "WARNING.*skipping post-create"; then
+  fail "fail-closed (no PR URL): still emitting WARNING/skipping language; stderr: $stderr_capture"
+else
+  pass "fail-closed (no PR URL): exit 5 with ERROR diagnostic"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8 (CodeRabbit round-1 id 3237851475 + 3237851481): fail-closed
+# when gh pr view (the verification read) fails. Prior to this round
+# the wrapper silently exited 0 on `gh pr view` failure, masking
+# transient network blips and permission issues as verified creates.
+# Set GH_VIEW_RC=1 and assert the wrapper exits 5.
+# ---------------------------------------------------------------------------
+GH_INITIAL_ACTIVE="nathanpayne-claude" \
+GH_CREATE_PR_URL="https://github.com/example/repo/pull/99" \
+GH_VIEW_RC=1 \
+reset_state
+
+set +e
+stderr_capture=$(
+  GH_INITIAL_ACTIVE="nathanpayne-claude" \
+  GH_CREATE_PR_URL="https://github.com/example/repo/pull/99" \
+  GH_VIEW_RC=1 \
+    run_wrapper -- gh pr create --title "t" --body "b" 2>&1 1>/dev/null
+)
+rc=$?
+set -e
+if [ "$rc" -ne 5 ]; then
+  fail "fail-closed (gh pr view error): wrapper exited $rc, expected 5"
+elif ! echo "$stderr_capture" | grep -qi "ERROR could not read PR author"; then
+  fail "fail-closed (gh pr view error): missing ERROR diagnostic; stderr: $stderr_capture"
+elif echo "$stderr_capture" | grep -qi "WARNING.*Skipping post-create"; then
+  fail "fail-closed (gh pr view error): still emitting WARNING/skipping language; stderr: $stderr_capture"
+else
+  pass "fail-closed (gh pr view error): exit 5 with ERROR diagnostic"
+fi
+
+# Both fail-closed paths must STILL have fired the trap to restore
+# the prior active account — verification failure must not leave
+# the keyring stuck on the author identity.
+if grep -qE $'^gh\tauth\tswitch\t-u\tnathanpayne-claude$' "$WORKDIR/calls.log"; then
+  pass "fail-closed (gh pr view error): trap EXIT switch-back fired"
+else
+  fail "fail-closed (gh pr view error): trap EXIT switch-back did NOT fire"
+  cat "$WORKDIR/calls.log" >&2
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gh_as_reviewer.sh
+++ b/tests/test_gh_as_reviewer.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# tests/test_gh_as_reviewer.sh
+#
+# Unit tests for scripts/gh-as-reviewer.sh — companion to
+# scripts/gh-as-author.sh. Same trap-EXIT shape, no post-create
+# verification.
+#
+# CodeRabbit round-1 on #245 flagged that `exec "$@"` at the end of
+# the wrapper replaces the bash process before the EXIT trap can
+# fire, leaving the gh keyring stuck on the reviewer identity. The
+# fix (this round) runs the wrapped command in-process and exits
+# with the wrapped command's rc. This test exists primarily to
+# regression-net that change (see CodeRabbit review id 3237851494).
+#
+# Strategy: identical to test_gh_as_author.sh — PATH-shim gh,
+# record each call, assert on the call log + exit code.
+#
+# Bash 3.2 portable.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$ROOT/scripts/gh-as-reviewer.sh"
+
+[[ -x "$WRAPPER" ]] || { echo "missing or non-executable $WRAPPER" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/gh-as-reviewer-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Build a PATH-shim `gh` stub. Same shape as the gh-as-author tests.
+#
+#   GH_CALLS_LOG          path to a file the stub appends each call to
+#   GH_INITIAL_ACTIVE     value `gh config get -h github.com user` returns
+#   GH_SWITCH_RC          exit code for `gh auth switch` (default 0)
+#   GH_PR_REVIEW_RC       exit code for `gh pr review` (default 0)
+#
+# Stub UPDATES the file backing GH_INITIAL_ACTIVE on `gh auth switch
+# -u <user>` so subsequent `gh config get` calls reflect the switch.
+# ---------------------------------------------------------------------------
+STUB_DIR="$WORKDIR/stub-bin"
+mkdir -p "$STUB_DIR"
+ACTIVE_STATE_FILE="$WORKDIR/active-state"
+
+cat >"$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+LOG="${GH_CALLS_LOG:-/dev/null}"
+printf 'gh' >> "$LOG"
+for a in "$@"; do
+  printf '\t%s' "$a" >> "$LOG"
+done
+printf '\n' >> "$LOG"
+
+case "$1 $2" in
+  "config get")
+    if [ -f "${ACTIVE_STATE_FILE:-/nonexistent}" ]; then
+      cat "$ACTIVE_STATE_FILE"
+    elif [ -n "${GH_INITIAL_ACTIVE:-}" ]; then
+      echo "$GH_INITIAL_ACTIVE"
+    fi
+    exit 0
+    ;;
+  "auth switch")
+    rc="${GH_SWITCH_RC:-0}"
+    if [ "$rc" -ne 0 ]; then exit "$rc"; fi
+    shift; shift
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "-u" ]; then
+        shift
+        echo "$1" > "$ACTIVE_STATE_FILE"
+        exit 0
+      fi
+      shift
+    done
+    exit 0
+    ;;
+  "pr review")
+    exit "${GH_PR_REVIEW_RC:-0}"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+STUB
+chmod +x "$STUB_DIR/gh"
+
+reset_state() {
+  : > "$WORKDIR/calls.log"
+  echo "${GH_INITIAL_ACTIVE:-nathanjohnpayne}" > "$ACTIVE_STATE_FILE"
+}
+
+run_wrapper() {
+  PATH="$STUB_DIR:$PATH" \
+  GH_CALLS_LOG="$WORKDIR/calls.log" \
+  ACTIVE_STATE_FILE="$ACTIVE_STATE_FILE" \
+    "$WRAPPER" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1 (CodeRabbit id 3237851494): EXIT trap fires on the success
+# path. The wrapper must NOT `exec` the wrapped command — that would
+# replace the bash process and skip the trap, leaving the keyring
+# stuck on the reviewer identity. Starting from nathanjohnpayne as
+# the prior active account, after a successful `gh pr review` we
+# expect to see a switch-back to nathanjohnpayne in the call log.
+# ---------------------------------------------------------------------------
+GH_INITIAL_ACTIVE="nathanjohnpayne" \
+reset_state
+
+GH_INITIAL_ACTIVE="nathanjohnpayne" \
+  run_wrapper -- gh pr review 123 --comment --body "ok" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "happy path: wrapper exited $rc, expected 0"
+else
+  if grep -qE $'^gh\tauth\tswitch\t-u\tnathanpayne-claude$' "$WORKDIR/calls.log"; then
+    pass "happy path: switched to nathanpayne-claude"
+  else
+    fail "happy path: did NOT switch to nathanpayne-claude"
+    cat "$WORKDIR/calls.log" >&2
+  fi
+  if grep -qE $'^gh\tpr\treview\t123\t' "$WORKDIR/calls.log"; then
+    pass "happy path: ran gh pr review"
+  else
+    fail "happy path: did NOT run gh pr review"
+  fi
+  if grep -qE $'^gh\tauth\tswitch\t-u\tnathanjohnpayne$' "$WORKDIR/calls.log"; then
+    pass "happy path: switched back to nathanjohnpayne (trap EXIT fired — no exec regression)"
+  else
+    fail "happy path: did NOT switch back to nathanjohnpayne — exec \"\$@\" regression?"
+    cat "$WORKDIR/calls.log" >&2
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: switch-back happens even when the wrapped command fails.
+# Confirms the trap fires on the non-zero-exit path too.
+# ---------------------------------------------------------------------------
+GH_INITIAL_ACTIVE="nathanjohnpayne" \
+GH_PR_REVIEW_RC=1 \
+reset_state
+
+set +e
+GH_INITIAL_ACTIVE="nathanjohnpayne" \
+GH_PR_REVIEW_RC=1 \
+  run_wrapper -- gh pr review 123 --comment --body "ok" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  fail "failure path: wrapper exited 0, expected non-zero"
+elif grep -qE $'^gh\tauth\tswitch\t-u\tnathanjohnpayne$' "$WORKDIR/calls.log"; then
+  pass "failure path: switch-back to nathanjohnpayne happened despite wrapped failure"
+else
+  fail "failure path: switch-back did NOT happen"
+  cat "$WORKDIR/calls.log" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: empty prior-active fails fast with exit 1, no switch.
+# ---------------------------------------------------------------------------
+GH_INITIAL_ACTIVE="" \
+reset_state
+: > "$ACTIVE_STATE_FILE"
+
+set +e
+PATH="$STUB_DIR:$PATH" \
+GH_CALLS_LOG="$WORKDIR/calls.log" \
+ACTIVE_STATE_FILE="$ACTIVE_STATE_FILE" \
+GH_INITIAL_ACTIVE="" \
+  "$WRAPPER" -- gh pr review 1 --comment --body "x" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -ne 1 ]; then
+  fail "empty prior: wrapper exited $rc, expected 1"
+elif grep -qE $'^gh\tauth\tswitch\t' "$WORKDIR/calls.log"; then
+  fail "empty prior: gh auth switch SHOULD NOT have run when prior is empty"
+  cat "$WORKDIR/calls.log" >&2
+else
+  pass "empty prior: failed fast without switching"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: GH_AS_REVIEWER_IDENTITY env var overrides default.
+# ---------------------------------------------------------------------------
+GH_INITIAL_ACTIVE="nathanjohnpayne" \
+reset_state
+
+GH_INITIAL_ACTIVE="nathanjohnpayne" \
+GH_AS_REVIEWER_IDENTITY="custom-reviewer" \
+  run_wrapper -- gh pr review 1 --comment --body "x" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "custom identity: wrapper exited $rc, expected 0"
+elif ! grep -qE $'^gh\tauth\tswitch\t-u\tcustom-reviewer$' "$WORKDIR/calls.log"; then
+  fail "custom identity: did not switch to custom-reviewer"
+  cat "$WORKDIR/calls.log" >&2
+else
+  pass "custom identity: GH_AS_REVIEWER_IDENTITY override switched to custom-reviewer"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "test_gh_as_reviewer: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# tests/test_gh_pr_guard.sh
+#
+# Unit tests for scripts/hooks/gh-pr-guard.sh — focused on the #241
+# identity-check addition, plus a regression net for the existing
+# Authoring-Agent / Self-Review body checks so the new check is
+# additive (doesn't break the old behavior).
+#
+# The hook reads tool_input.command from a JSON envelope on stdin
+# (PreToolUse contract). We feed it crafted envelopes and assert on
+# exit code + stderr.
+#
+# Bash 3.2 portable. Runs from `scripts/ci/check_gh_as_author`
+# (bundled with the wrapper test) and is also a useful local
+# debugging entry point when fiddling with the hook.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$ROOT/scripts/hooks/gh-pr-guard.sh"
+
+[[ -x "$HOOK" ]] || { echo "missing or non-executable $HOOK" >&2; exit 1; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "SKIP: python3 not available (gh-pr-guard.sh requires python3 for tokenization)" >&2
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not available (gh-pr-guard.sh reads stdin via jq)" >&2
+  exit 0
+fi
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/gh-pr-guard-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Build a fake `gh` on PATH so the hook's `gh config get -h github.com user`
+# returns a configurable value. Note: the hook ALSO calls `gh pr view`
+# in the merge branch; this stub handles both.
+STUB_DIR="$WORKDIR/stub-bin"
+mkdir -p "$STUB_DIR"
+cat >"$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "config get")
+    if [ -n "${STUB_ACTIVE_USER:-}" ]; then
+      echo "$STUB_ACTIVE_USER"
+    fi
+    exit 0
+    ;;
+  "pr view")
+    # Return a labels JSON-friendly string for the merge guard.
+    echo "${STUB_LABELS:-}"
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+STUB
+chmod +x "$STUB_DIR/gh"
+
+# Build a hook-invocation envelope. The hook reads tool_input.command.
+run_hook() {
+  local cmd="$1"
+  local stub_user="${2:-nathanjohnpayne}"
+  local skip_id="${3:-0}"
+  local payload
+  payload=$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}')
+  PATH="$STUB_DIR:$PATH" \
+  STUB_ACTIVE_USER="$stub_user" \
+  BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK="$skip_id" \
+    bash "$HOOK" <<<"$payload"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: gh pr create with correct identity + required body → exit 0
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr create --title "t" --body "Authoring-Agent: claude
+
+## Self-Review
+- ok"' "nathanjohnpayne" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "correct identity + valid body: hook exits 0"
+else
+  fail "correct identity + valid body: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: gh pr create with WRONG identity → exit 2 with #241 diagnostic
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr create --title "t" --body "Authoring-Agent: claude
+
+## Self-Review
+- ok"' "nathanpayne-claude" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "wrong identity: exit $rc, expected 2"
+elif ! echo "$out" | grep -qi "#241"; then
+  fail "wrong identity: diagnostic missing #241 reference; output: $out"
+elif ! echo "$out" | grep -qi "gh-as-author.sh"; then
+  fail "wrong identity: diagnostic missing gh-as-author.sh reference; output: $out"
+else
+  pass "wrong identity: blocked with #241 + gh-as-author.sh diagnostic"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: gh pr create with WRONG identity + escape hatch → fall through
+# to existing body checks (still blocks if body missing markers, otherwise allows).
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr create --title "t" --body "Authoring-Agent: claude
+
+## Self-Review
+- ok"' "nathanpayne-claude" "1" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "escape hatch: identity check bypassed, body checks pass"
+else
+  fail "escape hatch: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: gh pr create with MISSING Authoring-Agent → existing check
+# still fires (regression net — additive check doesn't break old behavior).
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr create --title "t" --body "## Self-Review
+- ok"' "nathanjohnpayne" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "missing Authoring-Agent: exit $rc, expected 2"
+elif ! echo "$out" | grep -qi "Authoring-Agent:"; then
+  fail "missing Authoring-Agent: diagnostic does not mention Authoring-Agent; output: $out"
+else
+  pass "missing Authoring-Agent: existing body check still fires"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: gh pr create with MISSING ## Self-Review → existing check fires
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr create --title "t" --body "Authoring-Agent: claude"' "nathanjohnpayne" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "missing Self-Review: exit $rc, expected 2"
+elif ! echo "$out" | grep -qi "Self-Review"; then
+  fail "missing Self-Review: diagnostic does not mention Self-Review; output: $out"
+else
+  pass "missing Self-Review: existing body check still fires"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: gh pr merge — identity check is gh pr CREATE only, so merge
+# should NOT be blocked by it. Stub the labels to be empty (no
+# needs-external-review) so the existing merge guard exits 0.
+# ---------------------------------------------------------------------------
+set +e
+STUB_LABELS="" \
+out=$(run_hook 'gh pr merge 123 --squash --delete-branch' "nathanpayne-claude" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "gh pr merge: identity check does NOT fire (create-only)"
+else
+  fail "gh pr merge: exit $rc, expected 0 (identity check should be create-only); output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: Non-gh command — hook should allow with exit 0 regardless of
+# active identity.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'echo hello world' "anyone" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "non-gh command: hook allows regardless of identity"
+else
+  fail "non-gh command: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: GH_PR_GUARD_EXPECTED_AUTHOR override — custom identity matches
+# active and the hook allows. Verifies the parameterization works for
+# downstream repos that might want a different author identity.
+# ---------------------------------------------------------------------------
+set +e
+payload=$(jq -n --arg c 'gh pr create --title "t" --body "Authoring-Agent: claude
+
+## Self-Review
+- ok"' '{tool_input: {command: $c}}')
+out=$(PATH="$STUB_DIR:$PATH" STUB_ACTIVE_USER="custom-author" GH_PR_GUARD_EXPECTED_AUTHOR="custom-author" bash "$HOOK" <<<"$payload" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "GH_PR_GUARD_EXPECTED_AUTHOR override: hook allows when active matches override"
+else
+  fail "GH_PR_GUARD_EXPECTED_AUTHOR override: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "test_gh_pr_guard: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #241.

## Summary

Hardens the gh keyring active-identity glitch documented in #241 (concrete
incident on `nathanjohnpayne/friends-and-family-billing#262` where a
`gh pr create` landed under the wrong identity because the
`switch -> create -> switch-back` sequence was split across two Bash tool
calls). Implements mitigations 1-4 from the issue body: wrapper script,
post-create verification, PreToolUse hook extension, and recovery docs.
Also promotes CLAUDE.md / AGENTS.md guidance from \"should\" to a hard
rule referencing the wrapper.

## Files

| File | Purpose |
|------|---------|
| ` scripts/gh-as-author.sh` | Atomic switch + run + switch-back via ` trap EXIT`; post-create author verification on ` gh pr create` |
| ` scripts/gh-as-reviewer.sh` | Companion wrapper for reviewer-identity writes |
| ` scripts/hooks/gh-pr-guard.sh` | Identity check added; blocks ` gh pr create` when keyring active != expected author |
| ` tests/test_gh_as_author.sh` | 9 cases: happy path, failure trap, verification mismatch (exit 5), non-create path, empty prior, custom identity |
| ` tests/test_gh_pr_guard.sh` | 8 cases: correct identity, wrong identity, escape hatch, regression net on existing body checks, custom expected-author |
| ` scripts/ci/check_gh_as_author` | CI wrapper; hard-fails on missing tests |
| ` .github/workflows/repo_lint.yml` | Wires ` check_gh_as_author` into CI |
| ` .mergepath-sync.yml` | Canonical paths for the new wrappers |
| ` CLAUDE.md` / ` AGENTS.md` | \"should\" -> \"must\" upgrade; references the wrapper as the canonical form |
| ` REVIEW_POLICY.md` | New \"Recovery: PR created under the wrong identity\" section |
| ` rules/repo_rules.md` | Documents the new check |

## Test plan

- [x] ` bash tests/test_gh_as_author.sh` -> 9/9 PASS
- [x] ` bash tests/test_gh_pr_guard.sh` -> 8/8 PASS
- [x] ` bash scripts/ci/check_gh_as_author` -> PASS
- [x] All ` scripts/ci/check_*` pass locally (17/17 including the new one)
- [ ] CI passes on this PR

## Out of scope

- Migrating existing call sites (e.g. ` scripts/bootstrap/template-mirror.sh`)
  to invoke the wrapper. That script already does its own switch-around
  via the same trap-style pattern, so it's already safe; a future PR can
  refactor it to call ` gh-as-author.sh` for consistency.
- Adding the wrapper / hook to downstream consumer repos. The
  ` .mergepath-sync.yml` entries land here; the next propagation run from
  ` scripts/sync-to-downstream.sh` will fan them out.
- Renaming or removing ` BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK`. The
  loud name is intentional; if a future test harness setup converges on a
  cleaner approach (e.g. parent-process detection via ` /proc`) we can
  retire it then.

Authoring-Agent: claude

## Self-Review

- **Correctness.** Wrapper captures prior active via ` gh config get
  -h github.com user`, NOT ` gh auth status` (per CLAUDE.md, the latter
  is GH_TOKEN-poisonable). ` trap EXIT` is installed BEFORE the switch
  to author, so a partial-failed switch still triggers restore. The
  verification path uses ` grep -oE` on captured stdout to find the PR
  URL (resilient to trailing diagnostic lines from ` gh`) and ` basename`
  for the PR number. The hook's identity check uses the same authoritative
  read.
- **Regression risk.** Low. The hook change is purely additive — all
  existing body checks (Authoring-Agent / Self-Review markers) and merge
  guards (--admin, needs-external-review label) remain unchanged. The new
  check has an env escape ` BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK=1`
  for test harnesses with PATH-shimmed ` gh`. The
  ` scripts/bootstrap/template-mirror.sh` cross-repo PR-create-on-
  mergepath path already switches to nathanjohnpayne before calling
  ` gh pr create`, so the hook check passes naturally there too.
- **Style.** Wrapper / hook are bash 3.2 portable (macOS default). Test
  files mirror the existing ` test_sync_overrides.sh` shape (mktemp
  workdir, PASS/FAIL counters, trap EXIT cleanup). CI wrapper mirrors
  ` check_sync_overrides`.
- **Test coverage.** 17 new test cases. The wrapper tests cover happy
  path, failure-on-wrapped-command trap-EXIT semantics, verification-
  mismatch diagnostic + exit-5, non-gh-pr-create no-verification path,
  empty-prior fail-fast, and ` GH_AS_AUTHOR_IDENTITY` override. The hook
  tests cover correct-identity allow, wrong-identity block with #241
  diagnostic, escape-hatch bypass, existing body-check regressions on
  Authoring-Agent / Self-Review, merge-not-create scope of the new check,
  non-gh command allow, and ` GH_PR_GUARD_EXPECTED_AUTHOR` override.
- **Security / dependency hygiene.** No new attack surface or
  dependencies. Wrapper is read-only against the same PAT the operator
  already uses. Verification call is a single ` gh pr view` GET. Escape
  hatch is loud-named (` BOOTSTRAP_*`) to discourage casual production
  use. No new third-party tooling.