### PR TITLE
fix(ci): check_workflow_parsers accepts a missing phase_4b_default

### DIFF
--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -55,6 +55,25 @@ assert_eq() {
   fi
 }
 
+# Classify a phase_4b_default value read from review-policy.yml.
+# Echoes "valid" or "invalid".
+#
+# A MISSING field (empty string) is VALID — the documented semantics
+# (CLAUDE.md, REVIEW_POLICY.md, and the `policy_field` unit fixture
+# below that asserts an absent field returns "") treat an absent
+# phase_4b_default as the `fallback-only` default. This check ships
+# in the propagated `scripts/ci/` kit; a consumer repo whose
+# review-policy.yml predates the field (#185) must NOT hard-fail just
+# for not having opted in. Only a PRESENT-but-unrecognized value is a
+# real failure. (Before this, the propagation wave's 8 consumer PRs
+# all failed `lint` here — see #264.)
+classify_phase_4b() {
+  case "$1" in
+    ""|fallback-only|complex-changes|always) echo "valid" ;;
+    *) echo "invalid" ;;
+  esac
+}
+
 echo "parse_policy_list.sh tests"
 
 # Covers bug 2: the range-based parser silently produced an empty
@@ -184,20 +203,35 @@ nested_only=$(printf 'codex:\n  phase_4b_default: nested-only\n')
 got=$(echo "$nested_only" | awk -v field="phase_4b_default" "$policy_field_awk")
 assert_eq "policy_field returns empty when only a nested same-named key exists" "" "$got"
 
-# Fixture: real mergepath review-policy.yml has the field set; verify
-# end-to-end against the actual file so a typo in the schema-doc
-# example doesn't pass the unit fixtures while breaking the real read.
+# classify_phase_4b: a MISSING field is valid (= the fallback-only
+# default), the three recognized values are valid, anything else is a
+# real failure. This is the classification the real-file check below
+# uses — fixtured here so the "missing is valid" branch (#264) is
+# covered even though mergepath's own review-policy.yml sets the field.
+assert_eq "classify_phase_4b: missing field is valid (defaults to fallback-only)" "valid" "$(classify_phase_4b "")"
+assert_eq "classify_phase_4b: fallback-only is valid" "valid" "$(classify_phase_4b "fallback-only")"
+assert_eq "classify_phase_4b: complex-changes is valid" "valid" "$(classify_phase_4b "complex-changes")"
+assert_eq "classify_phase_4b: always is valid" "valid" "$(classify_phase_4b "always")"
+assert_eq "classify_phase_4b: a present-but-unrecognized value is invalid" "invalid" "$(classify_phase_4b "strict-mode")"
+
+# Fixture: verify end-to-end against the actual review-policy.yml so a
+# typo in the schema-doc example doesn't pass the unit fixtures while
+# breaking the real read. A missing field is accepted as valid (the
+# documented fallback-only default) per classify_phase_4b — this check
+# ships in the propagated kit and must not hard-fail a consumer repo
+# that simply hasn't opted into phase_4b_default yet (#264).
 got=$(awk -v field="phase_4b_default" "$policy_field_awk" "$ROOT/.github/review-policy.yml")
-case "$got" in
-  fallback-only|complex-changes|always)
-    pass=$((pass + 1))
+if [ "$(classify_phase_4b "$got")" = "valid" ]; then
+  pass=$((pass + 1))
+  if [ -z "$got" ]; then
+    echo "  PASS: real .github/review-policy.yml has no phase_4b_default (valid — defaults to fallback-only)"
+  else
     echo "  PASS: real .github/review-policy.yml has a valid phase_4b_default value ('$got')"
-    ;;
-  *)
-    fail=$((fail + 1))
-    echo "  FAIL: real .github/review-policy.yml phase_4b_default is missing or invalid (got '$got'; expected one of fallback-only / complex-changes / always)"
-    ;;
-esac
+  fi
+else
+  fail=$((fail + 1))
+  echo "  FAIL: real .github/review-policy.yml phase_4b_default is set to an unrecognized value (got '$got'; expected one of fallback-only / complex-changes / always, or absent for the fallback-only default)"
+fi
 
 echo
 if [ "$fail" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Part of the #264 manifest-coupling fix. The `--sync-all` propagation wave's 8 consumer PRs **all failed `lint`** here:

```
FAIL: real .github/review-policy.yml phase_4b_default is missing or invalid
      (got ''; expected one of fallback-only / complex-changes / always)
```

**The root cause was an internal contradiction in this check, not the manifest.** `check_workflow_parsers`' own `policy_field` *unit* fixture already asserts that an absent `phase_4b_default` correctly returns `""`, and the documented semantics (CLAUDE.md, REVIEW_POLICY.md) are explicit that a missing field defaults to `fallback-only`. But the *real-file* assertion treated that same empty string as a hard failure.

`scripts/ci/` is a propagated kit path. Consumer repos whose `review-policy.yml` predates `phase_4b_default` (#185) got the new fail-closed check run against their older config and broke — even though "no `phase_4b_default`" is a valid, documented state.

## Fix

Extract `classify_phase_4b()` — empty / `fallback-only` / `complex-changes` / `always` are all **valid**; only a *present-but-unrecognized* value fails. The real-file check uses it and prints a distinct PASS line for the missing-but-valid case. Five classification fixtures cover the branch (mergepath's own `review-policy.yml` sets the field, so the missing-is-valid path needs explicit fixture coverage rather than relying on the real-file read).

This unblocks `check_workflow_parsers` for **all 8 consumers**. (`check_workflow_parsers` is in the kit, so once this lands and re-propagates, the corrected check ships everywhere.)

## Scope note

The matchline-only `check_hook_tests` failure is **separate** — it's a matchline consumer-side divergent extra (only matchline runs it; verified across all 8 consumers' `repo_lint.yml`). #263 already did the mergepath-side hook unification; the remaining matchline cleanup is tracked in #264.

## Test plan

- [x] `bash scripts/ci/check_workflow_parsers` → PASS (26 tests, +5 new `classify_phase_4b` fixtures)
- [x] Full `scripts/ci/check_*` sweep → all PASS
- [x] `bash -n scripts/ci/check_workflow_parsers` → clean
- [x] Behavioral check: a `review-policy.yml` with no `phase_4b_default` → `classify_phase_4b ""` → `valid` → PASS (was FAIL)

## Self-Review

- **Correctness**: the fix aligns the real-file assertion with the check's *own* unit fixture and the documented `fallback-only` default. `classify_phase_4b` is the single source of truth for both the fixtures and the real-file read.
- **Regression risk**: low. mergepath's `review-policy.yml` sets `phase_4b_default: complex-changes` → still classified `valid` → still PASS. The only behavior change is: a *missing* field is now PASS instead of FAIL (the intended fix); a *present-but-bogus* value is still FAIL.
- **Style**: matches the file's existing `assert_eq` + `pass`/`fail` counter idiom.
- **Test coverage**: 5 new fixtures over `classify_phase_4b`, covering empty / all three valid values / a bogus value.
- **Security/dependency hygiene**: no new attack surface; no dependencies. The check stays fail-closed for genuinely-invalid values.

Authoring-Agent: claude