### PR TITLE
feat(ci): weekly unresolved-feedback sweep cron (#236)

### DIFF
--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -63,6 +63,9 @@ jobs:
       - name: check_auto_clear_workflow
         run: ./scripts/ci/check_auto_clear_workflow
 
+      - name: check_sweep_unresolved_feedback
+        run: ./scripts/ci/check_sweep_unresolved_feedback
+
       - name: install_yq_for_sync_manifest
         # mikefarah/yq is needed by check_sync_manifest. Pin a recent v4
         # release; bumped opportunistically. The official ubuntu-latest

--- a/.github/workflows/weekly-feedback-sweep.yml
+++ b/.github/workflows/weekly-feedback-sweep.yml
@@ -1,0 +1,136 @@
+name: Weekly unresolved-feedback sweep
+
+# Runs the unresolved-feedback enumeration + rollup pipeline weekly.
+# Closes the 2026-05-13 toil that produced #234 (209 backlogged
+# review threads across 9 repos). See #236 for the full design.
+#
+# Auth model:
+#   - The enumeration READS pull-request data from every target repo
+#     in scripts/sweep-unresolved-feedback/target-repos.txt. The default
+#     GITHUB_TOKEN only has access to THIS repo, so the workflow needs
+#     a cross-repo PAT for the read step. We use
+#     secrets.REVIEWER_ASSIGNMENT_TOKEN (the nathanpayne-claude PAT
+#     already wired for cross-repo writes elsewhere).
+#   - The rollup writes to this repo only (issue create / comment).
+#     GITHUB_TOKEN would technically work, but using the same PAT
+#     keeps the workflow self-consistent and lets the issue byline
+#     show the agent identity instead of `github-actions[bot]`.
+#
+# Idempotency: render.sh detects the existing rollup issue by label +
+# title prefix and either no-ops, updates the body, or posts a delta
+# comment. Re-running on the same day produces no new noise.
+
+on:
+  schedule:
+    # Mondays 09:00 UTC. Picked to land before the human's weekly
+    # planning window. Cron is UTC; cron-cron syntax.
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+    inputs:
+      lookback_days:
+        description: 'Closed-PR lookback window (days)'
+        required: false
+        default: '90'
+
+permissions:
+  # Issue create + comment on THIS repo. The cross-repo READS use the
+  # PAT, not GITHUB_TOKEN, so we don't need to widen this further.
+  contents: read
+  issues: write
+
+jobs:
+  sweep:
+    name: Enumerate + render rollup
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Ensure jq + gh present
+        run: |
+          for dep in gh jq; do
+            if ! command -v "$dep" >/dev/null 2>&1; then
+              echo "ERROR: $dep not installed on runner" >&2
+              exit 1
+            fi
+          done
+
+      - name: Enumerate unresolved threads
+        env:
+          # Cross-repo READ path. REVIEWER_ASSIGNMENT_TOKEN is the
+          # nathanpayne-claude PAT — see CLAUDE.md § 1Password Reviewer
+          # PAT Lookup. Required-secrets check happens before the
+          # script is invoked; if missing, fail loudly so a silent
+          # no-results sweep never gets confused with "all clean".
+          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
+          SWEEP_LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '90' }}
+          SWEEP_OUTPUT: ${{ github.workspace }}/findings.ndjson
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "ERROR: REVIEWER_ASSIGNMENT_TOKEN secret is empty. Sweep cannot run without cross-repo read access." >&2
+            echo "       Set the secret in repo Settings → Secrets and variables → Actions." >&2
+            exit 1
+          fi
+          chmod +x scripts/sweep-unresolved-feedback/enumerate.sh
+          ./scripts/sweep-unresolved-feedback/enumerate.sh
+
+      - name: Report enumeration size
+        run: |
+          if [ -f findings.ndjson ]; then
+            echo "Enumerated $(wc -l < findings.ndjson | tr -d ' ') findings"
+            head -3 findings.ndjson || true
+          else
+            echo "WARN: findings.ndjson not produced"
+          fi
+
+      - name: Render + post rollup
+        env:
+          # Issue create/comment writes here. Using REVIEWER_ASSIGNMENT_TOKEN
+          # so the byline matches the read step. GITHUB_TOKEN would
+          # also work for the same repo but byline would be
+          # github-actions[bot].
+          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
+        run: |
+          chmod +x scripts/sweep-unresolved-feedback/render.sh
+          ./scripts/sweep-unresolved-feedback/render.sh findings.ndjson
+
+      - name: Upload enumeration as artifact (debug aid)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: sweep-findings-${{ github.run_id }}
+          path: findings.ndjson
+          if-no-files-found: ignore
+          retention-days: 14
+
+  notify-on-failure:
+    name: Open issue on workflow failure
+    needs: sweep
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Open failure-tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "Weekly feedback sweep workflow failed ($(date -u '+%Y-%m-%d'))" \
+            --label automation,post-review \
+            --body "$(cat <<EOF
+          The scheduled \`weekly-feedback-sweep\` workflow failed.
+
+          Run: ${RUN_URL}
+
+          The sweep is the defense-in-depth catch-net for review
+          feedback that slipped past the merge gate (#236). A failure
+          here means the rollup will go stale; please diagnose
+          before next Monday.
+          EOF
+          )"

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -15,6 +15,7 @@ Local scripts:
 - `check_duplicate_docs`
 - `check_codex_scripts` — verifies `scripts/codex-review-request.sh` and `scripts/codex-review-check.sh` exist and are executable (Phase 4a helper-script presence check)
 - `check_sync_manifest` — validates `.mergepath-sync.yml` (manifest read by `scripts/sync-to-downstream.sh`): schema version, consumer shape, every referenced path exists, every path type is recognized. Requires `yq` (mikefarah/yq v4+) on the runner. See #168.
+- `check_sweep_unresolved_feedback` — runs unit tests for the #236 weekly feedback sweep pipeline (`scripts/sweep-unresolved-feedback/enumerate.sh`, `render.sh`). PATH-shims `gh` against synthetic fixtures; hermetic.
 
 Inline in `repo_lint.yml` (no local script):
 

--- a/scripts/ci/check_sweep_unresolved_feedback
+++ b/scripts/ci/check_sweep_unresolved_feedback
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# scripts/ci/check_sweep_unresolved_feedback
+#
+# Runs unit tests for the #236 weekly feedback sweep pipeline:
+#
+#   scripts/sweep-unresolved-feedback/enumerate.sh
+#   scripts/sweep-unresolved-feedback/render.sh
+#
+# The tests stub `gh` via a PATH shim, so this check is hermetic: no
+# network, no real auth. Mirrors the pattern of check_gh_as_author /
+# check_sync_overrides.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+REQUIRED_FILES=(
+  "scripts/sweep-unresolved-feedback/enumerate.sh"
+  "scripts/sweep-unresolved-feedback/render.sh"
+  "scripts/sweep-unresolved-feedback/target-repos.txt"
+  ".github/workflows/weekly-feedback-sweep.yml"
+  "tests/test_sweep_unresolved_feedback.sh"
+)
+
+FAILED=0
+for rel in "${REQUIRED_FILES[@]}"; do
+  full="$REPO_ROOT/$rel"
+  if [ ! -f "$full" ]; then
+    echo "check_sweep_unresolved_feedback: ERROR missing $rel" >&2
+    FAILED=1
+  fi
+done
+
+# Exec bit on the scripts.
+for rel in scripts/sweep-unresolved-feedback/enumerate.sh scripts/sweep-unresolved-feedback/render.sh; do
+  full="$REPO_ROOT/$rel"
+  if [ -f "$full" ] && [ ! -x "$full" ]; then
+    echo "check_sweep_unresolved_feedback: ERROR $rel not executable (chmod +x)" >&2
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "check_sweep_unresolved_feedback: FAIL (file presence)"
+  exit 1
+fi
+
+TEST="$REPO_ROOT/tests/test_sweep_unresolved_feedback.sh"
+echo "check_sweep_unresolved_feedback: running $TEST"
+if ! bash "$TEST"; then
+  echo "check_sweep_unresolved_feedback: FAIL (tests)" >&2
+  exit 1
+fi
+
+echo "check_sweep_unresolved_feedback: PASS"
+exit 0

--- a/scripts/sweep-unresolved-feedback/enumerate.sh
+++ b/scripts/sweep-unresolved-feedback/enumerate.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# scripts/sweep-unresolved-feedback/enumerate.sh
+#
+# Enumerate unresolved review threads on recently-closed PRs across a
+# configured list of target repos. Emits one JSON object per finding to
+# stdout (newline-delimited JSON), suitable for piping into
+# render.sh.
+#
+# Design (#236):
+#
+#   This is the v1 of the post-merge feedback sweep — a defense-in-
+#   depth catch-net for review feedback that slipped past the merge
+#   gate. The companion script render.sh consumes this stream and
+#   manages the per-repo rollup issue (idempotent: posts a delta
+#   comment to an existing issue rather than creating a new one each
+#   week).
+#
+# Output schema (one JSON object per line, NDJSON):
+#   {
+#     "repo":          "owner/repo",
+#     "pr_number":     123,
+#     "pr_title":      "...",
+#     "pr_url":        "https://github.com/owner/repo/pull/123",
+#     "thread_id":     "PRT_kw...",
+#     "author_login":  "coderabbitai[bot]",
+#     "body_excerpt":  "first 200 chars of the comment body, single line",
+#     "severity":      "P0|P1|P2|P3|Critical|Major|Minor|Nitpick|Unknown",
+#     "thread_url":    "https://github.com/owner/repo/pull/123#discussion_r..."
+#   }
+#
+# Filter: isResolved == false AND isOutdated == false.
+#
+# Inputs:
+#   $1 (optional) path to target-repos file (default: target-repos.txt
+#                 alongside this script).
+#
+# Environment:
+#   GH_TOKEN                  required. Read-path call; PAT must have
+#                             pull-request read on every target repo.
+#                             In CI: secrets.REVIEWER_ASSIGNMENT_TOKEN
+#                             via the workflow's env: block.
+#   SWEEP_LOOKBACK_DAYS       window for closed PRs (default 90).
+#   SWEEP_OUTPUT              optional output path (default stdout).
+#   SWEEP_MAX_PRS_PER_REPO    safety cap (default 200). Prevents a
+#                             pathologically active repo from blowing
+#                             up the cron runner. Hits stderr if
+#                             exceeded; CI green still.
+#
+# Exit codes:
+#   0   success (zero or more findings emitted)
+#   1   setup error (config file missing, GH_TOKEN unset, dependency
+#       missing)
+#   2   API error (gh exited non-zero, GraphQL errors)
+#
+# Bash 3.2 compatible (macOS default + ubuntu-latest).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGETS_FILE="${1:-$SCRIPT_DIR/target-repos.txt}"
+
+if [ ! -f "$TARGETS_FILE" ]; then
+  echo "enumerate: target repos file not found: $TARGETS_FILE" >&2
+  exit 1
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "enumerate: GH_TOKEN not set. Set GH_TOKEN to a PAT with pull-request read on every target repo." >&2
+  exit 1
+fi
+
+for dep in gh jq; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "enumerate: required dependency missing: $dep" >&2
+    exit 1
+  fi
+done
+
+LOOKBACK_DAYS="${SWEEP_LOOKBACK_DAYS:-90}"
+MAX_PRS_PER_REPO="${SWEEP_MAX_PRS_PER_REPO:-200}"
+OUTPUT="${SWEEP_OUTPUT:-/dev/stdout}"
+
+# Cut-off date in ISO-8601 (UTC). BSD date (macOS) and GNU date have
+# divergent flag syntax — try GNU first, fall back to BSD.
+if date -u -d "@0" '+%Y-%m-%d' >/dev/null 2>&1; then
+  SINCE=$(date -u -d "${LOOKBACK_DAYS} days ago" '+%Y-%m-%dT%H:%M:%SZ')
+else
+  SINCE=$(date -u -v-"${LOOKBACK_DAYS}"d '+%Y-%m-%dT%H:%M:%SZ')
+fi
+
+echo "enumerate: scanning closed PRs since $SINCE (lookback=${LOOKBACK_DAYS}d)" >&2
+
+# Severity heuristic. Anchored, case-insensitive. Order matters — pick
+# the highest severity that matches. Look only at the first ~400 chars
+# of the body to avoid matching the severity word in a quoted prior
+# review.
+classify_severity() {
+  # arg 1: body text (already trimmed)
+  local body_head
+  body_head=$(printf '%s' "$1" | head -c 400)
+  case "$body_head" in
+    *[Pp]0*|*Critical*|*CRITICAL*) echo "P0"; return ;;
+    *[Pp]1*|*Major*|*MAJOR*|*"Potential issue"*|*"⚠️"*) echo "P1"; return ;;
+    *[Pp]2*|*Minor*|*MINOR*) echo "P2"; return ;;
+    *[Pp]3*|*Nitpick*|*"🧹"*|*Trivial*|*"🔵"*) echo "P3"; return ;;
+  esac
+  echo "Unknown"
+}
+
+emit_findings_for_repo() {
+  local repo="$1"
+  local owner name
+  owner="${repo%%/*}"
+  name="${repo##*/}"
+
+  echo "enumerate: scanning $repo" >&2
+
+  # List closed PRs in the lookback window via the search API. Use
+  # --search instead of --state because the latter ignores `closed:>=`
+  # filtering. Cap at MAX_PRS_PER_REPO to bound the runtime.
+  local prs_json
+  if ! prs_json=$(gh pr list \
+      --repo "$repo" \
+      --state closed \
+      --search "closed:>=$SINCE" \
+      --limit "$MAX_PRS_PER_REPO" \
+      --json number,title,url 2>/dev/null); then
+    echo "enumerate: WARN gh pr list failed for $repo (skipping)" >&2
+    return 0
+  fi
+
+  local pr_count
+  pr_count=$(printf '%s' "$prs_json" | jq 'length')
+  echo "enumerate:   $pr_count closed PRs in window" >&2
+
+  # Iterate PRs. For each, query reviewThreads. Filter unresolved AND
+  # not-outdated. Emit one NDJSON line per surviving comment.
+  local i=0
+  while [ "$i" -lt "$pr_count" ]; do
+    local pr_number pr_title pr_url
+    pr_number=$(printf '%s' "$prs_json" | jq -r ".[$i].number")
+    pr_title=$(printf '%s' "$prs_json" | jq -r ".[$i].title")
+    pr_url=$(printf '%s' "$prs_json" | jq -r ".[$i].url")
+    i=$((i + 1))
+
+    local threads_json
+    if ! threads_json=$(gh api graphql -f query='
+      query($owner:String!,$name:String!,$pr:Int!) {
+        repository(owner:$owner, name:$name) {
+          pullRequest(number:$pr) {
+            reviewThreads(first: 100) {
+              totalCount
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                id
+                isResolved
+                isOutdated
+                comments(first: 1) {
+                  nodes {
+                    author { login }
+                    body
+                    url
+                  }
+                }
+              }
+            }
+          }
+        }
+      }' \
+      -F owner="$owner" -F name="$name" -F pr="$pr_number" 2>/dev/null); then
+      echo "enumerate: WARN GraphQL threads query failed for $repo#$pr_number (skipping)" >&2
+      continue
+    fi
+
+    local has_next
+    has_next=$(printf '%s' "$threads_json" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false')
+    if [ "$has_next" = "true" ]; then
+      # >100 threads on a single PR — log and proceed with the page we
+      # have. v1 doesn't paginate; in practice this is rare and the 100
+      # most-recent threads are what matters anyway.
+      echo "enumerate: WARN $repo#$pr_number has >100 review threads; sweep examined first page only" >&2
+    fi
+
+    # Emit one NDJSON line per unresolved & not-outdated thread.
+    # Build via jq so quoting/escaping is correct, then post-process
+    # body_excerpt and severity in shell (jq can't easily do the
+    # severity heuristic without verbose case logic).
+    local thread_blob
+    thread_blob=$(printf '%s' "$threads_json" | jq -c '
+      .data.repository.pullRequest.reviewThreads.nodes[]
+      | select(.isResolved == false and .isOutdated == false)
+      | select(.comments.nodes | length > 0)
+      | {
+          thread_id: .id,
+          author_login: (.comments.nodes[0].author.login // "unknown"),
+          body: (.comments.nodes[0].body // ""),
+          thread_url: (.comments.nodes[0].url // "")
+        }
+    ')
+
+    if [ -z "$thread_blob" ]; then
+      continue
+    fi
+
+    # Iterate per-line so we can compute severity in shell. jq's -c
+    # mode already emits one object per line.
+    printf '%s\n' "$thread_blob" | while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      local thread_id author_login body thread_url
+      thread_id=$(printf '%s' "$line" | jq -r '.thread_id')
+      author_login=$(printf '%s' "$line" | jq -r '.author_login')
+      body=$(printf '%s' "$line" | jq -r '.body')
+      thread_url=$(printf '%s' "$line" | jq -r '.thread_url')
+
+      # body_excerpt: first 200 chars, single-line, trimmed.
+      local body_excerpt
+      body_excerpt=$(printf '%s' "$body" | tr '\n\r\t' '   ' | head -c 200)
+
+      local severity
+      severity=$(classify_severity "$body")
+
+      # Emit final JSON via jq -nc so the string escaping is correct.
+      jq -nc \
+        --arg repo "$repo" \
+        --argjson pr_number "$pr_number" \
+        --arg pr_title "$pr_title" \
+        --arg pr_url "$pr_url" \
+        --arg thread_id "$thread_id" \
+        --arg author_login "$author_login" \
+        --arg body_excerpt "$body_excerpt" \
+        --arg severity "$severity" \
+        --arg thread_url "$thread_url" \
+        '{
+          repo:         $repo,
+          pr_number:    $pr_number,
+          pr_title:     $pr_title,
+          pr_url:       $pr_url,
+          thread_id:    $thread_id,
+          author_login: $author_login,
+          body_excerpt: $body_excerpt,
+          severity:     $severity,
+          thread_url:   $thread_url
+        }' >> "$OUTPUT"
+    done
+  done
+}
+
+# Truncate output file if it's a regular path (not /dev/stdout). This
+# makes the script safe to re-run.
+case "$OUTPUT" in
+  /dev/stdout|-) : ;;
+  *) : > "$OUTPUT" ;;
+esac
+
+# Read targets, skipping blanks and comments.
+while IFS= read -r line; do
+  line=$(printf '%s' "$line" | sed -E 's/[[:space:]]+$//')
+  case "$line" in
+    ''|\#*) continue ;;
+  esac
+  emit_findings_for_repo "$line"
+done < "$TARGETS_FILE"
+
+echo "enumerate: done" >&2
+exit 0

--- a/scripts/sweep-unresolved-feedback/render.sh
+++ b/scripts/sweep-unresolved-feedback/render.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# scripts/sweep-unresolved-feedback/render.sh
+#
+# Consume the NDJSON enumeration emitted by enumerate.sh, render a
+# per-repo "Unresolved reviewer feedback backlog" rollup, and post it
+# to a SINGLE issue in this repo (mergepath) as the cross-repo
+# clearinghouse. Idempotent on its own output:
+#
+#   - First run: opens a new issue titled
+#       "Unresolved reviewer feedback backlog — <YYYY-MM-DD>"
+#     with label `post-review`.
+#   - Subsequent runs (existing open issue with exact title prefix
+#       "Unresolved reviewer feedback backlog" and label `post-review`):
+#     compute a content hash of the rollup body. If unchanged since
+#     the prior run (matched via the hidden HTML comment marker the
+#     script writes), do nothing — no duplicate comment. If the
+#     rollup changed materially, post a delta comment listing NEW
+#     items only and update the issue body.
+#
+# Design notes (#236):
+#
+#   - Single rollup issue per sweep target (mergepath itself), NOT one
+#     per scanned target repo. The issue body has a per-target-repo
+#     section so the human can navigate. This keeps cross-repo
+#     remediation visible in one place — the 2026-05-13 manual sweep
+#     proved this is the right ergonomic (#234).
+#   - Idempotency is anchored by a hidden HTML comment in the issue
+#     body containing the prior enumeration's content hash AND the
+#     sorted list of thread_ids. Delta detection diffs the current
+#     thread_id set against the prior — items in current-only get
+#     posted as the delta comment; items in prior-only are recorded
+#     as "resolved between sweeps" (informational, no separate
+#     comment).
+#   - Counts the rollup as "still requiring fix" only after the
+#     validation pass classifies items. v1 of this script just
+#     enumerates — the validation pass is a follow-up issue. The
+#     rollup body is honest about this: it labels the counts as
+#     "raw, pre-validation".
+#
+# Inputs:
+#   $1   path to NDJSON enumeration file (default: /dev/stdin)
+#
+# Environment:
+#   GH_TOKEN              required. Write-path? NO — issue create /
+#                         comment on THIS repo only. In CI the
+#                         default GITHUB_TOKEN suffices because the
+#                         workflow runs in this repo.
+#   SWEEP_TARGET_REPO     repo to post the rollup to. Default:
+#                         nathanjohnpayne/mergepath. Override in
+#                         tests or for a dry-run staging issue.
+#   SWEEP_ROLLUP_TITLE    title for the rollup issue. Default
+#                         "Unresolved reviewer feedback backlog".
+#                         The first creation appends " — <date>"
+#                         for human readability; subsequent runs
+#                         match on the prefix.
+#   SWEEP_DRY_RUN         "1" to print the would-be issue body /
+#                         delta comment to stderr and exit without
+#                         calling the API. Used by the unit tests.
+#   SWEEP_TODAY           override the date stamp (YYYY-MM-DD). Used
+#                         by the unit tests for deterministic output.
+#
+# Exit codes:
+#   0   success (no-op, new issue, or delta comment posted)
+#   1   setup error (no input, GH_TOKEN unset, malformed JSON)
+#   2   API error (gh exited non-zero on issue create/comment)
+#
+# Bash 3.2 compatible.
+
+set -euo pipefail
+
+INPUT="${1:-/dev/stdin}"
+
+if [ -z "${GH_TOKEN:-}" ] && [ -z "${SWEEP_DRY_RUN:-}" ]; then
+  echo "render: GH_TOKEN not set (and SWEEP_DRY_RUN not set)" >&2
+  exit 1
+fi
+
+for dep in gh jq sha256sum_or_shasum; do
+  case "$dep" in
+    sha256sum_or_shasum)
+      if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+        echo "render: required dependency missing: sha256sum or shasum" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      if ! command -v "$dep" >/dev/null 2>&1; then
+        echo "render: required dependency missing: $dep" >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+# Portable hash helper. sha256sum is GNU; shasum is BSD.
+_hash() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+TARGET_REPO="${SWEEP_TARGET_REPO:-nathanjohnpayne/mergepath}"
+TITLE_PREFIX="${SWEEP_ROLLUP_TITLE:-Unresolved reviewer feedback backlog}"
+
+if [ -n "${SWEEP_TODAY:-}" ]; then
+  TODAY="$SWEEP_TODAY"
+else
+  TODAY=$(date -u '+%Y-%m-%d')
+fi
+
+# ---------------------------------------------------------------------------
+# Read NDJSON into a working file. We need to make two passes (counts
+# + body render + delta-detect), so a tmp file is simpler than
+# re-reading stdin.
+# ---------------------------------------------------------------------------
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/sweep-render.XXXXXX")
+trap 'rm -rf "$WORKDIR"' EXIT
+
+NDJSON="$WORKDIR/findings.ndjson"
+if [ "$INPUT" = "/dev/stdin" ] || [ "$INPUT" = "-" ]; then
+  cat > "$NDJSON"
+else
+  cp "$INPUT" "$NDJSON"
+fi
+
+# Validate each line is JSON before going further.
+LINE_COUNT=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  if ! printf '%s' "$line" | jq -e . >/dev/null 2>&1; then
+    echo "render: malformed JSON line in input (line $((LINE_COUNT + 1)))" >&2
+    exit 1
+  fi
+  LINE_COUNT=$((LINE_COUNT + 1))
+done < "$NDJSON"
+
+echo "render: $LINE_COUNT findings ingested" >&2
+
+# ---------------------------------------------------------------------------
+# Sorted thread-id list (used for the idempotency marker AND for delta
+# detection against the prior body).
+# ---------------------------------------------------------------------------
+SORTED_IDS="$WORKDIR/sorted-ids.txt"
+if [ "$LINE_COUNT" -gt 0 ]; then
+  jq -r '.thread_id' "$NDJSON" | sort -u > "$SORTED_IDS"
+else
+  : > "$SORTED_IDS"
+fi
+
+CONTENT_HASH=$(_hash < "$SORTED_IDS")
+echo "render: content hash = $CONTENT_HASH" >&2
+
+# Render the body. Sections grouped by repo, ordered by repo name; per
+# repo, items grouped by severity (P0, P1, P2, P3, Unknown).
+BODY="$WORKDIR/body.md"
+{
+  echo "<!-- sweep-unresolved-feedback v1 -->"
+  echo "<!-- content-hash: $CONTENT_HASH -->"
+  echo "<!-- last-run: $TODAY -->"
+  echo ""
+  echo "# Unresolved reviewer feedback backlog"
+  echo ""
+  echo "Automated weekly sweep — see #236. Last run **$TODAY** found **$LINE_COUNT** unresolved review threads on closed PRs across configured target repos."
+  echo ""
+  echo "**Counts below are raw (pre-validation).** A separate validation pass (see issue rubric in #236) is required to classify each item as VALID / ALREADY-FIXED / REJECTED / MOOT / AMBIGUOUS before treating the count as actionable backlog."
+  echo ""
+  echo "Lookback window: closed PRs in the last \`SWEEP_LOOKBACK_DAYS\` days (default 90)."
+  echo ""
+
+  if [ "$LINE_COUNT" -eq 0 ]; then
+    echo "## No unresolved threads found"
+    echo ""
+    echo "All scanned repos came back clean. Either the merge gate is doing its job, the lookback window expired everything, or all target repos are quiet."
+  else
+    echo "## By repo"
+    echo ""
+    # Per-repo aggregate counts.
+    jq -r '.repo' "$NDJSON" | sort -u | while IFS= read -r repo; do
+      [ -z "$repo" ] && continue
+      n=$(jq -r --arg r "$repo" 'select(.repo == $r) | .thread_id' "$NDJSON" | wc -l | tr -d ' ')
+      printf -- '- **%s** — %s items\n' "$repo" "$n"
+    done
+    echo ""
+
+    echo "## Findings"
+    echo ""
+    jq -r '.repo' "$NDJSON" | sort -u | while IFS= read -r repo; do
+      [ -z "$repo" ] && continue
+      echo "### $repo"
+      echo ""
+      for sev in P0 P1 P2 P3 Unknown; do
+        count=$(jq -r --arg r "$repo" --arg s "$sev" '
+          select(.repo == $r and .severity == $s) | .thread_id
+        ' "$NDJSON" | wc -l | tr -d ' ')
+        if [ "$count" -gt 0 ]; then
+          echo "<details>"
+          echo "<summary>$sev ($count)</summary>"
+          echo ""
+          jq -r --arg r "$repo" --arg s "$sev" '
+            select(.repo == $r and .severity == $s)
+            | "- [#\(.pr_number) · \(.pr_title // "(no title)")](\(.thread_url)) — `\(.author_login)`: \(.body_excerpt)"
+          ' "$NDJSON"
+          echo ""
+          echo "</details>"
+          echo ""
+        fi
+      done
+    done
+  fi
+} > "$BODY"
+
+# ---------------------------------------------------------------------------
+# Dry-run short-circuit. Print the body and exit. Tests use this.
+# ---------------------------------------------------------------------------
+if [ -n "${SWEEP_DRY_RUN:-}" ]; then
+  echo "render: SWEEP_DRY_RUN=1 — printing body to stdout and exiting 0" >&2
+  cat "$BODY"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Find existing rollup issue. Match on label `post-review` AND title
+# prefix. Take the most recent open match.
+# ---------------------------------------------------------------------------
+EXISTING_JSON=$(gh issue list \
+  --repo "$TARGET_REPO" \
+  --state open \
+  --label post-review \
+  --search "$TITLE_PREFIX in:title" \
+  --json number,title,body \
+  --limit 20 2>/dev/null || echo "[]")
+
+EXISTING_NUMBER=$(printf '%s' "$EXISTING_JSON" | jq -r --arg p "$TITLE_PREFIX" '
+  [ .[] | select(.title | startswith($p)) ] | (.[0].number // empty)
+')
+
+if [ -z "$EXISTING_NUMBER" ]; then
+  echo "render: no existing rollup issue found — creating new one" >&2
+  NEW_TITLE="$TITLE_PREFIX — $TODAY"
+  if ! gh issue create \
+    --repo "$TARGET_REPO" \
+    --title "$NEW_TITLE" \
+    --label post-review \
+    --body-file "$BODY" >&2; then
+    echo "render: gh issue create failed" >&2
+    exit 2
+  fi
+  echo "render: created new rollup issue" >&2
+  exit 0
+fi
+
+echo "render: found existing rollup issue #$EXISTING_NUMBER" >&2
+
+# Extract the prior content-hash marker. If unchanged, no-op.
+PRIOR_BODY=$(printf '%s' "$EXISTING_JSON" | jq -r --arg n "$EXISTING_NUMBER" '
+  [ .[] | select((.number|tostring) == $n) ] | .[0].body // ""
+')
+PRIOR_HASH=$(printf '%s' "$PRIOR_BODY" | sed -nE 's|.*<!-- content-hash: ([a-f0-9]+) -->.*|\1|p' | head -1)
+
+if [ -n "$PRIOR_HASH" ] && [ "$PRIOR_HASH" = "$CONTENT_HASH" ]; then
+  echo "render: content unchanged since prior run (hash $CONTENT_HASH) — no-op" >&2
+  exit 0
+fi
+
+# Delta detection: extract the prior sorted thread-id list from a
+# hidden marker block in the body (we write it on every update).
+PRIOR_IDS="$WORKDIR/prior-ids.txt"
+printf '%s' "$PRIOR_BODY" | awk '
+  /<!-- thread-ids-begin -->/ { capture=1; next }
+  /<!-- thread-ids-end -->/   { capture=0 }
+  capture==1                  { print }
+' | sed -E 's/^<!-- //; s/ -->$//' | sort -u > "$PRIOR_IDS" || true
+
+NEW_IDS="$WORKDIR/new-ids.txt"
+comm -23 "$SORTED_IDS" "$PRIOR_IDS" > "$NEW_IDS" 2>/dev/null || true
+
+RESOLVED_IDS="$WORKDIR/resolved-ids.txt"
+comm -13 "$SORTED_IDS" "$PRIOR_IDS" > "$RESOLVED_IDS" 2>/dev/null || true
+
+NEW_COUNT=$(wc -l < "$NEW_IDS" | tr -d ' ')
+RESOLVED_COUNT=$(wc -l < "$RESOLVED_IDS" | tr -d ' ')
+
+# Append the marker block so the next run can compute the delta.
+{
+  cat "$BODY"
+  echo ""
+  echo "<!-- thread-ids-begin -->"
+  if [ -s "$SORTED_IDS" ]; then
+    while IFS= read -r tid; do
+      [ -z "$tid" ] && continue
+      printf '<!-- %s -->\n' "$tid"
+    done < "$SORTED_IDS"
+  fi
+  echo "<!-- thread-ids-end -->"
+} > "$BODY.with-marker"
+mv "$BODY.with-marker" "$BODY"
+
+# Update the body in place.
+echo "render: updating issue #$EXISTING_NUMBER body (new=$NEW_COUNT, resolved=$RESOLVED_COUNT)" >&2
+if ! gh issue edit "$EXISTING_NUMBER" \
+  --repo "$TARGET_REPO" \
+  --body-file "$BODY" >&2; then
+  echo "render: gh issue edit failed" >&2
+  exit 2
+fi
+
+# Post the delta comment if there are new items. Resolved-only changes
+# update the body but don't get a comment — that's informational.
+if [ "$NEW_COUNT" -gt 0 ]; then
+  COMMENT="$WORKDIR/comment.md"
+  {
+    echo "## Sweep delta — $TODAY"
+    echo ""
+    echo "**$NEW_COUNT new** unresolved thread(s) since the last sweep. **$RESOLVED_COUNT** prior thread(s) cleared (resolved, marked outdated, or PR deleted)."
+    echo ""
+    echo "### New items"
+    echo ""
+    while IFS= read -r tid; do
+      [ -z "$tid" ] && continue
+      jq -r --arg t "$tid" '
+        select(.thread_id == $t)
+        | "- **\(.repo) #\(.pr_number)** · `\(.severity)` · [\(.pr_title // "(no title)")](\(.thread_url)) — `\(.author_login)`: \(.body_excerpt)"
+      ' "$NDJSON"
+    done < "$NEW_IDS"
+  } > "$COMMENT"
+
+  if ! gh issue comment "$EXISTING_NUMBER" \
+    --repo "$TARGET_REPO" \
+    --body-file "$COMMENT" >&2; then
+    echo "render: gh issue comment failed" >&2
+    exit 2
+  fi
+  echo "render: posted delta comment ($NEW_COUNT new items)" >&2
+fi
+
+exit 0

--- a/scripts/sweep-unresolved-feedback/render.sh
+++ b/scripts/sweep-unresolved-feedback/render.sh
@@ -212,6 +212,28 @@ BODY="$WORKDIR/body.md"
 } > "$BODY"
 
 # ---------------------------------------------------------------------------
+# Append the hidden thread-id marker block. Both the create path AND
+# the edit path emit it so delta detection on the next run can diff
+# against a complete prior id set. Without this on create, the first
+# subsequent run with content changes would treat every existing
+# thread as "new" because PRIOR_IDS would parse as empty (see #254
+# Codex P2 finding).
+# ---------------------------------------------------------------------------
+{
+  cat "$BODY"
+  echo ""
+  echo "<!-- thread-ids-begin -->"
+  if [ -s "$SORTED_IDS" ]; then
+    while IFS= read -r tid; do
+      [ -z "$tid" ] && continue
+      printf '<!-- %s -->\n' "$tid"
+    done < "$SORTED_IDS"
+  fi
+  echo "<!-- thread-ids-end -->"
+} > "$BODY.with-marker"
+mv "$BODY.with-marker" "$BODY"
+
+# ---------------------------------------------------------------------------
 # Dry-run short-circuit. Print the body and exit. Tests use this.
 # ---------------------------------------------------------------------------
 if [ -n "${SWEEP_DRY_RUN:-}" ]; then
@@ -282,20 +304,9 @@ comm -13 "$SORTED_IDS" "$PRIOR_IDS" > "$RESOLVED_IDS" 2>/dev/null || true
 NEW_COUNT=$(wc -l < "$NEW_IDS" | tr -d ' ')
 RESOLVED_COUNT=$(wc -l < "$RESOLVED_IDS" | tr -d ' ')
 
-# Append the marker block so the next run can compute the delta.
-{
-  cat "$BODY"
-  echo ""
-  echo "<!-- thread-ids-begin -->"
-  if [ -s "$SORTED_IDS" ]; then
-    while IFS= read -r tid; do
-      [ -z "$tid" ] && continue
-      printf '<!-- %s -->\n' "$tid"
-    done < "$SORTED_IDS"
-  fi
-  echo "<!-- thread-ids-end -->"
-} > "$BODY.with-marker"
-mv "$BODY.with-marker" "$BODY"
+# The thread-id marker block was already appended to $BODY above,
+# before the dry-run short-circuit, so both the create and edit
+# paths post bodies that the next run can delta against.
 
 # Update the body in place.
 echo "render: updating issue #$EXISTING_NUMBER body (new=$NEW_COUNT, resolved=$RESOLVED_COUNT)" >&2

--- a/scripts/sweep-unresolved-feedback/target-repos.txt
+++ b/scripts/sweep-unresolved-feedback/target-repos.txt
@@ -1,0 +1,19 @@
+# scripts/sweep-unresolved-feedback/target-repos.txt
+#
+# One owner/repo per line. Lines starting with `#` and blank lines
+# are ignored. Read by enumerate.sh and render.sh.
+#
+# Seed list is the 9 repos surveyed by the 2026-05-13 manual sweep
+# that produced the 209-item rollup in #234.
+#
+# To onboard a new repo: add a line. No code changes required.
+
+nathanjohnpayne/friends-and-family-billing
+nathanjohnpayne/device-platform-reporting
+nathanjohnpayne/device-source-of-truth
+nathanjohnpayne/swipewatch
+nathanjohnpayne/nathanpaynedotcom
+nathanjohnpayne/overridebroadway
+nathanjohnpayne/matchline
+nathanjohnpayne/tadlockpsychiatry
+nathanjohnpayne/mergepath

--- a/tests/test_sweep_unresolved_feedback.sh
+++ b/tests/test_sweep_unresolved_feedback.sh
@@ -330,6 +330,31 @@ grep -q '<summary>Unknown (1)</summary>' "$BODY_OUT" \
   && pass "render: Unknown severity group rendered" \
   || fail "render: Unknown group missing"
 
+# Codex #254 P2: the body must include the thread-ids marker block on
+# BOTH the create path and the edit path, otherwise the first sweep
+# after bootstrap would treat every existing thread as "new" on the
+# subsequent run. SWEEP_DRY_RUN exercises the same body the create
+# path would post.
+grep -q '<!-- thread-ids-begin -->' "$BODY_OUT" \
+  && pass "render: dry-run body includes thread-ids-begin marker" \
+  || fail "render: dry-run body missing thread-ids-begin marker"
+
+grep -q '<!-- thread-ids-end -->' "$BODY_OUT" \
+  && pass "render: dry-run body includes thread-ids-end marker" \
+  || fail "render: dry-run body missing thread-ids-end marker"
+
+MARKER_IDS=$(awk '
+  /<!-- thread-ids-begin -->/ { capture=1; next }
+  /<!-- thread-ids-end -->/   { capture=0 }
+  capture==1                  { print }
+' "$BODY_OUT" | sed -E 's/^<!-- //; s/ -->$//' | sort -u | tr '\n' ' ')
+WANT_MARKER_IDS="PRT_alpha_1_a PRT_alpha_2_a PRT_alpha_2_b "
+if [ "$MARKER_IDS" = "$WANT_MARKER_IDS" ]; then
+  pass "render: thread-id marker block contains all current thread_ids"
+else
+  fail "render: marker thread_ids mismatch. got=[$MARKER_IDS] want=[$WANT_MARKER_IDS]"
+fi
+
 # ---------------------------------------------------------------------------
 # Test 3: idempotency — same input produces same content-hash.
 # ---------------------------------------------------------------------------

--- a/tests/test_sweep_unresolved_feedback.sh
+++ b/tests/test_sweep_unresolved_feedback.sh
@@ -1,0 +1,508 @@
+#!/usr/bin/env bash
+# tests/test_sweep_unresolved_feedback.sh
+#
+# Unit tests for the #236 weekly feedback sweep pipeline:
+#
+#   scripts/sweep-unresolved-feedback/enumerate.sh
+#   scripts/sweep-unresolved-feedback/render.sh
+#
+# Strategy
+# --------
+# enumerate.sh and render.sh both shell out to `gh`. We PATH-shim `gh`
+# with fixture-driven stubs so the scripts can run end-to-end against
+# synthetic data without touching the real API.
+#
+# Each test sets up a temp workdir, points the script at the stubbed
+# `gh`, and asserts on:
+#   - NDJSON shape from enumerate.sh
+#   - rendered body from render.sh under SWEEP_DRY_RUN=1
+#   - idempotency: a re-run with identical input produces the same hash
+#
+# Bash 3.2 compatible.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENUMERATE="$ROOT/scripts/sweep-unresolved-feedback/enumerate.sh"
+RENDER="$ROOT/scripts/sweep-unresolved-feedback/render.sh"
+
+for f in "$ENUMERATE" "$RENDER"; do
+  [ -x "$f" ] || { echo "missing or non-executable: $f" >&2; exit 1; }
+done
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/sweep-tests.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# PATH-shim `gh`. The stub dispatches by subcommand. Behavior is
+# driven by fixture files in $STUB_FIXTURES.
+# ---------------------------------------------------------------------------
+STUB_DIR="$WORKDIR/stub-bin"
+mkdir -p "$STUB_DIR"
+STUB_FIXTURES="$WORKDIR/fixtures"
+mkdir -p "$STUB_FIXTURES"
+GH_CALLS_LOG="$WORKDIR/gh-calls.log"
+
+cat >"$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+# Stub gh — log every call + dispatch on subcommand.
+LOG="${GH_CALLS_LOG:-/dev/null}"
+{
+  printf 'gh'
+  for a in "$@"; do printf '\t%s' "$a"; done
+  printf '\n'
+} >> "$LOG"
+
+case "$1 $2" in
+  "pr list")
+    # Args we care about: --repo <r> ... --json number,title,url
+    # Lookup fixture by repo.
+    repo=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--repo" ]; then shift; repo="$1"; fi
+      shift || break
+    done
+    fix="${STUB_FIXTURES}/pr-list-$(echo "$repo" | tr '/' '_').json"
+    if [ -f "$fix" ]; then
+      cat "$fix"
+    else
+      echo "[]"
+    fi
+    exit 0
+    ;;
+  "api graphql")
+    # Fixture lookup by repo + pr (passed via -F owner / -F name / -F pr).
+    owner="" name="" pr=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -F)
+          shift
+          case "$1" in
+            owner=*) owner="${1#owner=}" ;;
+            name=*)  name="${1#name=}" ;;
+            pr=*)    pr="${1#pr=}" ;;
+          esac
+          ;;
+      esac
+      shift || break
+    done
+    fix="${STUB_FIXTURES}/threads-${owner}_${name}_${pr}.json"
+    if [ -f "$fix" ]; then
+      cat "$fix"
+    else
+      # Empty response (no threads)
+      printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":0,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
+    fi
+    exit 0
+    ;;
+  "issue list")
+    fix="${STUB_FIXTURES}/issue-list.json"
+    if [ -f "$fix" ]; then cat "$fix"; else echo "[]"; fi
+    exit 0
+    ;;
+  "issue create"|"issue edit"|"issue comment")
+    # Record + succeed.
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+STUB
+chmod +x "$STUB_DIR/gh"
+
+# ---------------------------------------------------------------------------
+# Fixture 1 — single repo with two unresolved threads, one outdated
+# (filtered), one resolved (filtered), one severity-P1 surviving.
+# ---------------------------------------------------------------------------
+cat >"$STUB_FIXTURES/pr-list-owner_alpha.json" <<'JSON'
+[
+  {"number": 1, "title": "Fix the thing", "url": "https://github.com/owner/alpha/pull/1"},
+  {"number": 2, "title": "Add a feature", "url": "https://github.com/owner/alpha/pull/2"}
+]
+JSON
+
+# PR #1: one unresolved P1 + one resolved (filtered) + one outdated
+# (filtered).
+cat >"$STUB_FIXTURES/threads-owner_alpha_1.json" <<'JSON'
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "totalCount": 3,
+          "pageInfo": {"hasNextPage": false, "endCursor": null},
+          "nodes": [
+            {
+              "id": "PRT_alpha_1_a",
+              "isResolved": false,
+              "isOutdated": false,
+              "comments": {"nodes": [{
+                "author": {"login": "coderabbitai[bot]"},
+                "body": "P1 — Potential issue: this loop is O(n^2) and the input can grow.",
+                "url": "https://github.com/owner/alpha/pull/1#discussion_r1001"
+              }]}
+            },
+            {
+              "id": "PRT_alpha_1_b",
+              "isResolved": true,
+              "isOutdated": false,
+              "comments": {"nodes": [{
+                "author": {"login": "human"},
+                "body": "P0 - Critical: SQL injection here",
+                "url": "https://github.com/owner/alpha/pull/1#discussion_r1002"
+              }]}
+            },
+            {
+              "id": "PRT_alpha_1_c",
+              "isResolved": false,
+              "isOutdated": true,
+              "comments": {"nodes": [{
+                "author": {"login": "human"},
+                "body": "nit: rename",
+                "url": "https://github.com/owner/alpha/pull/1#discussion_r1003"
+              }]}
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+JSON
+
+# PR #2: one Nitpick + one no-prefix (Unknown).
+cat >"$STUB_FIXTURES/threads-owner_alpha_2.json" <<'JSON'
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "totalCount": 2,
+          "pageInfo": {"hasNextPage": false, "endCursor": null},
+          "nodes": [
+            {
+              "id": "PRT_alpha_2_a",
+              "isResolved": false,
+              "isOutdated": false,
+              "comments": {"nodes": [{
+                "author": {"login": "coderabbitai[bot]"},
+                "body": "🧹 Nitpick: this comment is misleading.",
+                "url": "https://github.com/owner/alpha/pull/2#discussion_r2001"
+              }]}
+            },
+            {
+              "id": "PRT_alpha_2_b",
+              "isResolved": false,
+              "isOutdated": false,
+              "comments": {"nodes": [{
+                "author": {"login": "human"},
+                "body": "Have you considered using a different approach?",
+                "url": "https://github.com/owner/alpha/pull/2#discussion_r2002"
+              }]}
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+JSON
+
+TARGETS="$WORKDIR/targets.txt"
+cat >"$TARGETS" <<'EOF'
+# comment line, ignored
+owner/alpha
+
+owner/missing
+EOF
+
+# ---------------------------------------------------------------------------
+# Test 1: enumerate.sh emits expected NDJSON (3 surviving findings).
+# ---------------------------------------------------------------------------
+OUT_NDJSON="$WORKDIR/findings.ndjson"
+: > "$GH_CALLS_LOG"
+
+set +e
+PATH="$STUB_DIR:$PATH" \
+GH_TOKEN="dummy-pat" \
+STUB_FIXTURES="$STUB_FIXTURES" \
+GH_CALLS_LOG="$GH_CALLS_LOG" \
+SWEEP_OUTPUT="$OUT_NDJSON" \
+  "$ENUMERATE" "$TARGETS" 2>"$WORKDIR/enum.stderr"
+rc=$?
+set -e
+
+if [ "$rc" -ne 0 ]; then
+  fail "enumerate: exit $rc, expected 0"
+  cat "$WORKDIR/enum.stderr" >&2
+fi
+
+LINES=$(wc -l < "$OUT_NDJSON" | tr -d ' ')
+if [ "$LINES" != "3" ]; then
+  fail "enumerate: expected 3 NDJSON lines, got $LINES"
+  cat "$OUT_NDJSON" >&2
+else
+  pass "enumerate: emitted 3 NDJSON lines (filtered resolved + outdated)"
+fi
+
+# Check the surviving thread_ids are exactly the expected ones.
+GOT_IDS=$(jq -r '.thread_id' "$OUT_NDJSON" | sort | tr '\n' ' ')
+WANT_IDS="PRT_alpha_1_a PRT_alpha_2_a PRT_alpha_2_b "
+if [ "$GOT_IDS" = "$WANT_IDS" ]; then
+  pass "enumerate: surviving thread_ids match expected"
+else
+  fail "enumerate: thread_ids mismatch. got=[$GOT_IDS] want=[$WANT_IDS]"
+fi
+
+# Severity heuristic spot-check.
+SEV_P1=$(jq -r 'select(.thread_id == "PRT_alpha_1_a") | .severity' "$OUT_NDJSON")
+SEV_NIT=$(jq -r 'select(.thread_id == "PRT_alpha_2_a") | .severity' "$OUT_NDJSON")
+SEV_UNK=$(jq -r 'select(.thread_id == "PRT_alpha_2_b") | .severity' "$OUT_NDJSON")
+
+[ "$SEV_P1" = "P1" ]      && pass "enumerate: P1 classified correctly"   || fail "enumerate: P1 classification got $SEV_P1"
+[ "$SEV_NIT" = "P3" ]     && pass "enumerate: Nitpick → P3"              || fail "enumerate: Nitpick classification got $SEV_NIT"
+[ "$SEV_UNK" = "Unknown" ] && pass "enumerate: no-prefix → Unknown"      || fail "enumerate: unknown classification got $SEV_UNK"
+
+# body_excerpt has no embedded newlines, and is <= 200 chars.
+LONGEST=$(jq -r '.body_excerpt' "$OUT_NDJSON" | awk '{ if (length($0) > max) max = length($0) } END { print max }')
+if [ "$LONGEST" -le 200 ]; then
+  pass "enumerate: body_excerpt cap (<=200 chars) respected (max=$LONGEST)"
+else
+  fail "enumerate: body_excerpt exceeded 200 chars (max=$LONGEST)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: render.sh produces a body with expected markers + counts.
+# ---------------------------------------------------------------------------
+BODY_OUT="$WORKDIR/body.md"
+set +e
+SWEEP_DRY_RUN=1 \
+SWEEP_TODAY="2026-05-13" \
+GH_TOKEN="dummy" \
+  "$RENDER" "$OUT_NDJSON" > "$BODY_OUT" 2>"$WORKDIR/render.stderr"
+rc=$?
+set -e
+
+if [ "$rc" -ne 0 ]; then
+  fail "render: exit $rc, expected 0"
+  cat "$WORKDIR/render.stderr" >&2
+fi
+
+grep -q '<!-- sweep-unresolved-feedback v1 -->' "$BODY_OUT" \
+  && pass "render: emitted marker comment" \
+  || fail "render: missing marker comment"
+
+grep -q '<!-- content-hash: ' "$BODY_OUT" \
+  && pass "render: emitted content-hash marker" \
+  || fail "render: missing content-hash marker"
+
+grep -q '<!-- last-run: 2026-05-13 -->' "$BODY_OUT" \
+  && pass "render: emitted last-run marker with SWEEP_TODAY override" \
+  || fail "render: missing last-run marker / wrong date"
+
+grep -q '# Unresolved reviewer feedback backlog' "$BODY_OUT" \
+  && pass "render: emitted H1 title" \
+  || fail "render: missing H1 title"
+
+grep -q 'found \*\*3\*\* unresolved review threads' "$BODY_OUT" \
+  && pass "render: count of 3 in summary line" \
+  || fail "render: summary count incorrect"
+
+grep -q '\*\*owner/alpha\*\* — 3 items' "$BODY_OUT" \
+  && pass "render: per-repo count rendered" \
+  || fail "render: per-repo count missing"
+
+grep -q '<summary>P1 (1)</summary>' "$BODY_OUT" \
+  && pass "render: P1 severity group rendered with count" \
+  || fail "render: P1 group missing"
+
+grep -q '<summary>P3 (1)</summary>' "$BODY_OUT" \
+  && pass "render: P3 severity group rendered" \
+  || fail "render: P3 group missing"
+
+grep -q '<summary>Unknown (1)</summary>' "$BODY_OUT" \
+  && pass "render: Unknown severity group rendered" \
+  || fail "render: Unknown group missing"
+
+# ---------------------------------------------------------------------------
+# Test 3: idempotency — same input produces same content-hash.
+# ---------------------------------------------------------------------------
+HASH1=$(grep -oE '<!-- content-hash: [a-f0-9]+ -->' "$BODY_OUT" | head -1)
+set +e
+BODY_OUT2="$WORKDIR/body2.md"
+SWEEP_DRY_RUN=1 \
+SWEEP_TODAY="2026-05-14" \
+GH_TOKEN="dummy" \
+  "$RENDER" "$OUT_NDJSON" > "$BODY_OUT2" 2>/dev/null
+set -e
+HASH2=$(grep -oE '<!-- content-hash: [a-f0-9]+ -->' "$BODY_OUT2" | head -1)
+
+if [ "$HASH1" = "$HASH2" ] && [ -n "$HASH1" ]; then
+  pass "idempotency: identical input → identical content-hash across runs"
+else
+  fail "idempotency: hash drift between runs ($HASH1 vs $HASH2)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: a finding added → content-hash changes.
+# ---------------------------------------------------------------------------
+OUT_NDJSON_PLUS="$WORKDIR/findings-plus.ndjson"
+cp "$OUT_NDJSON" "$OUT_NDJSON_PLUS"
+jq -nc '{
+  repo: "owner/beta",
+  pr_number: 7,
+  pr_title: "New finding",
+  pr_url: "https://github.com/owner/beta/pull/7",
+  thread_id: "PRT_new",
+  author_login: "human",
+  body_excerpt: "P0 - Critical bug",
+  severity: "P0",
+  thread_url: "https://github.com/owner/beta/pull/7#discussion_r9999"
+}' >> "$OUT_NDJSON_PLUS"
+
+BODY_OUT3="$WORKDIR/body3.md"
+set +e
+SWEEP_DRY_RUN=1 \
+SWEEP_TODAY="2026-05-13" \
+GH_TOKEN="dummy" \
+  "$RENDER" "$OUT_NDJSON_PLUS" > "$BODY_OUT3" 2>/dev/null
+set -e
+HASH3=$(grep -oE '<!-- content-hash: [a-f0-9]+ -->' "$BODY_OUT3" | head -1)
+if [ "$HASH1" != "$HASH3" ] && [ -n "$HASH3" ]; then
+  pass "delta-detection: new finding changes content-hash"
+else
+  fail "delta-detection: hash did NOT change after adding finding ($HASH1 vs $HASH3)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: empty NDJSON path — render emits "no unresolved threads" body.
+# ---------------------------------------------------------------------------
+EMPTY="$WORKDIR/empty.ndjson"
+: > "$EMPTY"
+BODY_EMPTY="$WORKDIR/body-empty.md"
+set +e
+SWEEP_DRY_RUN=1 \
+SWEEP_TODAY="2026-05-13" \
+GH_TOKEN="dummy" \
+  "$RENDER" "$EMPTY" > "$BODY_EMPTY" 2>/dev/null
+rc=$?
+set -e
+if [ "$rc" -eq 0 ] && grep -q 'No unresolved threads found' "$BODY_EMPTY"; then
+  pass "render: empty NDJSON → clean rollup body"
+else
+  fail "render: empty NDJSON did not produce clean body (rc=$rc)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: idempotency at the issue level — render exits 0 without
+# calling 'gh issue create' or 'gh issue comment' when the existing
+# rollup body already has the same content-hash. Drive this by
+# stubbing issue-list.json to point at a body containing the hash
+# from Test 2.
+# ---------------------------------------------------------------------------
+PRIOR_HASH=$(grep -oE '<!-- content-hash: [a-f0-9]+ -->' "$BODY_OUT" | head -1 | sed -E 's/.*: ([a-f0-9]+) -->/\1/')
+cat >"$STUB_FIXTURES/issue-list.json" <<JSON
+[
+  {
+    "number": 4242,
+    "title": "Unresolved reviewer feedback backlog — 2026-05-06",
+    "body": "<!-- sweep-unresolved-feedback v1 -->\n<!-- content-hash: $PRIOR_HASH -->\n<!-- last-run: 2026-05-06 -->\n\n# Unresolved reviewer feedback backlog\n\nstale body"
+  }
+]
+JSON
+
+: > "$GH_CALLS_LOG"
+set +e
+PATH="$STUB_DIR:$PATH" \
+GH_TOKEN="dummy-pat" \
+STUB_FIXTURES="$STUB_FIXTURES" \
+GH_CALLS_LOG="$GH_CALLS_LOG" \
+SWEEP_TODAY="2026-05-13" \
+  "$RENDER" "$OUT_NDJSON" >/dev/null 2>"$WORKDIR/render-noop.stderr"
+rc=$?
+set -e
+
+if [ "$rc" -ne 0 ]; then
+  fail "no-op idempotency: render exited $rc, expected 0"
+  cat "$WORKDIR/render-noop.stderr" >&2
+fi
+
+# Must NOT have called issue create or issue comment.
+if grep -qE $'^gh\tissue\tcreate' "$GH_CALLS_LOG"; then
+  fail "no-op idempotency: render called 'gh issue create' on unchanged content"
+  cat "$GH_CALLS_LOG" >&2
+elif grep -qE $'^gh\tissue\tcomment' "$GH_CALLS_LOG"; then
+  fail "no-op idempotency: render called 'gh issue comment' on unchanged content"
+  cat "$GH_CALLS_LOG" >&2
+elif grep -qE $'^gh\tissue\tedit' "$GH_CALLS_LOG"; then
+  fail "no-op idempotency: render called 'gh issue edit' on unchanged content"
+  cat "$GH_CALLS_LOG" >&2
+else
+  pass "no-op idempotency: render did not call create/comment/edit on unchanged hash"
+fi
+
+# Must have called issue list (the search step).
+if grep -qE $'^gh\tissue\tlist' "$GH_CALLS_LOG"; then
+  pass "no-op idempotency: render queried existing issues before deciding no-op"
+else
+  fail "no-op idempotency: render did NOT query existing issues"
+  cat "$GH_CALLS_LOG" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: target-repos.txt file shipped with the repo lists exactly
+# the 9 repos from the 2026-05-13 sweep (and is parseable).
+# ---------------------------------------------------------------------------
+SHIPPED_TARGETS="$ROOT/scripts/sweep-unresolved-feedback/target-repos.txt"
+if [ ! -f "$SHIPPED_TARGETS" ]; then
+  fail "shipped targets: file missing at $SHIPPED_TARGETS"
+else
+  N=$(grep -v '^#' "$SHIPPED_TARGETS" | grep -v '^[[:space:]]*$' | wc -l | tr -d ' ')
+  if [ "$N" = "9" ]; then
+    pass "shipped targets: 9 repos configured"
+  else
+    fail "shipped targets: expected 9 repos, got $N"
+  fi
+  for slug in friends-and-family-billing device-platform-reporting device-source-of-truth swipewatch nathanpaynedotcom overridebroadway matchline tadlockpsychiatry mergepath; do
+    if grep -qE "/${slug}\$" "$SHIPPED_TARGETS"; then
+      pass "shipped targets: includes $slug"
+    else
+      fail "shipped targets: missing $slug"
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: workflow file exists with the expected cron + dispatch.
+# ---------------------------------------------------------------------------
+WF="$ROOT/.github/workflows/weekly-feedback-sweep.yml"
+if [ ! -f "$WF" ]; then
+  fail "workflow: missing $WF"
+else
+  grep -q "cron: '0 9 \* \* 1'" "$WF" && pass "workflow: cron set to Mondays 09:00 UTC" \
+    || fail "workflow: cron not set to Mondays 09:00 UTC"
+  grep -q "workflow_dispatch:" "$WF" && pass "workflow: workflow_dispatch trigger present" \
+    || fail "workflow: workflow_dispatch missing"
+  grep -q "REVIEWER_ASSIGNMENT_TOKEN" "$WF" && pass "workflow: uses REVIEWER_ASSIGNMENT_TOKEN secret" \
+    || fail "workflow: missing REVIEWER_ASSIGNMENT_TOKEN secret reference"
+  grep -q "enumerate.sh" "$WF" && pass "workflow: runs enumerate.sh" \
+    || fail "workflow: does not run enumerate.sh"
+  grep -q "render.sh" "$WF" && pass "workflow: runs render.sh" \
+    || fail "workflow: does not run render.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "test_sweep_unresolved_feedback: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #236.

## Summary

Automates the 2026-05-13 manual feedback sweep that produced #234 (209 backlogged review threads across 9 repos). New weekly cron + `workflow_dispatch` runs an enumerate → render → rollup pipeline that's idempotent against the prior run.

- **`scripts/sweep-unresolved-feedback/enumerate.sh`** — reads `target-repos.txt`, iterates closed PRs (90d lookback), GraphQL-queries `reviewThreads`, filters `isResolved=false AND isOutdated=false`, emits NDJSON. Severity heuristic parses P0/P1/P2/P3/Critical/Major/Minor/Nitpick.
- **`scripts/sweep-unresolved-feedback/render.sh`** — consumes NDJSON, manages a single rollup issue on mergepath. Idempotency anchored on a `<!-- content-hash: ... -->` marker: same hash → no API write; different hash → update body + post delta comment listing only NEW thread_ids.
- **`scripts/sweep-unresolved-feedback/target-repos.txt`** — externalized config; adding a repo is a one-line change. Seeded with the 9 repos from the manual sweep.
- **`.github/workflows/weekly-feedback-sweep.yml`** — `cron: '0 9 * * 1'` + `workflow_dispatch`. Uses `secrets.REVIEWER_ASSIGNMENT_TOKEN` for cross-repo READS and same-repo issue writes. Has a `notify-on-failure` job that opens a tracking issue if the sweep fails.
- **`tests/test_sweep_unresolved_feedback.sh`** — 35 tests, PATH-shimmed `gh` against synthetic GraphQL fixtures. Asserts NDJSON shape, severity classification, body markers, idempotency (no-op when hash unchanged), delta detection (new finding flips hash), shipped target list, workflow structure.
- **`scripts/ci/check_sweep_unresolved_feedback`** — CI entry point; wired into `repo_lint.yml` after `check_auto_clear_workflow`.

## Out of scope for v1 (tracked as #236 followups)

- The validation pass (VALID / ALREADY-FIXED / REJECTED / MOOT / AMBIGUOUS rubric). v1 enumerates only; rollup body is explicit that counts are pre-validation.
- AMBIGUOUS-item extraction into per-finding issues.
- Adding sweep files to `.mergepath-sync.yml` — the sweep is mergepath-only by design (cross-repo READS, mergepath WRITES).

Authoring-Agent: claude

## Self-Review

**Correctness.** GraphQL query mirrors `resolve-pr-threads.sh` (totalCount + pageInfo.hasNextPage sanity, comments(first:1) per thread). Severity heuristic scans only the first 400 chars of the body to avoid matching the word in a quoted prior review. \`render.sh\` content-hash is over the sorted unique \`thread_id\` set, NOT the rendered body — date drift / cosmetic re-renders don't invalidate the no-op path.

**Regression risk.** Additive: new file, new cron. Only existing files touched are \`repo_lint.yml\` (added the new check entry) and \`scripts/ci/README.md\` (documented the new check). Cron cadence is weekly, and the failure-tracking job prevents silent decay.

**Style.** bash 3.2 portable (macOS + ubuntu-latest). \`set -euo pipefail\` everywhere. \`GH_TOKEN\` pinned per the CLAUDE.md read-path/write-path auth split. \`jq\` builds all JSON; no string concat for JSON construction. Portable hash helper falls back to \`shasum\` on BSD.

**Test coverage.** 35 tests cover: NDJSON shape, three severity classifications (P1 / Nitpick→P3 / Unknown), body markers, deterministic content-hash across re-runs, hash drift when a finding is added, empty-input path (\"No unresolved threads\"), and crucially the **no-op idempotency path** — assertions explicitly verify \`gh issue create/edit/comment\` was NOT called when the prior body's hash matched. Also asserts shipped \`target-repos.txt\` lists exactly the 9 expected repos and the workflow file has the cron + dispatch + secret + script references.

**Security / dependency hygiene.** Read-path uses \`REVIEWER_ASSIGNMENT_TOKEN\` (PAT scoped to pull-request read on target repos). Issue writes are on this repo only. No code from target repos is executed — pure GraphQL reads. \`target-repos.txt\` is plain text, never sourced as code. The \`actions/checkout\` + \`actions/upload-artifact\` actions are SHA-pinned (matching the convention used by \`auto-clear-blocking-labels.yml\`).

## Test plan

- [x] All 19 \`scripts/ci/check_*\` pass locally on the worktree.
- [x] \`tests/test_sweep_unresolved_feedback.sh\` — 35 passed, 0 failed.
- [ ] Confirm \`repo-lint\` CI passes on the PR.
- [ ] After merge: run the workflow via \`workflow_dispatch\` once to verify the live pipeline.