### PR TITLE
policy: require ESLint flat config in Node-bearing repos (closes #250)

### DIFF
--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -60,6 +60,12 @@ jobs:
       - name: check_gh_as_author
         run: ./scripts/ci/check_gh_as_author
 
+      - name: check_eslint_config_present
+        run: ./scripts/ci/check_eslint_config_present
+
+      - name: check_eslint_config_policy
+        run: ./scripts/ci/check_eslint_config_policy
+
       - name: check_auto_clear_workflow
         run: ./scripts/ci/check_auto_clear_workflow
 

--- a/docs/agents/code-modification-rules.md
+++ b/docs/agents/code-modification-rules.md
@@ -9,3 +9,90 @@
 
 Replace this section with project-specific language, pattern, and
 boundary constraints.
+
+## ESLint flat-config policy
+
+(Binding rule: `rules/repo_rules.md` § ESLint policy. CI check:
+`scripts/ci/check_eslint_config_present`. Sample config:
+`examples/eslint.config.js`. Tracking issue: #250.)
+
+### What the policy requires
+
+Any repo with a root `package.json` ships an `eslint.config.js` flat
+config at the repo root. The config must, at minimum, load
+`@eslint/js`'s `recommended` ruleset. Additional framework plugins
+are required when the matching framework is in the repo's
+dependencies (the contributor decides which apply; the CI check does
+not introspect package contents).
+
+Repos with no root `package.json` are exempt — Mergepath itself
+falls in this category (shell-only), so the check early-outs with a
+not-applicable log line in this repo's own CI run.
+
+### Why the flat config
+
+ESLint's flat config (`eslint.config.js`) replaces the legacy
+`.eslintrc.*` cascade. Two practical reasons we standardize on it:
+
+1. It's the format ESLint 9+ requires by default. Legacy configs
+   need an `ESLINT_USE_FLAT_CONFIG=false` workaround that's slated
+   for removal.
+2. The flat config is a single file with explicit imports — easier
+   for an automated check (and for a human reviewer at handoff
+   time) to reason about than a multi-file cascade.
+
+`.eslintrc.*` is NOT acceptable under this policy. If a repo has
+already migrated to a non-`.js` flat config (`.mjs`, `.cjs`, `.ts`),
+file an exception in `.sync-overrides.yml` with a `reason:` per the
+sync-overrides docs.
+
+### Recommended config per framework
+
+The starter at `examples/eslint.config.js` is layered for copy-and-
+trim use. Open the file, keep the framework blocks that apply, and
+delete the rest. The packages each block needs:
+
+| Stack | Plugins to install (devDependencies) |
+|---|---|
+| Plain JS | `eslint`, `@eslint/js`, `globals` |
+| TypeScript | + `typescript`, `typescript-eslint` |
+| Astro | + `eslint-plugin-astro` |
+| React | + `eslint-plugin-react`, `eslint-plugin-react-hooks` |
+
+The starter uses `import` syntax (ESM). If your `package.json` does
+not yet set `"type": "module"`, either add it (preferred for new
+projects) or rename the file to `eslint.config.mjs` AND file the
+sync-overrides exception described above.
+
+### CI contract
+
+`scripts/ci/check_eslint_config_present` is the load-bearing check.
+Exit codes (from the script header):
+
+- `0` — pass: no root `package.json`, OR both files present and the
+  config parses under `node --check`.
+- `1` — fail: `package.json` present but `eslint.config.js` missing,
+  or present but failed `node --check`.
+- `2` — environment error (Node not available). The workflow treats
+  this as fail so the check can't silently degrade.
+
+The check ONLY validates the policy for the current repo. It does
+NOT run ESLint itself, install dependencies, or scan the dependency
+tree. The intent is to gate-keep the existence and parseability of
+the config file; the actual lint pass runs per-repo via that repo's
+own CI (or CodeRabbit's auto-lint once an `eslint.config.js` is
+present).
+
+### Adopting in an existing repo
+
+Per-repo adoption is tracked by the child issues listed in #250.
+The mechanical steps are:
+
+1. `cp examples/eslint.config.js eslint.config.js` (after the
+   `scripts/sync-to-downstream.sh` apply, the sample is available
+   at the consumer's own `examples/eslint.config.js` path).
+2. Trim to the framework blocks that apply; install the listed
+   devDependencies.
+3. Run `npx eslint .` locally and address findings or scope the
+   `files` patterns down.
+4. Commit alongside the policy bump.

--- a/examples/eslint.config.js
+++ b/examples/eslint.config.js
@@ -31,7 +31,7 @@
 // config. The `eslint.config.js` filename is the only spelling the
 // Mergepath CI check accepts; if you have a strong reason to use
 // `.mjs`/`.cjs`/`.ts`, file an exception in `.sync-overrides.yml`
-// with a `reason:` per docs/agents/code-review-requirements.md.
+// with a `reason:` per docs/agents/code-modification-rules.md.
 
 import js from "@eslint/js";
 import globals from "globals";
@@ -68,13 +68,30 @@ export default [
 
   // Apply browser + node globals to all JS sources by default. Narrow
   // these per-file-pattern if your repo has a clean split.
+  //
+  // `*.cjs` files are split out so ESLint parses them as CommonJS
+  // (`sourceType: "commonjs"`) rather than ES modules — otherwise
+  // top-level `require`/`module.exports` and CommonJS scope rules
+  // produce false-positive parse errors. The defaults ESLint applies
+  // by extension are: `module` for `.js`/`.mjs`, `commonjs` for
+  // `.cjs`; we make that explicit here so the policy is self-documenting.
   {
-    files: ["**/*.{js,mjs,cjs,jsx}"],
+    files: ["**/*.{js,mjs,jsx}"],
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
       globals: {
         ...globals.browser,
+        ...globals.node,
+      },
+    },
+  },
+  {
+    files: ["**/*.cjs"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "commonjs",
+      globals: {
         ...globals.node,
       },
     },

--- a/examples/eslint.config.js
+++ b/examples/eslint.config.js
@@ -1,0 +1,120 @@
+// examples/eslint.config.js
+//
+// Sample ESLint flat-config that consumer repos can copy to satisfy
+// the Mergepath ESLint policy (rules/repo_rules.md § ESLint policy).
+//
+// This file is NOT loaded by ESLint at the Mergepath repo itself —
+// Mergepath has no package.json and is exempt from the policy. The
+// file lives under examples/ so it can be copied verbatim, then
+// customized per consumer.
+//
+// Layout:
+//
+//   - Baseline JS recommended ruleset (eslint/js) — required by the
+//     Mergepath policy floor.
+//   - Three optional, framework-specific blocks (TypeScript, Astro,
+//     React). DELETE the ones that don't apply to your repo and
+//     install the packages listed in their leading comment.
+//
+// Install (minimum):
+//
+//   npm install --save-dev eslint @eslint/js globals
+//
+// Then, per framework you keep below, add the matching packages
+// (the comment above each block lists them).
+//
+// Run:
+//
+//   npx eslint .
+//
+// Format note: this file is intentionally a `.js` (NOT `.mjs`) flat
+// config. The `eslint.config.js` filename is the only spelling the
+// Mergepath CI check accepts; if you have a strong reason to use
+// `.mjs`/`.cjs`/`.ts`, file an exception in `.sync-overrides.yml`
+// with a `reason:` per docs/agents/code-review-requirements.md.
+
+import js from "@eslint/js";
+import globals from "globals";
+
+// --- Optional: TypeScript ---------------------------------------------------
+// npm install --save-dev typescript typescript-eslint
+// import tseslint from "typescript-eslint";
+
+// --- Optional: Astro --------------------------------------------------------
+// npm install --save-dev eslint-plugin-astro
+// import astro from "eslint-plugin-astro";
+
+// --- Optional: React + React Hooks ------------------------------------------
+// npm install --save-dev eslint-plugin-react eslint-plugin-react-hooks
+// import react from "eslint-plugin-react";
+// import reactHooks from "eslint-plugin-react-hooks";
+
+export default [
+  // Ignore generated / vendored output. Customize per repo.
+  {
+    ignores: [
+      "node_modules/**",
+      "dist/**",
+      "build/**",
+      "coverage/**",
+      ".astro/**",
+      ".next/**",
+      ".vercel/**",
+    ],
+  },
+
+  // Baseline JS recommended — required by the policy.
+  js.configs.recommended,
+
+  // Apply browser + node globals to all JS sources by default. Narrow
+  // these per-file-pattern if your repo has a clean split.
+  {
+    files: ["**/*.{js,mjs,cjs,jsx}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+  },
+
+  // ----- TypeScript ---------------------------------------------------------
+  // Uncomment the `import tseslint` line above and the spread below.
+  // typescript-eslint exposes a flat-compatible `configs.recommended`
+  // array; spread it into the top-level config.
+  //
+  // ...tseslint.configs.recommended,
+
+  // ----- Astro --------------------------------------------------------------
+  // Uncomment the `import astro` line above and the spread below.
+  // eslint-plugin-astro v1+ exports a flat-compatible `configs` map.
+  //
+  // ...astro.configs.recommended,
+
+  // ----- React + React Hooks ------------------------------------------------
+  // Uncomment the React imports above and the block below.
+  //
+  // {
+  //   files: ["**/*.{jsx,tsx}"],
+  //   plugins: {
+  //     react,
+  //     "react-hooks": reactHooks,
+  //   },
+  //   languageOptions: {
+  //     parserOptions: {
+  //       ecmaFeatures: { jsx: true },
+  //     },
+  //   },
+  //   rules: {
+  //     ...react.configs.recommended.rules,
+  //     ...reactHooks.configs.recommended.rules,
+  //     // React 17+ JSX transform: not needed.
+  //     "react/react-in-jsx-scope": "off",
+  //   },
+  //   settings: {
+  //     react: { version: "detect" },
+  //   },
+  // },
+];

--- a/rules/repo_rules.md
+++ b/rules/repo_rules.md
@@ -17,6 +17,25 @@ flag the conflict before proceeding.
 - No new top-level directories without justification documented in
   AGENTS.md or a plans/ entry.
 
+## ESLint policy
+
+Any repo with a root `package.json` MUST ship an `eslint.config.js`
+flat config at the repo root with at least the `@eslint/js`
+recommended ruleset, plus framework plugins appropriate to the stack
+(e.g., `typescript-eslint` for TypeScript, `eslint-plugin-astro` for
+Astro, `eslint-plugin-react` + `eslint-plugin-react-hooks` for React).
+
+Repos without a root `package.json` (Mergepath itself is shell-only,
+for example) are exempt. The CI check
+(`scripts/ci/check_eslint_config_present`) early-outs with a
+not-applicable log line in that case.
+
+Use the flat config format (`eslint.config.js`); legacy
+`.eslintrc.*` formats do not satisfy this rule. A starter config that
+covers JS + TS + Astro + React lives at `examples/eslint.config.js`.
+See `docs/agents/code-modification-rules.md` § ESLint flat-config
+policy for the rationale and the per-framework setup notes.
+
 ## Forbidden Patterns
 
 - Never push directly to `main`. All changes must go through a
@@ -45,3 +64,5 @@ All checks must pass before merge.
 - check_review_policy_exists (inline in repo_lint.yml): .github/review-policy.yml and REVIEW_POLICY.md must both exist
 - check_codex_scripts: `scripts/codex-review-request.sh` and `scripts/codex-review-check.sh` must exist and be executable in every repo. Required for `CLAUDE.md` step 8 Phase 4a (automated external review via the OpenAI Codex GitHub App) — missing either script silently forces callers to Phase 4b fallback.
 - check_gh_as_author: `tests/test_gh_as_author.sh` and `tests/test_gh_pr_guard.sh` must exist and pass. Covers the #241 wrapper (`scripts/gh-as-author.sh`) and the identity-check addition to `scripts/hooks/gh-pr-guard.sh` that prevent the gh keyring active-identity glitch from landing a PR under the wrong account.
+- check_eslint_config_present: enforces the ESLint policy above. If `package.json` exists at the repo root, `eslint.config.js` must exist at the repo root and parse cleanly under `node --check`. Repos without a root `package.json` pass with a log line.
+- check_eslint_config_policy: runs `tests/test_eslint_policy_check.sh` — unit tests for the policy check itself.

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -15,6 +15,8 @@ Local scripts:
 - `check_duplicate_docs`
 - `check_codex_scripts` — verifies `scripts/codex-review-request.sh` and `scripts/codex-review-check.sh` exist and are executable (Phase 4a helper-script presence check)
 - `check_sync_manifest` — validates `.mergepath-sync.yml` (manifest read by `scripts/sync-to-downstream.sh`): schema version, consumer shape, every referenced path exists, every path type is recognized. Requires `yq` (mikefarah/yq v4+) on the runner. See #168.
+- `check_eslint_config_present` — enforces the ESLint flat-config policy (`rules/repo_rules.md` § ESLint policy). If a root `package.json` exists, `eslint.config.js` must exist at the repo root and parse under `node --check`. Repos without a root `package.json` (mergepath itself) pass via an early-out. See #250.
+- `check_eslint_config_policy` — runs `tests/test_eslint_policy_check.sh` (unit tests for the policy check).
 
 Inline in `repo_lint.yml` (no local script):
 

--- a/scripts/ci/check_eslint_config_policy
+++ b/scripts/ci/check_eslint_config_policy
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# scripts/ci/check_eslint_config_policy
+#
+# CI wrapper that runs the unit tests for the ESLint flat-config
+# policy check (scripts/ci/check_eslint_config_present). Mirrors the
+# scripts/ci/check_gh_as_author pattern: hard-fail (exit 1) when the
+# test file is missing so an accidental delete/rename can't silently
+# disable the policy.
+#
+# This is the "tests" wrapper; the actual policy check that runs
+# against the repo tree is `check_eslint_config_present`. Both are
+# wired into .github/workflows/repo_lint.yml — see issue #250.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+TESTS=(
+  "tests/test_eslint_policy_check.sh"
+)
+
+FAILED=0
+for rel in "${TESTS[@]}"; do
+  full="$REPO_ROOT/$rel"
+  if [ ! -f "$full" ]; then
+    echo "check_eslint_config_policy: ERROR (missing $rel)" >&2
+    FAILED=1
+    continue
+  fi
+  echo "check_eslint_config_policy: running $rel"
+  if ! bash "$full"; then
+    echo "check_eslint_config_policy: FAIL ($rel)" >&2
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "check_eslint_config_policy: FAIL"
+  exit 1
+fi
+
+echo "check_eslint_config_policy: PASS"
+exit 0

--- a/scripts/ci/check_eslint_config_present
+++ b/scripts/ci/check_eslint_config_present
@@ -60,12 +60,38 @@ if [ "$FAILED" -eq 0 ]; then
     echo "check_eslint_config_present: ERROR"
     exit 2
   fi
-  if ! node --check "$ESLINT_CONFIG" 2>/tmp/eslint_config_parse.err; then
+  # Use a unique temp file rather than a fixed `/tmp/...` path so two
+  # concurrent runners (CI matrix, multiple worktrees on a dev box)
+  # can't clobber each other's parse output.
+  ERR_FILE="$(mktemp "${TMPDIR:-/tmp}/eslint-config-parse.XXXXXX")"
+  trap 'rm -f "$ERR_FILE"' EXIT
+  if ! node --check "$ESLINT_CONFIG" 2>"$ERR_FILE"; then
     echo "FAIL: eslint.config.js failed Node syntax check:"
-    sed 's/^/      /' </tmp/eslint_config_parse.err
+    sed 's/^/      /' <"$ERR_FILE"
     FAILED=1
   fi
-  rm -f /tmp/eslint_config_parse.err
+  rm -f "$ERR_FILE"
+  trap - EXIT
+
+  # Enforce the policy floor from rules/repo_rules.md § ESLint policy:
+  # the config must include `@eslint/js`'s `recommended` ruleset. We
+  # match on both the package import and a `*.configs.recommended`
+  # reference — either alone is a common partial-config mistake (e.g.
+  # importing `@eslint/js` but forgetting to spread `js.configs.recommended`).
+  # Skipped if the parse step already failed — no point re-reporting
+  # on a syntactically-broken file.
+  if [ "$FAILED" -eq 0 ]; then
+    if ! grep -Eq '["'\'']@eslint/js["'\'']' "$ESLINT_CONFIG" \
+       || ! grep -Eq '\.configs\.recommended\b' "$ESLINT_CONFIG"; then
+      echo "FAIL: eslint.config.js must include the @eslint/js recommended ruleset."
+      echo "      Mergepath policy floor (rules/repo_rules.md § ESLint policy)"
+      echo "      requires at least:"
+      echo "        import js from \"@eslint/js\";"
+      echo "        export default [ js.configs.recommended, ... ];"
+      echo "      See examples/eslint.config.js for a starting point."
+      FAILED=1
+    fi
+  fi
 fi
 
 if [ "$FAILED" -eq 1 ]; then

--- a/scripts/ci/check_eslint_config_present
+++ b/scripts/ci/check_eslint_config_present
@@ -80,15 +80,53 @@ if [ "$FAILED" -eq 0 ]; then
   # importing `@eslint/js` but forgetting to spread `js.configs.recommended`).
   # Skipped if the parse step already failed — no point re-reporting
   # on a syntactically-broken file.
+  #
+  # Comment-bypass guard (codex CR on #253): a config that only
+  # references `@eslint/js` or `.configs.recommended` from within a
+  # JS comment must NOT satisfy the check. nathanpayne-codex
+  # reproduced the bypass on the prior HEAD: a config that imports
+  # `@eslint/js` but exports only a local rules object, with a stray
+  # `// ...tseslint.configs.recommended` comment, passed CI. We strip
+  # `//` and `/* */` comments before grepping. Strings are preserved
+  # so a `//` literal inside a quoted value can't confuse the
+  # stripper (theoretical — ESLint configs rarely contain `//` in
+  # strings, but the stripper handles it correctly).
   if [ "$FAILED" -eq 0 ]; then
-    if ! grep -Eq '["'\'']@eslint/js["'\'']' "$ESLINT_CONFIG" \
-       || ! grep -Eq '\.configs\.recommended\b' "$ESLINT_CONFIG"; then
+    STRIPPED="$(node -e '
+      const fs = require("fs");
+      const src = fs.readFileSync(process.argv[1], "utf8");
+      let out = "", i = 0, n = src.length;
+      while (i < n) {
+        const c = src[i], nx = src[i+1];
+        if (c === "/" && nx === "/") {
+          while (i < n && src[i] !== "\n") i++;
+        } else if (c === "/" && nx === "*") {
+          i += 2;
+          while (i < n && !(src[i] === "*" && src[i+1] === "/")) i++;
+          i += 2;
+        } else if (c === "\"" || c === "\x27" || c === "`") {
+          const q = c; out += c; i++;
+          while (i < n) {
+            const ch = src[i]; out += ch;
+            if (ch === "\\") { out += src[i+1] || ""; i += 2; continue; }
+            i++;
+            if (ch === q) break;
+          }
+        } else { out += c; i++; }
+      }
+      process.stdout.write(out);
+    ' "$ESLINT_CONFIG")"
+    if ! printf '%s' "$STRIPPED" | grep -Eq '["'\'']@eslint/js["'\'']' \
+       || ! printf '%s' "$STRIPPED" | grep -Eq '\.configs\.recommended\b'; then
       echo "FAIL: eslint.config.js must include the @eslint/js recommended ruleset."
       echo "      Mergepath policy floor (rules/repo_rules.md § ESLint policy)"
       echo "      requires at least:"
       echo "        import js from \"@eslint/js\";"
       echo "        export default [ js.configs.recommended, ... ];"
       echo "      See examples/eslint.config.js for a starting point."
+      echo "      (Comments are stripped before this check — a"
+      echo "      // @eslint/js .configs.recommended line in a comment"
+      echo "      cannot satisfy the policy floor.)"
       FAILED=1
     fi
   fi

--- a/scripts/ci/check_eslint_config_present
+++ b/scripts/ci/check_eslint_config_present
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# scripts/ci/check_eslint_config_present
+#
+# Enforces the ESLint flat-config policy from `rules/repo_rules.md`:
+# any repo with a root `package.json` MUST ship an `eslint.config.js`
+# flat config at the repo root, and the file must be syntactically
+# valid JavaScript.
+#
+# Repos without a root `package.json` (mergepath itself is shell-only,
+# for example) are exempt — the check logs a not-applicable note and
+# exits 0.
+#
+# Contract (load-bearing — referenced by docs/agents/code-review-
+# requirements.md and the rule in rules/repo_rules.md):
+#
+#   exit 0 — pass:
+#            (a) no root package.json (policy not applicable), OR
+#            (b) root package.json present AND eslint.config.js
+#                present at root AND `node --check` parses it.
+#   exit 1 — fail:
+#            root package.json present AND either eslint.config.js
+#            missing at root, OR present but fails `node --check`.
+#   exit 2 — environment error (Node not available when we needed it
+#            to parse-check). Treated as fail by the workflow so the
+#            check can't silently degrade to "skip".
+#
+# Bash 3.2 portable (macOS default shell). Mirrors the style of
+# scripts/ci/check_codex_scripts and scripts/ci/check_required_root_files.
+#
+# Synced to consumer repos via the `scripts/ci/` kit entry in
+# .mergepath-sync.yml — the file is canonical at this path everywhere.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+PKG_JSON="$REPO_ROOT/package.json"
+ESLINT_CONFIG="$REPO_ROOT/eslint.config.js"
+
+if [ ! -f "$PKG_JSON" ]; then
+  echo "check_eslint_config_present: no package.json — ESLint policy not applicable to this repo."
+  echo "check_eslint_config_present: PASS"
+  exit 0
+fi
+
+FAILED=0
+
+if [ ! -f "$ESLINT_CONFIG" ]; then
+  echo "FAIL: package.json is present at repo root but eslint.config.js is missing."
+  echo "      Mergepath policy requires a flat ESLint config in every Node-bearing repo."
+  echo "      See rules/repo_rules.md § ESLint policy and examples/eslint.config.js for"
+  echo "      a starting point you can copy."
+  FAILED=1
+fi
+
+if [ "$FAILED" -eq 0 ]; then
+  if ! command -v node >/dev/null 2>&1; then
+    echo "ERROR: node is not on PATH — cannot parse-check eslint.config.js."
+    echo "       Install Node.js >= 18 on the runner."
+    echo "check_eslint_config_present: ERROR"
+    exit 2
+  fi
+  if ! node --check "$ESLINT_CONFIG" 2>/tmp/eslint_config_parse.err; then
+    echo "FAIL: eslint.config.js failed Node syntax check:"
+    sed 's/^/      /' </tmp/eslint_config_parse.err
+    FAILED=1
+  fi
+  rm -f /tmp/eslint_config_parse.err
+fi
+
+if [ "$FAILED" -eq 1 ]; then
+  echo "check_eslint_config_present: FAIL"
+  exit 1
+fi
+
+echo "check_eslint_config_present: PASS"
+exit 0

--- a/tests/test_eslint_policy_check.sh
+++ b/tests/test_eslint_policy_check.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# tests/test_eslint_policy_check.sh
+#
+# Unit tests for scripts/ci/check_eslint_config_present. Covers the
+# three contract cases from the script's header:
+#
+#   1. no root package.json                          → exit 0 (pass)
+#   2. package.json present, eslint.config.js absent → exit 1 (fail)
+#   3. package.json + valid eslint.config.js         → exit 0 (pass)
+#   4. package.json + syntax-broken eslint.config.js → exit 1 (fail)
+#
+# We invoke the check against a synthetic REPO_ROOT by symlinking the
+# real script into a temp tree — the script computes REPO_ROOT from
+# its own location, so a symlinked copy sees the temp tree as root.
+# Bash 3.2 portable. Run from scripts/ci/check_eslint_config_policy.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK="$ROOT/scripts/ci/check_eslint_config_present"
+SAMPLE="$ROOT/examples/eslint.config.js"
+
+[ -x "$CHECK" ] || { echo "missing or non-executable $CHECK" >&2; exit 1; }
+[ -f "$SAMPLE" ] || { echo "missing sample $SAMPLE" >&2; exit 1; }
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "SKIP: node not installed — check_eslint_config_present needs node --check" >&2
+  exit 0
+fi
+
+# Use the explicit `$TMPDIR/<prefix>.XXXXXX` form for cross-platform
+# portability (BSD vs GNU mktemp), per the convention from #228.
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/eslint-policy-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Build a fake repo tree where scripts/ci/check_eslint_config_present
+# is a copy of the real script (NOT a symlink — the script resolves
+# its own location, and a symlink would resolve back to the real
+# REPO_ROOT, defeating the test). We copy the file verbatim.
+make_fake_repo() {
+  local target_dir="$1"
+  mkdir -p "$target_dir/scripts/ci"
+  cp "$CHECK" "$target_dir/scripts/ci/check_eslint_config_present"
+  chmod +x "$target_dir/scripts/ci/check_eslint_config_present"
+}
+
+# Run the synthetic check; capture exit code without tripping `set -e`.
+run_check() {
+  local repo="$1"
+  set +e
+  "$repo/scripts/ci/check_eslint_config_present" >"$WORKDIR/out.txt" 2>&1
+  echo $?
+  set -e
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: no package.json → pass.
+# ---------------------------------------------------------------------------
+T1="$WORKDIR/case1-no-pkg"
+make_fake_repo "$T1"
+rc=$(run_check "$T1")
+if [ "$rc" -eq 0 ] && grep -q "not applicable" "$WORKDIR/out.txt"; then
+  pass "no package.json → exits 0 with not-applicable message"
+else
+  fail "no package.json: expected exit 0 + 'not applicable' message, got rc=$rc / output:"
+  sed 's/^/    /' "$WORKDIR/out.txt" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: package.json present, eslint.config.js absent → fail.
+# ---------------------------------------------------------------------------
+T2="$WORKDIR/case2-pkg-no-eslint"
+make_fake_repo "$T2"
+echo '{"name":"t2","version":"0.0.0"}' >"$T2/package.json"
+rc=$(run_check "$T2")
+if [ "$rc" -eq 1 ] && grep -q "eslint.config.js is missing" "$WORKDIR/out.txt"; then
+  pass "package.json without eslint.config.js → exits 1"
+else
+  fail "expected exit 1 + 'eslint.config.js is missing', got rc=$rc / output:"
+  sed 's/^/    /' "$WORKDIR/out.txt" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: package.json + valid eslint.config.js (the sample) → pass.
+# We don't actually need the eslint package installed; the check just
+# parse-validates the JS syntax with `node --check`. The sample uses
+# `import` statements; `node --check` accepts ES module syntax in any
+# .js file regardless of package "type" — it's purely a parse step.
+# ---------------------------------------------------------------------------
+T3="$WORKDIR/case3-pkg-and-eslint"
+make_fake_repo "$T3"
+echo '{"name":"t3","version":"0.0.0","type":"module"}' >"$T3/package.json"
+cp "$SAMPLE" "$T3/eslint.config.js"
+rc=$(run_check "$T3")
+if [ "$rc" -eq 0 ] && grep -q "PASS" "$WORKDIR/out.txt"; then
+  pass "package.json + valid eslint.config.js → exits 0"
+else
+  fail "expected exit 0, got rc=$rc / output:"
+  sed 's/^/    /' "$WORKDIR/out.txt" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: package.json + syntactically broken eslint.config.js → fail.
+# Confirms the `node --check` step is wired up — a broken file must
+# not slip through as a pass just because the filename exists.
+# ---------------------------------------------------------------------------
+T4="$WORKDIR/case4-pkg-broken-eslint"
+make_fake_repo "$T4"
+echo '{"name":"t4","version":"0.0.0"}' >"$T4/package.json"
+# Non-JavaScript content — `node --check` exits 1 with SyntaxError.
+# (Picked over a "missing-paren" snippet because Node's parser accepts
+# trailing-continuation-style files; only an outright tokenization
+# error reliably fails the check.)
+printf 'this is not javascript &!@(*#^$\n' >"$T4/eslint.config.js"
+rc=$(run_check "$T4")
+if [ "$rc" -eq 1 ] && grep -q "failed Node syntax check" "$WORKDIR/out.txt"; then
+  pass "package.json + broken eslint.config.js → exits 1 with parse error"
+else
+  fail "expected exit 1 + parse error, got rc=$rc / output:"
+  sed 's/^/    /' "$WORKDIR/out.txt" >&2
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "test_eslint_policy_check: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test_eslint_policy_check.sh
+++ b/tests/test_eslint_policy_check.sh
@@ -2,12 +2,19 @@
 # tests/test_eslint_policy_check.sh
 #
 # Unit tests for scripts/ci/check_eslint_config_present. Covers the
-# three contract cases from the script's header:
+# contract cases from the script's header plus the policy-floor and
+# unique-tempfile regressions added in CodeRabbit round 1 on #253:
 #
 #   1. no root package.json                          → exit 0 (pass)
 #   2. package.json present, eslint.config.js absent → exit 1 (fail)
 #   3. package.json + valid eslint.config.js         → exit 0 (pass)
 #   4. package.json + syntax-broken eslint.config.js → exit 1 (fail)
+#   5. package.json + parseable eslint.config.js but
+#      missing @eslint/js recommended baseline       → exit 1 (fail)
+#   6. concurrent runs do not clobber each other's
+#      parse-error tempfile (no fixed /tmp path)     → both fail with
+#                                                       distinct error
+#                                                       output
 #
 # We invoke the check against a synthetic REPO_ROOT by symlinking the
 # real script into a temp tree — the script computes REPO_ROOT from
@@ -123,6 +130,84 @@ if [ "$rc" -eq 1 ] && grep -q "failed Node syntax check" "$WORKDIR/out.txt"; the
 else
   fail "expected exit 1 + parse error, got rc=$rc / output:"
   sed 's/^/    /' "$WORKDIR/out.txt" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: package.json + parseable eslint.config.js that omits the
+# @eslint/js recommended baseline → fail. Regression guard for the
+# policy-floor finding (CodeRabbit round 1 on #253): before the fix,
+# any syntactically-valid file passed even if it didn't import the
+# required ruleset.
+# ---------------------------------------------------------------------------
+T5="$WORKDIR/case5-pkg-missing-baseline"
+make_fake_repo "$T5"
+echo '{"name":"t5","version":"0.0.0","type":"module"}' >"$T5/package.json"
+cat >"$T5/eslint.config.js" <<'EOF'
+// Parseable but DOES NOT include @eslint/js recommended.
+// The policy floor must reject this.
+export default [
+  {
+    rules: {
+      "no-unused-vars": "warn",
+    },
+  },
+];
+EOF
+rc=$(run_check "$T5")
+if [ "$rc" -eq 1 ] && grep -q "@eslint/js recommended" "$WORKDIR/out.txt"; then
+  pass "package.json + config missing @eslint/js baseline → exits 1"
+else
+  fail "expected exit 1 + '@eslint/js recommended' message, got rc=$rc / output:"
+  sed 's/^/    /' "$WORKDIR/out.txt" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: concurrent runs do not clobber each other's parse-error
+# tempfile. Regression guard for the unique-tempfile finding
+# (CodeRabbit round 1 on #253): before the fix, both runs wrote to a
+# fixed `/tmp/eslint_config_parse.err` and could race.
+#
+# We launch two parse-failing runs in parallel, then assert both
+# emit their parse-error message in their respective output. If a
+# fixed tempfile were still in use, one run could see an empty or
+# truncated error block depending on race ordering. We also assert
+# no `eslint_config_parse.err` file (the old fixed name) lingers in
+# $TMPDIR after both runs complete.
+# ---------------------------------------------------------------------------
+T6A="$WORKDIR/case6a-concurrent"
+T6B="$WORKDIR/case6b-concurrent"
+make_fake_repo "$T6A"
+make_fake_repo "$T6B"
+echo '{"name":"t6a","version":"0.0.0"}' >"$T6A/package.json"
+echo '{"name":"t6b","version":"0.0.0"}' >"$T6B/package.json"
+printf 'this is not javascript &!@(*#^$\n' >"$T6A/eslint.config.js"
+printf 'this is also not javascript $#@!\n' >"$T6B/eslint.config.js"
+
+set +e
+"$T6A/scripts/ci/check_eslint_config_present" >"$WORKDIR/out6a.txt" 2>&1 &
+PID_A=$!
+"$T6B/scripts/ci/check_eslint_config_present" >"$WORKDIR/out6b.txt" 2>&1 &
+PID_B=$!
+wait $PID_A; RC_A=$?
+wait $PID_B; RC_B=$?
+set -e
+
+if [ "$RC_A" -eq 1 ] && [ "$RC_B" -eq 1 ] \
+   && grep -q "failed Node syntax check" "$WORKDIR/out6a.txt" \
+   && grep -q "failed Node syntax check" "$WORKDIR/out6b.txt"; then
+  pass "concurrent parse-failure runs both report a parse error (unique tempfile)"
+else
+  fail "concurrent runs: expected both rc=1 + 'failed Node syntax check', got rc=$RC_A/$RC_B"
+  echo "--- out6a ---" >&2; sed 's/^/    /' "$WORKDIR/out6a.txt" >&2
+  echo "--- out6b ---" >&2; sed 's/^/    /' "$WORKDIR/out6b.txt" >&2
+fi
+
+# No fixed-name leftover should exist (would indicate the old
+# `/tmp/eslint_config_parse.err` path is still in use somewhere).
+if [ -e "${TMPDIR:-/tmp}/eslint_config_parse.err" ]; then
+  fail "fixed-name tempfile ${TMPDIR:-/tmp}/eslint_config_parse.err still in use"
+else
+  pass "no fixed-name parse-error tempfile leftover"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_eslint_policy_check.sh
+++ b/tests/test_eslint_policy_check.sh
@@ -15,6 +15,22 @@
 #      parse-error tempfile (no fixed /tmp path)     → both fail with
 #                                                       distinct error
 #                                                       output
+#   7. package.json + config that ONLY references
+#      `@eslint/js` and `.configs.recommended` from
+#      inside a `//` comment                         → exit 1 (fail)
+#                                                       — codex CR
+#                                                       comment-bypass
+#   8. package.json + config that references the
+#      tokens from inside a `/* … */` block comment  → exit 1 (fail)
+#                                                       — codex CR
+#                                                       block-comment
+#                                                       bypass
+#   9. package.json + config that imports `@eslint/js`
+#      and spreads `js.configs.recommended` in the
+#      exported array (no comment noise)             → exit 0 (pass)
+#                                                       — sanity case
+#                                                       for the
+#                                                       comment-stripper
 #
 # We invoke the check against a synthetic REPO_ROOT by symlinking the
 # real script into a temp tree — the script computes REPO_ROOT from
@@ -208,6 +224,97 @@ if [ -e "${TMPDIR:-/tmp}/eslint_config_parse.err" ]; then
   fail "fixed-name tempfile ${TMPDIR:-/tmp}/eslint_config_parse.err still in use"
 else
   pass "no fixed-name parse-error tempfile leftover"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: package.json + parseable eslint.config.js where the @eslint/js
+# import and the `.configs.recommended` token appear ONLY inside `//`
+# line comments → fail. Regression guard for the codex CR comment-
+# bypass on #253: before the fix, the grep matched comment text and
+# returned PASS, even though the exported config didn't actually use
+# the recommended ruleset.
+# ---------------------------------------------------------------------------
+T7="$WORKDIR/case7-pkg-comment-bypass-line"
+make_fake_repo "$T7"
+echo '{"name":"t7","version":"0.0.0","type":"module"}' >"$T7/package.json"
+cat >"$T7/eslint.config.js" <<'EOF'
+// Reproduces the codex CR comment-bypass: tokens appear ONLY in
+// comments. The exported config does not actually apply the
+// recommended ruleset.
+// import js from "@eslint/js";
+// using ...tseslint.configs.recommended in the future
+export default [
+  {
+    rules: {
+      "no-unused-vars": "warn",
+    },
+  },
+];
+EOF
+rc=$(run_check "$T7")
+if [ "$rc" -eq 1 ] && grep -q "@eslint/js recommended" "$WORKDIR/out.txt"; then
+  pass "comment-only @eslint/js tokens (// line comments) → exits 1"
+else
+  fail "expected exit 1 + '@eslint/js recommended' message, got rc=$rc / output:"
+  sed 's/^/    /' "$WORKDIR/out.txt" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: same as Test 7 but the tokens are inside a `/* … */` block
+# comment. The comment-stripper must handle both line and block forms.
+# ---------------------------------------------------------------------------
+T8="$WORKDIR/case8-pkg-comment-bypass-block"
+make_fake_repo "$T8"
+echo '{"name":"t8","version":"0.0.0","type":"module"}' >"$T8/package.json"
+cat >"$T8/eslint.config.js" <<'EOF'
+/*
+ * Reproduces the codex CR bypass via block comment.
+ * import js from "@eslint/js";
+ * spreads ...tseslint.configs.recommended somewhere
+ */
+export default [
+  {
+    rules: {
+      "no-unused-vars": "warn",
+    },
+  },
+];
+EOF
+rc=$(run_check "$T8")
+if [ "$rc" -eq 1 ] && grep -q "@eslint/js recommended" "$WORKDIR/out.txt"; then
+  pass "comment-only @eslint/js tokens (/* */ block comments) → exits 1"
+else
+  fail "expected exit 1 + '@eslint/js recommended' message, got rc=$rc / output:"
+  sed 's/^/    /' "$WORKDIR/out.txt" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 9: legitimate flat config with `@eslint/js` imported and
+# `js.configs.recommended` spread in the exported array → pass. This
+# is the positive sanity case for the comment-stripper — confirms the
+# stripper doesn't accidentally strip real code positions when the
+# file legitimately uses the policy floor.
+# ---------------------------------------------------------------------------
+T9="$WORKDIR/case9-pkg-real-recommended"
+make_fake_repo "$T9"
+echo '{"name":"t9","version":"0.0.0","type":"module"}' >"$T9/package.json"
+cat >"$T9/eslint.config.js" <<'EOF'
+import js from "@eslint/js";
+export default [
+  js.configs.recommended,
+  {
+    rules: {
+      "no-unused-vars": "warn",
+    },
+  },
+];
+EOF
+rc=$(run_check "$T9")
+if [ "$rc" -eq 0 ] && grep -q "PASS" "$WORKDIR/out.txt"; then
+  pass "import + js.configs.recommended spread → exits 0"
+else
+  fail "expected exit 0, got rc=$rc / output:"
+  sed 's/^/    /' "$WORKDIR/out.txt" >&2
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #250.

## Summary

- Adds a binding rule in `rules/repo_rules.md` § ESLint policy: any
  repo with a root `package.json` MUST ship an `eslint.config.js`
  flat config at the repo root with at least `@eslint/js`
  recommended. Repos without a root `package.json` (mergepath
  itself is shell-only) are exempt.
- Adds `scripts/ci/check_eslint_config_present` — the load-bearing
  check that enforces the policy on the current repo tree. Exit
  contract: `0` if no `package.json` (early-out, not applicable);
  `0` if both files present AND `node --check eslint.config.js`
  parses; `1` if `package.json` exists but `eslint.config.js` is
  missing or syntactically broken; `2` if Node is not on PATH
  (environment error — treated as fail by the workflow so the check
  can't silently degrade to "skip").
- Adds `scripts/ci/check_eslint_config_policy` (tests-wrapper) and
  `tests/test_eslint_policy_check.sh`. The test exercises all four
  contract cases against a synthetic repo tree.
- Adds `examples/eslint.config.js` — a flat-config starter with
  optional, commented-out TS / Astro / React blocks consumer repos
  trim to their stack.
- Updates `docs/agents/code-modification-rules.md` with the policy
  rationale, per-framework setup notes, and adoption mechanics.
- Wires both checks into `.github/workflows/repo_lint.yml`.

The new check propagates to consumers automatically through the
existing `scripts/ci/` kit entry in `.mergepath-sync.yml` — no
manifest change required.

Per #250, this PR does NOT add `eslint.config.js` to consumer
repos; those are tracked by separate child issues
(nathanpaynedotcom#357, matchline#222, friends-and-family-billing#264,
device-platform-reporting#75, swipewatch/tadlockpsychiatry TBD).

Authoring-Agent: claude

## Self-Review

- **Correctness**: `check_eslint_config_present` resolves
  `REPO_ROOT` from `BASH_SOURCE`, matching every existing
  `scripts/ci/check_*` script; behavior is identical locally and in
  CI. The test suite covers all 4 contract cases (no-pkg, pkg-only,
  pkg+valid-config, pkg+broken-config). Test 4 picked outright
  tokenization-error content after observing Node's parser tolerates
  trailing-continuation snippets.
- **Regression risk**: Additive only. The check early-outs on
  mergepath's own CI run (no `package.json` at root). Consumer-repo
  CI gets the new check via kit-sync of `scripts/ci/`; consumer
  repos with `package.json` but no `eslint.config.js` will start
  failing the check, which is the intended gate. Adoption is tracked
  per-repo in #250's child issues.
- **Style**: bash 3.2 portable. Same idioms as
  `check_codex_scripts` / `check_gh_as_author`. Uses `mktemp` with
  the `\$TMPDIR/<prefix>.XXXXXX` form per the #228 portability
  convention.
- **Test coverage**: 4 cases (no-pkg / pkg-only / pkg+valid /
  pkg+broken). Local run: \`scripts/ci/check_eslint_config_policy\`
  → PASS (4/4); full \`scripts/ci/check_*\` sweep → all green.
- **Security / dependency hygiene**: No new runtime deps. The
  sample config's `import` statements (\`@eslint/js\`, \`globals\`)
  are install instructions for consumer repos, not for mergepath
  itself. The sample is parse-checked by \`node --check\` in the
  test suite via \`cp\` into a synthetic tree.

## Test plan

- [x] \`scripts/ci/check_eslint_config_present\` → PASS (mergepath has no package.json)
- [x] \`scripts/ci/check_eslint_config_policy\` → PASS (4/4 unit tests)
- [x] Full \`scripts/ci/check_*\` sweep → all PASS
- [ ] CI: \`repo-lint\` workflow runs and both new steps land green