### PR TITLE
docs(preflight): document shared cache directory rationale

### DIFF
--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -106,6 +106,12 @@ ssh_host_for() {
 }
 
 # ── Cache layout ──────────────────────────────────────────────────────
+# Cache directory is intentionally shared across all consumer repos:
+#   - The session file is keyed by --agent (see SESSION_FILE below).
+#   - PATs are agent-keyed and currently uniform across the Phase 4
+#     propagation set, so a shared cache is functionally correct.
+# Re-evaluate if per-repo PATs ever diverge — at that point, namespace
+# the cache path per consumer repo (e.g. $HOME/.cache/mergepath/$REPO).
 DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/mergepath"
 CACHE_DIR="${OP_PREFLIGHT_CACHE_DIR:-$DEFAULT_CACHE_DIR}"
 DEFAULT_TTL_SECONDS=14400  # 4 hours


### PR DESCRIPTION
Authoring-Agent: claude

Resolves the open question raised in swipewatch#44 (https://github.com/nathanjohnpayne/swipewatch/issues/44).

The validation pass on swipewatch#43 flagged `scripts/op-preflight.sh:87` as AMBIGUOUS — the shared cache path `${HOME}/.cache/mergepath` is unchanged across all consumer repos, but no inline comment documents why. The audit could neither confirm "intentional" (no commit message defends the choice) nor flag as a bug (the session file is `--agent`-keyed and PATs are uniform, so the shared cache is functionally correct).

This PR adds the missing rationale inline so future audits classify the call as REJECTED-with-citation rather than AMBIGUOUS, and so the design choice is discoverable when someone considers per-repo namespacing.

Once this lands and propagates via the Phase 4 sync, all 7 consumer repos pick up the comment.

## Self-Review

- **Correctness**: Comment-only change. No behavioral diff — `DEFAULT_CACHE_DIR` assignment is byte-identical. Verified by `git diff` (additions are only comment lines preceding the existing assignment).
- **Regression risk**: None. Shell parses `#`-prefixed lines as comments; no execution path touched.
- **Style**: Matches the existing `# ── Heading ──` block style and the multi-line explanatory comment pattern already in use elsewhere in this script (e.g. the Cloudflare token block at lines 117-124).
- **Test coverage**: N/A — doc-only change. No existing tests would exercise a comment.
- **Security/dependency hygiene**: No new dependencies. No credential paths or PAT handling touched.

## Test plan
- [ ] CI passes (doc-only change in a shell script — no behavioral change)
- [ ] Verified `shellcheck` / lint clean if the repo runs that