### PR TITLE
docs(playground): document sync-scroll wire-up + guard rationale (#240)

### DIFF
--- a/mergepath/playground/index.html
+++ b/mergepath/playground/index.html
@@ -1471,6 +1471,13 @@
   // source and we rescale to the target's own range. A re-entry flag
   // prevents the mirrored assignment from re-firing the opposite
   // handler into an infinite loop.
+  //
+  // Either pane can lose its internal scroll range depending on
+  // viewport size and content — most reliably the workspace at the
+  // ≤960px stacked-layout breakpoint. We wire up listeners
+  // unconditionally and let the sMax/tMax guard below no-op when
+  // either side has nothing to scroll. Simpler than attaching and
+  // detaching on resize transitions.
   // ---------------------------------------------------------------------
   function initSyncScroll() {
     const rail = document.querySelector('.rail');


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Resolves [#240](https://github.com/nathanjohnpayne/mergepath/issues/240) — an AMBIGUOUS finding from the 2026-05-13 validation pass on rollup #234 (originating from PR #81). The reviewer had asked that sync-scroll listener wire-up be skipped in stacked layout; the current code wires up unconditionally and short-circuits inside the handler via the existing `if (sMax <= 0 || tMax <= 0) return;` guard.

Per the issue's own resolution path: "If 'wire-up + guard' is intentional → close, add an inline comment documenting the choice."

This PR adds that inline comment. No behavior change. The `Closes #240` keyword auto-closes the issue on merge.

## Self-Review

- **Correctness**: Pure comment addition. No JS, CSS, or markup change. Smoke-tested in the static preview server at desktop (1280x800), short desktop (1280x500), and mobile (375x812) viewports — no console errors, scroll handlers fire without throwing, guard correctly no-ops when a target pane has zero scroll range.
- **Regression risk**: None. The change is inside a JS comment block; the Python static-server preview rendered identically before and after.
- **Style**: Matches the surrounding comment-block formatting in [mergepath/playground/index.html:1464-1493](mergepath/playground/index.html). Five-line note fits the repo's "comments only when the WHY is non-obvious" rule — the WHY here is non-obvious (you have to know the breakpoint behavior + that listeners-on-resize is a known anti-pattern).
- **Test coverage**: N/A for a comment.
- **Security/dependency hygiene**: No dependency changes, no new code paths, no inputs handled.

## Test plan

- [x] `git diff` shows only the comment-block addition in `mergepath/playground/index.html` (7 lines added, 0 removed).
- [x] Loaded the playground in a static preview at 1280x800, 1280x500, and 375x812. No JS errors in any viewport.
- [x] Triggered `scroll` events on both `.rail` and `.workspace` programmatically; verified the guard fires (no exception, no spurious mirror) when one pane has zero scroll range.
- [ ] After merge: confirm issue #240 is closed and the `needs-human-review` label no longer blocks downstream work.

Closes #240