### PR TITLE
feat: tighten op-preflight contract — --check mode, default review, helper auto-source (#282)

### DIFF
--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -83,6 +83,9 @@ jobs:
       - name: check_gh_as_author
         run: ./scripts/ci/check_gh_as_author
 
+      - name: check_op_preflight_contract
+        run: ./scripts/ci/check_op_preflight_contract
+
       - name: check_eslint_config_present
         run: ./scripts/ci/check_eslint_config_present
 

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -140,6 +140,12 @@ paths:
   - path: scripts/op-preflight.sh
     type: canonical
     consumers: all
+  # Sourced by all five GH_TOKEN-using helper scripts; carries the
+  # auto-source logic that lets agents drop the explicit
+  # `GH_TOKEN=...` prefix once the preflight cache is warm. See #282.
+  - path: scripts/lib/preflight-helpers.sh
+    type: canonical
+    consumers: all
   - path: scripts/coderabbit-wait.sh
     type: canonical
     consumers: all
@@ -233,6 +239,16 @@ paths:
   # gh; no live GitHub network. Travels with the helper so consumers
   # exercise the same renderer they propagate.
   - path: tests/test_post_phase_4b_handoff.sh
+    type: canonical
+    consumers: all
+  # Pairs with scripts/op-preflight.sh + scripts/lib/preflight-helpers.sh
+  # + scripts/ci/check_op_preflight_contract. The check wrapper requires
+  # both test files; same coupling pattern as the gh-as-author and
+  # codex-p1-gate suites above. See #282.
+  - path: tests/test_op_preflight_check.sh
+    type: canonical
+    consumers: all
+  - path: tests/test_helper_autosource.sh
     type: canonical
     consumers: all
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,29 +24,51 @@ This repository uses a multi-identity AI agent code review system. The full poli
 
 ### Workflow Summary
 
-0. Run credential preflight at the start of every PR session (and safely
-   at the top of every subsequent tool call — re-running within the TTL
-   returns cached values without a new biometric prompt):
-   `eval "$(scripts/op-preflight.sh --agent {your-agent} --mode all)"`
-   This triggers biometric prompts once and writes a chmod-600 session
-   file at `$XDG_CACHE_HOME/mergepath/op-preflight-<agent>.env` so fresh
-   subshells can reuse the credentials (see REVIEW_POLICY.md § Phase 0).
-   `gh` resolves auth differently for read vs write paths: read paths
-   (`gh api user`, GETs, helper scripts) honor `GH_TOKEN`; write paths
-   (`gh pr review`, `gh pr create`, `gh pr merge`, `gh pr edit`) use
-   the keyring's **active** account. Set the active account once per
-   machine: `gh auth switch -u nathanpayne-{your-agent}`. Then use
-   `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"` (or `$OP_PREFLIGHT_AUTHOR_PAT`)
-   only for read-path API calls and helper scripts. For author-identity
-   writes (PR create/merge/label edits), MUST wrap the call in
-   `scripts/gh-as-author.sh -- gh pr create ...` — a single bash process
-   that switches, runs, and switches back via `trap EXIT`. Splitting the
-   sequence across two Bash tool calls lands the PR under the wrong
-   identity (#241). The `gh-pr-guard.sh` PreToolUse hook now blocks
-   `gh pr create` when the keyring's active is not `nathanjohnpayne`.
-   See REVIEW_POLICY.md § Reviewer PAT Quick Start for the full convention
-   and § Recovery: PR created under the wrong identity for what to do
-   if a PR already landed under the wrong account.
+0. Run credential preflight at the start of every PR session. The
+   canonical session-loop snippet (read-path GH_TOKEN, write-path
+   active-keyring, author-write wrapper — full details in REVIEW_POLICY.md
+   § Phase 0 and § PAT lookup table):
+
+   ```bash
+   # Session start (one biometric burst). Default --mode is `review`.
+   eval "$(scripts/op-preflight.sh --agent {your-agent} --mode review)"
+
+   # Every subsequent tool call (idempotent, NEVER prompts):
+   eval "$(scripts/op-preflight.sh --agent {your-agent} --check)"
+
+   # Read-path API call (uses cached PAT, no biometric):
+   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq .login
+
+   # Write-path API call (gh keyring active = nathanpayne-{your-agent}):
+   gh pr review <PR#> --comment --body "..."
+
+   # Author write (temporary switch via the gh-as-author.sh wrapper):
+   scripts/gh-as-author.sh -- gh pr create ...
+   ```
+
+   `--check` (alias `--status`) is the lightweight re-validator: never
+   invokes `op`, never warms SSH, exits non-zero on missing/stale
+   cache. Set `OP_PREFLIGHT_QUIET=1` to collapse the cache-hit stderr
+   block. The helper scripts (`coderabbit-wait.sh`,
+   `codex-review-request.sh`, `codex-review-check.sh`,
+   `resolve-pr-threads.sh`, `request-label-removal.sh`) auto-source
+   the cache when `GH_TOKEN` is unset (#282), so the explicit
+   `GH_TOKEN=...` prefix is optional once preflight has run.
+
+   Set the gh keyring active account once per machine: `gh auth switch
+   -u nathanpayne-{your-agent}`. Then read-path commands use
+   `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"`; write paths use the
+   keyring active. For author-identity writes (PR create/merge/label
+   edits), MUST wrap the call in `scripts/gh-as-author.sh -- gh pr
+   create ...` — a single bash process that switches, runs, and
+   switches back via `trap EXIT`. Splitting the sequence across two
+   Bash tool calls lands the PR under the wrong identity (#241). The
+   `gh-pr-guard.sh` PreToolUse hook now blocks `gh pr create` when
+   the keyring's active is not `nathanjohnpayne`. See REVIEW_POLICY.md
+   § Reviewer PAT Quick Start for the full convention and § Recovery:
+   PR created under the wrong identity for what to do if a PR already
+   landed under the wrong account.
+
    Run `scripts/op-preflight.sh --agent {your-agent} --purge` (or
    `--purge-all`) at end of session to delete the cached PATs.
 1. Author code as nathanjohnpayne. File a PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,22 +78,43 @@ keyring active is your agent identity. No switch needed for commits.
 
 ## Session start (run once)
 
-0. Run credential preflight to front-load all biometric prompts:
-   `eval "$(scripts/op-preflight.sh --agent claude --mode all)"`
-   This caches PATs and deploy credentials in a chmod-600 session file
-   at `$XDG_CACHE_HOME/mergepath/op-preflight-claude.env` (default
-   `$HOME/.cache/mergepath/`). Safe to re-run at the top of every tool
-   call — within the TTL (4h default, override via
-   `OP_PREFLIGHT_TTL_SECONDS`) the script reads the session file and
-   emits the same exports without a new biometric prompt. Read-path
-   API calls and helper scripts use
-   `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"` (or `…AUTHOR_PAT`) instead
-   of `op read`. Write paths (`gh pr review` / `create` / `merge` /
-   `edit`) use the active keyring account regardless of `GH_TOKEN`
-   per the Active-account convention above.
+0. Run credential preflight to front-load all biometric prompts. The
+   canonical session-loop snippet (see REVIEW_POLICY.md § Phase 0 for
+   the full doc, and § PAT lookup table for the per-agent item IDs):
+
+   ```bash
+   # Session start (one biometric burst). Default --mode is `review`.
+   eval "$(scripts/op-preflight.sh --agent claude --mode review)"
+
+   # Every subsequent tool call (idempotent, NEVER prompts):
+   eval "$(scripts/op-preflight.sh --agent claude --check)"
+
+   # Read-path API call (uses cached PAT, no biometric):
+   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq .login
+
+   # Write-path API call (gh keyring active = nathanpayne-<agent>):
+   gh pr review <PR#> --comment --body "..."
+
+   # Author write (temporary switch via the gh-as-author.sh wrapper):
+   scripts/gh-as-author.sh -- gh pr create ...
+   ```
+
+   The cache lives at `$XDG_CACHE_HOME/mergepath/op-preflight-claude.env`
+   (default `$HOME/.cache/mergepath/`), chmod 600. The `--check` mode
+   is a read-only validator: it never invokes `op`, never warms SSH,
+   never reads ADC; on a missing/stale cache it exits non-zero with a
+   pointer back at `--mode review`. Safe to re-run at the top of every
+   tool call. Within the TTL (4h default, override via
+   `OP_PREFLIGHT_TTL_SECONDS`) the script emits the cached exports
+   without a new biometric prompt. Set `OP_PREFLIGHT_QUIET=1` to
+   collapse the cache-hit stderr block to a single line.
+
    Run `scripts/op-preflight.sh --agent claude --purge` at end of
-   session to wipe the cache. If preflight was not run (or failed), fall
-   back to inline `op read` (original pattern).
+   session to wipe the cache. If preflight is unavailable (e.g.
+   first-time bootstrap on a fresh machine), fall back to inline
+   `op read` per REVIEW_POLICY.md § PAT lookup table > Fallback —
+   every call triggers biometric, so use only for setup, never for
+   routine work.
 
 ## Before opening a PR
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -432,14 +432,15 @@ for collaborators), not repos they collaborate on.
 **Use classic PATs with `repo` scope for all reviewer identities.** This is stored
 in 1Password with the field name `token` (not `credential` or `password`).
 
-1Password item IDs (all classic PATs with `ghp_` prefix, field `token`, vault `Private`):
+**Canonical PAT lookup table:** see [REVIEW_POLICY.md § PAT lookup
+table](REVIEW_POLICY.md#pat-lookup-table). The single source of truth
+for agent-to-item-ID mappings lives there, alongside the cached
+`$OP_PREFLIGHT_*_PAT` env-var conventions. Routine work should use the
+cached env vars (no biometric per call); the inline `op read` form is
+a setup-only fallback documented in the same section.
 
-| Reviewer Identity | 1Password Item ID | `op read` command |
-|---|---|---|
-| `nathanpayne-claude` | `pvbq24vl2h6gl7yjclxy2hbote` | `op read "op://Private/pvbq24vl2h6gl7yjclxy2hbote/token"` |
-| `nathanpayne-cursor` | `bslrih4spwxgookzfy6zedz5g4` | `op read "op://Private/bslrih4spwxgookzfy6zedz5g4/token"` |
-| `nathanpayne-codex` | `o6ekjxjjl5gq6rmcneomrjahpu` | `op read "op://Private/o6ekjxjjl5gq6rmcneomrjahpu/token"` |
-| `nathanjohnpayne` | `sm5kopwk6t6p3xmu2igesndzhe` | `op read "op://Private/sm5kopwk6t6p3xmu2igesndzhe/token"` |
+All 1Password items in that table are classic PATs with the `ghp_`
+prefix, stored with field name `token` in the `Private` vault.
 
 Use the item ID (not the item title) to avoid shell issues with parentheses in
 1Password item names like `GitHub PAT (pr-review-claude)`.
@@ -457,10 +458,9 @@ and `CLAUDE.md` § Active-account convention. Short form:
   machine: `gh auth switch -u nathanpayne-<agent>`.
 
 ```bash
-# Read-path identity check — GH_TOKEN works here.
-GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
-  gh api user --jq '.login'
-# expected: nathanpayne-claude
+# Read-path identity check (PRIMARY — uses cached PAT, no biometric).
+GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq '.login'
+# expected: nathanpayne-<agent>
 
 # Write-path: with the agent identity active, GH_TOKEN is irrelevant
 # for the byline. Just run the command.
@@ -472,6 +472,13 @@ gh auth switch -u nathanjohnpayne && \
   gh pr merge <PR#> --squash --delete-branch && \
   gh auth switch -u nathanpayne-<agent>
 ```
+
+> **⚠️ Fallback / setup-only:** the inline `GH_TOKEN="$(op read
+> 'op://Private/<item-id>/token')"` form triggers a biometric prompt
+> on **every** invocation. Use only when `op-preflight.sh` is
+> unavailable. Routine agent work should always use the cached
+> `$OP_PREFLIGHT_REVIEWER_PAT` env var after a one-time
+> `eval "$(scripts/op-preflight.sh --agent <agent> --mode review)"`.
 
 - Use the item ID from the table above for your agent identity. Do not use the 1Password item title.
 - Verify the keyring active account with `gh config get -h github.com user`

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -71,18 +71,28 @@ matters for audit-trail consistency.
 
 #### PAT lookup table
 
-| Agent | Reviewer Identity | 1Password Item ID | `op read` path |
-|-------|-------------------|-------------------|----------------|
-| Claude | `nathanpayne-claude` | `pvbq24vl2h6gl7yjclxy2hbote` | `op://Private/pvbq24vl2h6gl7yjclxy2hbote/token` |
-| Cursor | `nathanpayne-cursor` | `bslrih4spwxgookzfy6zedz5g4` | `op://Private/bslrih4spwxgookzfy6zedz5g4/token` |
-| Codex | `nathanpayne-codex` | `o6ekjxjjl5gq6rmcneomrjahpu` | `op://Private/o6ekjxjjl5gq6rmcneomrjahpu/token` |
-| Human | `nathanjohnpayne` | `sm5kopwk6t6p3xmu2igesndzhe` | `op://Private/sm5kopwk6t6p3xmu2igesndzhe/token` |
+> This is the **canonical source** for PAT lookups across the
+> mergepath ecosystem. `CLAUDE.md` (project), `AGENTS.md`, and
+> `DEPLOYMENT.md` all reference this section instead of duplicating
+> the table. Machine-level `~/GitHub/CLAUDE.md` mirrors the same
+> rows for cross-repo work.
+
+| Agent | Reviewer Identity | 1Password Item ID | Cached env var (primary) | `op read` path (setup-only fallback) |
+|-------|-------------------|-------------------|--------------------------|--------------------------------------|
+| Claude | `nathanpayne-claude` | `pvbq24vl2h6gl7yjclxy2hbote` | `$OP_PREFLIGHT_REVIEWER_PAT` | `op://Private/pvbq24vl2h6gl7yjclxy2hbote/token` |
+| Cursor | `nathanpayne-cursor` | `bslrih4spwxgookzfy6zedz5g4` | `$OP_PREFLIGHT_REVIEWER_PAT` | `op://Private/bslrih4spwxgookzfy6zedz5g4/token` |
+| Codex | `nathanpayne-codex` | `o6ekjxjjl5gq6rmcneomrjahpu` | `$OP_PREFLIGHT_REVIEWER_PAT` | `op://Private/o6ekjxjjl5gq6rmcneomrjahpu/token` |
+| Human | `nathanjohnpayne` | `sm5kopwk6t6p3xmu2igesndzhe` | `$OP_PREFLIGHT_AUTHOR_PAT` | `op://Private/sm5kopwk6t6p3xmu2igesndzhe/token` |
+
+**Cached-variable usage is the primary pattern.** After a single
+`eval "$(scripts/op-preflight.sh --agent <agent> --mode review)"` at
+session start, all subsequent API calls use the env var directly —
+no biometric burned per call:
 
 ```bash
-# Read-path identity check — GH_TOKEN works here.
-GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
-  gh api user --jq '.login'
-# expected: nathanpayne-claude
+# Read-path identity check (PRIMARY — uses cached PAT, no biometric).
+GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq '.login'
+# expected: nathanpayne-<agent>
 
 # Write-path: with the agent identity active, GH_TOKEN is irrelevant
 # for the byline. Just run the command.
@@ -100,6 +110,21 @@ scripts/gh-as-author.sh -- gh pr create --title "..." --body "..."
 gh auth switch -u nathanjohnpayne && \
   gh pr create --title "..." --body "..." && \
   gh auth switch -u nathanpayne-claude
+```
+
+##### Fallback / setup-only: inline `op read`
+
+> **⚠️ This triggers a biometric prompt every call. Use only when
+> `op-preflight.sh` is unavailable** — for example, during the
+> initial bootstrap of a new machine before the cache directory
+> exists, or in a CI runner that has not been wired through
+> preflight. Routine agent work should always use the cached
+> `$OP_PREFLIGHT_*_PAT` env vars above.
+
+```bash
+# Setup-only — every invocation prompts for Touch ID.
+GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
+  gh api user --jq '.login'
 ```
 
 - Use the item ID from the lookup table above for your agent identity. Do not use the 1Password item title.
@@ -150,16 +175,31 @@ text below.
 > Run this once at the start of every PR review or deploy session. It front-loads all 1Password credential reads and SSH key authorization into a single burst of biometric prompts (~15 seconds), so the human can step away for the rest of the session.
 
 ```bash
-eval "$(scripts/op-preflight.sh --agent claude --mode all)"
+# Session start (one biometric burst). `--mode review` is the DEFAULT
+# (changed from `--mode all` in #282) — most agent work only needs the
+# reviewer/author PATs + SSH warming, not deploy credentials.
+eval "$(scripts/op-preflight.sh --agent claude --mode review)"
+
+# Every subsequent tool call (idempotent, NEVER prompts for biometric):
+eval "$(scripts/op-preflight.sh --agent claude --check)"
 ```
+
+The `--check` (alias `--status`) mode is the lightweight idempotent re-
+validation pattern: it loads the cached export statements without
+invoking `op`, without warming SSH, and without reading ADC. On a
+missing or stale cache it exits non-zero with a remediation message
+pointing back at `--mode review`. Combined with `OP_PREFLIGHT_QUIET=1`
+the cache-hit path collapses to a single stderr line, so noisy agent
+sessions don't accumulate a verbose preflight block on every tool call.
+See nathanjohnpayne/mergepath#282.
 
 Replace `claude` with `cursor` or `codex` depending on which agent is running. The `--mode` flag controls what is loaded:
 
 | Mode | What's loaded |
 |------|--------------|
-| `review` | Reviewer PAT + author PAT + SSH keys |
-| `deploy` | GCP ADC credential |
-| `all` | Everything (recommended) |
+| `review` | Reviewer PAT + author PAT + SSH keys (**DEFAULT**) |
+| `deploy` | GCP ADC credential + Cloudflare cache-purge token |
+| `all` | Everything |
 
 After preflight, these environment variables are set:
 - `OP_PREFLIGHT_REVIEWER_PAT` — use with `GH_TOKEN=` for reviewer-identity **read-path** API calls and helper scripts (`coderabbit-wait.sh`, `codex-review-request.sh`, `codex-review-check.sh`). Write paths (`gh pr review` / `create` / `merge` / `edit`) use the active keyring account regardless of `GH_TOKEN` — see [Reviewer PAT Quick Start](#reviewer-pat-quick-start).

--- a/docs/agents/deployment-process.md
+++ b/docs/agents/deployment-process.md
@@ -11,8 +11,12 @@ If the project uses Firebase or Google Cloud, prefer the canonical
 - When the resolved source credential is the project SA key directly, no impersonation wrapper is used (faster, no `serviceAccountTokenCreator` IAM dependency). When it's the shared ADC or another non-matching credential, `op-firebase-deploy` writes a temporary `impersonated_service_account` credential and stamps the target project as the quota project.
 - Do not introduce long-lived service account keys into repo docs,
   scripts, or secret stores unless a project explicitly requires them. The Firebase-vault SA key in 1Password is the supported on-account form; on-disk deploy keys are not.
-- If credential preflight was run at session start (`scripts/op-preflight.sh --mode all`),
-  deploy credentials are already cached. No additional biometric prompt is needed for deployment.
+- If credential preflight was run at session start with deploy creds
+  loaded (`scripts/op-preflight.sh --mode deploy` or `--mode all`),
+  deploy credentials are already cached. No additional biometric
+  prompt is needed for deployment. The default `--mode review` does
+  NOT load deploy credentials (#282); pass `--mode deploy` explicitly
+  for a deploy session.
 - If an `op` command fails with a sign-in or biometric error during deploy, follow the pause-and-prompt procedure in [operating-rules.md](operating-rules.md#1password-cli-authentication-failures). Do not retry or work around the failure without the human present.
 
 ## Credential source debugging

--- a/docs/agents/operating-rules.md
+++ b/docs/agents/operating-rules.md
@@ -41,7 +41,10 @@ Then follow this procedure:
    suggest running the preflight script:
    > "1Password auth failed. Would you like to run credential preflight
    > to cache all credentials at once?
-   > `eval \"$(scripts/op-preflight.sh --agent claude --mode all)\"`"
+   > `eval \"$(scripts/op-preflight.sh --agent claude --mode review)\"`"
+   >
+   > (Use `--mode deploy` or `--mode all` instead if a deploy is in
+   > scope; the default is now `review` per #282.)
 3. **If preflight was already run** but credentials expired (rare —
    only after 1Password locks or the 12-hour hard limit), prompt
    the human and suggest re-running preflight:

--- a/scripts/ci/check_op_preflight_contract
+++ b/scripts/ci/check_op_preflight_contract
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# scripts/ci/check_op_preflight_contract — CI entry point for #282.
+#
+# Runs the unit tests for the tightened op-preflight contract:
+#   - --check / --status mode never invokes op, never warms SSH
+#   - Default --mode is review (not all)
+#   - OP_PREFLIGHT_QUIET=1 collapses the cache-hit stderr block
+#   - The five helper scripts auto-source the cache when GH_TOKEN is
+#     unset, and the shared preflight-helpers.sh library works as
+#     documented.
+#
+# Hard-fails when either test file is missing so a rename can't
+# silently disable the check.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+TESTS=(
+  "tests/test_op_preflight_check.sh"
+  "tests/test_helper_autosource.sh"
+)
+
+FAILED=0
+for rel in "${TESTS[@]}"; do
+  full="$REPO_ROOT/$rel"
+  if [ ! -f "$full" ]; then
+    echo "check_op_preflight_contract: ERROR (missing $rel)" >&2
+    FAILED=1
+    continue
+  fi
+  echo "check_op_preflight_contract: running $rel"
+  if ! bash "$full"; then
+    echo "check_op_preflight_contract: FAIL ($rel)" >&2
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "check_op_preflight_contract: FAIL"
+  exit 1
+fi
+
+echo "check_op_preflight_contract: PASS"
+exit 0

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -98,6 +98,25 @@
 
 set -euo pipefail
 
+# --- preflight auto-source (#282) ------------------------------------------
+# If GH_TOKEN is unset and a fresh op-preflight cache exists for this
+# agent, source it and export OP_PREFLIGHT_REVIEWER_PAT as GH_TOKEN.
+# This lets agents drop the explicit `GH_TOKEN=...` prefix when their
+# preflight cache is already warm. Preserves existing behavior when
+# GH_TOKEN is already set. The existing
+# `[ -z "${GH_TOKEN:-}" ] && exit 3` guard below still fires on a
+# missing cache + missing env var (no regression).
+__CODERABBIT_WAIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -r "$__CODERABBIT_WAIT_DIR/lib/preflight-helpers.sh" ]; then
+  # shellcheck source=lib/preflight-helpers.sh
+  . "$__CODERABBIT_WAIT_DIR/lib/preflight-helpers.sh"
+  # Author PAT per the original docstring contract — this helper posts
+  # `@coderabbitai, try again.` on rate-limit retries. GH_TOKEN
+  # authenticates the API call; the trigger-comment byline is the
+  # keyring's active account regardless.
+  preflight_require_token author || true
+fi
+
 # --- argument parsing -------------------------------------------------------
 
 if [ $# -lt 1 ] || [ $# -gt 2 ]; then
@@ -121,7 +140,10 @@ if [ -z "$REPO" ]; then
 fi
 
 if [ -z "${GH_TOKEN:-}" ]; then
-  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  echo "ERROR: GH_TOKEN is required. Either:" >&2
+  echo "  - Run: eval \"\$(scripts/op-preflight.sh --agent <agent> --mode review)\"" >&2
+  echo "    so this helper auto-sources OP_PREFLIGHT_REVIEWER_PAT, OR" >&2
+  echo "  - Set GH_TOKEN inline per REVIEW_POLICY.md § PAT lookup table." >&2
   exit 3
 fi
 

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -85,6 +85,19 @@
 
 set -euo pipefail
 
+# --- preflight auto-source (#282) ------------------------------------------
+# Auto-source the op-preflight cache when GH_TOKEN is unset and a fresh
+# cache exists for this agent. codex-review-check.sh is read-only, so
+# reviewer scope is the right PAT — but the auto-source picks whatever
+# is in the cache, both PATs are available, and we only need one for
+# the API calls below.
+__CODEX_CHECK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -r "$__CODEX_CHECK_DIR/lib/preflight-helpers.sh" ]; then
+  # shellcheck source=lib/preflight-helpers.sh
+  . "$__CODEX_CHECK_DIR/lib/preflight-helpers.sh"
+  preflight_require_token reviewer || true
+fi
+
 # --- argument parsing -------------------------------------------------------
 
 if [ $# -lt 1 ] || [ $# -gt 2 ]; then
@@ -108,7 +121,10 @@ if [ -z "$REPO" ]; then
 fi
 
 if [ -z "${GH_TOKEN:-}" ]; then
-  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  echo "ERROR: GH_TOKEN is required. Either:" >&2
+  echo "  - Run: eval \"\$(scripts/op-preflight.sh --agent <agent> --mode review)\"" >&2
+  echo "    so this helper auto-sources OP_PREFLIGHT_REVIEWER_PAT, OR" >&2
+  echo "  - Set GH_TOKEN inline per REVIEW_POLICY.md § PAT lookup table." >&2
   exit 3
 fi
 

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -104,6 +104,23 @@
 
 set -euo pipefail
 
+# --- preflight auto-source (#282) ------------------------------------------
+# Auto-source the op-preflight cache when GH_TOKEN is unset and a fresh
+# cache exists for this agent. No-op when GH_TOKEN is already set.
+__CODEX_REQUEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -r "$__CODEX_REQUEST_DIR/lib/preflight-helpers.sh" ]; then
+  # shellcheck source=lib/preflight-helpers.sh
+  . "$__CODEX_REQUEST_DIR/lib/preflight-helpers.sh"
+  # Author PAT is correct for this helper: codex-review-request.sh
+  # both reads PR state AND posts the `@codex review` trigger comment.
+  # The byline of the trigger comment is the keyring's active account
+  # (write-path), but the GitHub API call itself authenticates with the
+  # PAT in GH_TOKEN. Use the author PAT so the API call is attributed
+  # to the author identity, consistent with the broader nathanjohnpayne
+  # = drives-the-PR convention. See REVIEW_POLICY.md § PAT scope below.
+  preflight_require_token author || true
+fi
+
 # --- argument parsing -------------------------------------------------------
 
 if [ $# -lt 1 ] || [ $# -gt 2 ]; then
@@ -129,7 +146,10 @@ if [ -z "$REPO" ]; then
 fi
 
 if [ -z "${GH_TOKEN:-}" ]; then
-  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  echo "ERROR: GH_TOKEN is required. Either:" >&2
+  echo "  - Run: eval \"\$(scripts/op-preflight.sh --agent <agent> --mode review)\"" >&2
+  echo "    so this helper auto-sources OP_PREFLIGHT_AUTHOR_PAT, OR" >&2
+  echo "  - Set GH_TOKEN inline per REVIEW_POLICY.md § PAT lookup table." >&2
   exit 3
 fi
 

--- a/scripts/lib/preflight-helpers.sh
+++ b/scripts/lib/preflight-helpers.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# scripts/lib/preflight-helpers.sh — shared auto-source logic for helpers.
+#
+# Sourced by the read-path helper scripts that previously required the
+# caller to set GH_TOKEN inline (codex-review-request.sh,
+# codex-review-check.sh, coderabbit-wait.sh, resolve-pr-threads.sh,
+# request-label-removal.sh). The contract:
+#
+#   * If GH_TOKEN is already set, do nothing (preserve existing behavior).
+#   * Otherwise, locate the op-preflight cache file for the current agent
+#     (or the agent inferred from MERGEPATH_AGENT / $USER / hostname) and
+#     source it if it is fresh per the TTL anchored on
+#     OP_PREFLIGHT_CREATED_AT_EPOCH.
+#   * After sourcing, helpers pick the right env var
+#     (OP_PREFLIGHT_REVIEWER_PAT vs OP_PREFLIGHT_AUTHOR_PAT) themselves —
+#     this library does NOT assign GH_TOKEN.
+#
+# Closes #282 (op-preflight contract): before this library, helpers that
+# required GH_TOKEN exited 3 when called from a fresh subshell even when
+# a warm preflight cache was sitting on disk for this agent. Auto-
+# sourcing means agents can drop the explicit `GH_TOKEN="$OP_PREFLIGHT_
+# REVIEWER_PAT" scripts/foo.sh` prefix without re-burning a biometric.
+#
+# Bash 3.2 portable.
+
+# Locate the cache directory the same way op-preflight.sh does.
+preflight_cache_dir() {
+  local override="${OP_PREFLIGHT_CACHE_DIR:-}"
+  if [[ -n "$override" ]]; then
+    printf '%s' "$override"
+    return 0
+  fi
+  local base="${XDG_CACHE_HOME:-$HOME/.cache}"
+  printf '%s/mergepath' "$base"
+}
+
+# Determine which agent's cache file to consult. Order of precedence:
+#   1. $MERGEPATH_AGENT (explicit override)
+#   2. $OP_PREFLIGHT_AGENT (left over from a prior eval in this shell)
+#   3. The single cache file under the cache dir (if exactly one exists)
+# Returns empty string if no agent can be determined.
+preflight_agent() {
+  if [[ -n "${MERGEPATH_AGENT:-}" ]]; then
+    printf '%s' "$MERGEPATH_AGENT"
+    return 0
+  fi
+  if [[ -n "${OP_PREFLIGHT_AGENT:-}" ]]; then
+    printf '%s' "$OP_PREFLIGHT_AGENT"
+    return 0
+  fi
+  local cache_dir
+  cache_dir="$(preflight_cache_dir)"
+  [[ -d "$cache_dir" ]] || return 0
+  local files=( "$cache_dir"/op-preflight-*.env )
+  if [[ ${#files[@]} -eq 1 && -f "${files[0]}" ]]; then
+    local base="${files[0]##*/}"
+    base="${base#op-preflight-}"
+    base="${base%.env}"
+    printf '%s' "$base"
+    return 0
+  fi
+  return 0
+}
+
+# Internal: returns 0 if the session file is fresh per its embedded
+# OP_PREFLIGHT_CREATED_AT_EPOCH (NOT mtime) and the active TTL.
+preflight_session_is_fresh() {
+  local session_file="$1"
+  [[ -f "$session_file" ]] || return 1
+  local created_at now age ttl
+  created_at=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$session_file" 2>/dev/null \
+    | cut -d= -f2- | tr -d "'\"" || true)
+  [[ -z "$created_at" ]] && return 1
+  [[ "$created_at" =~ ^[0-9]+$ ]] || return 1
+  ttl="${OP_PREFLIGHT_TTL_SECONDS:-14400}"
+  [[ "$ttl" =~ ^[0-9]+$ ]] || ttl=14400
+  now=$(date +%s)
+  age=$((now - created_at))
+  [[ "$age" -lt "$ttl" ]]
+}
+
+# Auto-source the op-preflight cache into the current shell IF:
+#   * GH_TOKEN is not already set (preserve caller-provided creds), AND
+#   * the cache file for the resolved agent exists and is fresh.
+#
+# Silent on the no-op paths (GH_TOKEN already set, no cache found,
+# stale cache). Emits a single-line diagnostic to stderr ONLY when it
+# actually sources, so noisy helpers don't accumulate prefix lines on
+# every tool call. Returns 0 in all cases — callers decide what to do
+# when GH_TOKEN is still unset after this returns.
+auto_source_preflight() {
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    return 0
+  fi
+  local agent cache_dir session_file
+  agent="$(preflight_agent)"
+  if [[ -z "$agent" ]]; then
+    return 0
+  fi
+  cache_dir="$(preflight_cache_dir)"
+  session_file="$cache_dir/op-preflight-${agent}.env"
+  if ! preflight_session_is_fresh "$session_file"; then
+    return 0
+  fi
+  # Source the cache file. Permissions are 0600 in a 0700 cache dir,
+  # owner-only; we trust the file the same way op-preflight.sh itself
+  # does on the cache-hit path.
+  # shellcheck disable=SC1090
+  . "$session_file"
+  if [[ "${OP_PREFLIGHT_QUIET:-0}" != "1" ]]; then
+    echo "# auto-source: loaded op-preflight cache for agent=$agent (no biometric)" >&2
+  fi
+  return 0
+}
+
+# Convenience wrappers: helpers that need a reviewer-scoped token call
+# `preflight_require_token reviewer`; helpers that want author scope
+# pass `author`. The function auto-sources the cache (if needed) and
+# exports GH_TOKEN from the matching OP_PREFLIGHT_*_PAT. Returns 0 if
+# GH_TOKEN ends up populated (either pre-existing or just exported by
+# auto-source), 1 otherwise. Callers that already validate
+# `[ -z "${GH_TOKEN:-}" ] && exit 3` get a no-op when this helper
+# succeeded and the same hard-error when it didn't — no regression.
+preflight_require_token() {
+  local scope="${1:-reviewer}"
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    return 0
+  fi
+  auto_source_preflight
+  local var_name
+  case "$scope" in
+    reviewer) var_name="OP_PREFLIGHT_REVIEWER_PAT" ;;
+    author)   var_name="OP_PREFLIGHT_AUTHOR_PAT" ;;
+    *)
+      echo "ERROR: preflight_require_token: unknown scope '$scope' (expected reviewer|author)" >&2
+      return 1
+      ;;
+  esac
+  local val="${!var_name:-}"
+  if [[ -n "$val" ]]; then
+    export GH_TOKEN="$val"
+    return 0
+  fi
+  return 1
+}

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -16,22 +16,35 @@
 # motivated this design.
 #
 # Usage:
-#   eval "$(scripts/op-preflight.sh --agent claude --mode all)"
+#   # Session start (one biometric burst) — review mode is the default:
+#   eval "$(scripts/op-preflight.sh --agent claude --mode review)"
+#
+#   # Idempotent re-check at the top of every subsequent tool call. NEVER
+#   # prompts for biometric; exits non-zero if no fresh cache exists:
+#   eval "$(scripts/op-preflight.sh --agent claude --check)"
 #
 #   # Force a fresh fetch even if the session file is still warm:
-#   eval "$(scripts/op-preflight.sh --agent claude --mode all --refresh)"
+#   eval "$(scripts/op-preflight.sh --agent claude --refresh)"
+#
+#   # Deploy scripts that genuinely need deploy credentials:
+#   eval "$(scripts/op-preflight.sh --agent claude --mode deploy)"
 #
 #   # Delete the session file + ADC tempfile (end-of-session cleanup):
 #   scripts/op-preflight.sh --agent claude --purge
 #
 # Modes:
-#   review  — reviewer PAT + author PAT + SSH key warming
+#   review  — reviewer PAT + author PAT + SSH key warming (DEFAULT)
 #   deploy  — GCP ADC credential + Cloudflare cache-purge token
-#   all     — everything (default)
+#   all     — everything
 #
 # Flags:
 #   --agent <name>   Agent name: claude, cursor, or codex (required except --purge-all)
-#   --mode <mode>    review, deploy, or all (default: all)
+#   --mode <mode>    review, deploy, or all (default: review). #282
+#   --check          Validate the session file is fresh and emit cached
+#   --status         (alias for --check) exports WITHOUT invoking op.
+#                    Never burns biometric, never warms SSH, never reads
+#                    ADC. Exits non-zero if cache missing/stale. Mutually
+#                    exclusive with --refresh, --purge, --purge-all. #282
 #   --dry-run        Show what would be fetched without prompting
 #   --skip-ssh       Skip SSH key warming (useful in CI or non-interactive)
 #   --refresh        Force biometric fetch even if session file is fresh
@@ -53,6 +66,11 @@
 #                             shorter than 4h. Skipping re-warm within
 #                             this window prevents a biometric prompt on
 #                             every cache-hit invocation. See #163.
+#   OP_PREFLIGHT_QUIET        When set to 1, suppress the verbose
+#                             cached-hit stderr block. A single-line
+#                             "# preflight: cache hit, no biometric
+#                             burned" message replaces it. Refresh
+#                             notices and warnings are unaffected. #282
 #
 # Session file:
 #   Path:        $cache_dir/op-preflight-<agent>.env
@@ -131,13 +149,19 @@ DEFAULT_CF_TOKEN_OP_URI="${CF_TOKEN_OP_URI:-op://Private/4x6wslp3f6pal5t6h3jhhe6
 SSH_AUTHOR_HOST="github.com"
 
 # ── Parse arguments ───────────────────────────────────────────────────
+# Default --mode is `review` (was `all` prior to #282). The vast majority
+# of agent tool calls only need the reviewer/author PATs + SSH warming;
+# loading ADC + Cloudflare on every preflight bloated the biometric
+# burst for no reason. Deploy scripts that genuinely need deploy
+# credentials must pass `--mode deploy` or `--mode all` explicitly.
 AGENT=""
-MODE="all"
+MODE="review"
 DRY_RUN=false
 SKIP_SSH=false
 REFRESH=false
 PURGE=false
 PURGE_ALL=false
+CHECK=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -148,13 +172,25 @@ while [[ $# -gt 0 ]]; do
     --refresh) REFRESH=true; shift ;;
     --purge) PURGE=true; shift ;;
     --purge-all) PURGE_ALL=true; shift ;;
+    --check|--status) CHECK=true; shift ;;
     *)
       echo "Error: unknown argument: $1" >&2
-      echo "Usage: eval \"\$(scripts/op-preflight.sh --agent claude --mode all)\"" >&2
+      echo "Usage: eval \"\$(scripts/op-preflight.sh --agent claude --mode review)\"" >&2
       exit 1
       ;;
   esac
 done
+
+# ── --check / --status mutual exclusion (#282) ────────────────────────
+# --check is the "never invoke op, never warm SSH, never touch ADC"
+# read-only validator. It is mutually exclusive with anything that
+# would mutate state or burn biometric.
+if $CHECK; then
+  if $REFRESH || $PURGE || $PURGE_ALL; then
+    echo "Error: --check / --status is mutually exclusive with --refresh, --purge, --purge-all." >&2
+    exit 1
+  fi
+fi
 
 # ── Validate ──────────────────────────────────────────────────────────
 if $PURGE_ALL; then
@@ -165,9 +201,9 @@ if $PURGE_ALL; then
   exit 0
 fi
 
-if [[ "$MODE" == "review" || "$MODE" == "all" || "$PURGE" == "true" ]] && [[ -z "$AGENT" ]]; then
-  echo "Error: --agent is required for review, all, or --purge mode." >&2
-  echo "Usage: eval \"\$(scripts/op-preflight.sh --agent claude --mode all)\"" >&2
+if [[ "$MODE" == "review" || "$MODE" == "all" || "$PURGE" == "true" || "$CHECK" == "true" ]] && [[ -z "$AGENT" ]]; then
+  echo "Error: --agent is required for review, all, --purge, or --check mode." >&2
+  echo "Usage: eval \"\$(scripts/op-preflight.sh --agent claude --mode review)\"" >&2
   exit 1
 fi
 
@@ -185,6 +221,8 @@ fi
 SESSION_FILE="$CACHE_DIR/op-preflight-$AGENT.env"
 ADC_TMPFILE="$CACHE_DIR/op-preflight-$AGENT-adc.json"
 SSH_WARM_MARKER="$CACHE_DIR/op-preflight-$AGENT.ssh-warmed"
+BIOMETRIC_LOG="$CACHE_DIR/biometric-log"  # #282: append a one-line
+                                          # record on each fresh fetch.
 SSH_WARM_TTL_SECONDS="${OP_PREFLIGHT_SSH_WARM_TTL_SECONDS:-1800}"  # 30 min default; #163
 # Validate the override is a non-negative integer before any arithmetic
 # context (`[[ "$age" -lt "$SSH_WARM_TTL_SECONDS" ]]` later in the
@@ -197,6 +235,27 @@ if [[ ! "$SSH_WARM_TTL_SECONDS" =~ ^[0-9]+$ ]]; then
   echo "# WARNING: OP_PREFLIGHT_SSH_WARM_TTL_SECONDS='$SSH_WARM_TTL_SECONDS' is not a non-negative integer; falling back to default 1800s" >&2
   SSH_WARM_TTL_SECONDS=1800
 fi
+
+# ── Biometric trigger log (#282) ──────────────────────────────────────
+# Append a one-line record every time we trigger a fresh op fetch (i.e.
+# every time `op inject` or `op read` is invoked for cache population).
+# Format: `<ISO8601> agent=<agent> mode=<mode> reason=<reason>` so a
+# session audit can correlate biometric prompts against agent behavior.
+# Always-on (independent of OP_PREFLIGHT_QUIET) — the file is local-only
+# and there's no privacy / log-volume tradeoff to suppress it for.
+log_biometric_trigger() {
+  local reason="${1:-full-fetch}"
+  local now_iso
+  now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%FT%TZ)
+  mkdir -p "$CACHE_DIR" 2>/dev/null || true
+  if [[ ! -f "$BIOMETRIC_LOG" ]]; then
+    touch "$BIOMETRIC_LOG" 2>/dev/null || return 0
+    chmod 600 "$BIOMETRIC_LOG" 2>/dev/null || true
+  fi
+  printf '%s agent=%s mode=%s reason=%s\n' \
+    "$now_iso" "${AGENT:-unknown}" "${MODE:-unknown}" "$reason" \
+    >> "$BIOMETRIC_LOG" 2>/dev/null || true
+}
 
 # ── Purge mode ────────────────────────────────────────────────────────
 if $PURGE; then
@@ -536,6 +595,50 @@ warm_ssh_keys() {
   chmod 600 "$SSH_WARM_MARKER" 2>/dev/null || true
 }
 
+# ── --check / --status mode (#282) ────────────────────────────────────
+# Read-only validator: emit cached exports if the session file is fresh,
+# OR exit non-zero with a diagnostic if it is missing/stale. NEVER
+# invokes op, NEVER warms SSH, NEVER reads ADC. Designed to be re-run
+# at the top of every agent tool call without the biometric prompt risk
+# of `--mode review`.
+if $CHECK; then
+  if ! session_is_fresh; then
+    echo "# preflight: cache missing or stale for agent=$AGENT" >&2
+    echo "#   run: scripts/op-preflight.sh --agent $AGENT --mode review" >&2
+    echo "#   then re-run this command." >&2
+    exit 2
+  fi
+  # The session is fresh. Emit the cached exports the same way the fast
+  # path does — but DO NOT warm SSH and DO NOT call any other helpers
+  # that might prompt. emit_from_session_file's ADC-usability probe
+  # (adc_is_usable) only runs when MODE is deploy/all; --check defaults
+  # to review and the deploy fields are simply omitted when absent.
+  if cached_exports=$(emit_from_session_file); then
+    rc=0
+  else
+    rc=$?
+  fi
+  if [[ "$rc" != "0" ]]; then
+    echo "# preflight: cache present but incomplete for agent=$AGENT (mode=$MODE)" >&2
+    echo "#   run: scripts/op-preflight.sh --agent $AGENT --mode review" >&2
+    exit 2
+  fi
+  echo "$cached_exports"
+  if [[ "${OP_PREFLIGHT_QUIET:-0}" != "1" ]]; then
+    epoch=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"" || true)
+    now=$(date +%s)
+    if [[ "$epoch" =~ ^[0-9]+$ ]]; then
+      age=$(( now - 10#$epoch ))
+    else
+      age=$now
+    fi
+    echo "# preflight: --check ok (age ${age}s / TTL ${TTL_SECONDS}s, no biometric)" >&2
+  else
+    echo "# preflight: cache hit, no biometric burned" >&2
+  fi
+  exit 0
+fi
+
 # ── Refresh forces both PAT cache + SSH-warm marker invalidation ─────
 # (--refresh is the "I want a brand-new biometric burst" knob; honor
 # it for SSH too, otherwise the warm would skip via the marker.)
@@ -581,20 +684,48 @@ if ! $REFRESH && session_is_fresh; then
     if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH; then
       warm_ssh_keys
     fi
-    echo "" >&2
-    echo "# ── Preflight cached hit (age ${age}s / TTL ${TTL_SECONDS}s) ──" >&2
-    echo "# Session file: $SESSION_FILE" >&2
-    for line in "${SUMMARY[@]}"; do
-      echo "#   $line" >&2
-    done
-    echo "# Run with --refresh to force a new biometric fetch." >&2
-    warn_active_account_mismatch
-    echo "# ──────────────────────────────────────────────────────────" >&2
+    if [[ "${OP_PREFLIGHT_QUIET:-0}" == "1" ]]; then
+      # #282: agents that re-run preflight at the top of every tool
+      # call want a single-line confirmation, not the verbose block.
+      # Refresh notices and warnings remain unaffected; only this
+      # routine cache-hit block collapses.
+      echo "# preflight: cache hit, no biometric burned" >&2
+      warn_active_account_mismatch
+    else
+      echo "" >&2
+      echo "# ── Preflight cached hit (age ${age}s / TTL ${TTL_SECONDS}s) ──" >&2
+      echo "# Session file: $SESSION_FILE" >&2
+      for line in "${SUMMARY[@]}"; do
+        echo "#   $line" >&2
+      done
+      echo "# Run with --refresh to force a new biometric fetch." >&2
+      warn_active_account_mismatch
+      echo "# ──────────────────────────────────────────────────────────" >&2
+    fi
     exit 0
   fi
   # emit_from_session_file returned non-zero (e.g. ADC file vanished).
   # Fall through to full fetch.
   echo "# Session file stale or incomplete — refreshing" >&2
+  # Distinguish a partial-cache miss (stale ADC, cross-mode invalidation)
+  # from a full-fetch when logging the biometric trigger reason. The rc
+  # from emit_from_session_file is in scope thanks to the if-condition
+  # capture above. rc=2 means cross-mode invalidation; anything else is
+  # treated as stale-ADC by default for log clarity.
+  if [[ "${rc:-0}" == "2" ]]; then
+    BIOMETRIC_REASON="cross-mode-invalidation"
+  else
+    BIOMETRIC_REASON="stale-adc"
+  fi
+fi
+
+# Default reason for full-fetch path (no cache hit at all, or --refresh).
+if [[ -z "${BIOMETRIC_REASON:-}" ]]; then
+  if $REFRESH; then
+    BIOMETRIC_REASON="refresh"
+  else
+    BIOMETRIC_REASON="full-fetch"
+  fi
 fi
 
 # ── Preflight checks for full fetch ──────────────────────────────────
@@ -624,6 +755,7 @@ AUTHOR_PAT={{ op://Private/${AUTHOR_PAT_ITEM}/token }}
 TPL
 
   echo "# Preflight: reading PATs (one biometric prompt)..." >&2
+  log_biometric_trigger "$BIOMETRIC_REASON"
   resolved="$(op inject -i "$tpl_file")"
   rm -f "$tpl_file"
 
@@ -655,6 +787,13 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
   touch "$ADC_TMPFILE"
   chmod 600 "$ADC_TMPFILE"
 
+  # For --mode deploy (no review credentials loaded), this is the first
+  # op call of the run — log it. For --mode all, the Phase 1 op inject
+  # above already logged a single line covering the whole biometric
+  # burst, so no second log entry is needed here.
+  if [[ "$MODE" == "deploy" ]]; then
+    log_biometric_trigger "$BIOMETRIC_REASON"
+  fi
   if op read "$DEFAULT_ADC_OP_URI" > "$ADC_TMPFILE" 2>/dev/null && [[ -s "$ADC_TMPFILE" ]]; then
     if adc_is_usable "$ADC_TMPFILE"; then
       EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -511,7 +511,16 @@ emit_from_session_file() (
     if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || [[ ! -s "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
       exit 2
     fi
-    if ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
+    # --check is the "no external probes" contract — never invoke op,
+    # ssh, OR python3. The `adc_is_usable` probe spawns python3 to
+    # validate the OAuth2 refresh token, which fires a network call.
+    # Under --check we trust the cache as-is and emit the ADC path
+    # without validating it; downstream deploy callers will surface
+    # their own auth failure if the cred is actually broken.
+    # (nathanpayne-codex Phase 4b r1 on PR #292 — they verified
+    # `--check --mode deploy` still spawned python3.)
+    if [[ "${OP_PREFLIGHT_CHECK_MODE:-0}" != "1" ]] && \
+       ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
       # File exists but refresh token is rejected. Warn and skip the
       # export so downstream deploy callers can fall back to local
       # firebase-login / ADC. OP_PREFLIGHT_DONE stays 1 and PATs are
@@ -610,10 +619,11 @@ if $CHECK; then
   fi
   # The session is fresh. Emit the cached exports the same way the fast
   # path does — but DO NOT warm SSH and DO NOT call any other helpers
-  # that might prompt. emit_from_session_file's ADC-usability probe
-  # (adc_is_usable) only runs when MODE is deploy/all; --check defaults
-  # to review and the deploy fields are simply omitted when absent.
-  if cached_exports=$(emit_from_session_file); then
+  # that might prompt. Setting OP_PREFLIGHT_CHECK_MODE=1 tells
+  # emit_from_session_file to skip the ADC-usability python3 probe
+  # under `--mode deploy`/`--mode all` so the helper stays probe-free
+  # in --check mode. (nathanpayne-codex Phase 4b r1 on PR #292.)
+  if cached_exports=$(OP_PREFLIGHT_CHECK_MODE=1 emit_from_session_file); then
     rc=0
   else
     rc=$?

--- a/scripts/request-label-removal.sh
+++ b/scripts/request-label-removal.sh
@@ -42,6 +42,18 @@
 
 set -eo pipefail
 
+# --- preflight auto-source (#282) ------------------------------------------
+# If OP_PREFLIGHT_REVIEWER_PAT is unset and a fresh op-preflight cache
+# exists for this agent, source it. The existing GH_READ_PAT logic
+# below already prefers OP_PREFLIGHT_REVIEWER_PAT over GH_TOKEN, so this
+# block needs only to populate the env var. Silent on no-op paths.
+__REQUEST_LABEL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ] && [ -r "$__REQUEST_LABEL_DIR/lib/preflight-helpers.sh" ]; then
+  # shellcheck source=lib/preflight-helpers.sh
+  . "$__REQUEST_LABEL_DIR/lib/preflight-helpers.sh"
+  auto_source_preflight
+fi
+
 ALLOWED_LABELS=(needs-external-review needs-human-review policy-violation)
 
 # Escape a string for embedding inside an AppleScript double-quoted

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -52,6 +52,18 @@
 
 set -eo pipefail
 
+# --- preflight auto-source (#282) ------------------------------------------
+# If OP_PREFLIGHT_REVIEWER_PAT is unset and a fresh op-preflight cache
+# exists for this agent, source it. The existing PAT_GH_TOKEN logic
+# below already prefers OP_PREFLIGHT_REVIEWER_PAT over GH_TOKEN, so this
+# block needs only to populate the env var. Silent on no-op paths.
+__RESOLVE_THREADS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ] && [ -r "$__RESOLVE_THREADS_DIR/lib/preflight-helpers.sh" ]; then
+  # shellcheck source=lib/preflight-helpers.sh
+  . "$__RESOLVE_THREADS_DIR/lib/preflight-helpers.sh"
+  auto_source_preflight
+fi
+
 usage() {
   cat <<'EOF' >&2
 Usage: scripts/resolve-pr-threads.sh <PR#> [--repo owner/name] [--list]

--- a/tests/test_helper_autosource.sh
+++ b/tests/test_helper_autosource.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# tests/test_helper_autosource.sh
+#
+# Verifies the #282 auto-source path on each of the five helper scripts
+# (coderabbit-wait, codex-review-request, codex-review-check,
+# resolve-pr-threads, request-label-removal). The contract:
+#
+#   * When GH_TOKEN is unset AND a fresh op-preflight cache exists in
+#     OP_PREFLIGHT_CACHE_DIR for $MERGEPATH_AGENT, sourcing the helper
+#     pulls OP_PREFLIGHT_REVIEWER_PAT / OP_PREFLIGHT_AUTHOR_PAT and (for
+#     the GH_TOKEN-required helpers) exports GH_TOKEN.
+#
+#   * When neither GH_TOKEN nor a fresh cache is available, the helper
+#     should NOT crash on source — the existing
+#     `[ -z "${GH_TOKEN:-}" ] && exit 3` guard is what surfaces the
+#     missing-token diagnostic.
+#
+# We don't actually invoke each helper end-to-end (each requires a real
+# PR, real network, etc). Instead the tests source the shared library
+# directly and verify the auto-source behavior, AND invoke each helper
+# with `--help`-equivalent inputs that exercise the early-source block
+# without reaching network calls.
+#
+# Bash 3.2 portable.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB="$ROOT/scripts/lib/preflight-helpers.sh"
+
+[[ -r "$LIB" ]] || { echo "missing $LIB" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/helper-autosource-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+make_fresh_cache() {
+  local dir="$1" agent="$2" reviewer_pat="$3" author_pat="$4"
+  mkdir -p "$dir"
+  chmod 700 "$dir"
+  local epoch
+  epoch=$(date +%s)
+  cat > "$dir/op-preflight-$agent.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=$agent
+OP_PREFLIGHT_MODE=review
+OP_PREFLIGHT_DONE=1
+OP_PREFLIGHT_REVIEWER_PAT=$reviewer_pat
+OP_PREFLIGHT_AUTHOR_PAT=$author_pat
+EOF
+  chmod 600 "$dir/op-preflight-$agent.env"
+}
+
+make_stale_cache() {
+  local dir="$1" agent="$2"
+  mkdir -p "$dir"
+  chmod 700 "$dir"
+  local epoch
+  epoch=$(( $(date +%s) - 18000 ))
+  cat > "$dir/op-preflight-$agent.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=$agent
+OP_PREFLIGHT_MODE=review
+OP_PREFLIGHT_DONE=1
+OP_PREFLIGHT_REVIEWER_PAT=stale-rev
+OP_PREFLIGHT_AUTHOR_PAT=stale-auth
+EOF
+  chmod 600 "$dir/op-preflight-$agent.env"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: auto_source_preflight loads a fresh cache when GH_TOKEN is
+# unset, and is silent when GH_TOKEN is already set.
+# ---------------------------------------------------------------------------
+test_lib_auto_source_basic() {
+  (
+    local case_dir="$WORKDIR/lib1"
+    make_fresh_cache "$case_dir" claude "rev-1" "auth-1"
+    unset GH_TOKEN OP_PREFLIGHT_REVIEWER_PAT OP_PREFLIGHT_AUTHOR_PAT
+    export OP_PREFLIGHT_CACHE_DIR="$case_dir"
+    export MERGEPATH_AGENT=claude
+    # shellcheck source=../scripts/lib/preflight-helpers.sh
+    . "$LIB"
+    auto_source_preflight
+    if [ "${OP_PREFLIGHT_REVIEWER_PAT:-}" != "rev-1" ]; then
+      echo "auto_source did not populate REVIEWER_PAT (got '${OP_PREFLIGHT_REVIEWER_PAT:-}')" >&2
+      exit 1
+    fi
+    if [ "${OP_PREFLIGHT_AUTHOR_PAT:-}" != "auth-1" ]; then
+      echo "auto_source did not populate AUTHOR_PAT (got '${OP_PREFLIGHT_AUTHOR_PAT:-}')" >&2
+      exit 1
+    fi
+  ) >"$WORKDIR/lib1.out" 2>"$WORKDIR/lib1.err"
+  local rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "test_lib_auto_source_basic: rc=$rc stderr=$(cat "$WORKDIR/lib1.err")"
+    return
+  fi
+  pass "test_lib_auto_source_basic: fresh cache loads via auto_source_preflight"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: auto_source_preflight is a no-op when GH_TOKEN is already set.
+# ---------------------------------------------------------------------------
+test_lib_gh_token_passthrough() {
+  (
+    local case_dir="$WORKDIR/lib2"
+    make_fresh_cache "$case_dir" claude "rev-2" "auth-2"
+    export OP_PREFLIGHT_CACHE_DIR="$case_dir"
+    export MERGEPATH_AGENT=claude
+    export GH_TOKEN="caller-supplied"
+    unset OP_PREFLIGHT_REVIEWER_PAT OP_PREFLIGHT_AUTHOR_PAT
+    # shellcheck source=../scripts/lib/preflight-helpers.sh
+    . "$LIB"
+    auto_source_preflight
+    if [ "$GH_TOKEN" != "caller-supplied" ]; then
+      echo "auto_source clobbered caller GH_TOKEN" >&2
+      exit 1
+    fi
+    if [ -n "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]; then
+      echo "auto_source loaded cache even though GH_TOKEN was set" >&2
+      exit 1
+    fi
+  ) >"$WORKDIR/lib2.out" 2>"$WORKDIR/lib2.err"
+  local rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "test_lib_gh_token_passthrough: rc=$rc stderr=$(cat "$WORKDIR/lib2.err")"
+    return
+  fi
+  pass "test_lib_gh_token_passthrough: GH_TOKEN preserved, cache untouched"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: auto_source_preflight is silent on a STALE cache.
+# ---------------------------------------------------------------------------
+test_lib_stale_cache_noop() {
+  (
+    local case_dir="$WORKDIR/lib3"
+    make_stale_cache "$case_dir" claude
+    export OP_PREFLIGHT_CACHE_DIR="$case_dir"
+    export MERGEPATH_AGENT=claude
+    unset GH_TOKEN OP_PREFLIGHT_REVIEWER_PAT OP_PREFLIGHT_AUTHOR_PAT
+    # shellcheck source=../scripts/lib/preflight-helpers.sh
+    . "$LIB"
+    auto_source_preflight
+    if [ -n "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]; then
+      echo "auto_source loaded a STALE cache" >&2
+      exit 1
+    fi
+  ) >"$WORKDIR/lib3.out" 2>"$WORKDIR/lib3.err"
+  local rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "test_lib_stale_cache_noop: rc=$rc stderr=$(cat "$WORKDIR/lib3.err")"
+    return
+  fi
+  pass "test_lib_stale_cache_noop: stale cache is not loaded"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: preflight_require_token reviewer exports GH_TOKEN from cache.
+# ---------------------------------------------------------------------------
+test_lib_require_token_reviewer() {
+  (
+    local case_dir="$WORKDIR/lib4"
+    make_fresh_cache "$case_dir" claude "rev-4" "auth-4"
+    export OP_PREFLIGHT_CACHE_DIR="$case_dir"
+    export MERGEPATH_AGENT=claude
+    unset GH_TOKEN OP_PREFLIGHT_REVIEWER_PAT OP_PREFLIGHT_AUTHOR_PAT
+    # shellcheck source=../scripts/lib/preflight-helpers.sh
+    . "$LIB"
+    if ! preflight_require_token reviewer; then
+      echo "preflight_require_token reviewer returned non-zero" >&2
+      exit 1
+    fi
+    if [ "${GH_TOKEN:-}" != "rev-4" ]; then
+      echo "GH_TOKEN not exported with reviewer PAT (got '${GH_TOKEN:-}')" >&2
+      exit 1
+    fi
+  ) >"$WORKDIR/lib4.out" 2>"$WORKDIR/lib4.err"
+  local rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "test_lib_require_token_reviewer: rc=$rc stderr=$(cat "$WORKDIR/lib4.err")"
+    return
+  fi
+  pass "test_lib_require_token_reviewer: GH_TOKEN exported from cache (reviewer)"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: preflight_require_token author exports GH_TOKEN from cache.
+# ---------------------------------------------------------------------------
+test_lib_require_token_author() {
+  (
+    local case_dir="$WORKDIR/lib5"
+    make_fresh_cache "$case_dir" claude "rev-5" "auth-5"
+    export OP_PREFLIGHT_CACHE_DIR="$case_dir"
+    export MERGEPATH_AGENT=claude
+    unset GH_TOKEN OP_PREFLIGHT_REVIEWER_PAT OP_PREFLIGHT_AUTHOR_PAT
+    # shellcheck source=../scripts/lib/preflight-helpers.sh
+    . "$LIB"
+    if ! preflight_require_token author; then
+      echo "preflight_require_token author returned non-zero" >&2
+      exit 1
+    fi
+    if [ "${GH_TOKEN:-}" != "auth-5" ]; then
+      echo "GH_TOKEN not exported with author PAT (got '${GH_TOKEN:-}')" >&2
+      exit 1
+    fi
+  ) >"$WORKDIR/lib5.out" 2>"$WORKDIR/lib5.err"
+  local rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "test_lib_require_token_author: rc=$rc stderr=$(cat "$WORKDIR/lib5.err")"
+    return
+  fi
+  pass "test_lib_require_token_author: GH_TOKEN exported from cache (author)"
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: Each helper script sources the shared library on startup. We
+# can't easily test the end-to-end path without network, but we CAN
+# verify each script has the source line and that running it with no
+# args + no GH_TOKEN + no cache emits a useful error message — i.e.
+# the early-source block didn't break the bare invocation.
+# ---------------------------------------------------------------------------
+test_helpers_source_lib() {
+  local helpers=(
+    coderabbit-wait.sh
+    codex-review-request.sh
+    codex-review-check.sh
+    resolve-pr-threads.sh
+    request-label-removal.sh
+  )
+  local h missing=0
+  for h in "${helpers[@]}"; do
+    if ! grep -q 'lib/preflight-helpers.sh' "$ROOT/scripts/$h"; then
+      fail "test_helpers_source_lib: $h does not source lib/preflight-helpers.sh"
+      missing=1
+    fi
+  done
+  if [ "$missing" -eq 0 ]; then
+    pass "test_helpers_source_lib: all 5 helpers source the shared library"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: GH_TOKEN-required helpers (coderabbit-wait, codex-review-request,
+# codex-review-check) auto-source GH_TOKEN from a fresh cache and proceed
+# past the early `[ -z "${GH_TOKEN:-}" ] && exit 3` guard.
+#
+# We can't reach the network in a test, so we use bash -n + a focused
+# check: invoke the helper with a synthetic cache and an invalid PR
+# number (which is parsed BEFORE GH_TOKEN check in some scripts).
+# Strategy: confirm the helper does NOT exit with the old
+# "GH_TOKEN is required" message when the cache is fresh.
+# ---------------------------------------------------------------------------
+test_helpers_no_gh_token_error_with_fresh_cache() {
+  local case_dir="$WORKDIR/lib7"
+  make_fresh_cache "$case_dir" claude "rev-7" "auth-7"
+
+  # We stub `gh` and `jq` to short-circuit each helper before it
+  # makes real API calls. Specifically: `gh repo view` returns a fake
+  # repo, then any subsequent `gh api ...` exits non-zero so the
+  # script's existing error path fires (we just want to verify the
+  # GH_TOKEN guard didn't fire first).
+  local stub_dir="$WORKDIR/stub-bin-7"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+# Print a minimal expected response for `gh repo view`; everything
+# else exits 99 so the helper bails before any network.
+if [ "${1:-}" = "repo" ] && [ "${2:-}" = "view" ]; then
+  echo "owner/repo"
+  exit 0
+fi
+echo "stub-gh: bailing on '$*'" >&2
+exit 99
+EOF
+  chmod +x "$stub_dir/gh"
+
+  # Test each GH_TOKEN-required helper. The new behavior: with a fresh
+  # cache, the helper auto-sources GH_TOKEN and proceeds. The old
+  # error "GH_TOKEN is required" should NOT appear in stderr.
+  local helpers=(
+    coderabbit-wait.sh
+    codex-review-request.sh
+    codex-review-check.sh
+  )
+  local h failed=0
+  for h in "${helpers[@]}"; do
+    local rc=0
+    PATH="$stub_dir:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$case_dir" \
+      MERGEPATH_AGENT=claude \
+      env -u GH_TOKEN "$ROOT/scripts/$h" 999999 owner/repo \
+      >"$WORKDIR/h.out" 2>"$WORKDIR/h.err" || rc=$?
+    if grep -q "GH_TOKEN is required" "$WORKDIR/h.err"; then
+      fail "test_helpers_no_gh_token_error_with_fresh_cache: $h still emits 'GH_TOKEN is required' with a fresh cache; stderr=$(cat "$WORKDIR/h.err")"
+      failed=1
+    fi
+  done
+  if [ "$failed" -eq 0 ]; then
+    pass "test_helpers_no_gh_token_error_with_fresh_cache: 3 helpers auto-source GH_TOKEN from cache"
+  fi
+}
+
+test_lib_auto_source_basic
+test_lib_gh_token_passthrough
+test_lib_stale_cache_noop
+test_lib_require_token_reviewer
+test_lib_require_token_author
+test_helpers_source_lib
+test_helpers_no_gh_token_error_with_fresh_cache
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -268,6 +268,68 @@ test_default_mode_is_review() {
   pass "test_default_mode_is_review: default --mode is review (no ADC)"
 }
 
+# ---------------------------------------------------------------------------
+# test_check_deploy_no_python3_probe (nathanpayne-codex Phase 4b r1 on
+# PR #292): --check --mode deploy must NOT invoke python3 to validate
+# ADC. Probe by PATH-shimming python3 with an aborting stub and
+# verifying the --check path exits 0 with cached exports rather than
+# aborting via the stub.
+# ---------------------------------------------------------------------------
+test_check_deploy_no_python3_probe() {
+  local cache_dir="$WORKDIR/deploy-no-python3-cache"
+  mkdir -p "$cache_dir" && chmod 700 "$cache_dir"
+  local adc_file="$WORKDIR/deploy-no-python3-adc.json"
+  # Fake but well-formed service_account JSON. adc_is_usable
+  # short-circuits to OK on service_account creds without HTTP, but
+  # if --check honors the contract it shouldn't even reach
+  # adc_is_usable.
+  cat > "$adc_file" <<'JSON'
+{"type":"service_account","project_id":"x","private_key_id":"x","private_key":"x","client_email":"x"}
+JSON
+  local epoch
+  epoch=$(date +%s)
+  cat > "$cache_dir/op-preflight-claude.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=claude
+OP_PREFLIGHT_MODE=all
+OP_PREFLIGHT_DONE=1
+OP_PREFLIGHT_REVIEWER_PAT=stub-reviewer
+OP_PREFLIGHT_AUTHOR_PAT=stub-author
+GOOGLE_APPLICATION_CREDENTIALS=$adc_file
+OP_PREFLIGHT_ADC_TMPFILE=$adc_file
+EOF
+  chmod 600 "$cache_dir/op-preflight-claude.env"
+
+  # Aborting python3 stub.
+  local py_stub="$WORKDIR/stub-bin-py"
+  mkdir -p "$py_stub"
+  cat > "$py_stub/python3" <<'EOF'
+#!/usr/bin/env bash
+echo "FATAL: --check --mode deploy invoked python3 with args: $*" >&2
+exit 97
+EOF
+  chmod +x "$py_stub/python3"
+
+  local out rc=0
+  out=$(OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+        PATH="$py_stub:$STUB_DIR:$PATH" \
+        "$SCRIPT" --agent claude --mode deploy --check 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "test_check_deploy_no_python3_probe: --check --mode deploy returned rc=$rc; out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "invoked python3"; then
+    fail "test_check_deploy_no_python3_probe: --check --mode deploy invoked python3 (ADC probe leaked)"
+    return
+  fi
+  if ! echo "$out" | grep -q "export GOOGLE_APPLICATION_CREDENTIALS="; then
+    fail "test_check_deploy_no_python3_probe: --check --mode deploy did not emit ADC export; out=$out"
+    return
+  fi
+  pass "test_check_deploy_no_python3_probe: --check --mode deploy emits ADC without python3 probe"
+}
+
 test_check_fresh_cache
 test_check_missing_cache
 test_check_stale_cache
@@ -275,6 +337,7 @@ test_check_mutex
 test_status_alias
 test_quiet_mode
 test_default_mode_is_review
+test_check_deploy_no_python3_probe
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# tests/test_op_preflight_check.sh
+#
+# Unit tests for the --check / --status mode added in #282.
+#
+# Strategy: PATH-shim `op` with a stub that aborts on call. The
+# --check path is contractually forbidden to invoke op (no biometric
+# possible). If any test triggers op, the stub exits 99 and the test
+# fails with a clear diagnostic.
+#
+# The cache file is synthesized directly into a scratch
+# OP_PREFLIGHT_CACHE_DIR so tests don't depend on prior preflight runs.
+#
+# Bash 3.2 portable.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/op-preflight.sh"
+
+[[ -x "$SCRIPT" ]] || { echo "missing or non-executable $SCRIPT" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/op-preflight-check-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Build a PATH-shim `op` stub that aborts on any call. Used in all
+# --check tests to enforce the "never invoke op" contract.
+# ---------------------------------------------------------------------------
+STUB_DIR="$WORKDIR/stub-bin"
+mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/op" <<'EOF'
+#!/usr/bin/env bash
+echo "FATAL: --check invoked op with args: $*" >&2
+exit 99
+EOF
+chmod +x "$STUB_DIR/op"
+
+# Also stub `ssh` to detect SSH-warm attempts. --check must NEVER warm
+# SSH (would also potentially burn biometric on the 1Password SSH agent).
+cat > "$STUB_DIR/ssh" <<'EOF'
+#!/usr/bin/env bash
+echo "FATAL: --check invoked ssh with args: $*" >&2
+exit 98
+EOF
+chmod +x "$STUB_DIR/ssh"
+
+# Helper: synthesize a fresh cache file.
+make_fresh_cache() {
+  local dir="$1" agent="$2" reviewer_pat="$3" author_pat="$4"
+  mkdir -p "$dir"
+  chmod 700 "$dir"
+  local epoch
+  epoch=$(date +%s)
+  cat > "$dir/op-preflight-$agent.env" <<EOF
+# synthetic test cache
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=$agent
+OP_PREFLIGHT_MODE=review
+OP_PREFLIGHT_DONE=1
+OP_PREFLIGHT_REVIEWER_PAT=$reviewer_pat
+OP_PREFLIGHT_AUTHOR_PAT=$author_pat
+EOF
+  chmod 600 "$dir/op-preflight-$agent.env"
+}
+
+# Helper: synthesize a STALE cache file (CREATED_AT older than TTL).
+make_stale_cache() {
+  local dir="$1" agent="$2"
+  mkdir -p "$dir"
+  chmod 700 "$dir"
+  # 5h ago, TTL is 4h
+  local epoch
+  epoch=$(( $(date +%s) - 18000 ))
+  cat > "$dir/op-preflight-$agent.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=$agent
+OP_PREFLIGHT_MODE=review
+OP_PREFLIGHT_DONE=1
+OP_PREFLIGHT_REVIEWER_PAT=stale-rev
+OP_PREFLIGHT_AUTHOR_PAT=stale-auth
+EOF
+  chmod 600 "$dir/op-preflight-$agent.env"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: --check with a fresh cache emits exports, never invokes op.
+# ---------------------------------------------------------------------------
+test_check_fresh_cache() {
+  local case_dir="$WORKDIR/case1"
+  make_fresh_cache "$case_dir" claude "rev-pat-1" "author-pat-1"
+
+  local out err rc
+  out=$(PATH="$STUB_DIR:$PATH" OP_PREFLIGHT_CACHE_DIR="$case_dir" \
+    "$SCRIPT" --agent claude --check 2>"$WORKDIR/case1.err") || rc=$?
+  rc=${rc:-0}
+  err=$(cat "$WORKDIR/case1.err")
+
+  if [ "$rc" -ne 0 ]; then
+    fail "test_check_fresh_cache: expected rc=0, got rc=$rc; stderr=$err"
+    return
+  fi
+  if ! echo "$out" | grep -q "OP_PREFLIGHT_REVIEWER_PAT=rev-pat-1"; then
+    fail "test_check_fresh_cache: stdout missing reviewer PAT export; got $out"
+    return
+  fi
+  if ! echo "$out" | grep -q "OP_PREFLIGHT_AUTHOR_PAT=author-pat-1"; then
+    fail "test_check_fresh_cache: stdout missing author PAT export; got $out"
+    return
+  fi
+  if echo "$err" | grep -q FATAL; then
+    fail "test_check_fresh_cache: --check invoked op or ssh; stderr=$err"
+    return
+  fi
+  pass "test_check_fresh_cache: fresh cache emits exports without op/ssh"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: --check with no cache exits non-zero, never invokes op.
+# ---------------------------------------------------------------------------
+test_check_missing_cache() {
+  local case_dir="$WORKDIR/case2"  # never created
+  local err rc=0
+  PATH="$STUB_DIR:$PATH" OP_PREFLIGHT_CACHE_DIR="$case_dir" \
+    "$SCRIPT" --agent claude --check 2>"$WORKDIR/case2.err" >"$WORKDIR/case2.out" || rc=$?
+  err=$(cat "$WORKDIR/case2.err")
+  if [ "$rc" -eq 0 ]; then
+    fail "test_check_missing_cache: expected non-zero exit, got 0"
+    return
+  fi
+  if [ -s "$WORKDIR/case2.out" ]; then
+    fail "test_check_missing_cache: expected empty stdout on miss, got $(cat "$WORKDIR/case2.out")"
+    return
+  fi
+  if ! echo "$err" | grep -q "cache missing or stale"; then
+    fail "test_check_missing_cache: stderr missing remediation; got $err"
+    return
+  fi
+  if echo "$err" | grep -q FATAL; then
+    fail "test_check_missing_cache: --check invoked op or ssh; stderr=$err"
+    return
+  fi
+  pass "test_check_missing_cache: missing cache exits non-zero with remediation"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: --check with a STALE cache exits non-zero, never invokes op.
+# ---------------------------------------------------------------------------
+test_check_stale_cache() {
+  local case_dir="$WORKDIR/case3"
+  make_stale_cache "$case_dir" claude
+
+  local err rc=0
+  PATH="$STUB_DIR:$PATH" OP_PREFLIGHT_CACHE_DIR="$case_dir" \
+    "$SCRIPT" --agent claude --check 2>"$WORKDIR/case3.err" >"$WORKDIR/case3.out" || rc=$?
+  err=$(cat "$WORKDIR/case3.err")
+  if [ "$rc" -eq 0 ]; then
+    fail "test_check_stale_cache: expected non-zero exit, got 0"
+    return
+  fi
+  if ! echo "$err" | grep -q "cache missing or stale"; then
+    fail "test_check_stale_cache: stderr missing remediation; got $err"
+    return
+  fi
+  if echo "$err" | grep -q FATAL; then
+    fail "test_check_stale_cache: --check invoked op or ssh; stderr=$err"
+    return
+  fi
+  pass "test_check_stale_cache: stale cache exits non-zero with remediation"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: --check refuses to combine with --refresh / --purge / --purge-all.
+# ---------------------------------------------------------------------------
+test_check_mutex() {
+  for flag in --refresh --purge --purge-all; do
+    local rc=0
+    PATH="$STUB_DIR:$PATH" "$SCRIPT" --agent claude --check "$flag" \
+      >"$WORKDIR/mutex.out" 2>"$WORKDIR/mutex.err" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      fail "test_check_mutex: expected non-zero exit for --check $flag, got 0"
+      return
+    fi
+    if ! grep -q "mutually exclusive" "$WORKDIR/mutex.err"; then
+      fail "test_check_mutex: --check $flag missing mutex error; stderr=$(cat "$WORKDIR/mutex.err")"
+      return
+    fi
+  done
+  pass "test_check_mutex: --check rejects --refresh / --purge / --purge-all"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: --status is an alias for --check.
+# ---------------------------------------------------------------------------
+test_status_alias() {
+  local case_dir="$WORKDIR/case5"
+  make_fresh_cache "$case_dir" claude "rev-pat-5" "author-pat-5"
+
+  local out rc=0
+  out=$(PATH="$STUB_DIR:$PATH" OP_PREFLIGHT_CACHE_DIR="$case_dir" \
+    "$SCRIPT" --agent claude --status 2>"$WORKDIR/case5.err") || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "test_status_alias: expected rc=0, got rc=$rc"
+    return
+  fi
+  if ! echo "$out" | grep -q "OP_PREFLIGHT_REVIEWER_PAT=rev-pat-5"; then
+    fail "test_status_alias: stdout missing reviewer PAT export"
+    return
+  fi
+  pass "test_status_alias: --status behaves like --check"
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: OP_PREFLIGHT_QUIET=1 collapses the cache-hit stderr block.
+# ---------------------------------------------------------------------------
+test_quiet_mode() {
+  local case_dir="$WORKDIR/case6"
+  make_fresh_cache "$case_dir" claude "rev-pat-6" "author-pat-6"
+
+  local err rc=0
+  PATH="$STUB_DIR:$PATH" OP_PREFLIGHT_CACHE_DIR="$case_dir" \
+    OP_PREFLIGHT_QUIET=1 \
+    "$SCRIPT" --agent claude --check >"$WORKDIR/case6.out" 2>"$WORKDIR/case6.err" || rc=$?
+  err=$(cat "$WORKDIR/case6.err")
+  if [ "$rc" -ne 0 ]; then
+    fail "test_quiet_mode: expected rc=0, got rc=$rc; stderr=$err"
+    return
+  fi
+  if ! echo "$err" | grep -q "no biometric burned"; then
+    fail "test_quiet_mode: stderr missing single-line confirmation; got $err"
+    return
+  fi
+  if echo "$err" | grep -q "── Preflight cached hit"; then
+    fail "test_quiet_mode: stderr still contains verbose block; got $err"
+    return
+  fi
+  pass "test_quiet_mode: OP_PREFLIGHT_QUIET=1 collapses verbose block"
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: Default --mode is review (not all). Without --mode, dry-run
+# should report Reviewer + Author PAT reads but NOT GCP ADC.
+# ---------------------------------------------------------------------------
+test_default_mode_is_review() {
+  local err rc=0
+  PATH="$STUB_DIR:$PATH" \
+    "$SCRIPT" --agent claude --dry-run >"$WORKDIR/case7.out" 2>"$WORKDIR/case7.err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "test_default_mode_is_review: dry-run rc=$rc"
+    return
+  fi
+  err=$(cat "$WORKDIR/case7.err")
+  if ! echo "$err" | grep -q "mode review"; then
+    fail "test_default_mode_is_review: dry-run header missing 'mode review'; got $err"
+    return
+  fi
+  if echo "$err" | grep -q "Would read: GCP ADC"; then
+    fail "test_default_mode_is_review: default mode should NOT load GCP ADC; got $err"
+    return
+  fi
+  pass "test_default_mode_is_review: default --mode is review (no ADC)"
+}
+
+test_check_fresh_cache
+test_check_missing_cache
+test_check_stale_cache
+test_check_mutex
+test_status_alias
+test_quiet_mode
+test_default_mode_is_review
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Addresses three brittleness modes in the agent ↔ op-preflight contract
identified in #282:

1. **--check / --status mode** (read-only validator). `op-preflight.sh`
   gains a `--check` flag (alias `--status`) that validates the session
   file for the requested --agent is fresh per the existing TTL anchor
   and emits the cached export statements — but NEVER invokes `op`,
   NEVER warms SSH, NEVER reads ADC. On a missing or stale cache the
   command exits non-zero with a remediation message pointing back at
   `--mode review`. This gives agents a safe idempotent "re-validate
   credentials" call at the top of every tool call without any risk
   of biometric prompt or write-side effects. Mutually exclusive with
   --refresh, --purge, --purge-all.

2. **Default --mode is now `review`** (was `all`). Most agent work
   only needs reviewer/author PATs + SSH warming; loading GCP ADC +
   Cloudflare on every session-start preflight bloated the biometric
   burst for no reason. Deploy scripts pass --mode deploy or
   --mode all explicitly.

3. **OP_PREFLIGHT_QUIET=1** collapses the verbose cache-hit stderr
   block to a single "# preflight: cache hit, no biometric burned"
   line. Refresh notices and warnings remain unaffected.

4. **Biometric trigger log** (`$CACHE_DIR/biometric-log`, chmod 600).
   Each fresh op fetch appends `<ISO8601> agent=<a> mode=<m>
   reason=<full-fetch|refresh|stale-adc|cross-mode-invalidation>` so
   a session audit can correlate biometric prompts against agent
   behavior. Always-on (local file, no privacy/log-volume tradeoff).

5. **Helper auto-source via scripts/lib/preflight-helpers.sh**. The
   five GH_TOKEN-using helpers — coderabbit-wait.sh,
   codex-review-request.sh, codex-review-check.sh,
   resolve-pr-threads.sh, request-label-removal.sh — now source a
   shared library that auto-loads the op-preflight cache when
   GH_TOKEN is unset and a fresh cache exists for the current agent.
   Preserves existing behavior when GH_TOKEN is already set. The
   `[ -z "${GH_TOKEN:-}" ] && exit 3` guard in each helper still
   fires when neither GH_TOKEN nor a fresh cache is available, but
   with a clearer remediation message pointing at op-preflight.

6. **PAT-table consolidation**. REVIEW_POLICY.md § PAT lookup table
   becomes the single source of truth. CLAUDE.md (project) and
   DEPLOYMENT.md reference it rather than duplicating. Machine-level
   ~/GitHub/CLAUDE.md keeps a mirror tagged with REVIEW_POLICY.md
   as authoritative.

7. **Cached env var is the primary pattern** across all PAT-related
   docs. The inline `op read 'op://...'` form is now clearly labeled
   "Fallback / setup-only" with a banner warning that it triggers a
   biometric prompt per call.

Tests:
  - tests/test_op_preflight_check.sh (7 tests): --check never invokes
    op, never warms SSH, emits cached exports on fresh cache, exits
    non-zero on missing/stale; --status alias; OP_PREFLIGHT_QUIET=1
    collapses verbose block; default --mode is review.
  - tests/test_helper_autosource.sh (7 tests): shared library
    auto-source loads fresh cache, preserves caller GH_TOKEN, skips
    stale caches; preflight_require_token reviewer/author both
    export GH_TOKEN; all five helpers source the shared library;
    GH_TOKEN-required helpers no longer error out with a fresh cache.
  - Wired into scripts/ci/check_op_preflight_contract and the
    repo_lint.yml workflow alongside the existing checks.
  - Added to the .mergepath-sync.yml manifest so consumers get the
    library + tests in lockstep with op-preflight.sh updates.

Closes #282 (mergepath surface only — #284's active-account
matrix and #281's chat-side handoff are out of scope here).

Authoring-Agent: claude

## Self-Review

- Correctness: --check path early-returns before any op/ssh call. All
  7 tests in test_op_preflight_check.sh PATH-shim `op` to abort on
  call and verify the stub is never invoked. Helper auto-source
  preserves the existing `[ -z "${GH_TOKEN:-}" ] && exit 3` guard so
  no regression when neither env var nor cache is available.
- Regression risk: low. The default --mode change is the only
  semantic shift in op-preflight.sh; deploy scripts that need ADC
  still pass --mode deploy or --mode all explicitly per
  DEPLOYMENT.md, and docs/agents/deployment-process.md is updated to
  reflect the new default. The helper auto-source is a strict
  superset of prior behavior (no-op when GH_TOKEN is set).
- Style: matches existing op-preflight.sh patterns
  (function-then-guard layout, numeric-only validation with `10#`
  decimal coercion, set -e safe `|| true` on optional grep paths).
  Shared library uses bash 3.2-portable parameter expansion
  throughout.
- Test coverage: 14 new tests covering the contract surface. The
  helper auto-source path is also exercised end-to-end via a stub
  gh + a synthetic cache (test 7 in test_helper_autosource.sh).
- Security/dependency hygiene: scripts/lib/preflight-helpers.sh is
  chmod 755 with no new dependencies (pure bash). The biometric log
  is chmod 600 in a chmod 700 cache dir. No PAT material added to
  any tracked file.
- Scope boundary: did NOT touch warn_active_account_mismatch or the
  SSH-warm marker code (#163), per the parallel agent coordination
  note in the issue. Did NOT add the operation-to-identity matrix
  to REVIEW_POLICY.md (that's #284's deliverable).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
