### PR TITLE
fix(scripts): #272b — robustness, cwd-resolution, fail-closed defaults

### DIFF
--- a/scripts/ci/check_phase_4b_classifier
+++ b/scripts/ci/check_phase_4b_classifier
@@ -33,10 +33,10 @@ fail=0
 
 # Run the classifier against a fixture and compare the triggers array
 # (sorted, comma-joined) to the expected list. The classifier reads
-# phase_4b_default from cwd's .github/review-policy.yml — to keep
-# fixture tests self-contained (and not depend on whatever the live
-# policy is on the branch where the test runs), set up a per-call
-# scratch dir with phase_4b_default: complex-changes and cd into it.
+# phase_4b_default from `.github/review-policy.yml` resolved relative
+# to ITS OWN script location (NOT cwd, #272). To keep fixture tests
+# self-contained, set MERGEPATH_REVIEW_POLICY_PATH per call to point
+# at a scratch fixture with phase_4b_default: complex-changes.
 SCRATCH_TRIGGERS=$(mktemp -d)
 mkdir -p "$SCRATCH_TRIGGERS/.github"
 echo "phase_4b_default: complex-changes" > "$SCRATCH_TRIGGERS/.github/review-policy.yml"
@@ -46,7 +46,7 @@ assert_triggers() {
   local out actual_triggers actual_exit
 
   set +e
-  out=$(cd "$SCRATCH_TRIGGERS" && bash "$ROOT/$CLASSIFIER" 99999 --fixture "$ROOT/$FIXTURES_DIR/$fixture" 2>/dev/null)
+  out=$(MERGEPATH_REVIEW_POLICY_PATH="$SCRATCH_TRIGGERS/.github/review-policy.yml" bash "$ROOT/$CLASSIFIER" 99999 --fixture "$ROOT/$FIXTURES_DIR/$fixture" 2>/dev/null)
   actual_exit=$?
   set -e
 
@@ -116,8 +116,8 @@ echo "phase-4b-classifier.sh policy short-circuit tests"
 
 # fallback-only short-circuit: the test harness uses a temp config to
 # avoid mutating the real .github/review-policy.yml. We swap the
-# config in via a temp dir + cd, since the script reads CONFIG=
-# "$.github/review-policy.yml" relative to cwd.
+# config in via MERGEPATH_REVIEW_POLICY_PATH per #272 (the script
+# resolves CONFIG relative to its own location, not cwd).
 SCRATCH=$(mktemp -d)
 trap 'rm -rf "$SCRATCH" "$SCRATCH_TRIGGERS"' EXIT
 mkdir -p "$SCRATCH/.github"
@@ -136,7 +136,7 @@ jq_get() {
 # fallback-only short-circuits without inspecting any diff.
 echo "phase_4b_default: fallback-only" > "$SCRATCH/.github/review-policy.yml"
 set +e
-out=$(cd "$SCRATCH" && bash "$ROOT/$CLASSIFIER" 99999 --fixture "$ROOT/$FIXTURES_DIR/state-machine.json" 2>/dev/null)
+out=$(MERGEPATH_REVIEW_POLICY_PATH="$SCRATCH/.github/review-policy.yml" bash "$ROOT/$CLASSIFIER" 99999 --fixture "$ROOT/$FIXTURES_DIR/state-machine.json" 2>/dev/null)
 rc=$?
 set -e
 jq_get recommendation; got_rec=$got_VAL; rec_rc=$got_rc
@@ -153,7 +153,7 @@ fi
 # always short-circuits to invoke-4b regardless of fixture content.
 echo "phase_4b_default: always" > "$SCRATCH/.github/review-policy.yml"
 set +e
-out=$(cd "$SCRATCH" && bash "$ROOT/$CLASSIFIER" 99999 --fixture "$ROOT/$FIXTURES_DIR/no-trigger.json" 2>/dev/null)
+out=$(MERGEPATH_REVIEW_POLICY_PATH="$SCRATCH/.github/review-policy.yml" bash "$ROOT/$CLASSIFIER" 99999 --fixture "$ROOT/$FIXTURES_DIR/no-trigger.json" 2>/dev/null)
 rc=$?
 set -e
 jq_get recommendation; got_rec=$got_VAL; rec_rc=$got_rc
@@ -169,7 +169,7 @@ fi
 # Unknown phase_4b_default value rejected with exit 2.
 echo "phase_4b_default: bogus-mode" > "$SCRATCH/.github/review-policy.yml"
 set +e
-err=$(cd "$SCRATCH" && bash "$ROOT/$CLASSIFIER" 99999 --fixture "$ROOT/$FIXTURES_DIR/no-trigger.json" 2>&1 >/dev/null)
+err=$(MERGEPATH_REVIEW_POLICY_PATH="$SCRATCH/.github/review-policy.yml" bash "$ROOT/$CLASSIFIER" 99999 --fixture "$ROOT/$FIXTURES_DIR/no-trigger.json" 2>&1 >/dev/null)
 rc=$?
 set -e
 if [ "$rc" = "2" ] && echo "$err" | grep -q "phase_4b_default must be one of"; then

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -620,11 +620,22 @@ emit_status_context_verdict() {
   # from the StatusContext check.
   local potential_issues synthetic
   potential_issues=$(count_potential_issues_for_sha "$HEAD_SHA")
+  # Keep the synthetic review object compatible with the documented
+  # contract at the top of this file: `{ id, created_at, endpoint,
+  # body_excerpt }`. The fast-path has no underlying GitHub review,
+  # so `id` is null and `created_at` is the synthesis time — but a
+  # caller reading `review.id` or `review.created_at` no longer hits
+  # a missing key and breaks. `endpoint` keeps the new
+  # "status_context" value (a documented extension for this path); the
+  # extra `head_sha` / `context_state` / `potential_issue_count`
+  # fields are additive. (CodeRabbit Major, #272.)
   synthetic=$(jq -nc \
     --arg sha "$HEAD_SHA" \
     --arg state "$state" \
     --argjson p "$potential_issues" \
     '{
+      id: null,
+      created_at: (now | todateiso8601),
       endpoint: "status_context",
       head_sha: $sha,
       context_state: $state,

--- a/scripts/disagreement-detector.cjs
+++ b/scripts/disagreement-detector.cjs
@@ -64,6 +64,15 @@ function decide(input) {
   const headSha = (input && input.headSha) || '';
   const hasLabel = !!(input && input.hasLabel);
 
+  // If `headSha` is missing, refuse to decide. Without it the
+  // HEAD-SHA filter below drops every review (`r.commit_id !==
+  // headSha` always true) → no live disagreement → the final branch
+  // returns `remove` when `hasLabel` is true, INCORRECTLY clearing
+  // `needs-human-review` from a malformed input. Return `noop` on
+  // malformed input so the label is never auto-cleared without a
+  // real signal. (CodeRabbit Major, #272.)
+  if (!headSha) return 'noop';
+
   const allowed = new Set(reviewerAccounts);
 
   // Step 1: collapse to latest review per reviewer. We collapse

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -180,6 +180,17 @@ SESSION_FILE="$CACHE_DIR/op-preflight-$AGENT.env"
 ADC_TMPFILE="$CACHE_DIR/op-preflight-$AGENT-adc.json"
 SSH_WARM_MARKER="$CACHE_DIR/op-preflight-$AGENT.ssh-warmed"
 SSH_WARM_TTL_SECONDS="${OP_PREFLIGHT_SSH_WARM_TTL_SECONDS:-1800}"  # 30 min default; #163
+# Validate the override is a non-negative integer before any arithmetic
+# context (`[[ "$age" -lt "$SSH_WARM_TTL_SECONDS" ]]` later in the
+# script). A non-numeric override (`OP_PREFLIGHT_SSH_WARM_TTL_SECONDS=foo`)
+# would otherwise abort the run under `set -e` with a "value too great
+# for base" error — one bad local env value would break every cache-hit
+# review. Fall back to the documented default with a warning rather
+# than crashing. (CodeRabbit Major, #272.)
+if [[ ! "$SSH_WARM_TTL_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "# WARNING: OP_PREFLIGHT_SSH_WARM_TTL_SECONDS='$SSH_WARM_TTL_SECONDS' is not a non-negative integer; falling back to default 1800s" >&2
+  SSH_WARM_TTL_SECONDS=1800
+fi
 
 # ── Purge mode ────────────────────────────────────────────────────────
 if $PURGE; then
@@ -196,7 +207,10 @@ if $DRY_RUN; then
   echo "# ADC tempfile:   $ADC_TMPFILE" >&2
   echo "# TTL seconds:    $TTL_SECONDS" >&2
   if [[ -f "$SESSION_FILE" ]]; then
-    embedded=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"")
+    # `|| true` so a missing/corrupt epoch key doesn't take down dry-run
+    # under set -e + pipefail (grep exits 1 on no match). `${embedded:-0}`
+    # below handles the empty result for the arithmetic. (CodeRabbit P2, #272.)
+    embedded=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"" || true)
     now=$(date +%s)
     age=$((now - ${embedded:-0}))
     echo "# Session age:    ${age}s (TTL ${TTL_SECONDS}s)" >&2
@@ -229,7 +243,7 @@ chmod 700 "$CACHE_DIR" 2>/dev/null || true
 session_is_fresh() {
   [[ -f "$SESSION_FILE" ]] || return 1
   local created_at now age
-  created_at=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" 2>/dev/null | cut -d= -f2- | tr -d "'\"")
+  created_at=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" 2>/dev/null | cut -d= -f2- | tr -d "'\"" || true)
   [[ -z "$created_at" ]] && return 1
   [[ "$created_at" =~ ^[0-9]+$ ]] || return 1
   now=$(date +%s)
@@ -532,7 +546,12 @@ if ! $REFRESH && session_is_fresh; then
   fi
   if [[ "$rc" == "0" ]]; then
     echo "$cached_exports"
-    age=$(( $(date +%s) - $(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"") ))
+    # `|| true` so a missing/corrupt epoch key doesn't take down the
+    # cache-hit path under set -e + pipefail; bash arithmetic treats
+    # an empty operand as 0, so a missing key yields age == now (huge,
+    # triggers a cache miss + refresh — the correct fallback).
+    epoch=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"" || true)
+    age=$(( $(date +%s) - ${epoch:-0} ))
     # Warm SSH keys on the cache-hit path too. The cached PATs are
     # worthless for git push/pull if SSH auth isn't also primed, and
     # the prior implementation skipped this step entirely on cache

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -207,12 +207,20 @@ if $DRY_RUN; then
   echo "# ADC tempfile:   $ADC_TMPFILE" >&2
   echo "# TTL seconds:    $TTL_SECONDS" >&2
   if [[ -f "$SESSION_FILE" ]]; then
-    # `|| true` so a missing/corrupt epoch key doesn't take down dry-run
-    # under set -e + pipefail (grep exits 1 on no match). `${embedded:-0}`
-    # below handles the empty result for the arithmetic. (CodeRabbit P2, #272.)
+    # `|| true` so a missing epoch key doesn't take down dry-run under
+    # set -e + pipefail (grep exits 1 on no match). The numeric-only
+    # validation + `10#` decimal coercion below covers the OTHER bad
+    # case CodeRabbit caught on PR #278: a key present with a garbage
+    # value (e.g. `123abc` errors in arithmetic, or `08` is parsed as
+    # invalid octal). On bad input we fall back to age=$now → huge →
+    # cache miss + refresh (the correct fallback). (CodeRabbit, #272.)
     embedded=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"" || true)
     now=$(date +%s)
-    age=$((now - ${embedded:-0}))
+    if [[ "$embedded" =~ ^[0-9]+$ ]]; then
+      age=$(( now - 10#$embedded ))
+    else
+      age=$now
+    fi
     echo "# Session age:    ${age}s (TTL ${TTL_SECONDS}s)" >&2
   else
     echo "# Session age:    n/a (no session file)" >&2
@@ -546,12 +554,19 @@ if ! $REFRESH && session_is_fresh; then
   fi
   if [[ "$rc" == "0" ]]; then
     echo "$cached_exports"
-    # `|| true` so a missing/corrupt epoch key doesn't take down the
-    # cache-hit path under set -e + pipefail; bash arithmetic treats
-    # an empty operand as 0, so a missing key yields age == now (huge,
-    # triggers a cache miss + refresh — the correct fallback).
+    # `|| true` + numeric-only validation + `10#` decimal coercion so
+    # neither a missing key NOR a garbage value (e.g. `123abc` errors
+    # in arithmetic; `08` is parsed as invalid octal) takes down the
+    # cache-hit path under set -e + pipefail. On bad input we fall
+    # back to age = $now → huge → cache miss + refresh (the correct
+    # fallback). (CodeRabbit Minor on PR #278, #272.)
     epoch=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"" || true)
-    age=$(( $(date +%s) - ${epoch:-0} ))
+    now=$(date +%s)
+    if [[ "$epoch" =~ ^[0-9]+$ ]]; then
+      age=$(( now - 10#$epoch ))
+    else
+      age=$now
+    fi
     # Warm SSH keys on the cache-hit path too. The cached PATs are
     # worthless for git push/pull if SSH auth isn't also primed, and
     # the prior implementation skipped this step entirely on cache

--- a/scripts/phase-4b-classifier.sh
+++ b/scripts/phase-4b-classifier.sh
@@ -114,7 +114,23 @@ fi
 # triggers. (CodeRabbit Major, #272.) An env override
 # (`MERGEPATH_REVIEW_POLICY_PATH`) lets tests point at a fixture
 # config without depending on cwd.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#
+# Follow symlinks: `dirname "${BASH_SOURCE[0]}"` alone resolves to
+# the symlink's directory, not the real script location — so if this
+# script is invoked through a `PATH` symlink
+# (e.g. `~/bin/phase-4b-classifier.sh`), CONFIG would be looked up
+# next to the symlink and silently fall through to fallback-only.
+# Portable bash-3.2 canonicalization loop (macOS BSD readlink has no
+# `-f` everywhere). (Codex P2 on PR #278, #272.)
+src="${BASH_SOURCE[0]}"
+while [ -L "$src" ]; do
+  link_target="$(readlink "$src")"
+  case "$link_target" in
+    /*) src="$link_target" ;;
+    *)  src="$(cd -P "$(dirname "$src")" && pwd)/$link_target" ;;
+  esac
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$src")" && pwd)"
 CONFIG="${MERGEPATH_REVIEW_POLICY_PATH:-$SCRIPT_DIR/../.github/review-policy.yml}"
 PHASE_4B_DEFAULT=""
 if [ -f "$CONFIG" ]; then

--- a/scripts/phase-4b-classifier.sh
+++ b/scripts/phase-4b-classifier.sh
@@ -36,6 +36,17 @@
 
 set -euo pipefail
 
+# Hard dependency: `jq`. The script invokes `jq` many times below to
+# parse the PR files payload and emit the recommendation. Without
+# `jq`, those calls exit 127 with `jq: command not found` and the
+# script falls through to undocumented behavior. Fail with a clear
+# error early. (CodeRabbit Major, #272.)
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required (used to parse the PR files payload + emit the recommendation)." >&2
+  echo "       Install via 'brew install jq' (macOS) or 'apt-get install jq' (Debian/Ubuntu)." >&2
+  exit 2
+fi
+
 # ── Argument parsing ─────────────────────────────────────────────────────────
 
 PR_NUM=""
@@ -97,7 +108,14 @@ fi
 
 # ── Policy: phase_4b_default ─────────────────────────────────────────────────
 
-CONFIG=".github/review-policy.yml"
+# Resolve the policy config from the script's repo root, NOT $PWD.
+# A cwd-relative path silently falls back to `fallback-only` when the
+# script is run from a subdirectory — suppressing real Phase 4b
+# triggers. (CodeRabbit Major, #272.) An env override
+# (`MERGEPATH_REVIEW_POLICY_PATH`) lets tests point at a fixture
+# config without depending on cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG="${MERGEPATH_REVIEW_POLICY_PATH:-$SCRIPT_DIR/../.github/review-policy.yml}"
 PHASE_4B_DEFAULT=""
 if [ -f "$CONFIG" ]; then
   PHASE_4B_DEFAULT=$(awk '

--- a/scripts/workflow/match_protected_paths.sh
+++ b/scripts/workflow/match_protected_paths.sh
@@ -30,7 +30,13 @@ fi
 
 patterns=("$@")
 
-while IFS= read -r file; do
+# `|| [ -n "$file" ]` so a non-newline-terminated final stdin line
+# is still processed in this iteration. Without it, `read` returns
+# non-zero on EOF-without-newline and the loop body is skipped — the
+# last changed file is silently dropped from protected-path matching,
+# which can false-pass the guard on EXACTLY the path you're trying
+# to protect. (CodeRabbit Major, #272.)
+while IFS= read -r file || [ -n "$file" ]; do
   [ -z "$file" ] && continue
   for pattern in "${patterns[@]}"; do
     # shellcheck disable=SC2053  # $pattern is intended to be a glob


### PR DESCRIPTION
## Summary

Second sub-batch of **#272**. Six findings across five canonical scripts + one test-harness update.

### `op-preflight.sh`
- **Validate `OP_PREFLIGHT_SSH_WARM_TTL_SECONDS`** as a non-negative integer before any arithmetic context. A non-numeric override aborted the run under `set -e` with a "value too great for base" error. Fall back to the documented 1800s default with a warning.
- **`|| true`** on the three `grep OP_PREFLIGHT_CREATED_AT_EPOCH` pipelines so a missing/corrupt epoch key doesn't take down dry-run (or the cache-hit path) under `set -euo pipefail`. The `${var:-0}` fallback handles the empty result for the arithmetic.

### `phase-4b-classifier.sh`
- **Resolve `.github/review-policy.yml` from the SCRIPT location**, not `$PWD`. A cwd-relative path silently fell back to `fallback-only` when the script was invoked from a subdir — suppressing real Phase 4b triggers. Tests set `MERGEPATH_REVIEW_POLICY_PATH` to point at a scratch fixture.
- **Hard `command -v jq`** check up front. A missing `jq` previously fell through to exit 127 with no clear diagnostic.

### `scripts/workflow/match_protected_paths.sh`
- `while IFS= read -r file || [ -n "$file" ]` so a **non-newline-terminated final stdin line** is still processed. Without it, the loop body was skipped for the last line — the last changed file would be silently dropped from protected-path matching, which can false-pass the guard on *exactly* the path you are trying to protect.

### `coderabbit-wait.sh`
- StatusContext fast-path's synthetic `review` payload now includes the documented `id` (null in this path — no underlying review) + `created_at` (synthesis time, ISO-8601). A caller reading `review.id` / `review.created_at` no longer hits a missing key. Extra `head_sha` / `context_state` / `potential_issue_count` fields are additive.

### `scripts/disagreement-detector.cjs`
- **Return `noop` early when `headSha` is missing.** Without it, the HEAD-SHA filter dropped every review (always-false comparison) → no live disagreement → final branch returned `remove` when `hasLabel` was true, **incorrectly clearing `needs-human-review`** from a malformed input.

### `scripts/ci/check_phase_4b_classifier`
- Updated test invocations to use `MERGEPATH_REVIEW_POLICY_PATH` (replaces the prior `cd $SCRATCH` setup that depended on the now-removed cwd-relative behavior).

## Deferred to a follow-up

- **`coderabbit-wait.sh`** SHA fast-path scoping (counts prior-round inline findings on the same SHA) — entangled with review-round semantics, separate work.
- **`codex-review-check.sh`** PR-body Authoring-Agent gate-(b) trust issue + missing-header behavior — the trust fix needs a cross-verification mechanism (`Co-Authored-By` trailer or similar) and the missing-header behavior may be intentional. Both too big / too judgment-laden for this batch.

## Test plan

- [x] All five `.sh` files `bash -n` clean; `disagreement-detector.cjs` `node --check` clean
- [x] `check_disagreement_detector` → PASS
- [x] `check_phase_4b_classifier` → PASS (14 tests, after porting to the env override)
- [x] `check_workflow_parsers` → PASS
- [x] Full `scripts/ci/check_*` sweep → clean

## Self-Review

- **Correctness**: each fix verified against the actual code path.
- **Regression risk**: the phase-4b cwd change broke 3 of the check_phase_4b_classifier tests on first cut — caught locally, fixed by porting the tests to the env override. Now passes.
- **Style**: matches each script's existing idioms (defensive `|| true`, `command -v` checks, fail-closed comments).
- **Test coverage**: relevant `check_*` suites pass; full sweep clean.
- **Security/dependency hygiene**: the `match_protected_paths` last-line fix closes a real protected-path-guard fail-OPEN; the `disagreement-detector` empty-`headSha` fix closes a real incorrect-label-clear; the `op-preflight` TTL validation closes a loud-fail-on-bad-env mode.

Authoring-Agent: claude

Part of #272 (sub-batch b). Surfaced by the `024e0da` propagation wave.
