### PR TITLE
docs: introduce loop-list anchors in DEPLOYMENT.md + REVIEW_POLICY.md (#238)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -69,9 +69,16 @@ The full bootstrap loop runs across each consumer repo. Current consumers:
 Run the bootstrap script across all of them:
 
 ```bash
-cd ~/Documents/GitHub
+# Resolve the repo list FIRST (while pwd is anywhere), THEN cd. The
+# awk lookup must point at mergepath's DEPLOYMENT.md explicitly —
+# `cd ~/Documents/GitHub` doesn't put us inside mergepath, so a bare
+# `DEPLOYMENT.md` arg would silently expand to nothing and the loop
+# would no-op. See #252 (Codex P1).
+repos=$(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' \
+        ~/Documents/GitHub/mergepath/DEPLOYMENT.md | grep '^- ' | sed 's/^- //')
 
-for repo in $(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' DEPLOYMENT.md | grep '^- ' | sed 's/^- //'); do
+cd ~/Documents/GitHub
+for repo in $repos; do
   git clone "https://github.com/nathanjohnpayne/$repo.git" 2>/dev/null || (cd "$repo" && git pull)
   cd "$repo"
   ./scripts/bootstrap.sh    # restores .env.local from 1Password via op inject
@@ -90,7 +97,10 @@ The bootstrap script for each repo:
 # Quick check that each repo's local config was restored.
 # Iterates over the consumer list defined above (§ 4). Repos that don't
 # carry .env files no-op via the fallback echo.
-for repo in $(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' DEPLOYMENT.md | grep '^- ' | sed 's/^- //'); do
+# Explicit path to mergepath/DEPLOYMENT.md — pwd may not be the
+# mergepath repo (see #252 Codex P1).
+for repo in $(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' \
+              ~/Documents/GitHub/mergepath/DEPLOYMENT.md | grep '^- ' | sed 's/^- //'); do
   echo "=== $repo ==="
   ls ~/Documents/GitHub/$repo/.env* 2>/dev/null || echo "  (no env files expected)"
 done
@@ -107,8 +117,12 @@ When you return from a temporary machine, tell your agent:
 ### 1. On the temporary machine (before leaving)
 
 ```bash
+# Resolve repo list before cd-ing away from mergepath (see #252 Codex P1).
+repos=$(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' \
+        ~/Documents/GitHub/mergepath/DEPLOYMENT.md | grep '^- ' | sed 's/^- //')
+
 cd ~/Documents/GitHub
-for repo in $(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' DEPLOYMENT.md | grep '^- ' | sed 's/^- //'); do
+for repo in $repos; do
   cd "$repo"
   # Push any local config changes to 1Password
   ./scripts/bootstrap.sh --sync
@@ -121,8 +135,12 @@ done
 ### 2. On the main machine (when you return)
 
 ```bash
+# Resolve repo list before cd-ing away from mergepath (see #252 Codex P1).
+repos=$(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' \
+        ~/Documents/GitHub/mergepath/DEPLOYMENT.md | grep '^- ' | sed 's/^- //')
+
 cd ~/Documents/GitHub
-for repo in $(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' DEPLOYMENT.md | grep '^- ' | sed 's/^- //'); do
+for repo in $repos; do
   cd "$repo"
   git pull                          # get code changes from the temp machine
   ./scripts/bootstrap.sh --force    # re-resolve .env.tpl from 1Password (latest values)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -55,10 +55,23 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
 
 ### 4. Clone and bootstrap all repos
 
+The full bootstrap loop runs across each consumer repo. Current consumers:
+
+<!-- bootstrap-loop-list-start -->
+- friends-and-family-billing
+- device-platform-reporting
+- device-source-of-truth
+- swipewatch
+- nathanpaynedotcom
+- overridebroadway
+<!-- bootstrap-loop-list-end -->
+
+Run the bootstrap script across all of them:
+
 ```bash
 cd ~/Documents/GitHub
 
-for repo in friends-and-family-billing device-platform-reporting device-source-of-truth swipewatch nathanpaynedotcom overridebroadway; do
+for repo in $(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' DEPLOYMENT.md | grep '^- ' | sed 's/^- //'); do
   git clone "https://github.com/nathanjohnpayne/$repo.git" 2>/dev/null || (cd "$repo" && git pull)
   cd "$repo"
   ./scripts/bootstrap.sh    # restores .env.local from 1Password via op inject
@@ -74,8 +87,10 @@ The bootstrap script for each repo:
 ### 5. Verify
 
 ```bash
-# Quick check that each repo's local config was restored
-for repo in friends-and-family-billing device-platform-reporting device-source-of-truth overridebroadway; do
+# Quick check that each repo's local config was restored.
+# Iterates over the consumer list defined above (§ 4). Repos that don't
+# carry .env files no-op via the fallback echo.
+for repo in $(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' DEPLOYMENT.md | grep '^- ' | sed 's/^- //'); do
   echo "=== $repo ==="
   ls ~/Documents/GitHub/$repo/.env* 2>/dev/null || echo "  (no env files expected)"
 done
@@ -93,7 +108,7 @@ When you return from a temporary machine, tell your agent:
 
 ```bash
 cd ~/Documents/GitHub
-for repo in friends-and-family-billing device-platform-reporting device-source-of-truth swipewatch nathanpaynedotcom overridebroadway; do
+for repo in $(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' DEPLOYMENT.md | grep '^- ' | sed 's/^- //'); do
   cd "$repo"
   # Push any local config changes to 1Password
   ./scripts/bootstrap.sh --sync
@@ -107,7 +122,7 @@ done
 
 ```bash
 cd ~/Documents/GitHub
-for repo in friends-and-family-billing device-platform-reporting device-source-of-truth swipewatch nathanpaynedotcom overridebroadway; do
+for repo in $(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' DEPLOYMENT.md | grep '^- ' | sed 's/^- //'); do
   cd "$repo"
   git pull                          # get code changes from the temp machine
   ./scripts/bootstrap.sh --force    # re-resolve .env.tpl from 1Password (latest values)

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -767,10 +767,22 @@ ssh -T git@github-claude        # → Hi nathanpayne-claude!
 
 ### Switching all repos to SSH remotes
 
+The SSH-remote-switch covers every repo on the operator's machine (template
++ consumers + docs). Current set:
+
+<!-- bootstrap-loop-list-start -->
+- mergepath
+- swipewatch
+- nathanpaynedotcom
+- device-platform-reporting
+- device-source-of-truth
+- overridebroadway
+- friends-and-family-billing
+- docs
+<!-- bootstrap-loop-list-end -->
+
 ```bash
-for repo in mergepath swipewatch nathanpaynedotcom \
-            device-platform-reporting device-source-of-truth \
-            overridebroadway friends-and-family-billing docs; do
+for repo in $(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' REVIEW_POLICY.md | grep '^- ' | sed 's/^- //'); do
   cd ~/Documents/GitHub/$repo
   CURRENT=$(git remote get-url origin)
   if [[ "$CURRENT" == https* ]]; then

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -782,7 +782,10 @@ The SSH-remote-switch covers every repo on the operator's machine (template
 <!-- bootstrap-loop-list-end -->
 
 ```bash
-for repo in $(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' REVIEW_POLICY.md | grep '^- ' | sed 's/^- //'); do
+# Explicit path to mergepath/REVIEW_POLICY.md — pwd may not be the
+# mergepath repo when the operator runs this (see #252 Codex P1).
+for repo in $(awk '/<!-- bootstrap-loop-list-start -->/,/<!-- bootstrap-loop-list-end -->/' \
+              ~/Documents/GitHub/mergepath/REVIEW_POLICY.md | grep '^- ' | sed 's/^- //'); do
   cd ~/Documents/GitHub/$repo
   CURRENT=$(git remote get-url origin)
   if [[ "$CURRENT" == https* ]]; then


### PR DESCRIPTION
Closes #238.

## Summary

Adds `<!-- bootstrap-loop-list-start -->` / `<!-- bootstrap-loop-list-end -->` anchor pairs around each documented cross-repo loop list in `DEPLOYMENT.md` and `REVIEW_POLICY.md`. The bootstrap wizard's `_cross_repo_loop_update` helper (shipped in #233 sub-B / commit e9c6a61) scans for these anchors and appends `- <new-repo>` above the closing anchor. Until now, the helper logged "manual action needed" and skipped — with anchors present, the wizard can keep the loop docs in sync automatically on every new-repo bootstrap.

## Files changed

- `DEPLOYMENT.md` — ONE anchored list at § 4 ("Clone and bootstrap all repos") is now consumed by all four downstream loops via `awk | grep | sed` extraction:
  - Clone-and-bootstrap loop (§ 4)
  - Verify env-file loop (§ 5) — previously a hand-curated 4-repo subset; now iterates the full 6, with the existing fallback `|| echo "(no env files expected)"` covering the 2 repos without `.env` files (swipewatch, nathanpaynedotcom)
  - Push-up-to-date / `--sync` loop (§ Returning to Your Main Machine)
  - Return-to-main / `--force` loop (same § )
- `REVIEW_POLICY.md` — ONE anchored list at § Switching all repos to SSH remotes, covering the broader template + consumers + docs set (8 repos including `mergepath` and `docs`).

## Design notes

- One anchored list per file matches the wizard's `_append_repo_to_loop_doc` semantic: it inserts above the FIRST `<!-- bootstrap-loop-list-end -->` it finds. With one list per file, all downstream loops in that file pick up the new repo automatically.
- The two files have different scopes:
  - `DEPLOYMENT.md` lists **consumer** repos (the bootstrap target set).
  - `REVIEW_POLICY.md` lists **all** repos on the operator's machine for the SSH-remote-switch (template + consumers + docs).
- The bash extraction (`awk '/start/,/end/' <file> | grep '^- ' | sed 's/^- //'`) is bash 3.2 portable and keeps each loop copy-pasteable for operators.

## Test plan

- [x] `bash tests/test_bootstrap_template_mirror.sh` — all 39 tests pass, including test 7 (no-anchor skip path via the synthetic FAKE_MP fixture, which has no `DEPLOYMENT.md` / `REVIEW_POLICY.md` so the live-doc anchors don't affect it).
- [x] All `scripts/ci/check_*` scripts pass.
- [x] Manual verification — `awk '/.../,/.../' <file> | grep '^- ' | sed 's/^- //'` extracts exactly the original repo list for each file:
  - `DEPLOYMENT.md`: `friends-and-family-billing`, `device-platform-reporting`, `device-source-of-truth`, `swipewatch`, `nathanpaynedotcom`, `overridebroadway` (matches pre-refactor)
  - `REVIEW_POLICY.md`: `mergepath`, `swipewatch`, `nathanpaynedotcom`, `device-platform-reporting`, `device-source-of-truth`, `overridebroadway`, `friends-and-family-billing`, `docs` (matches pre-refactor)
- [ ] Next bootstrap run against live mergepath — the wizard should successfully open the loop-doc PR instead of skipping with the "no anchor" warning.

## Authoring-Agent

`Authoring-Agent: claude`

## Self-Review

- **Correctness** — anchor pairs introduced around the existing repo lists. Bash extraction yields byte-identical repo lists to the original hardcoded enumerations (verified by direct comparison). Single anchored list per file matches the wizard's "insert above FIRST end-anchor" semantic so all downstream loops in a file stay in sync.
- **Regression risk** — low; pure doc refactor. The env-check loop now iterates over 2 extra repos (swipewatch + nathanpaynedotcom), but the existing `2>/dev/null || echo "(no env files expected)"` fallback handles them gracefully — operator-visible output gains 2 no-op lines, nothing breaks.
- **Style** — matches existing anchored-marker idioms used elsewhere in the repo; bash snippets remain copy-pasteable for operators.
- **Test coverage** — existing template-mirror test 7 covers the no-anchor-present skip path via the FAKE_MP fixture. The anchor-present insertion path is exercised manually here (parity check) and will be exercised end-to-end in the next bootstrap run.
- **Security/dependency hygiene** — no new attack surface; only Markdown comments + `awk` / `grep` / `sed` (all bash 3.2 portable).
