### PR TITLE
fix(ci): fail-closed hardening — check_sync_manifest, detector wiring, label guard (#271)

### DIFF
--- a/scripts/ci/check_disagreement_detector
+++ b/scripts/ci/check_disagreement_detector
@@ -47,7 +47,16 @@ fi
 # If detect-disagreement is re-inlined, the module can rot silently
 # while this test still passes against the stale file. This canary
 # fails first.
-if ! grep -qF 'scripts/disagreement-detector.cjs' "$WORKFLOW"; then
+#
+# Match the path within 2 lines of a `require(` call, not just the
+# bare path anywhere in the file — otherwise the assertion false-
+# passes if the `require(...)` is removed but a comment still
+# mentions the path. The workflow wraps the require across lines:
+#   const { decide } = require(
+#     path.resolve(process.env.GITHUB_WORKSPACE,
+#                  'scripts/disagreement-detector.cjs'));
+# so a -A2 window after `require(` covers it. (CodeRabbit Major, #271.)
+if ! grep -A2 -E 'require\(' "$WORKFLOW" | grep -qF 'scripts/disagreement-detector.cjs'; then
   echo "check_disagreement_detector: $WORKFLOW no longer require()s scripts/disagreement-detector.cjs — the detect-disagreement job and its test may have drifted" >&2
   exit 1
 fi

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -52,14 +52,39 @@ if [ "$version" != "$SUPPORTED_VERSION" ]; then
   FAILED=1
 fi
 
-# 3. consumers shape
+# 3. consumers shape.
+# Assert `.consumers` is actually a sequence first. Without this, a
+# scalar like `consumers: "oops"` makes `.consumers | length` return
+# a string length and `.consumers[]` iterate garbage instead of
+# failing — a fail-open path the error-check below can't catch
+# because yq still exits 0. (CodeRabbit Major, #271.)
+consumers_tag=$(yq '.consumers | tag' "$MANIFEST" 2>/dev/null || echo "")
+if [ "$consumers_tag" != "!!seq" ]; then
+  echo "FAIL: .consumers must be a list (got YAML tag '$consumers_tag')"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
 consumer_count=$(yq '.consumers | length' "$MANIFEST")
 if [ "$consumer_count" -lt 1 ]; then
   echo "FAIL: consumers list is empty"
   FAILED=1
 fi
 
+# Extract the consumer rows into a variable FIRST, with an explicit
+# error check. `while ... done < <(yq ...)` would swallow a yq
+# failure (malformed `.consumers`, or a null field that errors the
+# `+` concat in some yq builds) and run the loop zero times, leaving
+# FAILED=0 → a false PASS. `(.repo // "null")` makes the concat
+# null-safe across yq versions; the loop below still flags the
+# literal "null". (CodeRabbit Major, propagation-wave audit #271.)
+if ! consumer_rows=$(yq -r '.consumers[] | ((.name // "null") + "\t" + (.repo // "null"))' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract .consumers from the manifest (yq error):"
+  printf '%s\n' "$consumer_rows"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
 while IFS=$'\t' read -r name repo; do
+  [ -z "$name$repo" ] && continue
   if [ -z "$name" ] || [ "$name" = "null" ]; then
     echo "FAIL: a consumer entry has no name (repo=$repo)"
     FAILED=1
@@ -68,14 +93,55 @@ while IFS=$'\t' read -r name repo; do
     echo "FAIL: consumer '$name' has no repo"
     FAILED=1
   fi
-done < <(yq -r '.consumers[] | (.name + "\t" + .repo)' "$MANIFEST")
+done <<< "$consumer_rows"
 
 # Build a set of valid consumer names for cross-check
 valid_consumers=$(yq -r '.consumers[].name' "$MANIFEST" | tr '\n' ',')
 
-# 4-6. path entries
+# 4-6. path entries.
+# Same fail-closed treatment as the consumers extraction above:
+# assert `.paths` is a sequence (a scalar `paths:` value would let
+# `.paths[]` iterate garbage while yq still exits 0), then capture
+# the rows with an explicit yq error check so a malformed `.paths`
+# block fails loudly instead of running the loop zero times and
+# reporting PASS. (CodeRabbit Major, #271.)
+paths_tag=$(yq '.paths | tag' "$MANIFEST" 2>/dev/null || echo "")
+if [ "$paths_tag" != "!!seq" ]; then
+  echo "FAIL: .paths must be a list (got YAML tag '$paths_tag')"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
+if ! path_rows=$(yq -r '
+  .paths[]
+  | ((.path // "") + "\t" + (.type // "") + "\t"
+     + (.consumers | (select(tag == "!!str") // (join(","))) | tostring))
+' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract .paths from the manifest (yq error):"
+  printf '%s\n' "$path_rows"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
 while IFS=$'\t' read -r path type consumers; do
   [ -z "$path" ] && continue
+
+  # 4a: reject repo-escaping paths. An absolute path or one
+  # containing a `..` segment would make the on-disk existence check
+  # below probe OUTSIDE REPO_ROOT, and (worse) sync-to-downstream.sh
+  # would propagate from / to a path outside the repo. A manifest
+  # path must be a repo-relative path with no `..` segment.
+  # (CodeRabbit Major, #271.)
+  case "$path" in
+    /*)
+      echo "FAIL: path '$path' is absolute — manifest paths must be repo-relative"
+      FAILED=1
+      continue
+      ;;
+    ../*|*/../*|*/..)
+      echo "FAIL: path '$path' contains a '..' segment — manifest paths must not escape the repo root"
+      FAILED=1
+      continue
+      ;;
+  esac
 
   # 4: path exists on disk
   case "$type" in
@@ -105,17 +171,24 @@ while IFS=$'\t' read -r path type consumers; do
   else
     IFS=',' read -ra consumer_arr <<< "$consumers"
     for c in "${consumer_arr[@]}"; do
-      if [[ ",$valid_consumers," != *",$c,"* ]]; then
-        echo "FAIL: path '$path' references unknown consumer '$c'"
+      # Reject an empty / whitespace-only token explicitly. Without
+      # this, an empty `c` makes the membership test `*",,"*`, which
+      # matches `,$valid_consumers,` (it has a trailing comma) — an
+      # empty token would silently pass. (CodeRabbit Major, #271.)
+      c_trimmed="${c#"${c%%[![:space:]]*}"}"
+      c_trimmed="${c_trimmed%"${c_trimmed##*[![:space:]]}"}"
+      if [ -z "$c_trimmed" ]; then
+        echo "FAIL: path '$path' has an empty consumer token in its consumers list"
+        FAILED=1
+        continue
+      fi
+      if [[ ",$valid_consumers," != *",$c_trimmed,"* ]]; then
+        echo "FAIL: path '$path' references unknown consumer '$c_trimmed'"
         FAILED=1
       fi
     done
   fi
-done < <(yq -r '
-  .paths[]
-  | (.path + "\t" + .type + "\t"
-     + (.consumers | (select(tag == "!!str") // (join(","))) | tostring))
-' "$MANIFEST")
+done <<< "$path_rows"
 
 if [ "$FAILED" -eq 1 ]; then
   echo "check_sync_manifest: FAIL"

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -83,17 +83,27 @@ if ! consumer_rows=$(yq -r '.consumers[] | ((.name // "null") + "\t" + (.repo //
   echo "check_sync_manifest: FAIL"
   exit 1
 fi
-while IFS=$'\t' read -r name repo; do
-  [ -z "$name$repo" ] && continue
-  if [ -z "$name" ] || [ "$name" = "null" ]; then
-    echo "FAIL: a consumer entry has no name (repo=$repo)"
-    FAILED=1
-  fi
-  if [ -z "$repo" ] || [ "$repo" = "null" ]; then
-    echo "FAIL: consumer '$name' has no repo"
-    FAILED=1
-  fi
-done <<< "$consumer_rows"
+# Guard the loop on non-empty `consumer_rows` at the OUTER level
+# rather than skipping empty rows INSIDE the loop. A `<<< ""` here-
+# string still yields one empty read, so an in-loop
+# `[ -z "$name$repo" ] && continue` would silently skip a consumer
+# entry whose name AND repo are both genuinely empty instead of
+# flagging it. With the outer guard, the only empty-row source —
+# zero consumers — is already caught by the `consumer_count` check
+# above, and any empty row that does reach the loop is validated
+# and FAILed. (Codex P2 on PR #275.)
+if [ -n "$consumer_rows" ]; then
+  while IFS=$'\t' read -r name repo; do
+    if [ -z "$name" ] || [ "$name" = "null" ]; then
+      echo "FAIL: a consumer entry has no name (repo=$repo)"
+      FAILED=1
+    fi
+    if [ -z "$repo" ] || [ "$repo" = "null" ]; then
+      echo "FAIL: consumer '$name' has no repo"
+      FAILED=1
+    fi
+  done <<< "$consumer_rows"
+fi
 
 # Build a set of valid consumer names for cross-check
 valid_consumers=$(yq -r '.consumers[].name' "$MANIFEST" | tr '\n' ',')
@@ -136,7 +146,14 @@ while IFS=$'\t' read -r path type consumers; do
       FAILED=1
       continue
       ;;
-    ../*|*/../*|*/..)
+  esac
+  # Wrap the path in slashes so EVERY `..` segment — leading
+  # (`../x`), embedded (`a/../b`), trailing (`a/..`), or a bare
+  # top-level `..` — normalizes to a `/../` substring. The earlier
+  # `../*|*/../*|*/..` form missed a bare `..`. (Codex P1 + CodeRabbit
+  # Major on PR #275.)
+  case "/$path/" in
+    */../*)
       echo "FAIL: path '$path' contains a '..' segment — manifest paths must not escape the repo root"
       FAILED=1
       continue

--- a/scripts/hooks/label-removal-guard.sh
+++ b/scripts/hooks/label-removal-guard.sh
@@ -96,7 +96,19 @@ try:
 except ValueError:
     sys.exit(1)
 ' > "$TMP_TOKENS" 2>/dev/null; then
-  exit 0
+  # FAIL CLOSED. This is a protection hook — the command already
+  # matched the `gh ... pr edit` prefix screen above, so it IS a
+  # `gh pr edit` invocation; we just can't parse it to check whether
+  # it removes a human-action label. Allowing an unparseable
+  # `gh pr edit` through (the old `exit 0`) was a fail-open hole:
+  # malformed quoting would bypass the guard entirely. Block it and
+  # tell the agent to fix the quoting — same posture as
+  # gh-pr-guard.sh's tokenization failure path. (CodeRabbit Major, #271.)
+  echo "BLOCKED: label-removal-guard could not tokenize the gh command (malformed shell quoting)." >&2
+  echo "  The command matched the 'gh pr edit' screen but cannot be parsed to verify it" >&2
+  echo "  does not remove a human-action label (needs-external-review / needs-human-review /" >&2
+  echo "  policy-violation). Fix the quoting and retry." >&2
+  exit 2
 fi
 
 TOKENS=()


### PR DESCRIPTION
## Summary

First batch of **#271** — the highest-confidence fail-open / fail-closed fixes the `024e0da` propagation wave's CodeRabbit pass surfaced across the 8 consumer sync PRs. Three files, all cohesive "fail-closed hardening."

### `check_sync_manifest` (5 findings)
- **Assert `.consumers` / `.paths` are sequences** before iterating — a scalar (`paths: "oops"`) made `.paths[]` iterate garbage while yq still exited 0 (a fail-open the error-check below couldn't catch).
- **Capture rows into variables with explicit yq error checks** — `while ... done < <(yq ...)` swallowed a yq failure and ran the loop zero times → `FAILED` stayed 0 → **false PASS**.
- **Reject repo-escaping `path` values** (absolute, or containing a `..` segment) — they made the on-disk existence check probe *outside* `REPO_ROOT` and would let `sync-to-downstream.sh` propagate from/to outside the repo.
- **Reject empty/whitespace consumer tokens** — an empty token matched the `*",,"*` membership pattern (`valid_consumers` has a trailing comma) and silently passed.
- `(.name // "null")` / `(.repo // "null")` make the yq concat null-safe across yq versions.

### `check_disagreement_detector` (1 finding)
- Strengthen the workflow-wiring canary: match the module path **within 2 lines of a `require(`** call, not the bare path anywhere in the file (a lingering comment would have false-passed it).

### `label-removal-guard.sh` (1 finding)
- **FAIL CLOSED on tokenization failure.** The old `exit 0` was a fail-open hole — a `gh pr edit` with malformed quoting bypassed the human-action-label guard entirely. Now exits 2 with a diagnostic, same posture as `gh-pr-guard.sh`.

## Test plan

- [x] Real `.mergepath-sync.yml` → `check_sync_manifest` PASS (27 entries)
- [x] Negative: malformed `.paths`, malformed `.consumers`, repo-escaping `../` path, empty consumer token → all FAIL closed (exit 1)
- [x] `check_disagreement_detector` → PASS against the real `agent-review.yml` (strengthened canary still matches the multi-line `require(...)`)
- [x] Functional: malformed `gh pr edit` payload → `label-removal-guard.sh` exits 2 (BLOCK) with diagnostic
- [x] Full `scripts/ci/check_*` sweep → clean

## Self-Review

- **Correctness**: each fix verified with a negative test (fail-closed paths) plus the real-input happy path.
- **Regression risk**: low. `check_sync_manifest`'s happy path is unchanged (real manifest still PASS); the new guards only add FAIL branches. `label-removal-guard`'s allow/block paths for well-formed commands are untouched — only the unparseable branch flipped from allow → block.
- **Style**: matches the existing `check_*` idiom (FAILED flag, explicit FAIL lines, fail-closed early-returns).
- **Test coverage**: `check_disagreement_detector` is itself the test; `check_sync_manifest` negative cases exercised manually (no fixture harness exists for it — possible follow-up).
- **Security/dependency hygiene**: the `label-removal-guard` fail-closed is a genuine hole closure; the repo-escaping path rejection closes a propagation attack surface.

Authoring-Agent: claude

Part of #271. Surfaced by the `024e0da` propagation wave.