### PR TITLE
fix(sync): RETURN trap aborts --sync-all under set -u (unbound var)

### DIFF
--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -965,9 +965,20 @@ sync_open_pr() {
   # Single-quote the trap body so $workspace is expanded when the trap
   # FIRES (RETURN), not when it's installed — a single quote in TMPDIR
   # or a consumer name can't then break the cleanup command or inject
-  # shell syntax. $workspace is function-local but still in scope at
-  # RETURN time.
-  trap 'rm -rf "$workspace"' RETURN
+  # shell syntax.
+  #
+  # `${workspace:-}` (not bare `$workspace`) is load-bearing: a bash
+  # RETURN trap set inside a function is NOT function-scoped — it stays
+  # installed and ALSO fires on the return of every PARENT function
+  # afterward (sync_all_one_consumer, run_sync_all, ...), where
+  # `workspace` (a `local` in THIS function) is out of scope. Under
+  # `set -u` a bare `$workspace` reference there aborts the whole
+  # script with "unbound variable" — observed live on the first
+  # --sync-all wave, right after the matchline PR was opened. The `:-`
+  # default makes the spurious parent-return firings a harmless
+  # `rm -rf ""` no-op, while the intended firing (this function's own
+  # RETURN, workspace still in scope) still cleans up correctly.
+  trap 'rm -rf "${workspace:-}"' RETURN
 
   printf "  ⤷ %s — cloning %s\n" "$consumer_name" "$consumer_repo"
   if ! gh repo clone "$consumer_repo" "$workspace/repo" -- --depth=10 --quiet >&2; then
@@ -1301,9 +1312,20 @@ sync_all_open_pr() {
   # Single-quote the trap body so $workspace is expanded when the trap
   # FIRES (RETURN), not when it's installed — a single quote in TMPDIR
   # or a consumer name can't then break the cleanup command or inject
-  # shell syntax. $workspace is function-local but still in scope at
-  # RETURN time.
-  trap 'rm -rf "$workspace"' RETURN
+  # shell syntax.
+  #
+  # `${workspace:-}` (not bare `$workspace`) is load-bearing: a bash
+  # RETURN trap set inside a function is NOT function-scoped — it stays
+  # installed and ALSO fires on the return of every PARENT function
+  # afterward (sync_all_one_consumer, run_sync_all, ...), where
+  # `workspace` (a `local` in THIS function) is out of scope. Under
+  # `set -u` a bare `$workspace` reference there aborts the whole
+  # script with "unbound variable" — observed live on the first
+  # --sync-all wave, right after the matchline PR was opened. The `:-`
+  # default makes the spurious parent-return firings a harmless
+  # `rm -rf ""` no-op, while the intended firing (this function's own
+  # RETURN, workspace still in scope) still cleans up correctly.
+  trap 'rm -rf "${workspace:-}"' RETURN
 
   printf "  ⤷ %s — cloning %s\n" "$consumer_name" "$consumer_repo"
   if ! gh repo clone "$consumer_repo" "$workspace/repo" -- --depth=10 --quiet >&2; then

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -610,6 +610,20 @@ awk '
   in_fn && /gh pr close/ { print "FAIL: sync_one_consumer should not call gh pr close — recreate is deferred to sync_open_pr"; exit 1 }
 ' "$SCRIPT" || fail "sync_one_consumer carries an inline gh pr close — recreate must be deferred to sync_open_pr"
 
+# RETURN-trap unbound-variable guard. A bash `trap ... RETURN` set
+# inside a function is NOT function-scoped: it stays installed and
+# fires again on every PARENT function's return, where the function-
+# local `workspace` is out of scope. Under `set -u` a bare
+# `"$workspace"` reference there aborts the whole script with
+# "unbound variable" (observed live on the first --sync-all wave,
+# right after the matchline PR was opened). The trap body MUST use
+# the `${workspace:-}` default form so the spurious parent-return
+# firings are a harmless `rm -rf ""` no-op.
+grep -q 'trap .rm -rf "\$workspace". RETURN' "$SCRIPT" \
+  && fail "RETURN trap uses bare \$workspace — must be \${workspace:-} (unbound-variable abort under set -u; see --sync-all wave regression)"
+[ "$(grep -c 'trap .rm -rf "${workspace:-}". RETURN' "$SCRIPT")" -eq 2 ] \
+  || fail "expected exactly 2 RETURN traps using the \${workspace:-} safe form (sync_open_pr + sync_all_open_pr)"
+
 # ---------------------------------------------------------------------------
 # --sync-all mode (#168 Layer 3 steady-state reconcile).
 #


### PR DESCRIPTION
## Summary

Live regression caught on the **first `--sync-all` wave**: the script aborted with `line 1617: workspace: unbound variable` immediately after the matchline consumer PR was opened — only 1 of 8 consumers processed before the crash.

**Root cause.** A bash `trap ... RETURN` set inside a function is **not function-scoped**. It stays installed after the setting function returns and fires *again* on every parent function's return (`sync_all_one_consumer`, `run_sync_all`, …). `workspace` is a `local` in `sync_open_pr` / `sync_all_open_pr`, so on those spurious parent-return firings it is out of scope — and under `set -euo pipefail` a bare `"$workspace"` reference there aborts the whole script.

The bug was **latent** under the original `trap "rm -rf '$workspace'"` form (path baked in at install time → spurious firings were a harmless `rm -rf '/gone/path'`). #261's CodeRabbit-driven switch to the lazily-expanded `trap 'rm -rf "$workspace"'` form is what exposed it as a fatal abort.

**Fix.** `${workspace:-}` default form in the trap body — applied to both `sync_open_pr` and `sync_all_open_pr`. The intended firing (the function's own RETURN, `workspace` in scope) still cleans up correctly; the spurious parent-return firings become a harmless `rm -rf ""` no-op.

## Test plan

- [x] `bash tests/test_sync_to_downstream.sh` — PASS (incl. new RETURN-trap source-grep guard)
- [x] `bash scripts/ci/check_sync_manifest` — PASS
- [x] `bash -n scripts/sync-to-downstream.sh` — clean
- [x] New regression guard: source-grep asserts no bare-`$workspace` RETURN trap and exactly 2 of the `${workspace:-}` safe form
- Post-merge: re-run `--sync-all` (idempotent — skips the already-open matchline PR #227, processes the remaining 7 consumers)

## Self-Review

- **Correctness**: the `${workspace:-}` default is the minimal correct fix for the RETURN-trap-scoping + `set -u` interaction. Verified the two trap sites are the only ones; both updated.
- **Regression risk**: very low. Two-character-class change inside a trap body; the intended cleanup behavior is unchanged. New source-grep test pins the safe form.
- **Style**: matches the file's existing heavily-commented trap/portability idiom.
- **Test coverage**: source-grep invariant added (the live crash is in the network-touching path and can't be unit-tested without real repos; the invariant guards the specific mistake).
- **Security/dependency hygiene**: no new attack surface; no dependency changes.

Authoring-Agent: claude