### PR TITLE
fix: pin scratch policy via MERGEPATH_REVIEW_POLICY_PATH in body-fetch test

### DIFF
--- a/scripts/ci/check_phase_4b_classifier
+++ b/scripts/ci/check_phase_4b_classifier
@@ -225,7 +225,23 @@ set +e
 # Drop --fixture so the script actually goes through the live API path
 # (which is what hits the PR body fetch). Set GH_TOKEN so the script
 # passes its empty-token guard before reaching the body fetch.
-out=$(cd "$SCRATCH_GH" && PATH="$SCRATCH_GH:$PATH" GH_TOKEN=stub-token bash "$ROOT/$CLASSIFIER" 99999 --repo nathanjohnpayne/mergepath 2>&1)
+#
+# The classifier now resolves policy relative to its own script
+# location (`$SCRIPT_DIR/../.github/review-policy.yml`) — so the
+# scratch `.github/review-policy.yml` written above is ignored
+# unless we override via `MERGEPATH_REVIEW_POLICY_PATH`. Without
+# that override, on consumers whose own policy omits
+# `phase_4b_default` (defaulting to `fallback-only`), the
+# classifier short-circuits on `mode != "complex-changes"` and
+# never reaches the body-fetch guard this test is meant to
+# exercise — the test would either FAIL for the wrong reason or
+# falsely report PASS depending on the consumer's policy. The env
+# override pins the test to the scratch policy regardless of the
+# consumer's review-policy.yml. (Codex P2 on the 263caf3
+# propagation wave.)
+out=$(cd "$SCRATCH_GH" && PATH="$SCRATCH_GH:$PATH" GH_TOKEN=stub-token \
+  MERGEPATH_REVIEW_POLICY_PATH="$SCRATCH_GH/.github/review-policy.yml" \
+  bash "$ROOT/$CLASSIFIER" 99999 --repo nathanjohnpayne/mergepath 2>&1)
 rc=$?
 set -e
 # Tightened assertion: must specifically be the BODY-fetch error, not


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

The PR-body fetch regression case in `scripts/ci/check_phase_4b_classifier`
writes a scratch `phase_4b_default: complex-changes` policy and `cd`s into
the scratch root, but the classifier (after #275) resolves its policy from
its own script location, not the cwd — so the scratch file is silently
ignored. On consumers whose `.github/review-policy.yml` omits
`phase_4b_default` (default `fallback-only`), the classifier short-circuits
to `rc=0` without reaching the body-fetch guard. The test asserts
`rc=2 + "failed to fetch PR body"`, so it FAILS for the wrong reason and
the regression coverage is effectively dead.

Pass `MERGEPATH_REVIEW_POLICY_PATH="$SCRATCH_GH/.github/review-policy.yml"`
on the invocation so the scratch policy is honored regardless of the
consumer's own review-policy.yml. The other complex-changes test paths in
this file already use the same env override — this one was missed in the
#275 round.

Caught by Codex on the 263caf3 propagation wave (matchline#232 +
device-source-of-truth#86, same P2 on both).

## Self-Review

- **Correctness**: ran `bash scripts/ci/check_phase_4b_classifier` — all
  14 tests pass. The body-fetch test now exercises the intended
  rc=2 path even when the consumer's policy is `fallback-only`.
- **Regression risk**: tiny — the change is one env var on one
  invocation in one regression case. No production code touched.
- **Style/conventions**: matches the env-override pattern already used
  in the other complex-changes test paths in this same file.
- **Test coverage**: this IS a test fix — restoring the coverage the
  regression case was supposed to provide.
- **Security/dependency hygiene**: no new dependencies, no security
  surface touched.
