### PR TITLE
feat(bootstrap): Firebase + CodeRabbit + Codex App posture (#206)

### DIFF
--- a/scripts/bootstrap/firebase-and-codereview.sh
+++ b/scripts/bootstrap/firebase-and-codereview.sh
@@ -1,37 +1,478 @@
 #!/usr/bin/env bash
 # scripts/bootstrap/firebase-and-codereview.sh — bootstrap wizard stage D.
+# Per #156 sub-D / #206.
 #
-# Stub shipped with #156 sub-A's scaffold. Real implementation lands
-# in #156 sub-D ("Firebase + CodeRabbit posture + Codex App posture").
+# Responsibilities (in order):
+#   1. Firebase bootstrap (skipped when BOOTSTRAP_INPUT_FIREBASE=none or
+#      BOOTSTRAP_SKIP_FIREBASE=1). For each env in dev / [dev+prod]:
+#        a. firebase projects:create "$REPO-$env" --display-name ...
+#        b. Invoke $MERGEPATH_ROOT/scripts/firebase/op-firebase-setup
+#           against the new project (if the helper exists; warn otherwise).
+#      Then optionally set ANTHROPIC_API_KEY / OPENAI_API_KEY into
+#      `firebase functions:secrets:set` per env. Both prompts are
+#      skippable. Finally print URLs the operator needs to click through
+#      for .env.local population.
+#   2. CodeRabbit posture based on visibility:
+#        - public:  verify .coderabbit.yml exists in TARGET_DIR; warn if not.
+#        - private: yq-flip .coderabbit.enabled=false in
+#                   $TARGET_DIR/.github/review-policy.yml, delete
+#                   $TARGET_DIR/.coderabbit.yml, commit + push origin main.
+#          The push to main on the new repo is legitimate here: sub-C
+#          just created the remote, branch protection isn't on yet.
+#   3. Codex App posture:
+#        - n: log "Codex App: NOT requested. PRs over external_review_threshold
+#             will fall to Phase 4b."
+#        - y: print the 3 install URLs (chatgpt-codex-connector,
+#             code-review settings, environments settings) and pause for
+#             human Enter (skippable via BOOTSTRAP_AUTO_CONFIRM=1).
 #
-# Stub responsibilities (per #156 sub-D):
-#   - Firebase project creation (when BOOTSTRAP_INPUT_FIREBASE != "none")
-#   - op-firebase-setup invocation per DEPLOYMENT.md
-#   - Mint per-project Firebase deployer SA key, store in 1Password
-#   - CodeRabbit App install URL printout (skip if BOOTSTRAP_INPUTS
-#     opts out)
-#   - Codex App install URL printout (display only; CLAUDE.md notes
-#     this can't be fully automated since environment config is
-#     manual at chatgpt.com/codex/cloud/settings)
-#   - Wire up .github/review-policy.yml's coderabbit/codex blocks per
-#     the operator's choices
+# Reads (set by the wizard):
+#   $TARGET_DIR                 Local path of the new repo.
+#   $BOOTSTRAP_MERGEPATH_ROOT   Path to mergepath's worktree (for
+#                               locating op-firebase-setup).
+#   bootstrap_input firebase    none|dev|dev+prod
+#   bootstrap_input visibility  public|private
+#   bootstrap_input codex_app   y|n
+#   bootstrap_input repo_name   New repo's name.
+#
+# Env overrides for tests / non-interactive runs:
+#   BOOTSTRAP_SKIP_FIREBASE=1      same as firebase=none
+#   BOOTSTRAP_AUTO_CONFIRM=1       skip "press Enter" prompts
+#   BOOTSTRAP_AUTO_PROMPT=skip     skip optional value prompts
+#   BOOTSTRAP_FIREBASE_SECRET_ANTHROPIC_API_KEY=...  inline value (tests)
+#   BOOTSTRAP_FIREBASE_SECRET_OPENAI_API_KEY=...     inline value (tests)
+#   BOOTSTRAP_DRY_RUN=1            bootstrap::run honors this; stage
+#                                  also short-circuits any probes that
+#                                  would touch firebase / gcloud.
+#
+# Test discipline: every firebase / git / gh call goes through
+# bootstrap::run so the test fixture's PATH-shimmed binaries record the
+# invocation shape and the --dry-run path produces a plan without side
+# effects.
 
 set -euo pipefail
 
 bootstrap::stage_firebase_and_codereview() {
-  bootstrap::stage_banner "firebase-and-codereview (sub-D stub)"
-  local fb=${BOOTSTRAP_INPUT_FIREBASE:-none}
-  if [ "$fb" = "none" ]; then
-    bootstrap::log "stub: firebase=none, skipping Firebase setup"
-  else
-    bootstrap::log "stub: would create Firebase project (${fb}) + mint deployer SA key"
+  bootstrap::stage_banner "firebase-and-codereview"
+
+  local repo_name target firebase_scope visibility codex_app
+  repo_name=$(bootstrap_input repo_name)
+  target=${TARGET_DIR:?TARGET_DIR not set by wizard}
+  firebase_scope=$(bootstrap_input firebase)
+  visibility=$(bootstrap_input visibility)
+  codex_app=$(bootstrap_input codex_app)
+
+  # Per-step rc capture so the stage propagates failures cleanly
+  # (same pattern as stage B sub-#233 round 4 / stage C sub-#239 round 1).
+  local step_rc=0
+
+  # Step 1: Firebase bootstrap.
+  bootstrap::_firebase_bootstrap "$repo_name" "$firebase_scope" || step_rc=$?
+  if [ "$step_rc" -ne 0 ]; then
+    bootstrap::err "firebase-and-codereview: Firebase bootstrap failed (rc=$step_rc); aborting stage"
+    return "$step_rc"
   fi
-  bootstrap::log "stub: would print CodeRabbit App install URL"
-  if [ "${BOOTSTRAP_INPUT_CODEX_APP:-prompt}" = "y" ]; then
-    bootstrap::log "stub: would print Codex App install URL + environment setup steps"
-  else
-    bootstrap::log "stub: codex_app=n, skipping Codex App URL printout"
+
+  # Step 2: CodeRabbit posture.
+  bootstrap::_coderabbit_posture "$target" "$visibility" || step_rc=$?
+  if [ "$step_rc" -ne 0 ]; then
+    bootstrap::err "firebase-and-codereview: CodeRabbit posture step failed (rc=$step_rc); aborting stage"
+    return "$step_rc"
   fi
+
+  # Step 3: Codex App posture.
+  bootstrap::_codex_app_posture "$repo_name" "$codex_app" || step_rc=$?
+  if [ "$step_rc" -ne 0 ]; then
+    bootstrap::err "firebase-and-codereview: Codex App posture step failed (rc=$step_rc); aborting stage"
+    return "$step_rc"
+  fi
+
   bootstrap::record_stage "firebase-and-codereview"
+  return 0
+}
+
+# --- internal helpers ------------------------------------------------------
+
+bootstrap::_firebase_bootstrap() {
+  local repo_name=$1 firebase_scope=$2
+
+  if [ "${BOOTSTRAP_SKIP_FIREBASE:-0}" = "1" ] || [ "$firebase_scope" = "none" ]; then
+    bootstrap::log "Firebase: scope=none (or BOOTSTRAP_SKIP_FIREBASE=1); skipping Firebase setup"
+    return 0
+  fi
+
+  # Resolve env list from the firebase scope flag. bash 3.2 portable —
+  # no associative arrays, no mapfile. The two supported scopes map
+  # to a space-separated list of env names.
+  local envs
+  case "$firebase_scope" in
+    dev)       envs="dev" ;;
+    dev+prod)  envs="dev prod" ;;
+    *)
+      bootstrap::err "Firebase: unsupported scope '$firebase_scope' (expected dev / dev+prod / none)"
+      return 2
+      ;;
+  esac
+
+  # Per-env loop: project create + op-firebase-setup invocation.
+  # Each project create failure is treated as fatal — a globally-taken
+  # project ID is a user-decision blocker (rename or skip), not a
+  # silent skip.
+  local env project_id step_rc=0
+  for env in $envs; do
+    project_id="${repo_name}-${env}"
+
+    bootstrap::run "firebase projects:create $project_id" \
+      firebase projects:create "$project_id" \
+        --display-name "$repo_name ($env)" || step_rc=$?
+    if [ "$step_rc" -ne 0 ]; then
+      bootstrap::err "Firebase: projects:create failed for $project_id (rc=$step_rc). Project ID may be globally taken — rename via --description / repo-name change, or skip via --firebase none."
+      return "$step_rc"
+    fi
+
+    # op-firebase-setup is in the mergepath worktree. If it's absent,
+    # warn + continue: the firebase project exists; the operator can
+    # run the setup helper later manually. Don't fail-closed because
+    # that would block a re-runnable step.
+    local helper="${BOOTSTRAP_MERGEPATH_ROOT:-}/scripts/firebase/op-firebase-setup"
+    if [ -n "${BOOTSTRAP_MERGEPATH_ROOT:-}" ] && [ -x "$helper" ]; then
+      bootstrap::run "op-firebase-setup $project_id" \
+        "$helper" "$project_id" || step_rc=$?
+      if [ "$step_rc" -ne 0 ]; then
+        # Non-fatal: gcloud auth may be stale; the operator can
+        # re-run the helper manually. Log + continue.
+        bootstrap::warn "Firebase: op-firebase-setup failed for $project_id (rc=$step_rc). Try 'gcloud auth application-default login' and re-run: $helper $project_id"
+        step_rc=0
+      fi
+    else
+      bootstrap::warn "Firebase: op-firebase-setup helper not found at $helper; deployer SA setup must be run manually for $project_id"
+    fi
+  done
+
+  # Optional secrets — ANTHROPIC_API_KEY + OPENAI_API_KEY into each
+  # env's firebase functions:secrets store. Skippable per secret.
+  bootstrap::_firebase_set_functions_secrets "$repo_name" "$envs" || step_rc=$?
+  if [ "$step_rc" -ne 0 ]; then
+    # Treat secret failures as warned-but-not-fatal — workflows can
+    # be re-tried manually. Don't block the bootstrap.
+    bootstrap::warn "Firebase: functions secrets provisioning hit errors (rc=$step_rc); re-run firebase functions:secrets:set manually"
+    step_rc=0
+  fi
+
+  # Web-app config: Firebase console-only, can't be scripted. Print
+  # the per-env console URL so the operator can click through and
+  # populate .env.local manually.
+  bootstrap::log "Firebase: .env.local population required from console:"
+  for env in $envs; do
+    bootstrap::log "  https://console.firebase.google.com/project/${repo_name}-${env}/settings/general"
+  done
+}
+
+bootstrap::_firebase_set_functions_secrets() {
+  local repo_name=$1 envs=$2
+
+  # Each entry: secret_name:prompt-friendly description. Extend here
+  # as new LLM secrets become standard fare for new repos.
+  local llm_secrets=(
+    "ANTHROPIC_API_KEY:Anthropic API key for Claude calls (sk-ant-...)"
+    "OPENAI_API_KEY:OpenAI API key for Codex / Cursor calls (sk-...)"
+  )
+
+  local any_fail=0
+  local secret name desc env value inline_var
+
+  for secret in "${llm_secrets[@]}"; do
+    name=${secret%%:*}
+    desc=${secret#*:}
+
+    # Inline override (tests / non-interactive runs). The env var
+    # BOOTSTRAP_FIREBASE_SECRET_<NAME> short-circuits the prompt;
+    # an empty value also short-circuits, signalling "skip this
+    # secret entirely". bash 3.2 portable — no ${var^^}, build the
+    # env var name via printf + tr.
+    inline_var="BOOTSTRAP_FIREBASE_SECRET_${name}"
+    eval "value=\${${inline_var}+set}"
+    if [ "${value:-}" = "set" ]; then
+      eval "value=\${${inline_var}}"
+      if [ -z "$value" ]; then
+        bootstrap::log "Firebase secret $name: explicit skip via $inline_var=''"
+        continue
+      fi
+    elif [ "${BOOTSTRAP_AUTO_PROMPT:-prompt}" = "skip" ] \
+         || [ "${BOOTSTRAP_DRY_RUN:-0}" = "1" ]; then
+      bootstrap::log "Firebase secret $name: prompts skipped (dry-run or auto-prompt=skip)"
+      continue
+    else
+      echo
+      echo "Set $name as a Firebase functions secret in each env?"
+      echo "  $desc"
+      local set_yn
+      read -r -p "Set $name? [y/N]: " set_yn
+      case "${set_yn:-}" in
+        y|Y|yes|YES) ;;
+        *)
+          bootstrap::log "Firebase secret $name: skipped"
+          continue
+          ;;
+      esac
+      read -r -s -p "Paste $name value (input hidden, blank to skip): " value
+      echo
+      if [ -z "$value" ]; then
+        bootstrap::log "Firebase secret $name: empty value; skipping"
+        continue
+      fi
+    fi
+
+    for env in $envs; do
+      local project_id="${repo_name}-${env}"
+      # firebase functions:secrets:set reads --data-file or stdin.
+      # Use --data-file with a process substitution to keep the
+      # secret out of argv. bootstrap::run logs the command shape;
+      # the value itself never lands in argv via this path.
+      #
+      # CAVEAT: dry-run mode logs the redacted command; live mode
+      # streams the value into a tempfile that firebase reads,
+      # then removes the tempfile.
+      if [ "${BOOTSTRAP_DRY_RUN:-0}" = "1" ]; then
+        bootstrap::run "firebase functions:secrets:set $name ($env, len=${#value})" \
+          firebase --project "$project_id" \
+            functions:secrets:set "$name" \
+            --data-file -
+        continue
+      fi
+
+      local tmp
+      tmp=$(mktemp "${TMPDIR:-/tmp}/bootstrap-fb-secret.XXXXXX")
+      # Restrict the tempfile to the user before writing the value
+      # to it. chmod after mktemp because mktemp's default is
+      # 0600 already on macOS+Linux but explicit is cheap insurance.
+      chmod 600 "$tmp"
+      printf '%s' "$value" >"$tmp"
+
+      local set_rc=0
+      bootstrap::run "firebase functions:secrets:set $name ($env, len=${#value})" \
+        firebase --project "$project_id" \
+          functions:secrets:set "$name" \
+          --data-file "$tmp" || set_rc=$?
+
+      rm -f "$tmp"
+
+      if [ "$set_rc" -ne 0 ]; then
+        bootstrap::warn "Firebase secret $name: set failed for $project_id (rc=$set_rc); continuing"
+        any_fail=1
+      fi
+    done
+  done
+
+  return "$any_fail"
+}
+
+bootstrap::_coderabbit_posture() {
+  local target=$1 visibility=$2
+
+  case "$visibility" in
+    public)
+      bootstrap::log "CodeRabbit: public repo — leaving CodeRabbit enabled (template default)"
+      if [ "${BOOTSTRAP_DRY_RUN:-0}" = "1" ]; then
+        # Skip the existence probe in dry-run — the template-mirror
+        # stage's rsync didn't actually run, so the file legitimately
+        # won't exist.
+        return 0
+      fi
+      if [ ! -f "$target/.coderabbit.yml" ]; then
+        bootstrap::warn "CodeRabbit: expected .coderabbit.yml at $target/.coderabbit.yml (should have been mirrored from template); not found"
+      fi
+      return 0
+      ;;
+    private)
+      bootstrap::_coderabbit_disable_for_private "$target"
+      return $?
+      ;;
+    *)
+      bootstrap::err "CodeRabbit: unsupported visibility '$visibility' (expected public / private)"
+      return 2
+      ;;
+  esac
+}
+
+bootstrap::_coderabbit_disable_for_private() {
+  local target=$1
+  local policy_file="$target/.github/review-policy.yml"
+  local coderabbit_file="$target/.coderabbit.yml"
+
+  bootstrap::log "CodeRabbit: private repo — disabling CodeRabbit (free tier is public-only)"
+
+  # In dry-run mode the template-mirror stage didn't actually create
+  # the files, so the existence probes would all miss. Emit the
+  # planned commands instead and return.
+  if [ "${BOOTSTRAP_DRY_RUN:-0}" = "1" ]; then
+    bootstrap::run "yq -i '.coderabbit.enabled = false' $policy_file" \
+      yq -i '.coderabbit.enabled = false' "$policy_file"
+    bootstrap::run "rm $coderabbit_file" rm -f "$coderabbit_file"
+    bootstrap::run "git add review-policy.yml + .coderabbit.yml" \
+      git -C "$target" add .github/review-policy.yml .coderabbit.yml
+    bootstrap::run "commit CodeRabbit-disable" \
+      git -C "$target" -c commit.gpgsign=false \
+        commit -q -m "config: disable CodeRabbit (private repo, free tier is public-only)"
+    bootstrap::run "push origin main (CodeRabbit-disable)" \
+      git -C "$target" push origin main
+    return 0
+  fi
+
+  local step_rc=0
+  local touched_any=0
+
+  # yq-flip the coderabbit.enabled key. The wizard's preflight requires
+  # yq globally so this should always succeed; the check is defense
+  # in depth.
+  if [ ! -f "$policy_file" ]; then
+    bootstrap::warn "CodeRabbit: $policy_file not found; cannot flip coderabbit.enabled. Skipping yq flip (manual edit needed if a future template adds the file)."
+  else
+    if ! command -v yq >/dev/null 2>&1; then
+      bootstrap::err "CodeRabbit: yq is required to flip coderabbit.enabled but is not on PATH. Install via 'brew install yq' (mikefarah/yq, v4+)."
+      return 2
+    fi
+    bootstrap::run "yq flip coderabbit.enabled=false in $policy_file" \
+      yq -i '.coderabbit.enabled = false' "$policy_file" || step_rc=$?
+    if [ "$step_rc" -ne 0 ]; then
+      bootstrap::err "CodeRabbit: yq flip failed (rc=$step_rc)"
+      return "$step_rc"
+    fi
+    touched_any=1
+  fi
+
+  # Delete .coderabbit.yml — the CodeRabbit App reads this for
+  # per-repo config; with the App disabled there's no point keeping
+  # the file. Absent file is fine.
+  if [ -f "$coderabbit_file" ]; then
+    bootstrap::run "rm $coderabbit_file" rm -f "$coderabbit_file" || step_rc=$?
+    if [ "$step_rc" -ne 0 ]; then
+      bootstrap::err "CodeRabbit: rm of $coderabbit_file failed (rc=$step_rc)"
+      return "$step_rc"
+    fi
+    touched_any=1
+  fi
+
+  if [ "$touched_any" = "0" ]; then
+    bootstrap::log "CodeRabbit: no files to modify (review-policy.yml + .coderabbit.yml both absent); nothing to commit"
+    return 0
+  fi
+
+  # Sanity: target must have .git to commit / push. Without it (e.g.,
+  # sub-B's git init didn't run), the commit will fail and the operator
+  # needs to resume from earlier.
+  if [ ! -d "$target/.git" ]; then
+    bootstrap::err "CodeRabbit: $target has no .git/ — re-run from --resume template-mirror to retry"
+    return 2
+  fi
+
+  # Stage + commit. Use -A on the two specific paths so absent files
+  # are gracefully ignored by git (-A is equivalent to add --all on
+  # the supplied paths under modern git; missing-path behavior is
+  # consistent with stage B's git add). Test code BOOTSTRAP_AUTHOR_NAME
+  # / BOOTSTRAP_AUTHOR_EMAIL parallels stage B's pattern.
+  local author_name="${BOOTSTRAP_AUTHOR_NAME:-}"
+  local author_email="${BOOTSTRAP_AUTHOR_EMAIL:-}"
+
+  bootstrap::run "git add review-policy.yml + .coderabbit.yml" \
+    git -C "$target" add --all .github/review-policy.yml .coderabbit.yml || step_rc=$?
+  if [ "$step_rc" -ne 0 ]; then
+    bootstrap::err "CodeRabbit: git add failed (rc=$step_rc)"
+    return "$step_rc"
+  fi
+
+  # Skip commit if the working tree is clean (e.g., the files
+  # were absent and nothing actually changed). `git diff --cached
+  # --quiet` returns 0 when there's nothing staged.
+  if git -C "$target" diff --cached --quiet 2>/dev/null; then
+    bootstrap::log "CodeRabbit: no staged changes after add; skipping commit + push"
+    return 0
+  fi
+
+  if [ -n "$author_name" ] && [ -n "$author_email" ]; then
+    bootstrap::run "commit CodeRabbit-disable" \
+      git -C "$target" \
+        -c "user.name=$author_name" \
+        -c "user.email=$author_email" \
+        -c commit.gpgsign=false \
+        commit -q -m "config: disable CodeRabbit (private repo, free tier is public-only)" || step_rc=$?
+  else
+    bootstrap::run "commit CodeRabbit-disable" \
+      git -C "$target" \
+        -c commit.gpgsign=false \
+        commit -q -m "config: disable CodeRabbit (private repo, free tier is public-only)" || step_rc=$?
+  fi
+  if [ "$step_rc" -ne 0 ]; then
+    bootstrap::err "CodeRabbit: commit failed (rc=$step_rc)"
+    return "$step_rc"
+  fi
+
+  # Push to origin main. Legitimate: sub-C just created the remote
+  # and there's no branch protection on the new repo yet. The
+  # gh-pr-guard.sh "never push to main" invariant doesn't apply
+  # because no protected main exists yet.
+  #
+  # BOOTSTRAP_SKIP_REMOTE_PUSH=1 (tests) suppresses the push so test
+  # fixtures don't need to spin up a bare remote just to satisfy
+  # git push origin main. The commit still lands in the local repo;
+  # only the push step is short-circuited.
+  if [ "${BOOTSTRAP_SKIP_REMOTE_PUSH:-0}" = "1" ]; then
+    bootstrap::log "CodeRabbit: BOOTSTRAP_SKIP_REMOTE_PUSH=1 — skipping git push origin main"
+    return 0
+  fi
+  bootstrap::run "push origin main (CodeRabbit-disable)" \
+    git -C "$target" push origin main || step_rc=$?
+  if [ "$step_rc" -ne 0 ]; then
+    bootstrap::err "CodeRabbit: push failed (rc=$step_rc); commit is local at $target — push manually once the remote is reachable"
+    return "$step_rc"
+  fi
+}
+
+bootstrap::_codex_app_posture() {
+  local repo_name=$1 codex_app=$2
+
+  case "$codex_app" in
+    n|"")
+      bootstrap::log "Codex App: NOT requested. PRs over external_review_threshold will fall to Phase 4b."
+      return 0
+      ;;
+    y) ;;
+    *)
+      bootstrap::warn "Codex App: unexpected codex_app value '$codex_app' (expected y/n); treating as 'n'"
+      bootstrap::log "Codex App: NOT requested. PRs over external_review_threshold will fall to Phase 4b."
+      return 0
+      ;;
+  esac
+
+  # codex_app=y: print the three install URLs + wait for human Enter.
+  echo
+  echo "==> Codex GitHub App setup (manual, requires biometric):"
+  echo
+  echo "  1. Install the App for ${BOOTSTRAP_REPO_OWNER:-nathanjohnpayne}/${repo_name}:"
+  echo "     https://github.com/apps/chatgpt-codex-connector"
+  echo
+  echo "  2. Enable Code Review for this repo:"
+  echo "     https://chatgpt.com/codex/cloud/settings/code-review"
+  echo
+  echo "  3. Configure a Codex environment for this repo:"
+  echo "     https://chatgpt.com/codex/cloud/settings/environments"
+  echo
+  echo "  After all three: open a small throwaway PR and verify"
+  echo "  chatgpt-codex-connector[bot] auto-reviews. That's the only reliable"
+  echo "  'App is review-ready' check from an agent identity"
+  echo "  (per CLAUDE.md § Phase 4a verification)."
+  echo
+
+  if [ "${BOOTSTRAP_AUTO_CONFIRM:-0}" = "1" ] \
+     || [ "${BOOTSTRAP_DRY_RUN:-0}" = "1" ]; then
+    bootstrap::log "Codex App: auto-confirm — skipping the press-Enter pause"
+    return 0
+  fi
+
+  local reply
+  read -r -p "Press Enter once all three steps are complete (or 'skip' to revisit later): " reply
+  if [ "${reply:-}" = "skip" ]; then
+    bootstrap::warn "Codex App: setup pause skipped — Phase 4a may not be ready until the operator completes the 3 manual steps"
+  fi
   return 0
 }

--- a/scripts/bootstrap/firebase-and-codereview.sh
+++ b/scripts/bootstrap/firebase-and-codereview.sh
@@ -366,16 +366,37 @@ bootstrap::_coderabbit_disable_for_private() {
     return 2
   fi
 
-  # Stage + commit. Use -A on the two specific paths so absent files
-  # are gracefully ignored by git (-A is equivalent to add --all on
-  # the supplied paths under modern git; missing-path behavior is
-  # consistent with stage B's git add). Test code BOOTSTRAP_AUTHOR_NAME
-  # / BOOTSTRAP_AUTHOR_EMAIL parallels stage B's pattern.
+  # Stage + commit. The earlier yq-flip + rm steps each touched
+  # at-most-one file, so build the add list dynamically: include each
+  # path only if the working tree has it OR git already tracks it
+  # (deletion case after `rm -f`). `git add --all <missing-path>`
+  # exits 128 with "pathspec did not match any files" — that would
+  # turn the preceding "warn and continue" misses into a hard
+  # stage failure, contradicting the absent-file tolerance above.
+  # Test code BOOTSTRAP_AUTHOR_NAME / BOOTSTRAP_AUTHOR_EMAIL parallels
+  # stage B's pattern.
   local author_name="${BOOTSTRAP_AUTHOR_NAME:-}"
   local author_email="${BOOTSTRAP_AUTHOR_EMAIL:-}"
 
-  bootstrap::run "git add review-policy.yml + .coderabbit.yml" \
-    git -C "$target" add --all .github/review-policy.yml .coderabbit.yml || step_rc=$?
+  # Build the list of paths that exist on disk or are tracked in git
+  # (deletion needs a stage). `git ls-files --error-unmatch -- <path>`
+  # exits 0 iff git tracks the path; we use the silent variant to
+  # avoid spurious stderr noise on the absent-and-untracked case.
+  local add_paths=()
+  for rel in .github/review-policy.yml .coderabbit.yml; do
+    if [ -e "$target/$rel" ] \
+       || git -C "$target" ls-files --error-unmatch -- "$rel" >/dev/null 2>&1; then
+      add_paths+=("$rel")
+    fi
+  done
+
+  if [ "${#add_paths[@]}" -eq 0 ]; then
+    bootstrap::log "CodeRabbit: neither .github/review-policy.yml nor .coderabbit.yml present or tracked; nothing to stage"
+    return 0
+  fi
+
+  bootstrap::run "git add ${add_paths[*]}" \
+    git -C "$target" add --all -- "${add_paths[@]}" || step_rc=$?
   if [ "$step_rc" -ne 0 ]; then
     bootstrap::err "CodeRabbit: git add failed (rc=$step_rc)"
     return "$step_rc"

--- a/scripts/ci/check_bootstrap_firebase_and_codereview
+++ b/scripts/ci/check_bootstrap_firebase_and_codereview
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/ci/check_bootstrap_firebase_and_codereview — CI entry point
+# for #156 sub-D / #206 tests.
+#
+# Wraps tests/test_bootstrap_firebase_and_codereview.sh so the
+# repo_lint workflow's "run all scripts/ci/check_*" loop picks it up.
+# Mirrors the pattern used by check_bootstrap_github_infra and the
+# other check_* scripts. Missing test script is a hard error (matches
+# the tightening applied to check_sync_overrides in #228 round 5).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_bootstrap_firebase_and_codereview.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  echo "check_bootstrap_firebase_and_codereview: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/tests/test_bootstrap_firebase_and_codereview.sh
+++ b/tests/test_bootstrap_firebase_and_codereview.sh
@@ -1,0 +1,477 @@
+#!/usr/bin/env bash
+# tests/test_bootstrap_firebase_and_codereview.sh
+#
+# Validates scripts/bootstrap/firebase-and-codereview.sh (sub-D / #206).
+#
+# Strategy: PATH-shim `firebase`, `gh`, and `yq` so each invocation is
+# recorded to a log file and tests can assert command shape + flag set
+# without contacting Firebase / GitHub / running yq's real edit. We
+# drive the stage end-to-end via the wizard with stages A/B/C/E
+# behaviors stubbed/skipped where appropriate, then assert against the
+# log.
+#
+# Cases:
+#   1. firebase=none  → zero firebase invocations.
+#   2. firebase=dev   → 1 projects:create call.
+#   3. firebase=dev+prod → 2 projects:create calls.
+#   4. visibility=public → no yq flip + no .coderabbit.yml delete.
+#   5. visibility=private → yq flip + delete + commit + push.
+#   6. codex_app=n → "NOT requested" log + no Codex URLs printed.
+#   7. codex_app=y → all 3 install URLs printed.
+#   8. State file records firebase-and-codereview on happy path.
+#   9. SHIM_EXIT_FIREBASE=1 → stage fails closed, no state entry.
+#  10. Dry-run produces a plan without invoking firebase / gh.
+#
+# Requires: bash 3.2+, rsync + yq (real, for sub-B to work).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/bootstrap-new-repo.sh"
+
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "SKIP: rsync not installed" >&2; exit 0
+fi
+if ! command -v yq >/dev/null 2>&1; then
+  echo "SKIP: yq not installed" >&2; exit 0
+fi
+if ! yq --version 2>&1 | grep -q "mikefarah/yq"; then
+  echo "SKIP: non-mikefarah yq" >&2; exit 0
+fi
+
+[ -x "$SCRIPT" ] || { echo "missing or non-executable $SCRIPT" >&2; exit 1; }
+
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/test-firebase-codereview.XXXXXX")
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0; FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# --- build fixture mergepath ----------------------------------------------
+# Sub-B (template-mirror) rsyncs from a fixture mergepath into the
+# target. Sub-D then operates on the resulting target. We populate the
+# fixture with a minimal .github/review-policy.yml (coderabbit
+# enabled) + a .coderabbit.yml stub so the private-visibility path has
+# real files to flip + delete.
+FAKE_MP="$WORKDIR/fake-mp"
+mkdir -p "$FAKE_MP"/{scripts/bootstrap,scripts/ci,scripts/sync,.github/workflows,docs/agents,tests,scripts/firebase}
+echo "# mergepath" >"$FAKE_MP/README.md"
+echo "Mergepath brand" >"$FAKE_MP/BRAND.md"
+echo "ai ctx" >"$FAKE_MP/.ai_context.md"
+echo "overview" >"$FAKE_MP/docs/agents/repository-overview.md"
+echo "Security" >"$FAKE_MP/SECURITY.md"
+cat >"$FAKE_MP/.repo-template.yml" <<'EOF'
+spec_test_map:
+  mergepath_playground:
+    - tests/test_mergepath_playground.sh
+extra_top_level_dirs: [mergepath, packaging]
+EOF
+cat >"$FAKE_MP/.github/review-policy.yml" <<'EOF'
+external_review_threshold: 300
+coderabbit:
+  enabled: true
+EOF
+cat >"$FAKE_MP/.coderabbit.yml" <<'EOF'
+language: en-US
+EOF
+
+# Stage modules — copy the real ones in so the wizard's source line
+# picks them up from the fixture mergepath.
+cp "$ROOT/scripts/bootstrap/_lib.sh"                    "$FAKE_MP/scripts/bootstrap/_lib.sh"
+cp "$ROOT/scripts/bootstrap/substitute.sh"              "$FAKE_MP/scripts/bootstrap/substitute.sh"
+cp "$ROOT/scripts/bootstrap/template-mirror.sh"         "$FAKE_MP/scripts/bootstrap/template-mirror.sh"
+cp "$ROOT/scripts/bootstrap/github-infra.sh"            "$FAKE_MP/scripts/bootstrap/github-infra.sh"
+cp "$ROOT/scripts/bootstrap/firebase-and-codereview.sh" "$FAKE_MP/scripts/bootstrap/firebase-and-codereview.sh"
+cp "$ROOT/scripts/bootstrap/board-and-summary.sh"       "$FAKE_MP/scripts/bootstrap/board-and-summary.sh"
+cp "$ROOT/scripts/bootstrap-new-repo.sh"                "$FAKE_MP/scripts/bootstrap-new-repo.sh"
+
+# Provide a stub op-firebase-setup so stage D's invocation lands on
+# something. The shim doesn't need to do anything — bootstrap::run
+# captures its invocation in the bootstrap log + the firebase shim
+# only fires on real `firebase` calls.
+cat >"$FAKE_MP/scripts/firebase/op-firebase-setup" <<'STUB_EOF'
+#!/usr/bin/env bash
+# Stub op-firebase-setup for tests. Logs invocation to $OP_FB_SETUP_LOG.
+echo "op-firebase-setup $*" >>"${OP_FB_SETUP_LOG:-/dev/null}"
+exit "${OP_FB_SETUP_EXIT:-0}"
+STUB_EOF
+chmod +x "$FAKE_MP/scripts/firebase/op-firebase-setup"
+
+git -C "$FAKE_MP" init -q
+git -C "$FAKE_MP" -c user.email=t@t -c user.name=t -c commit.gpgsign=false add -A
+git -C "$FAKE_MP" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m "fixture"
+
+# --- shim PATH (gh, firebase, gcloud) -------------------------------------
+# Recorded log file + per-subcommand exit overrides.
+SHIM_DIR="$WORKDIR/shim-bin"
+SHIM_LOG="$WORKDIR/shim.log"
+OP_FB_SETUP_LOG="$WORKDIR/op-fb-setup.log"
+mkdir -p "$SHIM_DIR"
+: >"$SHIM_LOG"
+
+# Real tool symlinks (so coreutils + git + yq + rsync still resolve).
+for tool in bash yq git rsync sed awk grep mktemp tr cut tail head wc ls rm cat printf chmod find dirname basename mv mkdir; do
+  src=$(command -v "$tool" 2>/dev/null || true)
+  [ -n "$src" ] && ln -sf "$src" "$SHIM_DIR/$tool"
+done
+
+# Make `op` exist as a stub — github-infra's secret provisioning
+# probes it. Always exits 1 to mean "no 1Password item" so the stage
+# falls through to BOOTSTRAP_REVIEWER_PAT_VALUE.
+cat >"$SHIM_DIR/op" <<'OP_EOF'
+#!/usr/bin/env bash
+exit 1
+OP_EOF
+chmod +x "$SHIM_DIR/op"
+
+# gh shim — same pattern as test_bootstrap_github_infra.sh. Records
+# every invocation; honors per-subcommand exit overrides.
+cat >"$SHIM_DIR/gh" <<'GH_EOF'
+#!/usr/bin/env bash
+LOG=${SHIM_LOG:?SHIM_LOG not set}
+echo "gh $*" >>"$LOG"
+case "$1" in
+  repo)
+    case "$2" in
+      create) exit "${SHIM_EXIT_REPO_CREATE:-0}" ;;
+      *) exit 0 ;;
+    esac ;;
+  label)   exit "${SHIM_EXIT_LABEL:-0}" ;;
+  api)     exit "${SHIM_EXIT_API:-0}" ;;
+  secret)
+    if [ "$2" = "set" ]; then cat >/dev/null 2>&1 || true; fi
+    exit "${SHIM_EXIT_SECRET:-0}" ;;
+  config)
+    # gh config get -h github.com user
+    echo "nathanpayne-claude"; exit 0 ;;
+  auth) exit 0 ;;
+  pr)   exit 0 ;;
+  *)    exit 0 ;;
+esac
+GH_EOF
+chmod +x "$SHIM_DIR/gh"
+
+# firebase shim — records every invocation; honors SHIM_EXIT_FIREBASE.
+# `--data-file <path>` reads the file but discards content; tests
+# don't need to inspect the value, just confirm the shape.
+cat >"$SHIM_DIR/firebase" <<'FIRE_EOF'
+#!/usr/bin/env bash
+LOG=${SHIM_LOG:?SHIM_LOG not set}
+echo "firebase $*" >>"$LOG"
+exit "${SHIM_EXIT_FIREBASE:-0}"
+FIRE_EOF
+chmod +x "$SHIM_DIR/firebase"
+
+# gcloud shim — preflight_firebase_deps requires it on PATH when
+# firebase scope != none. Records invocations + exits 0.
+cat >"$SHIM_DIR/gcloud" <<'GCLOUD_EOF'
+#!/usr/bin/env bash
+LOG=${SHIM_LOG:?SHIM_LOG not set}
+echo "gcloud $*" >>"$LOG"
+exit 0
+GCLOUD_EOF
+chmod +x "$SHIM_DIR/gcloud"
+
+SHIM_PATH="$SHIM_DIR:/usr/bin:/bin"
+
+# --- wizard runner --------------------------------------------------------
+# The runner re-shims every call so per-test env vars (e.g.,
+# SHIM_EXIT_FIREBASE) apply. Stage E (board-and-summary) is skipped
+# because it's still a stub and we don't care about it for this test.
+run_wizard() {
+  PATH="$SHIM_PATH" \
+  SHIM_LOG="$SHIM_LOG" \
+  OP_FB_SETUP_LOG="$OP_FB_SETUP_LOG" \
+  BOOTSTRAP_MERGEPATH_ROOT="$FAKE_MP" \
+  BOOTSTRAP_SKIP_TOOL_CHECK=1 \
+  BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
+  BOOTSTRAP_AUTO_CONFIRM=1 \
+  BOOTSTRAP_AUTO_PROMPT=skip \
+  BOOTSTRAP_AUTHOR_NAME="test" \
+  BOOTSTRAP_AUTHOR_EMAIL="t@t" \
+  BOOTSTRAP_SKIP_INVITE_PAUSE=1 \
+  BOOTSTRAP_REVIEWER_PAT_VALUE="fake-test-pat-1234567890" \
+  BOOTSTRAP_SKIP_STAGES="board-and-summary" \
+  BOOTSTRAP_SKIP_REMOTE_PUSH=1 \
+  "$SCRIPT" "$@"
+}
+
+# ========================================================================
+# Case 1: firebase=none → zero firebase invocations.
+# ========================================================================
+: >"$SHIM_LOG"; : >"$OP_FB_SETUP_LOG"
+TARGET="$WORKDIR/none-repo"
+rm -rf "$TARGET"
+set +e
+out=$(run_wizard none-repo \
+        --target-dir "$TARGET" \
+        --description "d" --visibility public \
+        --firebase none --codex-app n --project new 2>&1)
+ec=$?
+set -e
+[ "$ec" -eq 0 ] \
+  && pass "firebase=none happy path completes (rc=0)" \
+  || fail "firebase=none failed; rc=$ec; out: $out"
+if grep -q "^firebase " "$SHIM_LOG"; then
+  fail "firebase=none invoked firebase shim ($(grep -c '^firebase ' "$SHIM_LOG") calls); should be 0"
+else
+  pass "firebase=none results in zero firebase invocations"
+fi
+
+# ========================================================================
+# Case 2: firebase=dev → exactly 1 projects:create call.
+# ========================================================================
+: >"$SHIM_LOG"; : >"$OP_FB_SETUP_LOG"
+TARGET="$WORKDIR/dev-repo"
+rm -rf "$TARGET"
+set +e
+out=$(run_wizard dev-repo \
+        --target-dir "$TARGET" \
+        --description "d" --visibility public \
+        --firebase dev --codex-app n --project new 2>&1)
+ec=$?
+set -e
+[ "$ec" -eq 0 ] \
+  && pass "firebase=dev happy path completes (rc=0)" \
+  || fail "firebase=dev failed; rc=$ec; out: $out"
+n=$(grep -c "^firebase projects:create " "$SHIM_LOG" || true)
+[ "$n" -eq 1 ] \
+  && pass "firebase=dev triggers exactly 1 projects:create" \
+  || fail "firebase=dev expected 1 projects:create, got $n; log: $(grep '^firebase ' "$SHIM_LOG")"
+grep -qF "firebase projects:create dev-repo-dev --display-name dev-repo (dev)" "$SHIM_LOG" \
+  && pass "firebase=dev creates 'dev-repo-dev' project with display name" \
+  || fail "firebase=dev wrong project ID / display name; log: $(grep projects:create "$SHIM_LOG")"
+# op-firebase-setup should have been invoked once per env.
+[ -s "$OP_FB_SETUP_LOG" ] \
+  && pass "op-firebase-setup invoked for dev env" \
+  || fail "op-firebase-setup not invoked: $(cat "$OP_FB_SETUP_LOG" 2>/dev/null)"
+
+# ========================================================================
+# Case 3: firebase=dev+prod → exactly 2 projects:create calls.
+# ========================================================================
+: >"$SHIM_LOG"; : >"$OP_FB_SETUP_LOG"
+TARGET="$WORKDIR/devprod-repo"
+rm -rf "$TARGET"
+set +e
+out=$(run_wizard devprod-repo \
+        --target-dir "$TARGET" \
+        --description "d" --visibility public \
+        --firebase dev+prod --codex-app n --project new 2>&1)
+ec=$?
+set -e
+[ "$ec" -eq 0 ] \
+  && pass "firebase=dev+prod happy path completes (rc=0)" \
+  || fail "firebase=dev+prod failed; rc=$ec; out: $out"
+n=$(grep -c "^firebase projects:create " "$SHIM_LOG" || true)
+[ "$n" -eq 2 ] \
+  && pass "firebase=dev+prod triggers exactly 2 projects:create" \
+  || fail "firebase=dev+prod expected 2 projects:create, got $n"
+grep -qF "firebase projects:create devprod-repo-dev " "$SHIM_LOG" \
+  && pass "firebase=dev+prod creates dev project" \
+  || fail "no devprod-repo-dev"
+grep -qF "firebase projects:create devprod-repo-prod " "$SHIM_LOG" \
+  && pass "firebase=dev+prod creates prod project" \
+  || fail "no devprod-repo-prod"
+
+# ========================================================================
+# Case 4: visibility=public → no yq flip + no .coderabbit.yml delete.
+# (already exercised in case 1; assert positively here.)
+# ========================================================================
+TARGET="$WORKDIR/none-repo"
+# Verify the rsync'd files are present (no flip happened).
+[ -f "$TARGET/.coderabbit.yml" ] \
+  && pass "public visibility: .coderabbit.yml preserved" \
+  || fail "public visibility: .coderabbit.yml was deleted ($TARGET/.coderabbit.yml absent)"
+if [ -f "$TARGET/.github/review-policy.yml" ]; then
+  if grep -q "enabled: true" "$TARGET/.github/review-policy.yml"; then
+    pass "public visibility: coderabbit.enabled stayed true"
+  else
+    fail "public visibility: coderabbit.enabled NOT true; file: $(cat "$TARGET/.github/review-policy.yml")"
+  fi
+else
+  fail "public visibility: review-policy.yml missing entirely at $TARGET/.github/"
+fi
+
+# ========================================================================
+# Case 5: visibility=private → yq flip + delete + commit + push.
+# ========================================================================
+: >"$SHIM_LOG"; : >"$OP_FB_SETUP_LOG"
+TARGET="$WORKDIR/priv-repo"
+rm -rf "$TARGET"
+set +e
+out=$(run_wizard priv-repo \
+        --target-dir "$TARGET" \
+        --description "d" --visibility private \
+        --firebase none --codex-app n --project new 2>&1)
+ec=$?
+set -e
+[ "$ec" -eq 0 ] \
+  && pass "visibility=private happy path completes (rc=0)" \
+  || fail "visibility=private failed; rc=$ec; out: $out"
+# yq flip happened — file should now show enabled: false.
+if [ -f "$TARGET/.github/review-policy.yml" ]; then
+  if grep -q "enabled: false" "$TARGET/.github/review-policy.yml"; then
+    pass "private visibility: coderabbit.enabled flipped to false"
+  else
+    fail "private visibility: yq flip did not stick; file: $(cat "$TARGET/.github/review-policy.yml")"
+  fi
+else
+  fail "private visibility: review-policy.yml missing"
+fi
+# .coderabbit.yml deleted.
+if [ ! -f "$TARGET/.coderabbit.yml" ]; then
+  pass "private visibility: .coderabbit.yml deleted"
+else
+  fail "private visibility: .coderabbit.yml still present"
+fi
+# Commit recorded in git log. Use a $(...) capture rather than a pipe
+# to grep — the `cmd | grep -q` pattern races with `set -o pipefail`
+# at the file-top because grep -q closes the pipe on first match,
+# SIGPIPE'ing git log and propagating rc=141 through the pipeline
+# even when the match was found (verified empirically on this fixture).
+_git_log_out=$(git -C "$TARGET" log --oneline 2>/dev/null)
+case "$_git_log_out" in
+  *"disable CodeRabbit"*)
+    pass "private visibility: commit 'disable CodeRabbit' recorded in git log"
+    ;;
+  *)
+    fail "private visibility: commit not found; git log: $_git_log_out"
+    ;;
+esac
+# Push: under BOOTSTRAP_SKIP_REMOTE_PUSH=1 (set by the test runner so
+# test fixtures don't need a real bare remote), the stage logs a
+# skip-of-push message instead of running `git push origin main`.
+# Verify the skip-message path fired — that's the test-mode signal
+# the push step ran (just short-circuited the network call).
+echo "$out" | grep -q "BOOTSTRAP_SKIP_REMOTE_PUSH=1 — skipping git push origin main" \
+  && pass "private visibility: push step ran (BOOTSTRAP_SKIP_REMOTE_PUSH=1 short-circuits the network call)" \
+  || fail "private visibility: push step did not log the skip message; out: $out"
+
+# ========================================================================
+# Case 6: codex_app=n → "NOT requested" log + no install URLs.
+# ========================================================================
+: >"$SHIM_LOG"
+TARGET="$WORKDIR/codexn-repo"
+rm -rf "$TARGET"
+set +e
+out=$(run_wizard codexn-repo \
+        --target-dir "$TARGET" \
+        --description "d" --visibility public \
+        --firebase none --codex-app n --project new 2>&1)
+ec=$?
+set -e
+[ "$ec" -eq 0 ] \
+  && pass "codex_app=n run completes (rc=0)" \
+  || fail "codex_app=n failed; rc=$ec; out: $out"
+echo "$out" | grep -q "Codex App: NOT requested" \
+  && pass "codex_app=n logs 'NOT requested' message" \
+  || fail "codex_app=n missing 'NOT requested' log; got: $out"
+# None of the Codex install URLs should appear in stdout when codex_app=n.
+if echo "$out" | grep -q "github.com/apps/chatgpt-codex-connector"; then
+  fail "codex_app=n leaked Codex install URL"
+else
+  pass "codex_app=n suppresses Codex install URLs"
+fi
+
+# ========================================================================
+# Case 7: codex_app=y → all 3 install URLs printed.
+# ========================================================================
+: >"$SHIM_LOG"
+TARGET="$WORKDIR/codexy-repo"
+rm -rf "$TARGET"
+set +e
+out=$(run_wizard codexy-repo \
+        --target-dir "$TARGET" \
+        --description "d" --visibility public \
+        --firebase none --codex-app y --project new 2>&1)
+ec=$?
+set -e
+[ "$ec" -eq 0 ] \
+  && pass "codex_app=y run completes (rc=0)" \
+  || fail "codex_app=y failed; rc=$ec; out: $out"
+echo "$out" | grep -q "github.com/apps/chatgpt-codex-connector" \
+  && pass "codex_app=y prints App install URL" \
+  || fail "codex_app=y missing App install URL; got: $out"
+echo "$out" | grep -q "chatgpt.com/codex/cloud/settings/code-review" \
+  && pass "codex_app=y prints code-review settings URL" \
+  || fail "codex_app=y missing code-review settings URL"
+echo "$out" | grep -q "chatgpt.com/codex/cloud/settings/environments" \
+  && pass "codex_app=y prints environments settings URL" \
+  || fail "codex_app=y missing environments URL"
+
+# ========================================================================
+# Case 8: State file records firebase-and-codereview on happy path.
+# (use the priv-repo target from case 5)
+# ========================================================================
+if [ -f "$WORKDIR/priv-repo/.bootstrap-state" ] \
+   && grep -q "^firebase-and-codereview\$" "$WORKDIR/priv-repo/.bootstrap-state"; then
+  pass "state file records firebase-and-codereview on happy path"
+else
+  fail "state file missing firebase-and-codereview entry: $(cat "$WORKDIR/priv-repo/.bootstrap-state" 2>/dev/null)"
+fi
+
+# ========================================================================
+# Case 9: SHIM_EXIT_FIREBASE=1 → stage fails closed, no state entry.
+# ========================================================================
+: >"$SHIM_LOG"; : >"$OP_FB_SETUP_LOG"
+TARGET="$WORKDIR/firefail-repo"
+rm -rf "$TARGET"
+set +e
+out=$(SHIM_EXIT_FIREBASE=1 run_wizard firefail-repo \
+        --target-dir "$TARGET" \
+        --description "d" --visibility public \
+        --firebase dev --codex-app n --project new 2>&1)
+ec=$?
+set -e
+[ "$ec" -ne 0 ] \
+  && pass "SHIM_EXIT_FIREBASE=1: stage fails closed (rc=$ec)" \
+  || fail "stage should fail when firebase create errors; rc=$ec"
+if [ -f "$TARGET/.bootstrap-state" ] && grep -q "^firebase-and-codereview\$" "$TARGET/.bootstrap-state"; then
+  fail "firebase-and-codereview recorded despite firebase failure"
+else
+  pass "firebase-and-codereview NOT recorded when firebase fails (resume can retry)"
+fi
+
+# ========================================================================
+# Case 10: Dry-run produces a plan without invoking firebase / gh.
+# ========================================================================
+: >"$SHIM_LOG"; : >"$OP_FB_SETUP_LOG"
+TARGET="$WORKDIR/dry-repo"
+rm -rf "$TARGET"
+set +e
+dry_out=$(run_wizard dry-repo \
+            --target-dir "$TARGET" \
+            --description "d" --visibility private \
+            --firebase dev+prod --codex-app y --project new --dry-run 2>&1)
+dry_ec=$?
+set -e
+[ "$dry_ec" -eq 0 ] \
+  && pass "stage D --dry-run exits 0" \
+  || fail "dry-run failed: rc=$dry_ec, out: $dry_out"
+# Dry-run must NOT actually invoke firebase or gh.
+if grep -q "^firebase " "$SHIM_LOG"; then
+  fail "dry-run invoked firebase shim ($(grep -c '^firebase ' "$SHIM_LOG") calls); should be 0"
+else
+  pass "dry-run did not invoke firebase (bootstrap::run honors --dry-run)"
+fi
+# op-firebase-setup is also a real script (not via the shim) but it
+# also goes through bootstrap::run. Verify it wasn't invoked.
+if [ -s "$OP_FB_SETUP_LOG" ]; then
+  fail "dry-run invoked op-firebase-setup ($(wc -l <"$OP_FB_SETUP_LOG") times); should be 0"
+else
+  pass "dry-run did not invoke op-firebase-setup"
+fi
+# Plan output should mention DRY-RUN tags for stage D actions.
+echo "$dry_out" | grep -q "DRY-RUN.*firebase projects:create" \
+  && pass "dry-run plan includes firebase projects:create action" \
+  || fail "dry-run plan missing firebase projects:create; got: $dry_out"
+echo "$dry_out" | grep -q "DRY-RUN.*yq.*coderabbit.enabled" \
+  && pass "dry-run plan includes yq coderabbit flip action" \
+  || fail "dry-run plan missing yq coderabbit flip; got: $dry_out"
+
+# --- summary --------------------------------------------------------------
+echo
+echo "test_bootstrap_firebase_and_codereview: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/tests/test_bootstrap_firebase_and_codereview.sh
+++ b/tests/test_bootstrap_firebase_and_codereview.sh
@@ -349,6 +349,148 @@ echo "$out" | grep -q "BOOTSTRAP_SKIP_REMOTE_PUSH=1 — skipping git push origin
   || fail "private visibility: push step did not log the skip message; out: $out"
 
 # ========================================================================
+# Case 5a/5b/5c: visibility=private with one or both CodeRabbit files
+# absent — regression for the round-1 Codex P1 finding (PR #248) that
+# `git add --all .github/review-policy.yml .coderabbit.yml` exits 128
+# when either pathspec doesn't match. The fix gates the add list to
+# only-existing-or-tracked paths; the stage must NOT hard-fail when
+# one or both files are missing.
+#
+# We invoke the disable-for-private function directly rather than
+# round-tripping through the full wizard — that keeps the regression
+# narrowly focused on the staging logic at the heart of the finding.
+# ========================================================================
+# Source helpers + the stage module so we can call the internal
+# function. Use a subshell so set -euo pipefail interactions don't
+# bleed into the rest of this test file.
+(
+  set -euo pipefail
+  BOOTSTRAP_DRY_RUN=0
+  BOOTSTRAP_LOG_FILE="$WORKDIR/case5x.bootstrap-log"
+  BOOTSTRAP_STATE_FILE="$WORKDIR/case5x.bootstrap-state"
+  export BOOTSTRAP_DRY_RUN BOOTSTRAP_LOG_FILE BOOTSTRAP_STATE_FILE
+  # shellcheck source=/dev/null
+  . "$ROOT/scripts/bootstrap/_lib.sh"
+  # shellcheck source=/dev/null
+  . "$ROOT/scripts/bootstrap/firebase-and-codereview.sh"
+
+  # Build a target repo with policy file but NO .coderabbit.yml.
+  T5a="$WORKDIR/case5a-policy-only"
+  mkdir -p "$T5a/.github"
+  cat >"$T5a/.github/review-policy.yml" <<'YAML'
+external_review_threshold: 300
+coderabbit:
+  enabled: true
+YAML
+  git -C "$T5a" init -q
+  git -C "$T5a" -c user.email=t@t -c user.name=t -c commit.gpgsign=false add -A
+  git -C "$T5a" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m seed
+
+  BOOTSTRAP_AUTHOR_NAME=t BOOTSTRAP_AUTHOR_EMAIL=t@t \
+    BOOTSTRAP_SKIP_REMOTE_PUSH=1 \
+    bootstrap::_coderabbit_disable_for_private "$T5a"
+) 2>"$WORKDIR/case5a.err"
+rc5a=$?
+if [ "$rc5a" -eq 0 ]; then
+  pass "case 5a: disable-for-private succeeds when .coderabbit.yml is absent"
+else
+  fail "case 5a: hard-failed when .coderabbit.yml was absent (rc=$rc5a); stderr: $(cat "$WORKDIR/case5a.err")"
+fi
+# Verify the commit landed AND only the policy file is in it (no
+# spurious pathspec error before commit).
+# Capture-and-case pattern avoids the `set -o pipefail` race where
+# grep -q closes the pipe on first match, SIGPIPE'ing git log and
+# propagating rc=141. (Same workaround as the case-5 commit check.)
+_5a_log=$(git -C "$WORKDIR/case5a-policy-only" log --oneline 2>/dev/null)
+case "$_5a_log" in
+  *"disable CodeRabbit"*)
+    pass "case 5a: 'disable CodeRabbit' commit recorded with only review-policy.yml present" ;;
+  *)
+    fail "case 5a: no disable-CodeRabbit commit; log: $_5a_log" ;;
+esac
+
+# 5b: .coderabbit.yml present but NO .github/review-policy.yml.
+(
+  set -euo pipefail
+  BOOTSTRAP_DRY_RUN=0
+  BOOTSTRAP_LOG_FILE="$WORKDIR/case5b.bootstrap-log"
+  BOOTSTRAP_STATE_FILE="$WORKDIR/case5b.bootstrap-state"
+  export BOOTSTRAP_DRY_RUN BOOTSTRAP_LOG_FILE BOOTSTRAP_STATE_FILE
+  # shellcheck source=/dev/null
+  . "$ROOT/scripts/bootstrap/_lib.sh"
+  # shellcheck source=/dev/null
+  . "$ROOT/scripts/bootstrap/firebase-and-codereview.sh"
+
+  T5b="$WORKDIR/case5b-coderabbit-only"
+  mkdir -p "$T5b"
+  echo "language: en-US" >"$T5b/.coderabbit.yml"
+  git -C "$T5b" init -q
+  git -C "$T5b" -c user.email=t@t -c user.name=t -c commit.gpgsign=false add -A
+  git -C "$T5b" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m seed
+
+  BOOTSTRAP_AUTHOR_NAME=t BOOTSTRAP_AUTHOR_EMAIL=t@t \
+    BOOTSTRAP_SKIP_REMOTE_PUSH=1 \
+    bootstrap::_coderabbit_disable_for_private "$T5b"
+) 2>"$WORKDIR/case5b.err"
+rc5b=$?
+if [ "$rc5b" -eq 0 ]; then
+  pass "case 5b: disable-for-private succeeds when review-policy.yml is absent"
+else
+  fail "case 5b: hard-failed when review-policy.yml was absent (rc=$rc5b); stderr: $(cat "$WORKDIR/case5b.err")"
+fi
+if [ ! -f "$WORKDIR/case5b-coderabbit-only/.coderabbit.yml" ]; then
+  pass "case 5b: .coderabbit.yml deleted as expected"
+else
+  fail "case 5b: .coderabbit.yml not deleted"
+fi
+_5b_log=$(git -C "$WORKDIR/case5b-coderabbit-only" log --oneline 2>/dev/null)
+case "$_5b_log" in
+  *"disable CodeRabbit"*)
+    pass "case 5b: 'disable CodeRabbit' commit recorded with only .coderabbit.yml present" ;;
+  *)
+    fail "case 5b: no disable-CodeRabbit commit; log: $_5b_log" ;;
+esac
+
+# 5c: both files absent — early return, no commit, exit 0 (already
+# covered by the touched_any=0 branch but assert explicitly so
+# regressions in either branch are caught).
+(
+  set -euo pipefail
+  BOOTSTRAP_DRY_RUN=0
+  BOOTSTRAP_LOG_FILE="$WORKDIR/case5c.bootstrap-log"
+  BOOTSTRAP_STATE_FILE="$WORKDIR/case5c.bootstrap-state"
+  export BOOTSTRAP_DRY_RUN BOOTSTRAP_LOG_FILE BOOTSTRAP_STATE_FILE
+  # shellcheck source=/dev/null
+  . "$ROOT/scripts/bootstrap/_lib.sh"
+  # shellcheck source=/dev/null
+  . "$ROOT/scripts/bootstrap/firebase-and-codereview.sh"
+
+  T5c="$WORKDIR/case5c-both-absent"
+  mkdir -p "$T5c"
+  echo "x" >"$T5c/README.md"
+  git -C "$T5c" init -q
+  git -C "$T5c" -c user.email=t@t -c user.name=t -c commit.gpgsign=false add -A
+  git -C "$T5c" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m seed
+
+  BOOTSTRAP_AUTHOR_NAME=t BOOTSTRAP_AUTHOR_EMAIL=t@t \
+    BOOTSTRAP_SKIP_REMOTE_PUSH=1 \
+    bootstrap::_coderabbit_disable_for_private "$T5c"
+) 2>"$WORKDIR/case5c.err"
+rc5c=$?
+if [ "$rc5c" -eq 0 ]; then
+  pass "case 5c: disable-for-private exits 0 when both files absent"
+else
+  fail "case 5c: hard-failed when both files absent (rc=$rc5c); stderr: $(cat "$WORKDIR/case5c.err")"
+fi
+_5c_log=$(git -C "$WORKDIR/case5c-both-absent" log --oneline 2>/dev/null)
+case "$_5c_log" in
+  *"disable CodeRabbit"*)
+    fail "case 5c: spurious disable-CodeRabbit commit (both files absent — nothing to do)" ;;
+  *)
+    pass "case 5c: no commit when both files absent (correct no-op)" ;;
+esac
+
+# ========================================================================
 # Case 6: codex_app=n → "NOT requested" log + no install URLs.
 # ========================================================================
 : >"$SHIM_LOG"

--- a/tests/test_bootstrap_wizard.sh
+++ b/tests/test_bootstrap_wizard.sh
@@ -138,8 +138,14 @@ set -e
 clean_target="$WORKDIR/clean-target"
 mkdir -p "$clean_target"
 set +e
+# Skip stages D/E so the wizard scaffold test doesn't try to do real
+# firebase work or wait for the board summary. Stage D is implemented
+# as of #206 and has its own dedicated test
+# (tests/test_bootstrap_firebase_and_codereview.sh); stage E is still
+# a stub.
 out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
       BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+      BOOTSTRAP_SKIP_STAGES="firebase-and-codereview,board-and-summary" \
       "$SCRIPT" my-new-repo \
       --target-dir "$clean_target" \
       --description "test repo" --visibility private --firebase none \
@@ -157,12 +163,12 @@ echo "$out" | grep -q "Starting stage: template-mirror" \
 echo "$out" | grep -q "Starting stage: github-infra" \
   && pass "stage C stub ran" \
   || fail "stage C stub didn't run"
-echo "$out" | grep -q "firebase-and-codereview (sub-D stub)" \
-  && pass "stage D stub ran" \
-  || fail "stage D stub didn't run"
-echo "$out" | grep -q "board-and-summary (sub-E stub)" \
-  && pass "stage E stub ran" \
-  || fail "stage E stub didn't run"
+echo "$out" | grep -q "skip firebase-and-codereview (BOOTSTRAP_SKIP_STAGES)" \
+  && pass "stage D skipped via BOOTSTRAP_SKIP_STAGES" \
+  || fail "stage D skip not logged; got: $out"
+echo "$out" | grep -q "skip board-and-summary (BOOTSTRAP_SKIP_STAGES)" \
+  && pass "stage E skipped via BOOTSTRAP_SKIP_STAGES" \
+  || fail "stage E skip not logged"
 
 # ---------------------------------------------------------------------------
 # Test 11: Resume mechanism. Pre-seed the state file with the first
@@ -175,8 +181,12 @@ template-mirror
 github-infra
 EOF
 set +e
+# Skip stage D since it's now implemented and has its own dedicated
+# test fixture (the wizard's scaffold-level test stays focused on
+# dispatch / resume mechanics).
 resume_out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
              BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+             BOOTSTRAP_SKIP_STAGES="firebase-and-codereview" \
              "$SCRIPT" my-new-repo \
              --target-dir "$resume_target" \
              --description "test repo" --visibility private --firebase none \
@@ -191,9 +201,9 @@ echo "$resume_out" | grep -q "skip template-mirror (already completed)" \
 echo "$resume_out" | grep -q "skip github-infra (already completed)" \
   && pass "resume skipped github-infra" \
   || fail "resume did not skip github-infra"
-echo "$resume_out" | grep -q "firebase-and-codereview (sub-D stub)" \
-  && pass "resume ran firebase-and-codereview" \
-  || fail "resume did not run firebase-and-codereview"
+echo "$resume_out" | grep -q "skip firebase-and-codereview (BOOTSTRAP_SKIP_STAGES)" \
+  && pass "resume skipped firebase-and-codereview via BOOTSTRAP_SKIP_STAGES" \
+  || fail "resume did not skip firebase-and-codereview"
 echo "$resume_out" | grep -q "board-and-summary (sub-E stub)" \
   && pass "resume ran board-and-summary" \
   || fail "resume did not run board-and-summary"
@@ -208,6 +218,7 @@ mkdir -p "$explicit_resume_target"
 set +e
 ex_out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
          BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+         BOOTSTRAP_SKIP_STAGES="firebase-and-codereview" \
          "$SCRIPT" my-new-repo \
          --target-dir "$explicit_resume_target" \
          --description "test repo" --visibility private --firebase none \
@@ -220,9 +231,9 @@ set -e
 echo "$ex_out" | grep -q "skip github-infra (already completed)" \
   && pass "explicit-resume skipped github-infra" \
   || fail "explicit-resume did not skip github-infra"
-echo "$ex_out" | grep -q "firebase-and-codereview (sub-D stub)" \
-  && pass "explicit-resume ran firebase-and-codereview" \
-  || fail "explicit-resume did not run firebase-and-codereview"
+echo "$ex_out" | grep -q "skip firebase-and-codereview (BOOTSTRAP_SKIP_STAGES)" \
+  && pass "explicit-resume skipped firebase-and-codereview via BOOTSTRAP_SKIP_STAGES" \
+  || fail "explicit-resume did not skip firebase-and-codereview"
 echo "$ex_out" | grep -q "Starting stage: template-mirror" \
   && fail "explicit-resume should have skipped template-mirror (came before github-infra)" \
   || pass "explicit-resume correctly skipped pre-target stages"
@@ -235,6 +246,7 @@ mkdir -p "$skip_board_target"
 set +e
 sb_out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
          BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+         BOOTSTRAP_SKIP_STAGES="firebase-and-codereview" \
          "$SCRIPT" my-new-repo \
          --target-dir "$skip_board_target" \
          --description "test repo" --visibility private --firebase none \
@@ -253,8 +265,14 @@ echo "$sb_out" | grep -q "skip board-and-summary (--skip-board)" \
 skip_fb_target="$WORKDIR/skip-fb-target"
 mkdir -p "$skip_fb_target"
 set +e
+# Note: this test exercises that --skip-firebase routes through the
+# real stage D's "Firebase: scope=none" branch. We deliberately do
+# NOT add stage D to BOOTSTRAP_SKIP_STAGES here — that defeats the
+# purpose. Stage E (board-and-summary) is still skipped to keep the
+# test focused on the firebase branch.
 sf_out=$(BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
          BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+         BOOTSTRAP_SKIP_STAGES="board-and-summary" \
          "$SCRIPT" my-new-repo \
          --target-dir "$skip_fb_target" \
          --description "test repo" --visibility private \
@@ -264,9 +282,9 @@ sf_ec=$?
 set -e
 [ "$sf_ec" -eq 0 ] && pass "--skip-firebase exits 0" \
                    || fail "--skip-firebase should exit 0; got $sf_ec"
-echo "$sf_out" | grep -q "firebase=none, skipping Firebase setup" \
-  && pass "--skip-firebase routes through firebase=none branch" \
-  || fail "--skip-firebase did not log firebase=none; got: $sf_out"
+echo "$sf_out" | grep -q "Firebase: scope=none" \
+  && pass "--skip-firebase routes through Firebase scope=none branch" \
+  || fail "--skip-firebase did not log Firebase scope=none; got: $sf_out"
 
 # ---------------------------------------------------------------------------
 # Test 15: Dry-run produces the transcript log but does NOT touch
@@ -277,18 +295,22 @@ log_check_target="$WORKDIR/log-check-target"
 mkdir -p "$log_check_target"
 BOOTSTRAP_SKIP_TOOL_CHECK=1 BOOTSTRAP_SKIP_MERGEPATH_GUARD=1 \
   BOOTSTRAP_AUTO_CONFIRM=1 BOOTSTRAP_AUTO_PROMPT=skip \
+  BOOTSTRAP_SKIP_STAGES="firebase-and-codereview,board-and-summary" \
   "$SCRIPT" my-new-repo \
   --target-dir "$log_check_target" \
   --description "test repo" --visibility private --firebase none \
   --codex-app n --project new --dry-run >/dev/null 2>&1
-# State file should exist with all four stages recorded.
+# State file should exist with the 2 unskipped stages recorded
+# (template-mirror + github-infra; D+E are in BOOTSTRAP_SKIP_STAGES).
+# BOOTSTRAP_SKIP_STAGES does not record skipped stages — only the
+# dispatched-and-completed ones land in state.
 [ -f "$log_check_target/.bootstrap-state" ] \
   && pass "dry-run created state file" \
   || fail "state file missing after dry-run"
 state_lines=$(wc -l <"$log_check_target/.bootstrap-state" | tr -d ' ')
-[ "$state_lines" -eq 4 ] \
-  && pass "state file has 4 stage entries" \
-  || fail "expected 4 state-file entries; got $state_lines"
+[ "$state_lines" -eq 2 ] \
+  && pass "state file has 2 stage entries (D+E skipped via BOOTSTRAP_SKIP_STAGES)" \
+  || fail "expected 2 state-file entries; got $state_lines"
 
 # ---------------------------------------------------------------------------
 # Test 16: --project with non-digit suffix (e.g., "12abc") → exit 1.


### PR DESCRIPTION
Closes #206 — sub-D of #156. Replaces the stub at
`scripts/bootstrap/firebase-and-codereview.sh` with the real
implementation: Firebase project bootstrap, CodeRabbit posture (public
keeps enabled / private disables), and Codex App posture (URL printout
or skip-with-Phase-4b-note).

Authoring-Agent: claude

## Summary

- **Firebase bootstrap** (gated on `--firebase` scope): per-env
  `firebase projects:create` + `op-firebase-setup` invocation, with
  optional `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` into
  `firebase functions:secrets:set` (skippable per secret). Final
  output: per-env Firebase console URLs the operator clicks through
  for `.env.local` population.
- **CodeRabbit posture**: public visibility verifies
  `.coderabbit.yml` was mirrored; private visibility `yq`-flips
  `.coderabbit.enabled=false` in
  `$TARGET/.github/review-policy.yml`, deletes
  `$TARGET/.coderabbit.yml`, commits, and pushes
  `origin main` on the new repo (legitimate — sub-C just created
  the remote and branch protection isn't on yet).
  `BOOTSTRAP_SKIP_REMOTE_PUSH=1` short-circuits the push for tests.
- **Codex App posture**: `n` logs the "NOT requested → Phase 4b
  fallback" message; `y` prints all 3 install URLs (App,
  code-review settings, environments settings) and pauses for human
  Enter (`BOOTSTRAP_AUTO_CONFIRM=1` skips).

## Files

- `scripts/bootstrap/firebase-and-codereview.sh` — stub → real
  implementation (~470 lines).
- `tests/test_bootstrap_firebase_and_codereview.sh` — new dedicated
  test suite (32 assertions, 10 cases).
- `scripts/ci/check_bootstrap_firebase_and_codereview` — CI wrapper
  mirroring `check_bootstrap_github_infra`.
- `tests/test_bootstrap_wizard.sh` — updated to use
  `BOOTSTRAP_SKIP_STAGES=firebase-and-codereview` on end-to-end
  wizard runs that don't fit the scaffold-test fixture; banner
  expectation changed from `(sub-D stub)` to the real banner.

## Conventions followed

- Per-step rc capture (sub-B/C pattern):
  `step_rc=0; helper ... || step_rc=$?; if rc != 0: err + return`.
- All side effects via `bootstrap::run` so `--dry-run` produces a
  plan without touching `firebase` / `gh` / `git push`.
- bash 3.2 portable (no `declare -A`, no `mapfile`, no `\${var^^}`).
- `bootstrap::record_stage` only on the all-clean path.
- Stage-scope reads from `$TARGET_DIR`, `$BOOTSTRAP_MERGEPATH_ROOT`,
  `bootstrap_input <name>`.

## Test plan

- [x] `bash tests/test_bootstrap_firebase_and_codereview.sh` →
  32 passed, 0 failed
- [x] `bash tests/test_bootstrap_wizard.sh` → 41 passed, 0 failed
  (sub-A regression)
- [x] `bash tests/test_bootstrap_template_mirror.sh` → 39 passed,
  0 failed (sub-B regression)
- [x] `bash tests/test_bootstrap_github_infra.sh` → 24 passed,
  0 failed (sub-C regression)
- [x] `for c in scripts/ci/check_*; do bash \"\$c\"; done` →
  all 17 pass

## Out of scope

- Project v2 board creation + final summary — sub-E (#207).
- Production-Firebase-vault SA key setup — #154's territory.
- Cross-repo loop docs update — handled by sub-B.

## Self-Review

- **Correctness**: per-step rc capture mirrors sub-B/C. Failure modes
  (missing `review-policy.yml`, missing `op-firebase-setup` helper,
  push failure) all log distinctly and the stage records completion
  ONLY on the all-clean path. The yq flip stays defensive even
  though wizard preflight requires yq globally.
- **Regression risk**: low. Stage D was a no-op stub; existing
  wizard tests now use `BOOTSTRAP_SKIP_STAGES` where the real
  stage's side effects don't fit the scaffold test fixture. All
  sub-A/B/C tests still pass.
- **Style**: matches sub-B/C structure (file-top docblock with
  Reads / Env overrides; `bootstrap::_`-prefixed helpers; same
  return-on-rc patterns).
- **Test coverage**: 32 assertions across the 10 #206 acceptance
  bullets. The `pipefail`+SIGPIPE trap on `git log | grep -q`
  documented inline for future maintainers.
- **Security**: secret values for `firebase functions:secrets:set`
  never hit argv (use chmod-600 tempfile + `--data-file`). Tempfile
  is cleaned even on set failure. Dry-run skips the live tempfile
  entirely and logs only the redacted command shape with
  `len=\${#value}`.