### PR TITLE
fix(hooks): unify gh-pr-guard.sh — restore mergeStateStatus merge guard

### DIFF
--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -14,7 +14,17 @@
 #      back in one bash process.
 #   2. gh pr merge --admin — blocks unless BREAK_GLASS_ADMIN=1
 #      (human must explicitly authorize in chat)
-#   3. gh pr merge (non-admin) — blocks when the target PR carries
+#   3. gh pr merge (any flavor) — blocks when the target PR's
+#      `mergeStateStatus` is BLOCKED / DIRTY / UNSTABLE / BEHIND /
+#      DRAFT (or any unrecognized future value) unless
+#      BREAK_GLASS_MERGE_STATE=1. This is the defense-in-depth
+#      layer behind GitHub branch protection — see #170 / #171 for
+#      the merge-gate gap this closes (a PR can otherwise be merged
+#      with failing CI because nothing in the merge path actually
+#      blocks). Originated downstream (matchline #170/#171) and is
+#      unified into the canonical hook here so propagation no longer
+#      clobbers the feature — see the propagation-wave retro.
+#   4. gh pr merge (non-admin) — blocks when the target PR carries
 #      the `needs-external-review` label unless CODEX_CLEARED=1
 #      (agent must have just run scripts/codex-review-check.sh
 #      successfully). This enforces REVIEW_POLICY.md § Phase 4a
@@ -300,6 +310,7 @@ done < "$TMP_TOKENS"
 # else starting with - is assumed boolean and skipped.
 INLINE_CODEX_CLEARED=""
 INLINE_BREAK_GLASS_ADMIN=""
+INLINE_BREAK_GLASS_MERGE_STATE=""
 GLOBAL_REPO=""
 PR_SUBCOMMAND=""
 PR_SUBCOMMAND_INDEX=-1    # index in TOKENS where the gh pr subcommand was found
@@ -405,6 +416,7 @@ for i in "${!TOKENS[@]}"; do
       if [ "$SEGMENT_HAS_COMMAND" -eq 1 ]; then
         INLINE_CODEX_CLEARED=""
         INLINE_BREAK_GLASS_ADMIN=""
+        INLINE_BREAK_GLASS_MERGE_STATE=""
       fi
       SEGMENT_HAS_COMMAND=0
       continue
@@ -426,6 +438,9 @@ for i in "${!TOKENS[@]}"; do
         ;;
       BREAK_GLASS_ADMIN=*)
         INLINE_BREAK_GLASS_ADMIN="${tok#BREAK_GLASS_ADMIN=}"
+        ;;
+      BREAK_GLASS_MERGE_STATE=*)
+        INLINE_BREAK_GLASS_MERGE_STATE="${tok#BREAK_GLASS_MERGE_STATE=}"
         ;;
     esac
   fi
@@ -514,6 +529,7 @@ done
 # must work.
 EFFECTIVE_CODEX_CLEARED="${CODEX_CLEARED:-${INLINE_CODEX_CLEARED:-}}"
 EFFECTIVE_BREAK_GLASS_ADMIN="${BREAK_GLASS_ADMIN:-${INLINE_BREAK_GLASS_ADMIN:-}}"
+EFFECTIVE_BREAK_GLASS_MERGE_STATE="${BREAK_GLASS_MERGE_STATE:-${INLINE_BREAK_GLASS_MERGE_STATE:-}}"
 
 # Not a pr create/merge command? Allow.
 if [ "$PR_SUBCOMMAND" != "create" ] && [ "$PR_SUBCOMMAND" != "merge" ]; then
@@ -684,19 +700,6 @@ for j in "${!TOKENS[@]}"; do
   fi
 done
 
-# --admin sub-guard: break-glass only. Now token-based: the walk
-# above sets ADMIN_REQUESTED=1 only when `--admin` appears as a
-# REAL flag of `merge`, not as a substring of another flag's value.
-if [ "$ADMIN_REQUESTED" -eq 1 ]; then
-  if [ "$EFFECTIVE_BREAK_GLASS_ADMIN" = "1" ]; then
-    echo "BREAK-GLASS: --admin merge authorized by human." >&2
-    exit 0
-  fi
-  echo "BLOCKED: --admin merge requires explicit human authorization." >&2
-  echo "Ask the human to confirm break-glass, then retry with BREAK_GLASS_ADMIN=1 (export or inline prefix)." >&2
-  exit 2
-fi
-
 # Subcommand-scoped REPO_ARG wins over global GLOBAL_REPO (mirrors
 # gh's typical "more specific flag wins" behavior). Fall back to
 # the global value only if the subcommand didn't specify one.
@@ -704,22 +707,150 @@ if [ -z "$REPO_ARG" ] && [ -n "$GLOBAL_REPO" ]; then
   REPO_ARG="$GLOBAL_REPO"
 fi
 
-# Fetch labels. `gh pr view` with no positional argument resolves
-# the PR from the current branch; with a positional argument it
-# accepts number / URL / branch forms identically to gh pr merge.
-GH_ARGS=(pr view --json labels --jq '[.labels[].name] | join(",")')
+# Fetch labels AND mergeStateStatus in a single API call. `gh pr
+# view` with no positional argument resolves the PR from the
+# current branch; with a positional argument it accepts number /
+# URL / branch forms identically to gh pr merge.
+#
+# Output format: a single line `MERGE_STATE|LABELS` (e.g.
+# `CLEAN|`, `BLOCKED|needs-external-review,bug`). The custom
+# `--jq` filter joins the two fields so the hook only has to
+# parse one string.
+#
+# #171 / #170 retrospective: pre-this-change the hook fetched
+# only labels and let `gh pr merge` run even when GitHub's
+# `mergeStateStatus` was BLOCKED (failing CI / active
+# CHANGES_REQUESTED). A PR could merge with red CI on every
+# matrix cell because nothing in the merge path actually
+# blocked. The new check is defense-in-depth behind branch
+# protection: even if branch protection is misconfigured or
+# disabled for an emergency hotfix, the hook will still refuse
+# to dispatch the merge.
+GH_JQ='"\(.mergeStateStatus)|\([.labels[].name] | join(","))"'
+GH_ARGS=(pr view --json labels,mergeStateStatus --jq "$GH_JQ")
 if [ -n "$PR_SELECTOR" ]; then
-  GH_ARGS=(pr view "$PR_SELECTOR" --json labels --jq '[.labels[].name] | join(",")')
+  GH_ARGS=(pr view "$PR_SELECTOR" --json labels,mergeStateStatus --jq "$GH_JQ")
 fi
 if [ -n "$REPO_ARG" ]; then
   GH_ARGS+=(--repo "$REPO_ARG")
 fi
 
-if ! LABELS=$(gh "${GH_ARGS[@]}" 2>&1); then
-  echo "BLOCKED: gh-pr-guard could not fetch PR labels to verify merge-gate clearance." >&2
-  echo "  error: $LABELS" >&2
+# Capture stdout and stderr separately. Codex P1 on matchline PR
+# #174 r2: a `2>&1` form would prepend ANY non-fatal stderr gh
+# emitted (update notifier, deprecation warnings, etc.) to the
+# stdout payload, then the `${GH_OUTPUT%%|*}` parameter expansion
+# would parse that noise as MERGE_STATE — corrupting a CLEAN PR
+# into the unrecognized-state block path. Routing stderr to a
+# tempfile keeps MERGE_STATE pure. We still surface stderr in the
+# error path for diagnostics.
+GH_STDERR=$(mktemp)
+# Re-declare the EXIT trap so $GH_STDERR is also cleaned up. The
+# trap call replaces (not appends) any prior trap; keep all three
+# tempfile names listed here so a future edit doesn't drop one.
+trap 'rm -f "$TMP_TOKENS" "$TMP_TOKENS_ERR" "$GH_STDERR"' EXIT
+if ! GH_OUTPUT=$(gh "${GH_ARGS[@]}" 2>"$GH_STDERR"); then
+  echo "BLOCKED: gh-pr-guard could not fetch PR metadata to verify merge-gate clearance." >&2
+  if [ -s "$GH_STDERR" ]; then
+    echo "  stderr: $(cat "$GH_STDERR")" >&2
+  fi
   echo "  command: gh ${GH_ARGS[*]}" >&2
-  echo "  Fix the underlying gh/auth issue and retry, or set BREAK_GLASS_ADMIN=1 + use --admin if this is a break-glass merge." >&2
+  # The metadata fetch is unconditional and runs BEFORE any break-
+  # glass override, so a BREAK_GLASS_* env var cannot bypass this
+  # failure — the only fix is restoring gh/auth connectivity. Once
+  # that's restored, BREAK_GLASS_MERGE_STATE / BREAK_GLASS_ADMIN
+  # are still available downstream if the PR's merge state or admin
+  # gate need to be overridden.
+  echo "  Fix the underlying gh/auth issue and retry." >&2
+  exit 2
+fi
+
+# Split on the first `|`. The mergeStateStatus enum values are
+# all uppercase ASCII identifiers without `|`, and the labels
+# are comma-joined (commas, not pipes), so the split is
+# unambiguous. Empty MERGE_STATE (e.g., transient API state)
+# falls into the `*` case below and fails closed.
+MERGE_STATE="${GH_OUTPUT%%|*}"
+LABELS="${GH_OUTPUT#*|}"
+
+# mergeStateStatus check (#171 layer 2). API enum (full set per
+# GitHub GraphQL `MergeStateStatus`):
+#   CLEAN       — checks pass, no merge conflicts, ready to merge
+#   HAS_HOOKS   — branch has post-commit hooks (legacy state)
+#   UNKNOWN     — state not yet determined (often transient; allow
+#                 rather than wedge on slow API responses)
+#   BLOCKED     — required check failing OR active CHANGES_REQUESTED
+#                 review
+#   DIRTY       — merge conflict
+#   UNSTABLE    — non-required check failed
+#   BEHIND      — base has commits the head lacks (with "Require
+#                 branches to be up to date" enabled)
+#   DRAFT       — PR is in draft mode (covered explicitly so the
+#                 diagnostic points at the right fix, "mark draft
+#                 as ready," not at "update the case statement for
+#                 a future state")
+#
+# Unknown future states (anything not in the case below) fail
+# CLOSED — a new GitHub API state shouldn't silently bypass the
+# guard. Override with BREAK_GLASS_MERGE_STATE=1 if needed.
+case "$MERGE_STATE" in
+  CLEAN|HAS_HOOKS|UNKNOWN)
+    ;;  # allow
+  DRAFT)
+    if [ "$EFFECTIVE_BREAK_GLASS_MERGE_STATE" = "1" ]; then
+      echo "BREAK-GLASS: merge of draft PR authorized by human." >&2
+    else
+      echo "BLOCKED: PR is a draft (mergeStateStatus=DRAFT)." >&2
+      echo "  Mark the PR as ready for review before merging (gh pr ready <PR#>)." >&2
+      echo "  Override: BREAK_GLASS_MERGE_STATE=1 (export or inline prefix)." >&2
+      exit 2
+    fi
+    ;;
+  BLOCKED|DIRTY|UNSTABLE|BEHIND)
+    if [ "$EFFECTIVE_BREAK_GLASS_MERGE_STATE" = "1" ]; then
+      echo "BREAK-GLASS: merge with mergeStateStatus=$MERGE_STATE authorized by human." >&2
+    else
+      echo "BLOCKED: PR mergeStateStatus is $MERGE_STATE." >&2
+      echo "  Resolve required checks / merge conflicts / change requests first." >&2
+      echo "  Override: BREAK_GLASS_MERGE_STATE=1 (export or inline prefix; must be authorized by human in chat)." >&2
+      echo "  See #170 / #171 for the regression this guard closes." >&2
+      exit 2
+    fi
+    ;;
+  *)
+    # Unknown state — fail closed with a hint pointing to the
+    # case statement above. New API states should be classified
+    # explicitly, not absorbed into a default-allow.
+    if [ "$EFFECTIVE_BREAK_GLASS_MERGE_STATE" = "1" ]; then
+      echo "BREAK-GLASS: merge with unrecognized mergeStateStatus=$MERGE_STATE authorized by human." >&2
+    else
+      echo "BLOCKED: PR mergeStateStatus=$MERGE_STATE is not recognized by gh-pr-guard." >&2
+      echo "  Update the case statement in scripts/hooks/gh-pr-guard.sh to classify it." >&2
+      echo "  Override: BREAK_GLASS_MERGE_STATE=1 (export or inline prefix)." >&2
+      exit 2
+    fi
+    ;;
+esac
+
+# --admin sub-guard: break-glass only. Now token-based: the walk
+# above sets ADMIN_REQUESTED=1 only when `--admin` appears as a
+# REAL flag of `merge`, not as a substring of another flag's value.
+#
+# Ordering note (#171): this guard is evaluated AFTER the
+# mergeStateStatus check above. Pre-this-ordering, `--admin +
+# BREAK_GLASS_ADMIN=1` exited before the merge-state guard ran —
+# meaning an emergency `--admin` merge would silently bypass the
+# BLOCKED/DIRTY/UNSTABLE/BEHIND refusal. The two break-glass
+# overrides are independent decisions: BREAK_GLASS_ADMIN authorizes
+# admin-flag use, BREAK_GLASS_MERGE_STATE authorizes merging despite
+# a failing merge state. Requiring both for the worst-case merge
+# (admin AND failing CI) is intentional.
+if [ "$ADMIN_REQUESTED" -eq 1 ]; then
+  if [ "$EFFECTIVE_BREAK_GLASS_ADMIN" = "1" ]; then
+    echo "BREAK-GLASS: --admin merge authorized by human." >&2
+    exit 0
+  fi
+  echo "BLOCKED: --admin merge requires explicit human authorization." >&2
+  echo "Ask the human to confirm break-glass, then retry with BREAK_GLASS_ADMIN=1 (export or inline prefix)." >&2
   exit 2
 fi
 

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -712,10 +712,16 @@ fi
 # current branch; with a positional argument it accepts number /
 # URL / branch forms identically to gh pr merge.
 #
-# Output format: a single line `MERGE_STATE|LABELS` (e.g.
-# `CLEAN|`, `BLOCKED|needs-external-review,bug`). The custom
-# `--jq` filter joins the two fields so the hook only has to
-# parse one string.
+# Output format: mergeStateStatus on line 1, then one label name
+# per line (zero or more lines). The `--jq` filter is
+# `.mergeStateStatus, .labels[].name` — jq emits each result on
+# its own line. NEWLINE-delimited, NOT comma-joined: GitHub label
+# names may legally contain commas (and spaces), so a CSV join
+# would make the later exact-match label gate ambiguous — a label
+# literally named `team,needs-external-review` would be parsed as
+# two labels and false-match the real `needs-external-review`
+# gate (CodeRabbit caught this on PR #263). Label names cannot
+# contain newlines, so one-label-per-line is unambiguous.
 #
 # #171 / #170 retrospective: pre-this-change the hook fetched
 # only labels and let `gh pr merge` run even when GitHub's
@@ -726,7 +732,7 @@ fi
 # protection: even if branch protection is misconfigured or
 # disabled for an emergency hotfix, the hook will still refuse
 # to dispatch the merge.
-GH_JQ='"\(.mergeStateStatus)|\([.labels[].name] | join(","))"'
+GH_JQ='.mergeStateStatus, .labels[].name'
 GH_ARGS=(pr view --json labels,mergeStateStatus --jq "$GH_JQ")
 if [ -n "$PR_SELECTOR" ]; then
   GH_ARGS=(pr view "$PR_SELECTOR" --json labels,mergeStateStatus --jq "$GH_JQ")
@@ -738,11 +744,11 @@ fi
 # Capture stdout and stderr separately. Codex P1 on matchline PR
 # #174 r2: a `2>&1` form would prepend ANY non-fatal stderr gh
 # emitted (update notifier, deprecation warnings, etc.) to the
-# stdout payload, then the `${GH_OUTPUT%%|*}` parameter expansion
-# would parse that noise as MERGE_STATE — corrupting a CLEAN PR
-# into the unrecognized-state block path. Routing stderr to a
-# tempfile keeps MERGE_STATE pure. We still surface stderr in the
-# error path for diagnostics.
+# stdout payload, then the line-1 `MERGE_STATE` extraction would
+# parse that noise as MERGE_STATE — corrupting a CLEAN PR into the
+# unrecognized-state block path. Routing stderr to a tempfile
+# keeps MERGE_STATE pure. We still surface stderr in the error
+# path for diagnostics.
 GH_STDERR=$(mktemp)
 # Re-declare the EXIT trap so $GH_STDERR is also cleaned up. The
 # trap call replaces (not appends) any prior trap; keep all three
@@ -764,13 +770,13 @@ if ! GH_OUTPUT=$(gh "${GH_ARGS[@]}" 2>"$GH_STDERR"); then
   exit 2
 fi
 
-# Split on the first `|`. The mergeStateStatus enum values are
-# all uppercase ASCII identifiers without `|`, and the labels
-# are comma-joined (commas, not pipes), so the split is
-# unambiguous. Empty MERGE_STATE (e.g., transient API state)
-# falls into the `*` case below and fails closed.
-MERGE_STATE="${GH_OUTPUT%%|*}"
-LABELS="${GH_OUTPUT#*|}"
+# Line 1 is mergeStateStatus; lines 2..N are label names (one per
+# line, possibly zero). Empty/missing MERGE_STATE (e.g. transient
+# API state) falls into the `*` case below and fails closed.
+# LABELS keeps the newline-delimited remainder for the exact-match
+# gate further down — never re-join it into a delimited string.
+MERGE_STATE=$(printf '%s\n' "$GH_OUTPUT" | sed -n '1p')
+LABELS=$(printf '%s\n' "$GH_OUTPUT" | sed -n '2,$p')
 
 # mergeStateStatus check (#171 layer 2). API enum (full set per
 # GitHub GraphQL `MergeStateStatus`):
@@ -854,17 +860,20 @@ if [ "$ADMIN_REQUESTED" -eq 1 ]; then
   exit 2
 fi
 
-case ",$LABELS," in
-  *,needs-external-review,*)
-    if [ "$EFFECTIVE_CODEX_CLEARED" != "1" ]; then
-      echo "BLOCKED: PR carries 'needs-external-review' and CODEX_CLEARED is not set." >&2
-      echo "  Phase 4a merge gate: run 'scripts/codex-review-check.sh <PR#>' first." >&2
-      echo "  When it exits 0, retry this merge with CODEX_CLEARED=1 (export or inline prefix)." >&2
-      echo "  See REVIEW_POLICY.md § Phase 4a for the full flow." >&2
-      exit 2
-    fi
-    echo "CODEX_CLEARED=1 set; PR is labeled needs-external-review but agent claims merge-gate has passed." >&2
-    ;;
-esac
+# Exact-match the label gate against the newline-delimited LABELS
+# list. `grep -Fxq` = fixed-string, whole-line, quiet — so a label
+# literally named `team,needs-external-review` (commas are legal in
+# GitHub label names) is its own line and does NOT false-match the
+# real `needs-external-review` gate.
+if printf '%s\n' "$LABELS" | grep -Fxq "needs-external-review"; then
+  if [ "$EFFECTIVE_CODEX_CLEARED" != "1" ]; then
+    echo "BLOCKED: PR carries 'needs-external-review' and CODEX_CLEARED is not set." >&2
+    echo "  Phase 4a merge gate: run 'scripts/codex-review-check.sh <PR#>' first." >&2
+    echo "  When it exits 0, retry this merge with CODEX_CLEARED=1 (export or inline prefix)." >&2
+    echo "  See REVIEW_POLICY.md § Phase 4a for the full flow." >&2
+    exit 2
+  fi
+  echo "CODEX_CLEARED=1 set; PR is labeled needs-external-review but agent claims merge-gate has passed." >&2
+fi
 
 exit 0

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -57,10 +57,18 @@ case "$1 $2" in
     exit 0
     ;;
   "pr view")
-    # The unified hook fetches labels + mergeStateStatus together and
-    # parses the `MERGE_STATE|LABELS` shape. Default to CLEAN so a
-    # test that only cares about labels doesn't have to set the state.
-    echo "${STUB_MERGE_STATE:-CLEAN}|${STUB_LABELS:-}"
+    # The unified hook fetches labels + mergeStateStatus together with
+    # `--jq '.mergeStateStatus, .labels[].name'` — mergeStateStatus on
+    # line 1, then one label name per line. Default state to CLEAN so a
+    # test that only cares about labels doesn't have to set it.
+    # STUB_LABELS is SEMICOLON-separated here for test-authoring
+    # convenience (NOT comma — a single label name may legally contain
+    # a comma, and a test must be able to pass exactly that); emit one
+    # label per line to match real `gh` output.
+    echo "${STUB_MERGE_STATE:-CLEAN}"
+    if [ -n "${STUB_LABELS:-}" ]; then
+      echo "$STUB_LABELS" | tr ';' '\n'
+    fi
     exit 0
     ;;
   *)
@@ -338,6 +346,23 @@ if [ "$rc" -ne 0 ]; then
   fail "merge CLEAN + needs-external-review + CODEX_CLEARED=1: exit $rc, expected 0; output: $out"
 else
   pass "merge CLEAN + needs-external-review + CODEX_CLEARED=1: allowed"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 16: a label literally NAMED `team,needs-external-review` (commas
+# are legal in GitHub label names) must NOT false-match the real
+# `needs-external-review` gate. Regression net for the CSV-join
+# ambiguity CodeRabbit caught on PR #263 — the gate is now an
+# exact whole-line match, not a substring/CSV-membership test.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr merge 123 --squash' "nathanjohnpayne" "0" "CLEAN" "team,needs-external-review" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "label 'team,needs-external-review' does NOT false-match the needs-external-review gate"
+else
+  fail "comma-in-label false-match: exit $rc, expected 0 (the label is not literally 'needs-external-review'); output: $out"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # tests/test_gh_pr_guard.sh
 #
-# Unit tests for scripts/hooks/gh-pr-guard.sh — focused on the #241
-# identity-check addition, plus a regression net for the existing
-# Authoring-Agent / Self-Review body checks so the new check is
-# additive (doesn't break the old behavior).
+# Unit tests for scripts/hooks/gh-pr-guard.sh — covers the #241
+# identity-check on `gh pr create`, the #170/#171 mergeStateStatus
+# guard on `gh pr merge`, and a regression net for the existing
+# Authoring-Agent / Self-Review body checks + needs-external-review
+# label check so the newer checks are additive (don't break old
+# behavior).
 #
 # The hook reads tool_input.command from a JSON envelope on stdin
 # (PreToolUse contract). We feed it crafted envelopes and assert on
@@ -38,9 +40,11 @@ FAIL=0
 pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
 
-# Build a fake `gh` on PATH so the hook's `gh config get -h github.com user`
-# returns a configurable value. Note: the hook ALSO calls `gh pr view`
-# in the merge branch; this stub handles both.
+# Build a fake `gh` on PATH so the hook's `gh config get -h github.com
+# user` returns a configurable value. The hook ALSO calls `gh pr view
+# --json labels,mergeStateStatus` in the merge branch; this stub
+# handles both. The merge-branch call emits the `MERGE_STATE|LABELS`
+# single-line format the unified hook parses.
 STUB_DIR="$WORKDIR/stub-bin"
 mkdir -p "$STUB_DIR"
 cat >"$STUB_DIR/gh" <<'STUB'
@@ -53,8 +57,10 @@ case "$1 $2" in
     exit 0
     ;;
   "pr view")
-    # Return a labels JSON-friendly string for the merge guard.
-    echo "${STUB_LABELS:-}"
+    # The unified hook fetches labels + mergeStateStatus together and
+    # parses the `MERGE_STATE|LABELS` shape. Default to CLEAN so a
+    # test that only cares about labels doesn't have to set the state.
+    echo "${STUB_MERGE_STATE:-CLEAN}|${STUB_LABELS:-}"
     exit 0
     ;;
   *)
@@ -65,14 +71,21 @@ STUB
 chmod +x "$STUB_DIR/gh"
 
 # Build a hook-invocation envelope. The hook reads tool_input.command.
+# merge_state / labels feed the `gh pr view` stub for merge-branch
+# tests; they're inert for create-branch tests (the create path
+# never calls `gh pr view`).
 run_hook() {
   local cmd="$1"
   local stub_user="${2:-nathanjohnpayne}"
   local skip_id="${3:-0}"
+  local merge_state="${4:-CLEAN}"
+  local labels="${5:-}"
   local payload
   payload=$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}')
   PATH="$STUB_DIR:$PATH" \
   STUB_ACTIVE_USER="$stub_user" \
+  STUB_MERGE_STATE="$merge_state" \
+  STUB_LABELS="$labels" \
   BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK="$skip_id" \
     bash "$HOOK" <<<"$payload"
 }
@@ -164,16 +177,15 @@ fi
 
 # ---------------------------------------------------------------------------
 # Test 6: gh pr merge — identity check is gh pr CREATE only, so merge
-# should NOT be blocked by it. Stub the labels to be empty (no
-# needs-external-review) so the existing merge guard exits 0.
+# should NOT be blocked by it. mergeStateStatus=CLEAN + no labels so
+# the merge guard exits 0.
 # ---------------------------------------------------------------------------
 set +e
-STUB_LABELS="" \
-out=$(run_hook 'gh pr merge 123 --squash --delete-branch' "nathanpayne-claude" "0" 2>&1)
+out=$(run_hook 'gh pr merge 123 --squash --delete-branch' "nathanpayne-claude" "0" "CLEAN" "" 2>&1)
 rc=$?
 set -e
 if [ "$rc" -eq 0 ]; then
-  pass "gh pr merge: identity check does NOT fire (create-only)"
+  pass "gh pr merge: identity check does NOT fire (create-only); CLEAN merge allowed"
 else
   fail "gh pr merge: exit $rc, expected 0 (identity check should be create-only); output: $out"
 fi
@@ -209,6 +221,123 @@ if [ "$rc" -eq 0 ]; then
   pass "GH_PR_GUARD_EXPECTED_AUTHOR override: hook allows when active matches override"
 else
   fail "GH_PR_GUARD_EXPECTED_AUTHOR override: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 9: gh pr merge with mergeStateStatus=BLOCKED → exit 2 with the
+# #170/#171 merge-state diagnostic. This is the regression the
+# propagation wave surfaced — the canonical hook had lost this guard.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr merge 123 --squash --delete-branch' "nathanjohnpayne" "0" "BLOCKED" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "merge BLOCKED: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "mergeStateStatus is BLOCKED"; then
+  fail "merge BLOCKED: diagnostic missing 'mergeStateStatus is BLOCKED'; output: $out"
+elif ! echo "$out" | grep -qi "BREAK_GLASS_MERGE_STATE"; then
+  fail "merge BLOCKED: diagnostic missing BREAK_GLASS_MERGE_STATE override hint; output: $out"
+else
+  pass "merge BLOCKED: blocked with #170/#171 merge-state diagnostic"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 10: gh pr merge BLOCKED + inline BREAK_GLASS_MERGE_STATE=1 →
+# exit 0 with BREAK-GLASS notice. Exercises the inline-env capture
+# path for the new override variable.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'BREAK_GLASS_MERGE_STATE=1 gh pr merge 123 --squash' "nathanjohnpayne" "0" "BLOCKED" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+  fail "merge BLOCKED + break-glass: exit $rc, expected 0; output: $out"
+elif ! echo "$out" | grep -qi "BREAK-GLASS"; then
+  fail "merge BLOCKED + break-glass: missing BREAK-GLASS notice; output: $out"
+else
+  pass "merge BLOCKED + inline BREAK_GLASS_MERGE_STATE=1: allowed with notice"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11: gh pr merge with mergeStateStatus=DIRTY → exit 2 (covers
+# the BLOCKED|DIRTY|UNSTABLE|BEHIND set beyond just BLOCKED).
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr merge 123 --squash' "nathanjohnpayne" "0" "DIRTY" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "merge DIRTY: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "mergeStateStatus is DIRTY"; then
+  fail "merge DIRTY: diagnostic missing 'mergeStateStatus is DIRTY'; output: $out"
+else
+  pass "merge DIRTY: blocked"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 12: gh pr merge with mergeStateStatus=DRAFT → exit 2 with the
+# draft-specific diagnostic (gh pr ready hint, not "update the case
+# statement").
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr merge 123 --squash' "nathanjohnpayne" "0" "DRAFT" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "merge DRAFT: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "draft"; then
+  fail "merge DRAFT: diagnostic missing draft-specific hint; output: $out"
+else
+  pass "merge DRAFT: blocked with draft-specific diagnostic"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 13: gh pr merge with an unrecognized future mergeStateStatus →
+# fail CLOSED (exit 2). A new GitHub API state must not silently pass.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr merge 123 --squash' "nathanjohnpayne" "0" "FUTURE_STATE" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "merge unknown-state: exit $rc, expected 2 (fail closed); output: $out"
+elif ! echo "$out" | grep -qi "not recognized"; then
+  fail "merge unknown-state: diagnostic missing 'not recognized'; output: $out"
+else
+  pass "merge unknown-state: fails closed"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 14: gh pr merge CLEAN but carrying needs-external-review with no
+# CODEX_CLEARED → exit 2. Regression net: the label guard still fires
+# AFTER the merge-state check passes (the two guards are independent).
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr merge 123 --squash' "nathanjohnpayne" "0" "CLEAN" "needs-external-review" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "merge CLEAN + needs-external-review: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "needs-external-review"; then
+  fail "merge CLEAN + needs-external-review: diagnostic missing label reference; output: $out"
+else
+  pass "merge CLEAN + needs-external-review (no CODEX_CLEARED): label guard still fires"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 15: gh pr merge CLEAN + needs-external-review + CODEX_CLEARED=1
+# inline → exit 0. The merge-state check passed and the label guard is
+# satisfied by the clearance claim.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'CODEX_CLEARED=1 gh pr merge 123 --squash' "nathanjohnpayne" "0" "CLEAN" "needs-external-review" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+  fail "merge CLEAN + needs-external-review + CODEX_CLEARED=1: exit $rc, expected 0; output: $out"
+else
+  pass "merge CLEAN + needs-external-review + CODEX_CLEARED=1: allowed"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The `--sync-all` propagation wave produced 8 broken consumer PRs (all closed). One of the two root causes: **`scripts/hooks/gh-pr-guard.sh` is a canonical manifest path, but the canonical version and the matchline/overridebroadway versions had diverged in *both* directions** —

- **canonical** (mergepath #241): gates `gh pr create` on the keyring's active account being the author identity.
- **matchline / overridebroadway** (#170/#171): gates `gh pr merge` on the target PR's `mergeStateStatus` — `BLOCKED` / `DIRTY` / `UNSTABLE` / `BEHIND` / `DRAFT` / unknown all refuse unless `BREAK_GLASS_MERGE_STATE=1`.

Propagating canonical-as-is **clobbered the downstream merge-state guard** — a real defense-in-depth safety feature — and those repos' `check_hook_tests` correctly caught the regression.

## Fix

Make the canonical hook the **superset** of both. Splices matchline's `mergeStateStatus` machinery into the canonical hook:

- `INLINE_BREAK_GLASS_MERGE_STATE` capture in the pre-gh token walk (+ separator-clearing + `EFFECTIVE_` resolution), mirroring the existing `CODEX_CLEARED` / `BREAK_GLASS_ADMIN` handling.
- The merge guard fetches labels + `mergeStateStatus` in one `gh pr view` call (`MERGE_STATE|LABELS` single-line shape), stderr routed to a tempfile so gh's non-fatal noise can't corrupt the parsed state (matchline Codex P1, their PR #174 r2).
- `mergeStateStatus` case block: `CLEAN`/`HAS_HOOKS`/`UNKNOWN` allow; `DRAFT` and `BLOCKED`/`DIRTY`/`UNSTABLE`/`BEHIND` block with override; unknown future states fail **closed**.
- `--admin` sub-guard moved **after** the merge-state check so an emergency `--admin` merge can't bypass the `BLOCKED` refusal (the two break-glass overrides are independent decisions).

The #241 create-identity check is **untouched** — both feature sets now coexist, so propagating this hook is non-destructive in both directions.

## Test plan

- [x] `bash tests/test_gh_pr_guard.sh` — **15/15 pass** (8 existing + 7 new: `BLOCKED`, inline `BREAK_GLASS_MERGE_STATE` override, `DIRTY`, `DRAFT`, unknown-state fail-closed, label guard still fires after a CLEAN merge-state, `CODEX_CLEARED` happy path)
- [x] `bash scripts/ci/check_gh_as_author` — PASS
- [x] Full `scripts/ci/check_*` sweep — all PASS
- [x] `bash -n scripts/hooks/gh-pr-guard.sh` — clean
- The `gh` test stub's `pr view` now emits the `MERGE_STATE|LABELS` shape; `run_hook` gained `merge_state` + `labels` params.

## Self-Review

- **Correctness**: the splice is matchline's proven `mergeStateStatus` block verbatim (it shipped + was Codex-reviewed downstream across their #170/#171/#174); the only structural change is interleaving it with the canonical #241 create-identity check, which lives in a separate `if [ \"$PR_SUBCOMMAND\" = \"create\" ]` branch and doesn't interact.
- **Regression risk**: low. The create path is byte-unchanged. The merge path gains a check (fail-closed on bad state) — strictly more conservative. Test 14 is the regression net proving the existing `needs-external-review` label guard still fires after the new merge-state check passes.
- **Style**: matches the hook's existing heavily-commented token-walk idiom; bash 3.2 portable.
- **Test coverage**: 7 new cases covering every branch of the new `case "$MERGE_STATE"` block + both override paths.
- **Security/dependency hygiene**: no new attack surface; no dependencies. The merge-state guard is itself a security control (defense-in-depth behind branch protection).

This is part 1 of the propagation-wave fix. Part 2 — the manifest coupling gap (`scripts/ci/` kit checks depend on un-propagated `tests/` + `scripts/hooks/__tests__/` + templated `.github/review-policy.yml`) — is filed separately as an issue.

Authoring-Agent: claude