### PR TITLE
fix(ci): workflow fail-closed hardening + stop leaking the consumer inventory (#271)

### DIFF
--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -157,7 +157,14 @@ jobs:
             # synchronize/workflow_run for under-threshold PRs).
             if ! HAS_LABEL=$(gh pr view "$PR" --repo "$REPO" --json labels \
               --jq '[.labels[].name] | contains(["needs-external-review"])'); then
-              echo "::warning::Failed to query labels for PR #$PR; skipping."
+              # Infra error — NOT a warning-only skip. This workflow
+              # exists to clear a merge-blocking label; if it can't even
+              # read the label state, it must NOT report success. A
+              # rate-limit / network / API error here previously let
+              # the job go green while a PR stayed stuck. (CodeRabbit
+              # Major, #271.)
+              echo "::error::Failed to query labels for PR #$PR — cannot evaluate."
+              had_infra_error=1
               echo "::endgroup::"
               continue
             fi
@@ -176,7 +183,13 @@ jobs:
               0)
                 echo "Gate passes — removing needs-external-review label."
                 if ! gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
-                  echo "::warning::Failed to remove needs-external-review on PR #$PR"
+                  # The gate passed but the removal API call failed —
+                  # the label is still stuck. That is an infra error,
+                  # not a warning: the job must not report success
+                  # when it failed to do its one job. (CodeRabbit
+                  # Major, #271.)
+                  echo "::error::Failed to remove needs-external-review on PR #$PR — label still stuck."
+                  had_infra_error=1
                   echo "::endgroup::"
                   continue
                 fi
@@ -324,7 +337,11 @@ jobs:
                   gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
                     || echo "::warning::Failed to post attribution comment for PR #$PR"
                 else
-                  echo "::warning::Failed to remove needs-external-review on PR #$PR"
+                  # Gate passed but the removal failed — infra error,
+                  # not warning-only. The label is still stuck; the
+                  # sweep must not report success. (CodeRabbit Major, #271.)
+                  echo "::error::Failed to remove needs-external-review on PR #$PR — label still stuck."
+                  had_infra_error=1
                 fi
                 ;;
               1) echo "Gate not yet met — leaving label in place." ;;

--- a/.github/workflows/codex-p1-gate.yml
+++ b/.github/workflows/codex-p1-gate.yml
@@ -75,17 +75,22 @@ jobs:
     # to non-schedule events avoids paying for an empty no-op run.
     if: github.event_name != 'schedule'
     steps:
-      - name: Checkout repo (for scripts/codex-p1-gate.sh)
-        # actions/checkout's default for pull_request events checks
-        # out the PR's HEAD ref, which is what this read-only gate
-        # wants — the gate script evolves alongside the PR diff.
-        # No `with:` block needed; actionlint/CodeRabbit rejects an
-        # empty `with:` (round-2 #257 fix).
-        # Unlike auto-clear-blocking-labels.yml (which writes labels
-        # and pins to main's TRUSTED copy to defend against a
-        # malicious PR editing the gate logic), this workflow is
-        # strictly read-only and can't be weaponized.
+      - name: Checkout repo (default branch — trusted gate script)
+        # Pin to the default branch, NOT the PR HEAD. The gate is a
+        # REQUIRED status check: if it ran scripts/codex-p1-gate.sh
+        # from the PR's own checkout, a PR could edit that script to
+        # `exit 0`, satisfy the required check, and merge past
+        # unresolved Codex P1 threads in the window before the
+        # scheduled sweep re-evaluates. "Read-only" (no label writes)
+        # does NOT mean "can't be weaponized" — satisfying a required
+        # check IS the weaponization. The gate script doesn't need the
+        # PR diff anyway: it takes a PR number + repo and queries the
+        # GitHub API. Same trusted-checkout posture as the scheduled-
+        # sweep job below. (Codex P1, #271.)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
 
       - name: Resolve PR number
         id: pr
@@ -232,15 +237,23 @@ jobs:
             # GitHub's 65535-char limit on check_run.output.summary.
             summary=$(printf '%s\n' "$output" | head -c 60000)
 
-            gh api -X POST "repos/$REPO/check-runs" \
+            # Posting the check_run IS the sweep's whole purpose —
+            # it's what supersedes the stale red required-check after
+            # a UI thread-resolve. If the POST fails, the sweep did
+            # not do its job; that's an infra error, not a warning.
+            # Swallowing it let the sweep finish green while the
+            # stale check stayed red. (CodeRabbit Major, #271.)
+            if ! gh api -X POST "repos/$REPO/check-runs" \
               -f name="$CHECK_NAME" \
               -f head_sha="$head_sha" \
               -f status="completed" \
               -f conclusion="$conclusion" \
               -f "output[title]=Codex P1 gate (scheduled re-evaluation)" \
               -f "output[summary]=$summary" \
-              >/dev/null \
-              || echo "::warning::Failed to post check_run for PR #$PR"
+              >/dev/null; then
+              echo "::error::Failed to post check_run for PR #$PR — stale required check not refreshed."
+              had_infra_error=1
+            fi
             echo "::endgroup::"
           done <<<"$PRS"
           if [ "$had_infra_error" -ne 0 ]; then

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -66,12 +66,23 @@ jobs:
             echo "::error::gh api user returned empty — REVIEWER_ASSIGNMENT_TOKEN may be invalid, expired, or lacks the user scope."
             exit 1
           fi
-          echo "::notice::Approving $PR_URL as $ACTING_AS"
+          echo "::notice::Approving $PR_URL as $ACTING_AS (PR author: $PR_AUTHOR)"
 
-          if [ "$ACTING_AS" = "nathanjohnpayne" ]; then
-            echo "::error::REVIEWER_ASSIGNMENT_TOKEN resolves to nathanjohnpayne (the author identity)."
+          # Self-approval guard. The real condition is "the reviewer
+          # token resolves to the PR's own author" — GitHub blocks
+          # that. The previous check hard-coded `nathanjohnpayne`,
+          # which is wrong here: a Dependabot PR's author is
+          # `dependabot[bot]`, never `nathanjohnpayne`, so the old
+          # check rejected a perfectly valid reviewer token while
+          # never actually testing the self-approval condition.
+          # Compare against the actual PR author. (CodeRabbit Major,
+          # #271.) The available_reviewers validation below is the
+          # broader gate — it independently rejects any ACTING_AS not
+          # in the reviewer-identity allowlist.
+          if [ "$ACTING_AS" = "$PR_AUTHOR" ]; then
+            echo "::error::REVIEWER_ASSIGNMENT_TOKEN resolves to '$ACTING_AS', the PR's own author."
             echo "::error::GitHub blocks self-approval, so the approve call would silently fail and the merge would proceed without an approval recorded."
-            echo "::error::Replace the secret with a reviewer-identity PAT (nathanpayne-claude / -cursor / -codex)."
+            echo "::error::Replace the secret with a distinct reviewer-identity PAT (nathanpayne-claude / -cursor / -codex)."
             exit 1
           fi
 
@@ -143,4 +154,10 @@ jobs:
           fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
+          # The actual PR author — `dependabot[bot]` for these events.
+          # Used for the genuine self-approval guard below (a hard-
+          # coded `nathanjohnpayne` compare was wrong: the author of a
+          # Dependabot PR is never `nathanjohnpayne`). (CodeRabbit
+          # Major, #271.)
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -152,16 +152,15 @@ paths:
     type: canonical
     consumers: all
 
-  # The manifest itself. Propagated so the propagation-PR review lane
-  # in .github/workflows/pr-review-policy.yml can read the propagation
-  # surface IN-REPO when it runs in a consumer (a sync PR carries this
-  # file, so the lane check sees the exact manifest version the sync
-  # was generated from). See #264 / REVIEW_POLICY.md § Propagation PR
-  # review lane. Consumers otherwise treat it as an inert mirror — they
-  # don't run scripts/sync-to-downstream.sh.
-  - path: .mergepath-sync.yml
-    type: canonical
-    consumers: all
+  # NOTE: `.mergepath-sync.yml` is deliberately NOT propagated.
+  # #268 briefly made it a canonical path on the theory the lane
+  # would read it in-repo — but the lane's redesign (after the Codex
+  # P1 on #268) runs verify-propagation-pr.sh from the CLONED
+  # mergepath@<sha>, which carries its own authoritative manifest.
+  # The consumer's copy would be unused — and worse, this file lists
+  # every consumer including private repo names, so propagating it to
+  # a PUBLIC consumer leaks the private inventory. Keep it
+  # mergepath-only. (CodeRabbit Major, #271.)
 
   # Kit directories — Mergepath-canonical files are required;
   # consumer-only additions in the same directory are allowed.


### PR DESCRIPTION
## Summary

**#271 batch 2** — the workflow-level findings from the `024e0da` propagation-wave CodeRabbit/Codex pass.

### `codex-p1-gate.yml`
- **P1 — trusted-branch checkout.** The event-driven gate job checked out the **PR HEAD** and ran `scripts/codex-p1-gate.sh` from it. The gate is a **required status check** — a PR could edit that script to exit 0, satisfy the required check, and merge past unresolved Codex P1 threads in the window before the scheduled sweep re-evaluates. "Read-only" (no label writes) is not "can't be weaponized" — satisfying a required check is the weaponization. Now pins the checkout to the default branch (trusted); the script takes a PR number + repo and queries the API, so it never needed the PR diff.
- **Sweep swallowed `check-runs` POST failures** (warning-only). Posting that `check_run` is the sweep's purpose. On failure it now sets `had_infra_error=1` and fails the job.

### `auto-clear-blocking-labels.yml`
- The label-query failure path and both label-removal failure paths (event-driven job + scheduled sweep) were warning-only continues — a rate-limit / network / API error let the job report success while a `needs-external-review` label stayed stuck. All three now set `had_infra_error=1`.

### `dependabot-auto-merge.yml`
- The self-approval guard hard-coded `ACTING_AS = nathanjohnpayne`, but a Dependabot PR's author is `dependabot[bot]` — so the check never tested the real self-approval condition and just rejected a valid reviewer token. Now compares `ACTING_AS` against the actual PR author (`github.event.pull_request.user.login`).

### `.mergepath-sync.yml` — inventory leak
- **Stop propagating the manifest itself.** #268 briefly made it canonical so the lane could read it in-repo — but the post-P1 lane redesign runs `verify-propagation-pr.sh` from the cloned `mergepath@<sha>` (its own authoritative manifest), so the consumer's copy is unused. Worse: the file lists every consumer incl. private repo names, so propagating it to a public consumer leaked the private inventory. Removed the entry (manifest now 26 paths). No consumer has it on `main` yet (all 8 sync PRs still open) so no orphan-file cleanup is needed.

## Deferred to a follow-up

- The `pr-audit.yml` sync-exemption findings (the title matcher never matches the real sync-PR title format; the exemption should use the `verify-propagation-pr.sh` byte-proof the merge-time lane requires). Entangled, and the second is a heavier design change — kept out to keep this batch reviewable; tracked in #271.
- `scripts/hooks/label-removal-guard.sh` prefix screen `*gh*pr*edit*` over-matches a `gh pr create` whose body prose merely contains "edit"; the #275 fail-closed change made that bite. Tightening the prefix screen to an actual `gh ... pr edit` invocation belongs in the #272 script-robustness batch.

## Test plan

- [x] All 4 YAML files valid (`yq -e`)
- [x] `check_sync_manifest` -> PASS (26 entries)
- [x] `check_codex_p1_gate` / `check_auto_clear_workflow` -> PASS (structural assertions still hold)
- [x] Full `scripts/ci/check_*` sweep -> clean

## Self-Review

- **Correctness**: each fix verified against the actual code. The `codex-p1-gate` checkout change mirrors the scheduled-sweep job's existing trusted-checkout pattern; the gate script genuinely doesn't read PR files (API-only).
- **Regression risk**: low-moderate. The fail-closed flips only add `had_infra_error=1` on paths that already `continue`/warn — the success path is unchanged. The dependabot guard now compares against a real value; `available_reviewers` validation is untouched and still independently gates. The `codex-p1-gate` checkout change is the one to review carefully — confirm the gate script needs no PR-diff context.
- **Style**: matches each workflow's existing idiom (`had_infra_error` sentinel, `::error::` annotations, pinned SHAs).
- **Test coverage**: `check_codex_p1_gate` / `check_auto_clear_workflow` cover those workflows' structural shape and still pass.
- **Security/dependency hygiene**: the `codex-p1-gate` trusted-branch fix closes a real required-check-bypass window; removing the manifest from the propagated set closes a private-inventory information leak.

Authoring-Agent: claude

Part of #271. Surfaced by the `024e0da` propagation wave.
