### PR TITLE
fix: final triage batch — gh-projects, manifest test-coupling, verifier mode/type (#272/#273/#274)

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -130,6 +130,20 @@ paths:
   - path: tests/test_verify_propagation_pr.sh
     type: canonical
     consumers: all
+  # Pairs with scripts/codex-p1-gate.sh + scripts/ci/check_codex_p1_gate
+  # (kit-propagated). The check wrapper hard-requires this test file;
+  # without it propagated, every consumer's check_codex_p1_gate fails
+  # in pre-flight with `Missing required file`. Same #264/#266 coupling
+  # class — surfaced again by the 024e0da propagation wave (#273).
+  - path: tests/test_codex_p1_gate.sh
+    type: canonical
+    consumers: all
+  # Pairs with scripts/disagreement-detector.cjs +
+  # scripts/ci/check_disagreement_detector. The check wrapper requires
+  # this test file; same #264/#266 coupling class (#273).
+  - path: tests/test_disagreement_detector.sh
+    type: canonical
+    consumers: all
 
   # Canonical workflows — review policy + automation surfaces that
   # should be lockstep across all consumers.

--- a/scripts/gh-projects/lib.sh
+++ b/scripts/gh-projects/lib.sh
@@ -47,12 +47,30 @@ link_sub_issue() {
 # Usage: prep_body <src> <parent_num> [c1] [c2] [c3] [c4]
 prep_body() {
   local src="$1" parent="$2" c1="${3:-}" c2="${4:-}" c3="${5:-}" c4="${6:-}"
-  # Preserve the full source path structure under $GHP_TMPDIR. The
-  # earlier `tr '/' '_'` transform was still collision-prone: a
-  # source like `phase-1/c1.md` mapped to `phase-1_c1.md`, which
-  # collides with an actual `phase-1_c1.md` source. Mirroring the
-  # full path eliminates any name-collision ambiguity. (CodeRabbit
-  # Major, #272.)
+  # Preserve the full source path structure under $GHP_TMPDIR — the
+  # earlier `tr '/' '_'` transform was still collision-prone (a source
+  # like `phase-1/c1.md` mapped to `phase-1_c1.md`, which collided
+  # with an actual `phase-1_c1.md` source). Mirroring the full path
+  # eliminates any name-collision ambiguity. (CodeRabbit Major, #272.)
+  #
+  # Reject path-traversal: an absolute `src` or one containing a `..`
+  # segment would let `dst=$GHP_TMPDIR/$src` write OUTSIDE $GHP_TMPDIR
+  # entirely. The old `tr '/' '_'` form was incidentally
+  # traversal-safe; preserving the path means restoring that
+  # explicitly. Same slash-wrapped check as `check_sync_manifest`'s
+  # repo-escape guard. (Codex P2 + CodeRabbit Major on PR #279.)
+  case "$src" in
+    /*)
+      echo "prep_body: refusing absolute src '$src'" >&2
+      return 2
+      ;;
+  esac
+  case "/$src/" in
+    */../*)
+      echo "prep_body: refusing src '$src' (contains '..' segment; would escape \$GHP_TMPDIR)" >&2
+      return 2
+      ;;
+  esac
   local dst="$GHP_TMPDIR/$src"
   mkdir -p "$(dirname "$dst")"
   sed \

--- a/scripts/gh-projects/lib.sh
+++ b/scripts/gh-projects/lib.sh
@@ -47,10 +47,14 @@ link_sub_issue() {
 # Usage: prep_body <src> <parent_num> [c1] [c2] [c3] [c4]
 prep_body() {
   local src="$1" parent="$2" c1="${3:-}" c2="${4:-}" c3="${5:-}" c4="${6:-}"
-  # Encode the full source path into the destination name by replacing
-  # slashes with underscores, so distinct source paths map to distinct
-  # destinations.
-  local dst="$GHP_TMPDIR/$(echo "$src" | tr '/' '_')"
+  # Preserve the full source path structure under $GHP_TMPDIR. The
+  # earlier `tr '/' '_'` transform was still collision-prone: a
+  # source like `phase-1/c1.md` mapped to `phase-1_c1.md`, which
+  # collides with an actual `phase-1_c1.md` source. Mirroring the
+  # full path eliminates any name-collision ambiguity. (CodeRabbit
+  # Major, #272.)
+  local dst="$GHP_TMPDIR/$src"
+  mkdir -p "$(dirname "$dst")"
   sed \
     -e "s|__PARENT_NUM__|$parent|g" \
     -e "s|__C1_NUM__|$c1|g" \

--- a/scripts/gh-projects/move-item.sh
+++ b/scripts/gh-projects/move-item.sh
@@ -2,8 +2,14 @@
 # Move a GitHub Project v2 item (by issue number) to a named Status swimlane.
 #
 # Usage:
+#   # Front-load the preflight, then run with the cached PAT.
+#   eval "$(scripts/op-preflight.sh --agent claude --mode review)"
 #   PROJECT=5 OWNER=nathanjohnpayne REPO=nathanjohnpayne/nathanpaynedotcom \
-#     GH_TOKEN="$(op read ...)" ./move-item.sh <issue_number> <status_name>
+#     GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT" ./move-item.sh <issue_number> <status_name>
+#
+# (The earlier example showed `GH_TOKEN="$(op read ...)"`, which is the
+# disallowed inline-secret-read pattern — caught by CodeRabbit on the
+# 024e0da propagation wave, #272.)
 #
 # <status_name> is the human-readable option name: Todo, In Progress, In Review,
 # Human, Done (or whatever options exist on the project's Status field).

--- a/scripts/workflow/verify-propagation-pr.sh
+++ b/scripts/workflow/verify-propagation-pr.sh
@@ -101,23 +101,37 @@ while IFS= read -r f; do
     continue
   fi
 
-  # 2. Byte-equality of the END STATE against mergepath@<sha>.
-  #    Compared via git BLOB HASHES (content-addressed) rather than
-  #    captured content: `$(git show ...)` strips trailing newlines,
-  #    which would false-positive a "differs" on any file with a
-  #    trailing newline. The consumer hash comes from its git object
-  #    store; the mergepath hash is computed from the file on disk
-  #    with `git hash-object` (works whether or not the mergepath
-  #    checkout dir is a worktree). Both sides use git's blob hashing,
-  #    so equal hash ⟺ byte-identical content.
+  # 2. Tree-entry equality of the END STATE against mergepath@<sha>.
+  #    Compare the full git TREE ENTRY (mode + type + oid) rather
+  #    than just the blob hash, so a file-mode change (exec-bit
+  #    flip, regular file ↔ symlink) is caught too — a hand-edited
+  #    `chmod +x` on a canonical script would otherwise pass the
+  #    blob-only check while leaving the consumer's on-disk mode
+  #    different from mergepath. `git ls-tree` returns
+  #    `<mode> <type> <oid>\t<path>`; we drop the path field (always
+  #    $f) and compare the mode+type+oid tuple. Empty output ⇒ path
+  #    not present at that ref. (CodeRabbit Major, #272/#274.)
   consumer_present=1
-  consumer_hash=$(git -C "$CONSUMER_DIR" rev-parse --verify -q "$HEAD_SHA:$f") || consumer_present=0
+  consumer_entry=$(git -C "$CONSUMER_DIR" ls-tree "$HEAD_SHA" -- "$f" 2>/dev/null | awk '{print $1, $2, $3}')
+  [ -z "$consumer_entry" ] && consumer_present=0
   mergepath_present=1
-  mergepath_hash=""
-  if [ -f "$MERGEPATH_DIR/$f" ]; then
-    mergepath_hash=$(git hash-object "$MERGEPATH_DIR/$f")
+  if [ -d "$MERGEPATH_DIR/.git" ] || [ -f "$MERGEPATH_DIR/.git" ]; then
+    # mergepath_dir is a git checkout — `ls-tree HEAD` gives the
+    # authoritative tree entry (mode/type from git's index, not a
+    # filesystem mode that could vary by clone permissions).
+    mergepath_entry=$(git -C "$MERGEPATH_DIR" ls-tree HEAD -- "$f" 2>/dev/null | awk '{print $1, $2, $3}')
+    [ -z "$mergepath_entry" ] && mergepath_present=0
   else
-    mergepath_present=0
+    # Test harness fallback: mergepath_dir is a plain directory.
+    # Synthesize a tree entry from the on-disk file: mode 100755 if
+    # executable else 100644, type blob, oid via hash-object.
+    if [ -f "$MERGEPATH_DIR/$f" ]; then
+      if [ -x "$MERGEPATH_DIR/$f" ]; then mode="100755"; else mode="100644"; fi
+      mp_oid=$(git hash-object "$MERGEPATH_DIR/$f")
+      mergepath_entry="$mode blob $mp_oid"
+    else
+      mergepath_entry=""; mergepath_present=0
+    fi
   fi
 
   if [ "$consumer_present" -eq 0 ] && [ "$mergepath_present" -eq 0 ]; then
@@ -132,9 +146,9 @@ while IFS= read -r f; do
     fail "$f — deleted in the PR but still present at mergepath@<sha> (not a faithful delete-propagation)"
     continue
   fi
-  # Both present — blob hashes must match.
-  if [ "$consumer_hash" != "$mergepath_hash" ]; then
-    fail "$f — content differs from mergepath@<sha> (hand-edited; not a verbatim mirror)"
+  # Both present — tree entries (mode + type + oid) must match.
+  if [ "$consumer_entry" != "$mergepath_entry" ]; then
+    fail "$f — tree entry differs from mergepath@<sha> (mode/type/oid mismatch; hand-edited or mode-flipped, not a verbatim mirror). consumer=[$consumer_entry] mergepath=[$mergepath_entry]"
     continue
   fi
 done <<< "$CHANGED_FILES"


### PR DESCRIPTION
## Summary

Three small bundled sub-batches — the **last** of the propagation-wave triage from #271.

### #272c — `scripts/gh-projects/`
- **`move-item.sh`** — usage example replaced the disallowed inline `GH_TOKEN="$(op read ...)"` pattern with the preflight token flow (`OP_PREFLIGHT_AUTHOR_PAT` after `eval "$(scripts/op-preflight.sh --agent claude --mode review)"`).
- **`lib.sh`** — `prep_body` destination naming was still collision-prone (`tr '/' '_'` maps `phase-1/c1.md` and `phase-1_c1.md` to the same output). Preserve the full source path structure under `$GHP_TMPDIR` with `mkdir -p "$(dirname "$dst")"` — no ambiguity.

### #273 — propagation manifest completeness
Same #264/#266 coupling class, two more instances:
- `tests/test_codex_p1_gate.sh` → **canonical** (required by the kit-propagated `check_codex_p1_gate`; without it every consumer's check failed pre-flight with `Missing required file`)
- `tests/test_disagreement_detector.sh` → **canonical** (required by `check_disagreement_detector`)

Manifest goes 26 → 28 entries; `check_sync_manifest` PASS.

### #274 — `verify-propagation-pr.sh` mode/type comparison
Compare the full git **tree entry** (mode + type + oid) instead of just the blob hash, so a file-mode change (exec-bit flip, regular file ↔ symlink) is caught too. A `chmod +x` on a canonical script would previously pass the blob-only check while leaving the consumer's on-disk mode different from `mergepath@<sha>`.

`git ls-tree HEAD -- $f` gives the authoritative entry when the mergepath checkout is a git repo. Test-harness fallback for the plain-dir case (the existing test fixtures): synthesize the entry from the on-disk file (mode 100755 if executable else 100644, type blob, oid via `hash-object`). **All 8** fixture tests in `test_verify_propagation_pr.sh` still pass.

## Test plan

- [x] `bash -n` on the two `.sh` files
- [x] `test_verify_propagation_pr.sh` → 8/8 pass (faithful mirror, hand-edit, off-manifest, faithful delete, unfaithful delete, kit-extra-add, usage error, missing manifest — all the cases)
- [x] `check_sync_manifest` → PASS (28 entries)
- [x] Full `scripts/ci/check_*` sweep → clean

## Self-Review

- **Correctness**: each fix verified against the actual code. The `prep_body` change preserves file structure (no name collisions possible); manifest additions validated by `check_sync_manifest`; the tree-entry comparison is *strictly more* than the prior blob-only check (catches mode flips), backward-compatible with the plain-dir test fixtures.
- **Regression risk**: low. `test_verify_propagation_pr` (8 fixture cases covering every interesting state — mirror, hand-edit, off-manifest, faithful/unfaithful delete, kit-extra-add, usage error, missing manifest) all still pass with the new comparison.
- **Style**: matches each script's existing idioms.
- **Test coverage**: full `scripts/ci/check_*` sweep clean.
- **Security/dependency hygiene**: the verifier mode/type tightens the faithful-mirror guarantee (a chmod-only hand-edit no longer slips past); the `prep_body` fix closes a silent-overwrite edge.

Authoring-Agent: claude

Closes (within #272/#273/#274): the gh-projects findings (#272c), the test-coupling findings (#273), and the verifier mode/type finding (#274). The remaining deferred items on #271/#272 (coderabbit-wait SHA scoping, codex-review-check Authoring-Agent trust, pr-audit sync exemption) stay tracked on their issues for separate work.
