### PR TITLE
fix(sync): pair canonical scripts with their canonical tests in the manifest

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -103,6 +103,26 @@ paths:
     type: canonical
     consumers: all
 
+  # Canonical tests — the suites that exercise the canonical
+  # scripts/hooks above. These MUST travel with the scripts they
+  # test: a consumer that runs the suite (via scripts/ci/
+  # check_gh_as_author, or a repo-local check_hook_tests) against a
+  # freshly-propagated canonical hook needs the matching canonical
+  # test, or the test fails closed on a version mismatch. The
+  # propagation wave's matchline failure (#264) was exactly this —
+  # matchline carried a divergent FORK of the gh-pr-guard test that
+  # drifted from the canonical hook. Pairing each script with its
+  # test in the manifest closes that coupling gap.
+  - path: tests/test_gh_pr_guard.sh
+    type: canonical
+    consumers: all
+  - path: tests/test_gh_as_author.sh
+    type: canonical
+    consumers: all
+  - path: tests/test_gh_as_reviewer.sh
+    type: canonical
+    consumers: all
+
   # Canonical workflows — review policy + automation surfaces that
   # should be lockstep across all consumers.
   - path: .github/workflows/agent-review.yml


### PR DESCRIPTION
## Summary

Closes the coupling gap from #264. The propagation wave's matchline failure: matchline carried a divergent **fork** of the gh-pr-guard test (`scripts/hooks/__tests__/gh-pr-guard.test.sh`) that drifted from the canonical hook — its `gh` stub still emitted the old `MERGE_STATE|LABELS` pipe format, and it had no #241 identity-check coverage. When the unified canonical hook (#263) propagated, matchline's stale fork failed 23 assertions against it.

**Root cause:** `scripts/hooks/gh-pr-guard.sh`, `scripts/gh-as-author.sh`, and `scripts/gh-as-reviewer.sh` are all `canonical` manifest paths, but their test suites were **not** — so a consumer running those tests exercised a freshly-propagated script against a divergent local test.

## Fix

Add the three test suites as `canonical` paths so they travel in lockstep with the scripts they exercise:

| canonical script (already in manifest) | canonical test (added here) |
|---|---|
| `scripts/hooks/gh-pr-guard.sh` | `tests/test_gh_pr_guard.sh` |
| `scripts/gh-as-author.sh` | `tests/test_gh_as_author.sh` |
| `scripts/gh-as-reviewer.sh` | `tests/test_gh_as_reviewer.sh` |

## Test plan

- [x] `bash scripts/ci/check_sync_manifest` → PASS (24 path entries, up from 21)
- [x] `scripts/sync-to-downstream.sh --audit --repos swipewatch` → the 3 new test paths show as `missing entirely` (expected — they propagate on the next `--sync-all`)
- The next `--sync-all` run propagates the canonical tests; matchline can then drop its `__tests__/` fork and repoint `check_hook_tests` at the canonical suite (matchline-side follow-up, tracked in #264).

## Self-Review

- **Correctness**: `canonical` is the right type — these test files should be byte-identical everywhere, exactly like the scripts they pair with. All three files exist (validated by `check_sync_manifest`).
- **Regression risk**: low. Manifest-only change; adds 3 entries, touches no existing entry. The 7 already-green consumer sync PRs are unaffected (they'd just pick up the 3 test files on a future re-sync as inert-but-correct additions).
- **Style**: matches the existing manifest grouping + comment idiom; new entries in a dedicated "Canonical tests" block with a rationale comment referencing #264.
- **Test coverage**: `check_sync_manifest` validates the schema; no new logic to test.
- **Security/dependency hygiene**: no new attack surface; no dependencies.

Authoring-Agent: claude