### PR TITLE
fix: two canonical bugs surfaced by Phase 4b on the 263caf3 wave

### DIFF
--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -48,6 +48,15 @@ jobs:
       - name: check_codex_scripts
         run: ./scripts/ci/check_codex_scripts
 
+      - name: check_canonical_bugs_263caf3
+        # Regression coverage for two nathanpayne-codex Phase 4b
+        # findings on the 263caf3 propagation wave:
+        #   - request-label-removal.sh set -e abort in no-`--repo` path
+        #   - codex-review-check.sh self-approval hole via
+        #     same-agent reviewer identity bypassing the author
+        #     exclusion in gate (b) + gate (c) Phase 4b substitute
+        run: ./scripts/ci/check_canonical_bugs_263caf3
+
       - name: check_workflow_parsers
         run: ./scripts/ci/check_workflow_parsers
 

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -356,12 +356,13 @@ echo "Bug 2 production parser path: AUTHORING_AGENT extraction under set -eo pip
 
 PARSER_HARNESS=$(cat <<'PARSER'
 set -eo pipefail
-# Verbatim from scripts/codex-review-check.sh
+# Verbatim from scripts/codex-review-check.sh (the r3 herestring form
+# — see the multi-iteration comment block above the live parser for
+# why this shape and not `printf | grep`).
 AUTHORING_AGENT=""
 SAME_AGENT_REVIEWER=""
-if printf '%s\n' "$PR_BODY" | grep -qiE '^Authoring-Agent:'; then
-  AUTHORING_AGENT=$(printf '%s\n' "$PR_BODY" \
-    | grep -i -m1 -E '^Authoring-Agent:' \
+if grep -qiE '^Authoring-Agent:' <<<"$PR_BODY"; then
+  AUTHORING_AGENT=$(grep -i -m1 -E '^Authoring-Agent:' <<<"$PR_BODY" \
     | sed -E 's/^[Aa]uthoring-[Aa]gent:[[:space:]]*([A-Za-z0-9_-]+).*/\1/' \
     | tr '[:upper:]' '[:lower:]')
   if [ -n "$AUTHORING_AGENT" ]; then
@@ -471,6 +472,38 @@ if [ "$rc" = "0" ] && [ "$got" = "cursor|nathanpayne-cursor" ]; then
 else
   fail=$((fail + 1))
   echo "  FAIL: mid-body header parse wrong (rc=$rc, got='$got')" >&2
+fi
+
+# Case L: LARGE PR body (>64KB pipe buffer) with Authoring-Agent near
+# the top. This is the regression nathanpayne-codex r3 flagged: r2
+# used `printf '%s\n' "$PR_BODY" | grep -q…`, a producer-pipe shape.
+# When the body crosses the OS pipe buffer (typically 64KB) and grep
+# matches near the top, grep exits early, printf gets SIGPIPE (141),
+# pipefail bubbles 141 as the pipeline's exit, the guard's `if` test
+# evaluates false even though the header IS present, and
+# SAME_AGENT_REVIEWER stays "" — reopening the same-agent self-
+# approval hole that #283 was meant to close. r3 replaced the
+# producer pipe with a bash herestring `<<<"$PR_BODY"`, which feeds
+# grep directly from the shell with no producer process to receive
+# SIGPIPE.
+#
+# Construct the body in a pipefail-safe way: `head -c N < /dev/zero`
+# has no upstream producer, so it can't be killed by SIGPIPE itself,
+# and `tr` reads to EOF.
+LARGE_FILLER=$(head -c 70000 < /dev/zero | tr '\0' 'x')
+LARGE_BODY="Authoring-Agent: claude"$'\n\n'"$LARGE_FILLER"
+
+set +e
+got=$(run_parser "$LARGE_BODY")
+rc=$?
+set -e
+if [ "$rc" = "0" ] && [ "$got" = "claude|nathanpayne-claude" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: >64KB PR body with header still parses (no SIGPIPE on producer; pipefail safe)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: large-body parser regressed — header silently lost (rc=$rc, got='$got')" >&2
+  echo "        body size was ${#LARGE_BODY} bytes; r2 producer-pipe shape would fail here." >&2
 fi
 
 echo

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -337,6 +337,143 @@ else
 fi
 
 echo
+echo "Bug 2 production parser path: AUTHORING_AGENT extraction under set -eo pipefail"
+
+# ── Bug 2 augmentation (nathanpayne-codex Phase 4b r2 on #283) ───────
+#
+# The original Case A–E above exercised only the jq filter literals
+# with `same_agent_reviewer` injected directly — they did NOT prove
+# the production code reaches the filter at all. Codex r2 caught
+# that the AUTHORING_AGENT parser at line ~286 of the script
+# (`echo "$PR_BODY" | grep ... | sed ... | tr ...`) aborts under
+# `set -eo pipefail` when the body has no `Authoring-Agent:` header
+# (grep rc=1 → pipefail bubbles it → assignment inherits rc=1 →
+# `set -e` aborts BEFORE `SAME_AGENT_REVIEWER=""` runs).
+#
+# Inline-literal pattern: the parser snippet below is duplicated
+# verbatim from `scripts/codex-review-check.sh` lines ~286–305.
+# Keep them in lockstep — same coupling the jq literals above use.
+
+PARSER_HARNESS=$(cat <<'PARSER'
+set -eo pipefail
+# Verbatim from scripts/codex-review-check.sh
+AUTHORING_AGENT=""
+SAME_AGENT_REVIEWER=""
+if printf '%s\n' "$PR_BODY" | grep -qiE '^Authoring-Agent:'; then
+  AUTHORING_AGENT=$(printf '%s\n' "$PR_BODY" \
+    | grep -i -m1 -E '^Authoring-Agent:' \
+    | sed -E 's/^[Aa]uthoring-[Aa]gent:[[:space:]]*([A-Za-z0-9_-]+).*/\1/' \
+    | tr '[:upper:]' '[:lower:]')
+  if [ -n "$AUTHORING_AGENT" ]; then
+    SAME_AGENT_REVIEWER=$(echo "$REVIEWERS" | awk -v agent="-$AUTHORING_AGENT" '$0 ~ agent"$" { print; exit }')
+  fi
+fi
+printf '%s|%s\n' "$AUTHORING_AGENT" "$SAME_AGENT_REVIEWER"
+PARSER
+)
+
+REVIEWERS_LIST=$'nathanpayne-claude\nnathanpayne-cursor\nnathanpayne-codex'
+
+run_parser() {
+  # Args: $1 = PR body. Prints "<AUTHORING_AGENT>|<SAME_AGENT_REVIEWER>".
+  # Runs in a fresh bash with set -eo pipefail so any abort surfaces
+  # as a non-zero exit code from this function.
+  PR_BODY="$1" REVIEWERS="$REVIEWERS_LIST" bash -c "$PARSER_HARNESS"
+}
+
+# Case F: no Authoring-Agent header. The pre-fix code aborts here
+# (grep rc=1 → pipefail → set -e abort). Post-fix: AUTHORING_AGENT=""
+# AND SAME_AGENT_REVIEWER="" AND non-zero exit propagates as failure.
+set +e
+got=$(run_parser "Some PR body with no Authoring-Agent line.
+Just regular content here.")
+rc=$?
+set -e
+if [ "$rc" = "0" ] && [ "$got" = "|" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: no-header PR body → AUTHORING_AGENT='' SAME_AGENT_REVIEWER='' (no abort under pipefail)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: no-header parser aborted or produced unexpected output (rc=$rc, got='$got')" >&2
+fi
+
+# Case G: empty PR body. Same expectation.
+set +e
+got=$(run_parser "")
+rc=$?
+set -e
+if [ "$rc" = "0" ] && [ "$got" = "|" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: empty PR body → AUTHORING_AGENT='' SAME_AGENT_REVIEWER='' (no abort)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: empty-body parser aborted or produced unexpected output (rc=$rc, got='$got')" >&2
+fi
+
+# Case H: Authoring-Agent: claude → maps to nathanpayne-claude.
+set +e
+got=$(run_parser "Authoring-Agent: claude
+
+## Summary
+Something.")
+rc=$?
+set -e
+if [ "$rc" = "0" ] && [ "$got" = "claude|nathanpayne-claude" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: Authoring-Agent: claude → AUTHORING_AGENT='claude' SAME_AGENT_REVIEWER='nathanpayne-claude'"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: claude-header parse wrong (rc=$rc, got='$got')" >&2
+fi
+
+# Case I: case-insensitive header key + capitalized value.
+set +e
+got=$(run_parser "authoring-agent: Codex
+
+body")
+rc=$?
+set -e
+if [ "$rc" = "0" ] && [ "$got" = "codex|nathanpayne-codex" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: case-insensitive header → AUTHORING_AGENT='codex' SAME_AGENT_REVIEWER='nathanpayne-codex'"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: case-insensitive parse wrong (rc=$rc, got='$got')" >&2
+fi
+
+# Case J: header value that doesn't match any available_reviewer.
+# AUTHORING_AGENT populated but SAME_AGENT_REVIEWER stays empty.
+set +e
+got=$(run_parser "Authoring-Agent: jules
+
+body")
+rc=$?
+set -e
+if [ "$rc" = "0" ] && [ "$got" = "jules|" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: unknown agent → AUTHORING_AGENT='jules' SAME_AGENT_REVIEWER='' (awk no-match is pipefail-safe)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: unknown-agent parse wrong (rc=$rc, got='$got')" >&2
+fi
+
+# Case K: header not at start-of-body (regression for the -m1 + ^
+# anchors). The line IS at start-of-line, just not start-of-body.
+set +e
+got=$(run_parser "Some preface line.
+Authoring-Agent: cursor
+Trailing line.")
+rc=$?
+set -e
+if [ "$rc" = "0" ] && [ "$got" = "cursor|nathanpayne-cursor" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: header on non-first line still parses (cursor → nathanpayne-cursor)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: mid-body header parse wrong (rc=$rc, got='$got')" >&2
+fi
+
+echo
 total=$((pass + fail))
 if [ "$fail" -gt 0 ]; then
   echo "check_canonical_bugs_263caf3: FAIL ($fail/$total failed)"

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# check_canonical_bugs_263caf3
+#
+# Regression coverage for two canonical-surface bugs found by
+# nathanpayne-codex while doing the Phase 4b external reviews on
+# the 263caf3 propagation wave (matchline#232, nathanpaynedotcom#368,
+# overridebroadway#59, device-source-of-truth#86,
+# friends-and-family-billing#270, device-platform-reporting#80,
+# swipewatch#51, tadlockpsychiatry#54). Both are upstream canonical
+# defects that affect every consumer, not consumer-local drift.
+#
+#   Bug 1: scripts/request-label-removal.sh aborted under `set -e`
+#          in the default no-`--repo` path. The BODY="..." assignment
+#          embedded `$([ -n "$REPO" ] && echo "--repo $REPO")`; the
+#          tested-empty `[` short-circuits the `&&` chain with rc=1,
+#          the command substitution's rc=1 propagates as the
+#          assignment's exit status, and `set -e` aborts the script
+#          BEFORE `gh pr comment` runs. Every `request-label-removal.sh
+#          <PR#> <label>` call without `--repo` silently failed.
+#
+#   Bug 2: scripts/codex-review-check.sh let the authoring agent's
+#          own reviewer identity satisfy both gate (b) branch 1 AND
+#          gate (c) Phase 4b substitute. The jq filter excluded only
+#          `.user.login != $author` (= nathanjohnpayne, the GitHub
+#          PR-author login), not the same-agent reviewer identity
+#          (e.g. nathanpayne-claude for a claude-authored PR). With
+#          nathanpayne-claude in `available_reviewers` and != the
+#          author, a claude-authored over-threshold PR could self-
+#          approve through the merge gate. The fix excludes BOTH
+#          `$author` AND `$same_agent_reviewer`.
+#
+# This check exercises the jq filter literals in isolation against
+# in-memory fixtures so a future edit can't silently regress either
+# guard. Inline-literal pattern matches check_workflow_parsers /
+# check_pr_audit_codex_clearance.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+LABEL_REMOVAL_SCRIPT="scripts/request-label-removal.sh"
+CODEX_CHECK_SCRIPT="scripts/codex-review-check.sh"
+
+for f in "$LABEL_REMOVAL_SCRIPT" "$CODEX_CHECK_SCRIPT"; do
+  if [ ! -f "$f" ]; then
+    echo "check_canonical_bugs_263caf3: FAIL — missing $f"
+    exit 1
+  fi
+done
+
+command -v jq >/dev/null 2>&1 || {
+  echo "check_canonical_bugs_263caf3: FAIL — jq not on PATH"
+  exit 1
+}
+
+pass=0
+fail=0
+
+# ── Bug 1 regression: request-label-removal.sh with no --repo ────────
+#
+# Drive the script far enough into the BODY assignment to prove the
+# `set -e` abort no longer fires. We stub `gh` so we don't need
+# network or a real PR — the assertion is that the script REACHES
+# the gh invocation, not what gh returns. The pre-fix code aborts
+# BEFORE reaching `gh pr comment`; the post-fix code reaches it.
+
+echo "Bug 1 regression: request-label-removal.sh set -e abort with no --repo"
+
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+# Stub: print a marker proving the script reached gh, then succeed.
+case "$1" in
+  "pr")
+    case "${2:-}" in
+      "view")    printf 'https://github.com/nathanjohnpayne/mergepath/pull/99999\n' ;;
+      "comment") printf 'STUB_GH_COMMENT_REACHED\n' >&2 ;;
+      *)         printf 'STUB_GH_UNEXPECTED %s\n' "$*" >&2 ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+set +e
+out=$(PATH="$SCRATCH:$PATH" \
+  MERGEPATH_NOTIFY_IMESSAGE_TO="" \
+  "$LABEL_REMOVAL_SCRIPT" 99999 needs-external-review 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" = "0" ] && echo "$out" | grep -q "STUB_GH_COMMENT_REACHED"; then
+  pass=$((pass + 1))
+  echo "  PASS: no-\`--repo\` invocation reaches \`gh pr comment\` (rc=0)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: no-\`--repo\` invocation did NOT reach gh pr comment (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+# Same, but WITH --repo — sanity-check that the explicit-repo path
+# is also still wired up.
+set +e
+out=$(PATH="$SCRATCH:$PATH" \
+  MERGEPATH_NOTIFY_IMESSAGE_TO="" \
+  "$LABEL_REMOVAL_SCRIPT" 99999 needs-external-review --repo nathanjohnpayne/mergepath 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" = "0" ] && echo "$out" | grep -q "STUB_GH_COMMENT_REACHED"; then
+  pass=$((pass + 1))
+  echo "  PASS: --repo invocation reaches \`gh pr comment\` (rc=0)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: --repo invocation did NOT reach gh pr comment (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+# Confirm the BODY ends up containing the right hint string in both
+# paths. Inspect via a different stub that echoes argv to stderr.
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+case "$1" in
+  "pr")
+    case "${2:-}" in
+      "view") printf 'https://github.com/nathanjohnpayne/mergepath/pull/99999\n' ;;
+      "comment")
+        # Dump --body content to a file so the test can inspect.
+        shift 2
+        while [ "$#" -gt 0 ]; do
+          if [ "$1" = "--body" ]; then printf '%s' "$2" > "$SCRATCH_BODY_OUT"; fi
+          shift
+        done
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+# no-repo path
+SCRATCH_BODY_OUT="$SCRATCH/body-norepo.txt" \
+  PATH="$SCRATCH:$PATH" \
+  MERGEPATH_NOTIFY_IMESSAGE_TO="" \
+  "$LABEL_REMOVAL_SCRIPT" 99999 needs-external-review >/dev/null 2>&1 || true
+
+if [ -f "$SCRATCH/body-norepo.txt" ] && \
+   grep -q "gh pr edit 99999 --remove-label needs-external-review\`" "$SCRATCH/body-norepo.txt" && \
+   ! grep -q -- "--repo " "$SCRATCH/body-norepo.txt"; then
+  pass=$((pass + 1))
+  echo "  PASS: no-\`--repo\` BODY contains correct CLI hint with no --repo flag"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: no-\`--repo\` BODY CLI hint malformed" >&2
+  [ -f "$SCRATCH/body-norepo.txt" ] && sed 's/^/    /' "$SCRATCH/body-norepo.txt" >&2
+fi
+
+# with-repo path
+SCRATCH_BODY_OUT="$SCRATCH/body-repo.txt" \
+  PATH="$SCRATCH:$PATH" \
+  MERGEPATH_NOTIFY_IMESSAGE_TO="" \
+  "$LABEL_REMOVAL_SCRIPT" 99999 needs-external-review --repo nathanjohnpayne/mergepath >/dev/null 2>&1 || true
+
+if [ -f "$SCRATCH/body-repo.txt" ] && \
+   grep -q "gh pr edit 99999 --remove-label needs-external-review --repo nathanjohnpayne/mergepath\`" "$SCRATCH/body-repo.txt"; then
+  pass=$((pass + 1))
+  echo "  PASS: --repo BODY contains correct CLI hint with --repo flag inline"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: --repo BODY CLI hint malformed" >&2
+  [ -f "$SCRATCH/body-repo.txt" ] && sed 's/^/    /' "$SCRATCH/body-repo.txt" >&2
+fi
+
+echo
+echo "Bug 2 regression: codex-review-check.sh self-approval exclusion"
+
+# ── Bug 2 regression: jq filter must exclude same-agent reviewer ─────
+#
+# The filter literals are extracted verbatim from
+# `scripts/codex-review-check.sh` gate (b) branch 1 + gate (c) Phase
+# 4b substitute. Keep this in lockstep with the script under test —
+# same inline-literal coupling the other scripts/ci/check_* files use.
+
+REVIEWERS_JSON='["nathanpayne-claude","nathanpayne-cursor","nathanpayne-codex"]'
+
+run_filter() {
+  # Args:
+  #   $1 = jq filter (gate-b form or gate-c form)
+  #   $2 = author login
+  #   $3 = same_agent_reviewer login (may be empty)
+  #   $4 = sha (only used by gate-c form; harmless for gate-b)
+  #   $5 = reviews_json
+  echo "$5" | jq -r \
+    --argjson reviewers "$REVIEWERS_JSON" \
+    --arg author "$2" \
+    --arg same_agent_reviewer "$3" \
+    --arg sha "$4" \
+    "$1"
+}
+
+GATE_B_FILTER='
+  [ .[]
+    | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+    | select(.user.login as $u | $reviewers | index($u))
+    | select(.user.login != $author)
+    | select($same_agent_reviewer == "" or .user.login != $same_agent_reviewer)
+  ]
+  | group_by(.user.login)
+  | map(max_by(.submitted_at))
+  | map(select(.state == "APPROVED"))
+  | first
+  | if . == null then empty else .user.login end
+'
+
+GATE_C_FILTER='
+  [ .[]
+    | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+    | select(.commit_id == $sha)
+    | select(.user.login as $u | $reviewers | index($u))
+    | select(.user.login != $author)
+    | select($same_agent_reviewer == "" or .user.login != $same_agent_reviewer)
+  ]
+  | group_by(.user.login)
+  | map(max_by(.submitted_at))
+  | map(select(.state == "APPROVED"))
+  | max_by(.submitted_at)
+  | if . == null then "" else .user.login + "|" + .submitted_at end
+'
+
+HEAD_SHA="abc123"
+
+# Case A: claude-authored PR, nathanpayne-claude tries to self-approve.
+#   Expected: gate (b) returns empty (no APPROVING_REVIEWER).
+#   Expected: gate (c) returns empty (no PHASE_4B_APPROVER).
+REVIEWS_A='[
+  {"user":{"login":"nathanpayne-claude"},"state":"APPROVED","commit_id":"abc123","submitted_at":"2026-05-15T10:00:00Z"}
+]'
+
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_A")
+if [ -z "$got" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) rejects same-agent self-approval (claude→claude)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) accepted same-agent self-approval — got '$got'" >&2
+fi
+
+got=$(run_filter "$GATE_C_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_A")
+if [ -z "$got" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (c) rejects same-agent self-approval (claude→claude)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (c) accepted same-agent self-approval — got '$got'" >&2
+fi
+
+# Case B: claude-authored PR, nathanpayne-codex (cross-agent) approves.
+#   Expected: gate (b) returns nathanpayne-codex.
+#   Expected: gate (c) returns nathanpayne-codex|<timestamp>.
+REVIEWS_B='[
+  {"user":{"login":"nathanpayne-codex"},"state":"APPROVED","commit_id":"abc123","submitted_at":"2026-05-15T10:00:00Z"}
+]'
+
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_B")
+if [ "$got" = "nathanpayne-codex" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) accepts cross-agent approval (claude-authored, codex-approved)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) rejected cross-agent approval — got '$got'" >&2
+fi
+
+got=$(run_filter "$GATE_C_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_B")
+case "$got" in
+  nathanpayne-codex\|*) pass=$((pass + 1)); echo "  PASS: gate (c) accepts cross-agent Phase 4b approval (claude-authored, codex-approved)" ;;
+  *) fail=$((fail + 1)); echo "  FAIL: gate (c) rejected cross-agent Phase 4b approval — got '$got'" >&2 ;;
+esac
+
+# Case C: no Authoring-Agent header (same_agent_reviewer=""), any
+# non-author reviewer approves. Filter must NOT over-exclude.
+REVIEWS_C='[
+  {"user":{"login":"nathanpayne-cursor"},"state":"APPROVED","commit_id":"abc123","submitted_at":"2026-05-15T10:00:00Z"}
+]'
+
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "" "$HEAD_SHA" "$REVIEWS_C")
+if [ "$got" = "nathanpayne-cursor" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) accepts non-author reviewer when no Authoring-Agent header"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) over-excluded with empty same_agent_reviewer — got '$got'" >&2
+fi
+
+got=$(run_filter "$GATE_C_FILTER" "nathanjohnpayne" "" "$HEAD_SHA" "$REVIEWS_C")
+case "$got" in
+  nathanpayne-cursor\|*) pass=$((pass + 1)); echo "  PASS: gate (c) accepts non-author reviewer when no Authoring-Agent header" ;;
+  *) fail=$((fail + 1)); echo "  FAIL: gate (c) over-excluded with empty same_agent_reviewer — got '$got'" >&2 ;;
+esac
+
+# Case D: explicit PR author (nathanjohnpayne) somehow posts a review
+# anyway. Filter must always reject the GitHub PR author.
+REVIEWS_D='[
+  {"user":{"login":"nathanjohnpayne"},"state":"APPROVED","commit_id":"abc123","submitted_at":"2026-05-15T10:00:00Z"}
+]'
+
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_D")
+if [ -z "$got" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) rejects PR-author self-approval (nathanjohnpayne→nathanjohnpayne)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) accepted PR-author self-approval — got '$got'" >&2
+fi
+
+# Case E: same-agent reviewer's LATEST state is CHANGES_REQUESTED
+# even though they previously approved → no clearance via the bare
+# group_by/max_by/latest-state filter. (Regression guard for the
+# pre-existing latest-state-wins behavior; ensures the new
+# same_agent_reviewer exclusion doesn't change unrelated semantics.)
+REVIEWS_E='[
+  {"user":{"login":"nathanpayne-codex"},"state":"APPROVED","commit_id":"abc123","submitted_at":"2026-05-15T10:00:00Z"},
+  {"user":{"login":"nathanpayne-codex"},"state":"CHANGES_REQUESTED","commit_id":"abc123","submitted_at":"2026-05-15T11:00:00Z"}
+]'
+
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_E")
+if [ -z "$got" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) honors latest-state CHANGES_REQUESTED over earlier APPROVED (regression)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) used stale APPROVED instead of latest CHANGES_REQUESTED — got '$got'" >&2
+fi
+
+echo
+total=$((pass + fail))
+if [ "$fail" -gt 0 ]; then
+  echo "check_canonical_bugs_263caf3: FAIL ($fail/$total failed)"
+  exit 1
+fi
+echo "check_canonical_bugs_263caf3: PASS ($total tests)"
+exit 0

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -356,15 +356,17 @@ echo "Bug 2 production parser path: AUTHORING_AGENT extraction under set -eo pip
 
 PARSER_HARNESS=$(cat <<'PARSER'
 set -eo pipefail
-# Verbatim from scripts/codex-review-check.sh (the r3 herestring form
-# — see the multi-iteration comment block above the live parser for
-# why this shape and not `printf | grep`).
+# Verbatim from scripts/codex-review-check.sh (the r4 form — tr
+# before sed, so sed sees canonical lowercase; see the multi-
+# iteration comment block above the live parser for the chain
+# r1 (initial) → r2 (pipefail abort) → r3 (SIGPIPE on producer) →
+# r4 (case coverage)).
 AUTHORING_AGENT=""
 SAME_AGENT_REVIEWER=""
 if grep -qiE '^Authoring-Agent:' <<<"$PR_BODY"; then
   AUTHORING_AGENT=$(grep -i -m1 -E '^Authoring-Agent:' <<<"$PR_BODY" \
-    | sed -E 's/^[Aa]uthoring-[Aa]gent:[[:space:]]*([A-Za-z0-9_-]+).*/\1/' \
-    | tr '[:upper:]' '[:lower:]')
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/^authoring-agent:[[:space:]]*([a-z0-9_-]+).*/\1/')
   if [ -n "$AUTHORING_AGENT" ]; then
     SAME_AGENT_REVIEWER=$(echo "$REVIEWERS" | awk -v agent="-$AUTHORING_AGENT" '$0 ~ agent"$" { print; exit }')
   fi
@@ -472,6 +474,76 @@ if [ "$rc" = "0" ] && [ "$got" = "cursor|nathanpayne-cursor" ]; then
 else
   fail=$((fail + 1))
   echo "  FAIL: mid-body header parse wrong (rc=$rc, got='$got')" >&2
+fi
+
+# Case M: fully-uppercase header key, capitalized value
+# (nathanpayne-codex Phase 4b r4 finding via CodeRabbit). The r3
+# pipeline (`grep -i | sed [Aa]uthoring | tr upper→lower`) silently
+# produced `authoring-agent: claude` for `AUTHORING-AGENT: Claude`
+# because sed's per-letter `[Aa]` only covered first-of-word casing
+# — the rest of the line fell through unchanged, then the trailing
+# `tr` lowercased the whole "header: value" string into the
+# AUTHORING_AGENT variable, so the awk suffix match against
+# `nathanpayne-claude` failed and SAME_AGENT_REVIEWER stayed "".
+# The r4 reorder (tr before sed) canonicalizes the line to lowercase
+# before extraction, so any case-permutation of the header key works.
+set +e
+got=$(run_parser "AUTHORING-AGENT: Claude
+
+## Summary")
+rc=$?
+set -e
+if [ "$rc" = "0" ] && [ "$got" = "claude|nathanpayne-claude" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: AUTHORING-AGENT: Claude (uppercase key) → claude (canonical extraction)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: uppercase-key header parse wrong (rc=$rc, got='$got')" >&2
+fi
+
+# Case N: uppercase value
+set +e
+got=$(run_parser "Authoring-Agent: CLAUDE
+
+body")
+rc=$?
+set -e
+if [ "$rc" = "0" ] && [ "$got" = "claude|nathanpayne-claude" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: Authoring-Agent: CLAUDE (uppercase value) → claude"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: uppercase-value parse wrong (rc=$rc, got='$got')" >&2
+fi
+
+# Case O: fully-uppercase key AND value (worst case)
+set +e
+got=$(run_parser "AUTHORING-AGENT: CODEX
+
+body")
+rc=$?
+set -e
+if [ "$rc" = "0" ] && [ "$got" = "codex|nathanpayne-codex" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: AUTHORING-AGENT: CODEX (fully upper) → codex"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: full-uppercase parse wrong (rc=$rc, got='$got')" >&2
+fi
+
+# Case P: mixed-case key in the middle of the word
+set +e
+got=$(run_parser "AuThOrInG-aGeNt: Cursor
+
+body")
+rc=$?
+set -e
+if [ "$rc" = "0" ] && [ "$got" = "cursor|nathanpayne-cursor" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: mixed-case AuThOrInG-aGeNt → cursor (canonical extraction)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: mixed-case parse wrong (rc=$rc, got='$got')" >&2
 fi
 
 # Case L: LARGE PR body (>64KB pipe buffer) with Authoring-Agent near

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -284,32 +284,56 @@ fi
 # by gate (b) branch 2 (#170) to detect the same-agent author/reviewer
 # case where Codex's 👍 reaction can substitute for an APPROVED review.
 #
-# Pipefail-safe header parse. The earlier form was a single pipeline
-# `echo "$PR_BODY" | grep ... | sed ... | tr ...` assigned to
-# AUTHORING_AGENT. On a PR body with no `Authoring-Agent:` line, the
-# `grep` step returned rc=1; under `set -eo pipefail` that rc=1
-# bubbled up as the pipeline's exit status, became the assignment's
-# exit status, and `set -e` aborted the script BEFORE reaching the
-# `SAME_AGENT_REVIEWER=""` initializer on the next line — so any PR
-# missing the header (UI-created PRs, external-contributor PRs, or
-# PRs predating the `gh-pr-guard.sh` enforcement of the header on
-# `gh pr create`) blew up the merge gate with an opaque `set -e`
-# trace instead of taking the intended "no Authoring-Agent → empty
-# SAME_AGENT_REVIEWER → branch 1 only" path. Gate the actual
-# extraction on a prior `if` test that uses `grep -q` — the if-test
-# context suppresses `set -e` on the test command itself per bash
-# semantics. (nathanpayne-codex Phase 4b r2 on PR #283.)
+# Pipefail-safe header parse, iteration history:
+#
+#   r1 (#283 initial): used `echo "$PR_BODY" | grep ... | sed ... | tr ...`
+#   assigned to AUTHORING_AGENT. On a PR with no `Authoring-Agent:` line
+#   the `grep` step returned rc=1; under `set -eo pipefail` that rc=1
+#   bubbled up as the pipeline's exit status and `set -e` aborted the
+#   script before `SAME_AGENT_REVIEWER=""` ran on the next line — so any
+#   PR missing the header (UI-created, external-contributor, or
+#   predating the `gh-pr-guard.sh` Authoring-Agent enforcement on
+#   `gh pr create`) blew up the merge gate with an opaque trace.
+#
+#   r2 (codex CHANGES_REQUESTED): gated extraction on a prior
+#   `if printf ... | grep -qiE ...`. The if-test context suppresses
+#   `set -e` on the test command, so no-header bodies now took the
+#   intended "skip extraction, leave SAME_AGENT_REVIEWER empty" path
+#   without aborting.
+#
+#   r3 (codex CHANGES_REQUESTED — THIS iteration): r2 still had a
+#   silent failure on LARGE bodies. `printf '%s\n' "$PR_BODY" | grep`
+#   is a producer pipe; once the body crosses the 64KB pipe buffer
+#   AND the `Authoring-Agent:` header is near the top of the body,
+#   `grep -q`/`grep -m1` matches and exits early, `printf` gets
+#   SIGPIPE (rc=141), and `pipefail` bubbles the 141 as the pipeline's
+#   exit status. In the guard `if` test, 141 is non-zero → the `if`
+#   evaluates false → AUTHORING_AGENT and SAME_AGENT_REVIEWER stay
+#   empty even though the header IS present. The same-agent
+#   exclusion in gate (b)/(c) then no-ops (empty-string clause), and
+#   the authoring agent's own reviewer identity can satisfy the
+#   merge gate. THE EXACT HOLE r1+r2 set out to close, reopened by
+#   a different mechanism.
+#
+#   Fix: replace `printf '%s\n' "$PR_BODY" |` with a bash herestring
+#   `<<<"$PR_BODY"`. The herestring feeds grep directly from the
+#   shell — there is no producer process, so SIGPIPE on producer-
+#   close cannot happen. `grep` reads what it needs and exits 0/1
+#   cleanly; pipefail has nothing to bubble. Bash 3.2+ supports
+#   `<<<` (added in 2.05b), so portability is not a concern.
+#   (nathanpayne-codex Phase 4b r3 on PR #283.)
 AUTHORING_AGENT=""
 SAME_AGENT_REVIEWER=""
-if printf '%s\n' "$PR_BODY" | grep -qiE '^Authoring-Agent:'; then
-  AUTHORING_AGENT=$(printf '%s\n' "$PR_BODY" \
-    | grep -i -m1 -E '^Authoring-Agent:' \
+if grep -qiE '^Authoring-Agent:' <<<"$PR_BODY"; then
+  AUTHORING_AGENT=$(grep -i -m1 -E '^Authoring-Agent:' <<<"$PR_BODY" \
     | sed -E 's/^[Aa]uthoring-[Aa]gent:[[:space:]]*([A-Za-z0-9_-]+).*/\1/' \
     | tr '[:upper:]' '[:lower:]')
   if [ -n "$AUTHORING_AGENT" ]; then
     # Match against available_reviewers via suffix (e.g., "claude"
     # matches "nathanpayne-claude"). Empty if no match — also
-    # pipefail-safe: awk always exits 0 even when no record matched.
+    # pipefail-safe: REVIEWERS is small (~3 lines) so SIGPIPE on the
+    # `echo` producer cannot fire here, and awk always exits 0 even
+    # when no record matched.
     SAME_AGENT_REVIEWER=$(echo "$REVIEWERS" | awk -v agent="-$AUTHORING_AGENT" '$0 ~ agent"$" { print; exit }')
   fi
 fi

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -581,13 +581,29 @@ REVIEWERS_JSON=$(echo "$REVIEWERS" | jq -R . | jq -s .)
 # changes) is caught by the preflight blocking-label check above: the
 # Agent Review Pipeline's detect-disagreement job applies
 # `needs-human-review`, which the preflight rejects before this gate runs.
+# Self-approval guard: exclude BOTH the GitHub PR-author login
+# (`$author`, typically nathanjohnpayne) AND the authoring-agent's
+# reviewer identity (`$same_agent_reviewer`, e.g.
+# nathanpayne-claude for a claude-authored PR). GitHub-native
+# branch protection only blocks reviewer == PR-author, but per
+# REVIEW_POLICY.md § No-self-approve scoping the authoring agent's
+# OWN reviewer identity is also disqualified for Phase 4 (over-
+# threshold) gate-(b) clearance — that's the exact case branch 2
+# below (same-agent + Codex 👍) is designed to handle. Without
+# the second exclusion, a claude-authored PR could be cleared by
+# nathanpayne-claude posting APPROVED, since nathanpayne-claude
+# is different from nathanjohnpayne and thus passes the bare
+# `.user.login != $author` filter. (nathanpayne-codex Phase 4b
+# finding on the 263caf3 sync wave.)
 APPROVING_REVIEWER=$(echo "$REVIEWS_JSON" | jq -r \
   --argjson reviewers "$REVIEWERS_JSON" \
-  --arg author "$PR_AUTHOR" '
+  --arg author "$PR_AUTHOR" \
+  --arg same_agent_reviewer "$SAME_AGENT_REVIEWER" '
     [ .[]
       | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
       | select(.user.login as $u | $reviewers | index($u))
       | select(.user.login != $author)
+      | select($same_agent_reviewer == "" or .user.login != $same_agent_reviewer)
     ]
     | group_by(.user.login)
     | map(max_by(.submitted_at))
@@ -794,15 +810,24 @@ fi
 # trigger or scheduled sweep, instead of stalling on a permanently-
 # failing gate (c) until a human clears the label by hand.
 if [ "$CLEARED" != "true" ] && [ "$ALLOW_PHASE_4B_SUBSTITUTE" = "true" ]; then
+  # Same self-approval guard as gate (b) branch 1 above: exclude
+  # the authoring-agent's reviewer identity in addition to the
+  # GitHub PR-author login. Without this, a claude-authored
+  # over-threshold PR could clear the Phase 4b substitute via
+  # nathanpayne-claude posting APPROVED on HEAD — collapsing the
+  # cross-agent guarantee Phase 4b is meant to provide. (Same
+  # nathanpayne-codex Phase 4b finding on the 263caf3 sync wave.)
   PHASE_4B_APPROVER=$(echo "$REVIEWS_JSON" | jq -r \
     --argjson reviewers "$REVIEWERS_JSON" \
     --arg author "$PR_AUTHOR" \
+    --arg same_agent_reviewer "$SAME_AGENT_REVIEWER" \
     --arg sha "$HEAD_SHA" '
       [ .[]
         | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
         | select(.commit_id == $sha)
         | select(.user.login as $u | $reviewers | index($u))
         | select(.user.login != $author)
+        | select($same_agent_reviewer == "" or .user.login != $same_agent_reviewer)
       ]
       | group_by(.user.login)
       | map(max_by(.submitted_at))

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -301,33 +301,46 @@ fi
 #   intended "skip extraction, leave SAME_AGENT_REVIEWER empty" path
 #   without aborting.
 #
-#   r3 (codex CHANGES_REQUESTED — THIS iteration): r2 still had a
-#   silent failure on LARGE bodies. `printf '%s\n' "$PR_BODY" | grep`
-#   is a producer pipe; once the body crosses the 64KB pipe buffer
-#   AND the `Authoring-Agent:` header is near the top of the body,
-#   `grep -q`/`grep -m1` matches and exits early, `printf` gets
-#   SIGPIPE (rc=141), and `pipefail` bubbles the 141 as the pipeline's
-#   exit status. In the guard `if` test, 141 is non-zero → the `if`
-#   evaluates false → AUTHORING_AGENT and SAME_AGENT_REVIEWER stay
-#   empty even though the header IS present. The same-agent
-#   exclusion in gate (b)/(c) then no-ops (empty-string clause), and
-#   the authoring agent's own reviewer identity can satisfy the
-#   merge gate. THE EXACT HOLE r1+r2 set out to close, reopened by
-#   a different mechanism.
+#   r3 (codex CHANGES_REQUESTED): r2 still had a silent failure on
+#   LARGE bodies. `printf '%s\n' "$PR_BODY" | grep` is a producer
+#   pipe; once the body crosses the 64KB pipe buffer AND the
+#   `Authoring-Agent:` header is near the top of the body, grep -q
+#   matches and exits early, printf gets SIGPIPE (rc=141), pipefail
+#   bubbles the 141 as the pipeline's exit. In the guard `if` test,
+#   141 is non-zero → the `if` evaluates false → AUTHORING_AGENT and
+#   SAME_AGENT_REVIEWER stay empty even though the header IS present.
+#   THE EXACT HOLE r1+r2 set out to close, reopened by a different
+#   mechanism. Fix: replace producer pipe with bash herestring
+#   `<<<"$PR_BODY"` — no producer process, no SIGPIPE.
 #
-#   Fix: replace `printf '%s\n' "$PR_BODY" |` with a bash herestring
-#   `<<<"$PR_BODY"`. The herestring feeds grep directly from the
-#   shell — there is no producer process, so SIGPIPE on producer-
-#   close cannot happen. `grep` reads what it needs and exits 0/1
-#   cleanly; pipefail has nothing to bubble. Bash 3.2+ supports
-#   `<<<` (added in 2.05b), so portability is not a concern.
-#   (nathanpayne-codex Phase 4b r3 on PR #283.)
+#   r4 (codex CHANGES_REQUESTED — THIS iteration): r3 still failed
+#   case-coverage. The guard's `grep -i` matched any case of the
+#   header (e.g. `AUTHORING-AGENT: Claude`), but the extraction
+#   `sed -E 's/^[Aa]uthoring-[Aa]gent:[[:space:]]*([A-Za-z0-9_-]+).*/\1/'`
+#   only character-classed the FIRST letter of each word — fully-
+#   uppercase keys fell through sed unchanged, and the trailing `tr`
+#   then lowercased the WHOLE line (`AUTHORING-AGENT: Claude` →
+#   `authoring-agent: claude`), so AUTHORING_AGENT was set to the
+#   string "authoring-agent: claude" rather than just "claude". The
+#   awk suffix match on `-authoring-agent: claude` against
+#   `nathanpayne-claude` then failed → SAME_AGENT_REVIEWER="" →
+#   same-agent exclusion no-op'd → self-approval hole reopened.
+#   GNU sed's `I` regex flag would be the natural fix but BSD/macOS
+#   sed doesn't support it, so we can't rely on it.
+#
+#   Fix: reorder the pipeline so `tr` lowercases BEFORE sed. sed
+#   then sees a canonical-lowercase line and uses a strict-lowercase
+#   pattern — no character classes needed. Order is grep -i (still
+#   case-insensitive on detection) → tr (canonicalize) → sed
+#   (extract from canonical). Works for every case-permutation of
+#   the header without per-letter character classing.
+#   (nathanpayne-codex Phase 4b r4 on PR #283.)
 AUTHORING_AGENT=""
 SAME_AGENT_REVIEWER=""
 if grep -qiE '^Authoring-Agent:' <<<"$PR_BODY"; then
   AUTHORING_AGENT=$(grep -i -m1 -E '^Authoring-Agent:' <<<"$PR_BODY" \
-    | sed -E 's/^[Aa]uthoring-[Aa]gent:[[:space:]]*([A-Za-z0-9_-]+).*/\1/' \
-    | tr '[:upper:]' '[:lower:]')
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/^authoring-agent:[[:space:]]*([a-z0-9_-]+).*/\1/')
   if [ -n "$AUTHORING_AGENT" ]; then
     # Match against available_reviewers via suffix (e.g., "claude"
     # matches "nathanpayne-claude"). Empty if no match — also

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -283,12 +283,35 @@ fi
 # identity (e.g., `Authoring-Agent: claude` → `nathanpayne-claude`). Used
 # by gate (b) branch 2 (#170) to detect the same-agent author/reviewer
 # case where Codex's 👍 reaction can substitute for an APPROVED review.
-AUTHORING_AGENT=$(echo "$PR_BODY" | grep -i -m1 -E '^Authoring-Agent:' | sed -E 's/^[Aa]uthoring-[Aa]gent:[[:space:]]*([A-Za-z0-9_-]+).*/\1/' | tr '[:upper:]' '[:lower:]')
+#
+# Pipefail-safe header parse. The earlier form was a single pipeline
+# `echo "$PR_BODY" | grep ... | sed ... | tr ...` assigned to
+# AUTHORING_AGENT. On a PR body with no `Authoring-Agent:` line, the
+# `grep` step returned rc=1; under `set -eo pipefail` that rc=1
+# bubbled up as the pipeline's exit status, became the assignment's
+# exit status, and `set -e` aborted the script BEFORE reaching the
+# `SAME_AGENT_REVIEWER=""` initializer on the next line — so any PR
+# missing the header (UI-created PRs, external-contributor PRs, or
+# PRs predating the `gh-pr-guard.sh` enforcement of the header on
+# `gh pr create`) blew up the merge gate with an opaque `set -e`
+# trace instead of taking the intended "no Authoring-Agent → empty
+# SAME_AGENT_REVIEWER → branch 1 only" path. Gate the actual
+# extraction on a prior `if` test that uses `grep -q` — the if-test
+# context suppresses `set -e` on the test command itself per bash
+# semantics. (nathanpayne-codex Phase 4b r2 on PR #283.)
+AUTHORING_AGENT=""
 SAME_AGENT_REVIEWER=""
-if [ -n "$AUTHORING_AGENT" ]; then
-  # Match against available_reviewers via suffix (e.g., "claude" matches
-  # "nathanpayne-claude"). Empty if no match.
-  SAME_AGENT_REVIEWER=$(echo "$REVIEWERS" | awk -v agent="-$AUTHORING_AGENT" '$0 ~ agent"$" { print; exit }')
+if printf '%s\n' "$PR_BODY" | grep -qiE '^Authoring-Agent:'; then
+  AUTHORING_AGENT=$(printf '%s\n' "$PR_BODY" \
+    | grep -i -m1 -E '^Authoring-Agent:' \
+    | sed -E 's/^[Aa]uthoring-[Aa]gent:[[:space:]]*([A-Za-z0-9_-]+).*/\1/' \
+    | tr '[:upper:]' '[:lower:]')
+  if [ -n "$AUTHORING_AGENT" ]; then
+    # Match against available_reviewers via suffix (e.g., "claude"
+    # matches "nathanpayne-claude"). Empty if no match — also
+    # pipefail-safe: awk always exits 0 even when no record matched.
+    SAME_AGENT_REVIEWER=$(echo "$REVIEWERS" | awk -v agent="-$AUTHORING_AGENT" '$0 ~ agent"$" { print; exit }')
+  fi
 fi
 
 HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \

--- a/scripts/request-label-removal.sh
+++ b/scripts/request-label-removal.sh
@@ -92,7 +92,23 @@ if [ "$allowed" -ne 1 ]; then
 fi
 
 REPO_FLAG=()
-if [ -n "$REPO" ]; then REPO_FLAG=(--repo "$REPO"); fi
+REPO_HINT_FOR_BODY=""
+if [ -n "$REPO" ]; then
+  REPO_FLAG=(--repo "$REPO")
+  REPO_HINT_FOR_BODY=" --repo $REPO"
+fi
+# Plain string (set -e safe). The previous form embedded
+# `$([ -n "$REPO" ] && echo "--repo $REPO")` directly inside the BODY
+# heredoc. In the default no-`--repo` case the inline `[` returns 1,
+# the `&&` short-circuits with rc=1, the command substitution's
+# rc=1 propagates as the assignment's exit status, and `set -e`
+# aborts the whole script BEFORE `gh pr comment` ever runs — so
+# every `request-label-removal.sh <PR#> <label>` call without
+# `--repo` silently failed (no PR comment, no iMessage, no error
+# message to chat past the bash trace). Compute the hint string
+# once in a normal `if` block so the assignment can never inherit
+# a non-zero exit from a tested-empty command substitution.
+# (nathanpayne-codex Phase 4b finding on the 263caf3 sync wave.)
 
 # Token policy (CodeRabbit Major, #271/#272):
 #  - The `gh pr view` READ below is pinned to a PAT
@@ -132,7 +148,7 @@ BODY="@nathanjohnpayne — this PR is blocked only on the \`$LABEL\` label.
 Per [REVIEW_POLICY.md § Agent prohibitions](https://github.com/nathanjohnpayne/mergepath/blob/main/REVIEW_POLICY.md), agents do not remove this label. When you're ready, clear it from any device:
 
 - GitHub UI: Labels sidebar → click \`x\` on \`$LABEL\`
-- CLI: \`gh pr edit $PR_NUM --remove-label $LABEL\` $([ -n "$REPO" ] && echo "--repo $REPO")
+- CLI: \`gh pr edit $PR_NUM --remove-label $LABEL${REPO_HINT_FOR_BODY}\`
 
 Auto-merge will fire as soon as the label is gone.${REASON_BLOCK}${AUTOCLEAR_NOTE}
 


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Two upstream-source canonical defects flagged by `nathanpayne-codex`
during the external Phase 4b reviews on the 263caf3 propagation wave.
Eight consumer sync PRs (matchline#232, nathanpaynedotcom#368,
overridebroadway#59, device-source-of-truth#86,
friends-and-family-billing#270, device-platform-reporting#80,
swipewatch#51, tadlockpsychiatry#54) passed `verify-propagation-pr.sh`
against current mergepath HEAD — the mirror mechanics are clean —
but the mirrored canonical content carries real blockers. Fixing
both here, then cherry-picking onto each of the 8 sync branches so
the wave can complete.

### Bug 1 — `scripts/request-label-removal.sh` aborts under `set -e` with no `--repo`

The `BODY="..."` heredoc embedded an inline command substitution:

```bash
$([ -n "$REPO" ] && echo "--repo $REPO")
```

In the default no-`--repo` case `$REPO=""`, so `[ -n "" ]` returns 1,
the `&&` short-circuits with rc=1, the command substitution's rc=1
becomes the assignment's exit status, and `set -eo pipefail` aborts
the script BEFORE `gh pr comment` runs. Every
`request-label-removal.sh <PR#> <label>` call without `--repo`
silently failed (no PR comment, no iMessage, no error past the bash
trace).

Empirically verified the abort with a minimal repro before fixing.

**Fix:** compute the hint string in a normal `if` block so the
assignment can never inherit a non-zero exit from a tested-empty
command substitution:

```bash
REPO_HINT_FOR_BODY=""
if [ -n "$REPO" ]; then
  REPO_HINT_FOR_BODY=" --repo $REPO"
fi
```

The `BODY` then interpolates `${REPO_HINT_FOR_BODY}` — a plain
string, always defined, always `set -e` safe.

### Bug 2 — `scripts/codex-review-check.sh` allows authoring-agent self-approval

The jq filters in **gate (b) branch 1** (line ~590) and the **gate (c)
Phase 4b substitute** (line ~805) excluded only the GitHub PR-author
login (`$author` = `nathanjohnpayne`), not the **authoring agent's
own reviewer identity** (e.g. `nathanpayne-claude` for a claude-
authored PR). Because `nathanpayne-claude` is in
`available_reviewers` AND is a different login from `nathanjohnpayne`,
a claude-authored over-threshold PR could clear the merge gate by
`nathanpayne-claude` posting `APPROVED` on HEAD.

GitHub-native branch protection only blocks reviewer == PR-author,
so this script IS the last line of defense against agent self-
approval at Phase 4. REVIEW_POLICY.md § No-self-approve scoping
already states the authoring agent's own reviewer identity is
disqualified for Phase 4 — the script wasn't enforcing it.

**Fix:** pass `--arg same_agent_reviewer "$SAME_AGENT_REVIEWER"`
(already computed earlier in the script from the PR body's
`Authoring-Agent:` header) into both filters, and exclude it
alongside `$author`:

```jq
| select(.user.login != $author)
| select($same_agent_reviewer == "" or .user.login != $same_agent_reviewer)
```

The empty-string clause preserves existing behavior for PRs without
an `Authoring-Agent:` header or whose value doesn't match a configured
reviewer identity — no exclusion when there's no authoring agent to
exclude.

Same-agent + Codex 👍 (branch 2 at line ~625) is unaffected: that
fallback is OPT-IN via the `Authoring-Agent:` header and remains the
correct path for single-agent sessions where no cross-agent reviewer
is available.

## Tests

New `scripts/ci/check_canonical_bugs_263caf3` — 12 cases:

**Bug 1 (4):**
- no-`--repo` invocation reaches `gh pr comment`
- `--repo` invocation reaches `gh pr comment`
- no-`--repo` BODY contains correct CLI hint
- `--repo` BODY contains correct CLI hint

**Bug 2 (8):**
- gate (b) rejects same-agent self-approval (claude→claude)
- gate (c) rejects same-agent self-approval (claude→claude)
- gate (b) accepts cross-agent approval (claude-authored, codex-approved)
- gate (c) accepts cross-agent Phase 4b approval
- gate (b) accepts non-author reviewer when no Authoring-Agent header
- gate (c) accepts non-author reviewer when no Authoring-Agent header
- gate (b) rejects PR-author self-approval (nathanjohnpayne→nathanjohnpayne)
- gate (b) honors latest-state CHANGES_REQUESTED over earlier APPROVED (regression)

Filter literals duplicated verbatim from `scripts/codex-review-check.sh`
— same inline-literal coupling `check_pr_audit_codex_clearance` and
`check_workflow_parsers` use. Wired into
`.github/workflows/repo_lint.yml` between `check_codex_scripts` and
`check_workflow_parsers`.

All 12 pass locally.

## Self-Review

- **Correctness**: empirical repro confirmed Bug 1's `set -e` abort
  before fixing; full 12-case test matrix covers Bug 2's expected
  accept/reject behavior including the cross-agent and no-header
  paths. `bash scripts/ci/check_canonical_bugs_263caf3` → PASS.
- **Regression risk**: low. Bug 1 fix is mechanically equivalent
  output with safer evaluation. Bug 2 fix's empty-string clause
  preserves all existing behavior for PRs without an `Authoring-Agent:`
  header. The latest-state-wins regression guard (case E) confirms
  the new filter doesn't disturb the pre-existing group_by/max_by
  semantics.
- **Style/conventions**: matches the env-override + inline-literal-
  test pattern already used in `check_workflow_parsers` and
  `check_pr_audit_codex_clearance`.
- **Test coverage**: the new check runs in CI and locally, and
  scripts/ci/ is propagated as a kit so consumers inherit it
  automatically on the next sync wave.
- **Security/dependency hygiene**: Bug 2 closes an agent-self-
  approval hole that bypassed the cross-agent Phase 4 guarantee.
  No new dependencies; jq + bash only.

