### PR TITLE
feat: add manifest requires: closure invariant + canary-first docs (#264)

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -9,6 +9,83 @@
 # plan): manifest + audit. Additional path types and per-path knobs
 # (kit-with-allowlist, three-way-merge for review-policy.yml,
 # substitution rules for templated docs) land in later layers.
+#
+# ─────────────────────────────────────────────────────────────────────
+# `requires:` — propagation closure invariant (#264)
+# ─────────────────────────────────────────────────────────────────────
+#
+# A path entry MAY declare a `requires:` list naming OTHER paths that
+# must travel with it to a consumer for the entry to function. The
+# canonical motivation is the propagation wave that triggered #264:
+# scripts/ci/check_gh_as_author was propagated as part of the
+# scripts/ci/ kit, but the test files it hard-requires
+# (tests/test_gh_pr_guard.sh, tests/test_gh_as_author.sh, etc.)
+# were NOT in the manifest. Every consumer's `lint` job then
+# failed in pre-flight on `Missing required file: tests/...`.
+#
+# The `requires:` field closes that gap structurally:
+# `scripts/ci/check_sync_manifest` enforces that for every required
+# path listed under any entry, that path is ALSO covered by the
+# manifest. "Covered" means EITHER an exact entry of its own OR a
+# path strictly inside a manifest kit entry (because kit propagation
+# walks the whole directory, so a fixtures subdir under a kit path
+# travels for free).
+#
+# Be conservative when adding `requires:` — only entries you can
+# verify by grepping the actual script/workflow for hard-required
+# paths. A `requires:` entry should be:
+#   - a test file under tests/ that a `scripts/ci/check_*` wrapper
+#     hard-fails on if missing,
+#   - a script that a propagated workflow shells out to (e.g.
+#     codex-p1-gate.yml → codex-p1-gate.sh), or
+#   - a fixture/library path that an extracted module depends on at
+#     runtime (e.g. agent-review.yml's detect-disagreement job
+#     requires scripts/disagreement-detector.cjs).
+#
+# Things that are NOT `requires:` material:
+#   - Soft dependencies (docs cross-references, comment pointers).
+#   - Paths inside the SAME manifest entry's kit directory (those
+#     travel automatically; declaring them is harmless and may help
+#     readability, but the validator accepts them either way).
+#   - Per-consumer config (e.g. .github/review-policy.yml) that is
+#     intentionally NOT propagated.
+#
+# Format:
+#   - path: scripts/ci/
+#     type: kit
+#     consumers: all
+#     requires:
+#       - "tests/test_gh_pr_guard.sh"       # check_gh_as_author
+#       - "tests/test_gh_as_author.sh"      # check_gh_as_author
+#       - "scripts/ci/fixtures/"            # check_disagreement_detector
+#
+# ─────────────────────────────────────────────────────────────────────
+# Canary-first procedure for --sync-all
+# ─────────────────────────────────────────────────────────────────────
+#
+# When propagating a large change set, prefer the canary-first pattern
+# over a parallel fan-out. The propagation wave that surfaced #264
+# opened 8 consumer PRs simultaneously; every one of them failed the
+# same `lint` job for the same reason, so a single canary would have
+# caught the gap before the fan-out blew up.
+#
+# Recommended steps for `scripts/sync-to-downstream.sh --sync-all`:
+#   1. Pick ONE consumer (typically a public repo so the failure is
+#      easy to read in a tab without auth): `--repos <one-name>`.
+#   2. Wait for that consumer's PR to pass `lint`. If it fails,
+#      investigate IN THE CONSUMER PR before opening any others —
+#      most failures (missing test files, missing fixtures, missing
+#      scripts the kit hard-requires) are upstream manifest gaps
+#      that `requires:` would have caught at the manifest layer.
+#   3. Once the canary is green, fan out: `--sync-all` (no `--repos`).
+#   4. The remaining consumers re-use the cleared invariant, so the
+#      fan-out is reduced to a verification step, not exploration.
+#
+# This is documentation, not enforcement — agents and humans share the
+# same recommendation. The `requires:` invariant above is the
+# structural guard; the canary procedure is the operational practice
+# that makes a manifest gap recoverable for a single PR instead of
+# eight.
 
 # Schema version. Bumped on incompatible changes; the script refuses
 # to run against an unknown version so old scripts can't silently
@@ -150,9 +227,24 @@ paths:
   - path: .github/workflows/agent-review.yml
     type: canonical
     consumers: all
+    # The detect-disagreement job runs `require('scripts/disagreement-
+    # detector.cjs')`. Without the module file, the job aborts on
+    # MODULE_NOT_FOUND. Same lockstep coupling as #259 — propagate the
+    # workflow without the module and every consumer's agent-review job
+    # fails on the very first PR.
+    requires:
+      - "scripts/disagreement-detector.cjs"
   - path: .github/workflows/pr-review-policy.yml
     type: canonical
     consumers: all
+    # The workflow shells out to the three scripts/workflow/ parser
+    # helpers (parse_policy_list, match_protected_paths,
+    # parse_manifest_paths). They are propagated as part of the
+    # scripts/workflow/ kit; declaring the dependency here makes the
+    # coupling explicit so the check_sync_manifest invariant flags any
+    # future split of the parser kit from the workflow.
+    requires:
+      - "scripts/workflow/"
   - path: .github/workflows/dependabot-auto-merge.yml
     type: canonical
     consumers: all
@@ -165,6 +257,12 @@ paths:
   - path: .github/workflows/codex-p1-gate.yml
     type: canonical
     consumers: all
+    # The workflow's only job runs `scripts/codex-p1-gate.sh` directly
+    # (see the `Run scripts/codex-p1-gate.sh` step). Propagating the
+    # workflow without the script makes the gate fail-closed on
+    # `command not found` for every PR in the consumer.
+    requires:
+      - "scripts/codex-p1-gate.sh"
 
   # NOTE: `.mergepath-sync.yml` is deliberately NOT propagated.
   # #268 briefly made it a canonical path on the theory the lane
@@ -181,6 +279,33 @@ paths:
   - path: scripts/ci/
     type: kit
     consumers: all
+    # check_* wrappers under scripts/ci/ hard-fail (exit 1) when their
+    # paired tests, scripts, workflows, or fixtures are missing. Every
+    # entry below is grep-verified against a `scripts/ci/check_*`
+    # script's REQUIRED_FILES / TEST / FIXTURE constants — the same
+    # closure gap that surfaced as #264 on the original propagation
+    # wave (check_gh_as_author missing its tests on every consumer).
+    requires:
+      - "tests/test_gh_pr_guard.sh"            # check_gh_as_author
+      - "tests/test_gh_as_author.sh"           # check_gh_as_author
+      - "tests/test_gh_as_reviewer.sh"         # check_gh_as_author
+      - "tests/test_codex_p1_gate.sh"          # check_codex_p1_gate
+      - "tests/test_disagreement_detector.sh"  # check_disagreement_detector
+      - "tests/test_verify_propagation_pr.sh"  # check_verify_propagation_pr
+      - "scripts/codex-p1-gate.sh"             # check_codex_p1_gate
+      - "scripts/codex-review-request.sh"      # check_codex_scripts
+      - "scripts/codex-review-check.sh"        # check_codex_scripts, check_canonical_bugs_263caf3
+      - "scripts/phase-4b-classifier.sh"       # check_phase_4b_classifier
+      - "scripts/disagreement-detector.cjs"    # check_disagreement_detector
+      - "scripts/request-label-removal.sh"     # check_canonical_bugs_263caf3
+      - "scripts/resolve-pr-threads.sh"        # check_resolve_pr_threads
+      - "scripts/gh-as-author.sh"              # check_gh_as_author (transitive)
+      - "scripts/gh-as-reviewer.sh"            # check_gh_as_author (transitive)
+      - "scripts/hooks/gh-pr-guard.sh"         # tests/test_gh_pr_guard.sh runs it
+      - "scripts/workflow/"                    # check_workflow_parsers
+      - ".github/workflows/agent-review.yml"   # check_disagreement_detector structural assertion
+      - ".github/workflows/codex-p1-gate.yml"  # check_codex_p1_gate workflow shape
+      - ".github/workflows/pr-audit.yml"       # check_pr_audit_codex_clearance
   - path: scripts/gh-projects/
     type: kit
     consumers: all

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -16,14 +16,27 @@
 #   5. Every path entry's `type` is one of: canonical, kit, templated.
 #   6. Every path's `consumers` is either the literal "all" or a list
 #      of consumer names that exist in the consumers block.
+#   7. Every `requires:` entry (if present) is a YAML list of strings,
+#      and every required path is COVERED by the manifest — i.e. it
+#      matches an exact manifest entry OR is strictly inside a kit
+#      manifest entry. Closes the propagation closure gap that
+#      surfaced as #264 on the original wave (check_gh_as_author
+#      hard-required tests/test_gh_pr_guard.sh, which was not in
+#      the manifest, so every consumer's lint job failed in pre-flight).
 #
 # This check is read-only and does NOT contact downstream repos —
 # that's the audit script's job and is too slow for CI.
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-MANIFEST="$REPO_ROOT/.mergepath-sync.yml"
+# Env overrides for tests/test_check_sync_manifest.sh:
+#   MERGEPATH_MANIFEST_PATH — point at a fixture manifest YAML
+#   MERGEPATH_REPO_ROOT      — point at a fixture repo tree (so the
+#                              path-existence check probes the fixture
+#                              instead of the live repo). Default is
+#                              the script's own repo root in PR CI.
+REPO_ROOT="${MERGEPATH_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+MANIFEST="${MERGEPATH_MANIFEST_PATH:-$REPO_ROOT/.mergepath-sync.yml}"
 SUPPORTED_VERSION=1
 
 if ! command -v yq >/dev/null 2>&1; then
@@ -207,9 +220,165 @@ while IFS=$'\t' read -r path type consumers; do
   fi
 done <<< "$path_rows"
 
+# 7. requires: closure invariant (#264).
+#
+# Collect the full set of manifest paths (with their types) so we can
+# decide whether each declared `requires:` entry is satisfied. A
+# required path is COVERED iff:
+#   - it equals a canonical / templated / kit manifest entry exactly,
+#     OR
+#   - it lives strictly inside a kit manifest entry (kit propagation
+#     mirrors the whole subtree, so a fixtures subdir under a kit path
+#     travels for free).
+#
+# Failing fail-closed: a malformed `requires:` (not a sequence) is a
+# hard error; a required path with no manifest coverage is a hard error
+# naming both the requirer and the missing path.
+#
+# Build the "kit prefixes" list (kit paths with a trailing slash so
+# the prefix match is unambiguous — `scripts/c` must not match a kit
+# entry `scripts/ci/`) and the exact-paths set up front.
+if ! kit_rows=$(yq -r '.paths[] | select(.type == "kit") | .path' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract kit paths from the manifest (yq error):"
+  printf '%s\n' "$kit_rows"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
+if ! exact_rows=$(yq -r '.paths[].path' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract manifest paths (yq error):"
+  printf '%s\n' "$exact_rows"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
+
+# Wrap exact_rows with a sentinel boundary so substring lookups can't
+# false-match (`,foo/bar,` is unambiguous; `foo/bar` matches a `foo` or
+# `bar` substring otherwise).
+exact_set=",$(echo "$exact_rows" | tr '\n' ',')"
+
+# kit_prefixes is space-separated kit paths with each guaranteed to end
+# in a slash so `scripts/ci/fixtures/foo.json` matches the kit
+# `scripts/ci/` prefix unambiguously and `scripts/cinema/foo.json` does
+# not match `scripts/ci/`.
+kit_prefixes=""
+while IFS= read -r kp; do
+  [ -z "$kp" ] && continue
+  case "$kp" in
+    */) kit_prefixes="$kit_prefixes $kp" ;;
+    *)  kit_prefixes="$kit_prefixes $kp/" ;;
+  esac
+done <<< "$kit_rows"
+
+# `requires:` is OPTIONAL — entries without it must remain valid.
+#
+# Two-pass design to dodge mikefarah/yq's silent-emit-nothing behavior
+# on `.requires[]` against a scalar (a malformed `requires: "foo"`
+# string would otherwise pass through with zero output instead of
+# erroring). Pass 1 type-checks every `requires:` field via the `type`
+# function and fails closed on any non-sequence shape. Pass 2 then
+# iterates the sequence safely.
+#
+# Pass 1: shape check.
+if ! shape_rows=$(yq -r '
+  .paths[] | select(has("requires"))
+  | .path + "\t" + (.requires | type)
+' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not type-check .paths[].requires (yq error):"
+  printf '%s\n' "$shape_rows"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
+if [ -n "$shape_rows" ]; then
+  while IFS=$'\t' read -r requirer rtype; do
+    [ -z "$requirer" ] && continue
+    if [ "$rtype" != "!!seq" ]; then
+      echo "FAIL: path '$requirer' has a malformed requires: field (expected a YAML sequence of strings, got type '$rtype')"
+      FAILED=1
+    fi
+  done <<< "$shape_rows"
+  if [ "$FAILED" -eq 1 ]; then
+    echo "check_sync_manifest: FAIL"
+    exit 1
+  fi
+fi
+
+# Pass 2: extract one (requirer, required_path) per line.
+if ! requires_rows=$(yq -r '
+  .paths[]
+  | select(has("requires"))
+  | .path as $p
+  | .requires[]
+  | $p + "\t" + .
+' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract .paths[].requires entries from the manifest (yq error):"
+  printf '%s\n' "$requires_rows"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
+
+# Defensive bash-side validation: yq -r outputs each requires string
+# unquoted. A scalar `requires: "tests/foo.sh"` (not a sequence) would
+# either yq-error above or — depending on yq version — emit the string
+# as a single-line value. Detect non-string output (lines with weird
+# whitespace, embedded newlines, structured-tag prefixes) and reject.
+if [ -n "$requires_rows" ]; then
+  while IFS=$'\t' read -r requirer required; do
+    [ -z "$requirer" ] && continue
+    # Required path must be a single non-empty token with no embedded
+    # whitespace beyond what `tr` could collapse — a sane file path.
+    case "$required" in
+      ""|*$'\n'*|*$'\t'*)
+        echo "FAIL: path '$requirer' has an empty or whitespace-broken requires: entry"
+        FAILED=1
+        continue
+        ;;
+    esac
+
+    # Exact match check.
+    if [[ "$exact_set" == *",$required,"* ]]; then
+      continue
+    fi
+
+    # Kit-prefix coverage: required path is strictly inside a kit entry.
+    covered=0
+    for kp in $kit_prefixes; do
+      if [[ "$required" == "$kp"* ]]; then
+        covered=1
+        break
+      fi
+    done
+
+    if [ "$covered" -eq 1 ]; then
+      continue
+    fi
+
+    # Anything still uncovered is a real manifest gap.
+    echo "FAIL: path '$requirer' requires '$required' but that path is not covered by the manifest"
+    echo "      (no exact entry, and not inside any kit entry — propagation would deliver '$requirer'"
+    echo "       to a consumer without '$required', and any tooling that hard-requires it will fail closed."
+    echo "       Fix by adding '$required' as its own manifest entry, or by extending an existing kit to cover it.)"
+    FAILED=1
+  done <<< "$requires_rows"
+fi
+
 if [ "$FAILED" -eq 1 ]; then
   echo "check_sync_manifest: FAIL"
   exit 1
+fi
+
+# Run the regression test suite if present. The fixture-based tests
+# under tests/test_check_sync_manifest.sh exercise the requires:
+# closure invariant against synthetic fixture manifests — they don't
+# re-run if this invocation was already driven by a fixture
+# (MERGEPATH_MANIFEST_PATH set) since that's the test harness calling
+# back into us.
+TEST_SUITE="$REPO_ROOT/tests/test_check_sync_manifest.sh"
+if [ -z "${MERGEPATH_MANIFEST_PATH:-}" ] && [ -x "$TEST_SUITE" ]; then
+  echo "check_sync_manifest: running regression test suite"
+  if ! bash "$TEST_SUITE"; then
+    echo "check_sync_manifest: FAIL (regression test suite failed)"
+    exit 1
+  fi
 fi
 
 echo "check_sync_manifest: PASS ($consumer_count consumer(s), $(yq '.paths | length' "$MANIFEST") path entry/entries)"

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -237,7 +237,15 @@ done <<< "$path_rows"
 #
 # Build the "kit prefixes" list (kit paths with a trailing slash so
 # the prefix match is unambiguous — `scripts/c` must not match a kit
-# entry `scripts/ci/`) and the exact-paths set up front.
+# entry `scripts/ci/`) and the exact-paths set up front. Also build
+# a path→consumer-set map so the closure check can verify that a
+# requirer's consumer scope is a subset of each required path's
+# consumer scope (#264 r2 — nathanpayne-codex Phase 4b finding).
+#
+# Consumer set is represented as a CSV: either the literal "all"
+# (universal) or comma-joined consumer names with surrounding commas
+# (",matchline,swipewatch," — sentinel-padded so substring lookup
+# can't false-match on a name prefix).
 if ! kit_rows=$(yq -r '.paths[] | select(.type == "kit") | .path' "$MANIFEST" 2>&1); then
   echo "FAIL: could not extract kit paths from the manifest (yq error):"
   printf '%s\n' "$kit_rows"
@@ -250,6 +258,28 @@ if ! exact_rows=$(yq -r '.paths[].path' "$MANIFEST" 2>&1); then
   echo "check_sync_manifest: FAIL"
   exit 1
 fi
+# Each line: <path>\t<consumers> where <consumers> is either the
+# literal "all" or a comma-joined list of consumer names. Two-pass
+# extraction (string-typed consumers, then sequence-typed consumers)
+# to dodge mikefarah/yq's inline-if/then/else parser limitations.
+if ! str_consumers_rows=$(yq -r '
+  .paths[] | select(.consumers | type == "!!str") | .path + "\t" + .consumers
+' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract string-typed path consumer sets from manifest (yq error):"
+  printf '%s\n' "$str_consumers_rows"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
+if ! seq_consumers_rows=$(yq -r '
+  .paths[] | select(.consumers | type == "!!seq") | .path + "\t" + (.consumers | join(","))
+' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract sequence-typed path consumer sets from manifest (yq error):"
+  printf '%s\n' "$seq_consumers_rows"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
+# Merge the two streams, filtering blanks.
+path_consumers_rows="$(printf '%s\n%s\n' "$str_consumers_rows" "$seq_consumers_rows" | grep -v '^$' || true)"
 
 # Wrap exact_rows with a sentinel boundary so substring lookups can't
 # false-match (`,foo/bar,` is unambiguous; `foo/bar` matches a `foo` or
@@ -268,6 +298,80 @@ while IFS= read -r kp; do
     *)  kit_prefixes="$kit_prefixes $kp/" ;;
   esac
 done <<< "$kit_rows"
+
+# path_consumers_for <path> → echoes the consumer set CSV ("all" or
+# comma-joined names) for the given path. Tries exact match first,
+# then kit-prefix match. Echoes empty string if no match (caller
+# will have already failed in the uncovered-path check).
+path_consumers_for() {
+  local needle="$1"
+  while IFS=$'\t' read -r p c; do
+    [ -z "$p" ] && continue
+    if [ "$p" = "$needle" ]; then
+      printf '%s' "$c"
+      return 0
+    fi
+  done <<< "$path_consumers_rows"
+  # Fall back to kit-prefix match. Find the kit whose prefix this
+  # path lives inside, then return that kit's consumer set.
+  for kp in $kit_prefixes; do
+    if [[ "$needle" == "$kp"* ]]; then
+      local kit_path="${kp%/}"
+      # Also try with trailing slash since some kit entries are
+      # stored that way in the manifest.
+      while IFS=$'\t' read -r p c; do
+        [ -z "$p" ] && continue
+        if [ "$p" = "$kit_path" ] || [ "$p" = "$kp" ]; then
+          printf '%s' "$c"
+          return 0
+        fi
+      done <<< "$path_consumers_rows"
+    fi
+  done
+  printf ''
+}
+
+# consumers_subset <sub_csv> <sup_csv> — returns 0 if sub is a
+# subset of sup, 1 otherwise. Special cases:
+#   - sup="all" always succeeds (universal set covers any explicit list).
+#   - sub="all" + sup explicit → fails (universal can't fit in finite).
+#   - both explicit → every consumer in sub must be in sup.
+consumers_subset() {
+  local sub="$1" sup="$2"
+  [ "$sup" = "all" ] && return 0
+  [ "$sub" = "all" ] && return 1
+  local IFS=','
+  local c
+  for c in $sub; do
+    [ -z "$c" ] && continue
+    case ",$sup," in
+      *",$c,"*) ;;
+      *) return 1 ;;
+    esac
+  done
+  return 0
+}
+
+# consumers_diff <sub_csv> <sup_csv> — echoes the comma-joined list
+# of consumers in sub that are NOT in sup. For diagnostic naming
+# when consumers_subset fails.
+consumers_diff() {
+  local sub="$1" sup="$2"
+  if [ "$sub" = "all" ] && [ "$sup" != "all" ]; then
+    printf '%s' "(requirer is consumers: all, required is only: $sup)"
+    return
+  fi
+  local IFS=','
+  local c missing=""
+  for c in $sub; do
+    [ -z "$c" ] && continue
+    case ",$sup," in
+      *",$c,"*) ;;
+      *) missing="${missing:+$missing,}$c" ;;
+    esac
+  done
+  printf '%s' "$missing"
+}
 
 # `requires:` is OPTIONAL — entries without it must remain valid.
 #
@@ -334,30 +438,55 @@ if [ -n "$requires_rows" ]; then
         ;;
     esac
 
-    # Exact match check.
-    if [[ "$exact_set" == *",$required,"* ]]; then
-      continue
-    fi
-
-    # Kit-prefix coverage: required path is strictly inside a kit entry.
+    # Path-coverage check first: exact entry OR strictly inside a kit.
     covered=0
-    for kp in $kit_prefixes; do
-      if [[ "$required" == "$kp"* ]]; then
-        covered=1
-        break
-      fi
-    done
+    if [[ "$exact_set" == *",$required,"* ]]; then
+      covered=1
+    else
+      for kp in $kit_prefixes; do
+        if [[ "$required" == "$kp"* ]]; then
+          covered=1
+          break
+        fi
+      done
+    fi
 
-    if [ "$covered" -eq 1 ]; then
+    if [ "$covered" -eq 0 ]; then
+      # Anything uncovered is a real manifest gap.
+      echo "FAIL: path '$requirer' requires '$required' but that path is not covered by the manifest"
+      echo "      (no exact entry, and not inside any kit entry — propagation would deliver '$requirer'"
+      echo "       to a consumer without '$required', and any tooling that hard-requires it will fail closed."
+      echo "       Fix by adding '$required' as its own manifest entry, or by extending an existing kit to cover it.)"
+      FAILED=1
       continue
     fi
 
-    # Anything still uncovered is a real manifest gap.
-    echo "FAIL: path '$requirer' requires '$required' but that path is not covered by the manifest"
-    echo "      (no exact entry, and not inside any kit entry — propagation would deliver '$requirer'"
-    echo "       to a consumer without '$required', and any tooling that hard-requires it will fail closed."
-    echo "       Fix by adding '$required' as its own manifest entry, or by extending an existing kit to cover it.)"
-    FAILED=1
+    # Consumer-scope coverage (#264 r2 — nathanpayne-codex Phase 4b
+    # finding). The path is covered by the manifest, but the consumer
+    # SET of the required path must be a SUPERSET of the requirer's
+    # consumer set. Otherwise a consumer that receives the requirer
+    # without the required path's coverage will still hit the
+    # closure gap at consumer-side lint time.
+    requirer_consumers=$(path_consumers_for "$requirer")
+    required_consumers=$(path_consumers_for "$required")
+    if [ -z "$requirer_consumers" ] || [ -z "$required_consumers" ]; then
+      # Defensive: a covered path with no consumer set is a logic
+      # error in this script, not a manifest defect. Fail loudly.
+      echo "FAIL: internal error — could not resolve consumer set for '$requirer' (got '$requirer_consumers') or '$required' (got '$required_consumers')"
+      FAILED=1
+      continue
+    fi
+    if ! consumers_subset "$requirer_consumers" "$required_consumers"; then
+      missing=$(consumers_diff "$requirer_consumers" "$required_consumers")
+      echo "FAIL: path '$requirer' (consumers: $requirer_consumers) requires '$required' (consumers: $required_consumers)"
+      echo "      but the required path's consumer set does NOT cover the requirer's. Consumers receiving"
+      echo "      '$requirer' but NOT '$required': $missing"
+      echo "      Propagation would deliver '$requirer' to those consumers without '$required', and any"
+      echo "      tooling that hard-requires it will fail closed on that consumer's lint."
+      echo "      Fix by widening '$required's consumers: to a superset of '$requirer's, or by narrowing"
+      echo "      '$requirer's consumers: to match '$required's."
+      FAILED=1
+    fi
   done <<< "$requires_rows"
 fi
 

--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -112,6 +112,34 @@
 #   --help, -h           Show this help.
 #   --version            Print version info.
 #
+# Canary-first procedure for --sync-all (#264):
+#   The original 263caf3 propagation wave (8 consumer PRs at once)
+#   failed lint on EVERY consumer because the kit `scripts/ci/`
+#   was propagated in isolation from coupled tests/fixtures it
+#   depended on. The pre-wave diff audit characterized all drift
+#   as staleness but did NOT exercise a consumer's CI to prove
+#   the propagated set was internally consistent — a content-level
+#   audit cannot catch a runtime-level closure gap.
+#
+#   The fix is a one-consumer canary BEFORE the full fan-out:
+#
+#     # 1. Pick one consumer (matchline is the canonical canary).
+#     scripts/sync-to-downstream.sh --sync-all --repos matchline
+#
+#     # 2. Wait for that consumer's `lint` workflow to pass on the
+#     #    opened PR. If it fails, fix the manifest gap in mergepath
+#     #    canonical first (most often a `requires:` closure miss
+#     #    flagged by `scripts/ci/check_sync_manifest`).
+#
+#     # 3. Once the canary's lint is green, fan out to the rest:
+#     scripts/sync-to-downstream.sh --sync-all
+#
+#   The `requires:` manifest invariant added in #264 catches the
+#   most common class of closure gap at the manifest layer, but the
+#   canary remains the operational safety net for cases the
+#   invariant can't see (consumer-specific repo_lint.yml steps,
+#   transitively-required files outside the manifest, etc.).
+#
 # Environment:
 #   MERGEPATH_SIBLINGS_DIR  Default: $HOME/GitHub. If a `.git` entry at
 #                           $MERGEPATH_SIBLINGS_DIR/<consumer-name>/.git

--- a/tests/test_check_sync_manifest.sh
+++ b/tests/test_check_sync_manifest.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# tests/test_check_sync_manifest.sh
+#
+# Unit tests for scripts/ci/check_sync_manifest — specifically the
+# new `requires:` closure invariant added in #264. The pre-existing
+# manifest-shape checks (consumer set, type set, etc.) are covered
+# implicitly by running the check against the live .mergepath-sync.yml
+# in PR CI; this file targets the new closure logic.
+#
+# Pattern matches tests/test_gh_pr_guard.sh — fixture manifests
+# written to a scratch dir, run check_sync_manifest via env override,
+# assert on exit code + diagnostic substring.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK="$ROOT/scripts/ci/check_sync_manifest"
+
+[[ -x "$CHECK" ]] || { echo "missing or non-executable $CHECK" >&2; exit 1; }
+command -v yq >/dev/null 2>&1 || { echo "SKIP: yq not available" >&2; exit 0; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/check-sync-manifest-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Helper: build a fixture repo tree (with stub files for every path
+# referenced in the manifest) and run the check against it. Sets both
+# MERGEPATH_MANIFEST_PATH and MERGEPATH_REPO_ROOT so the check probes
+# the fixture instead of the live repo. The pre-existing path-
+# existence check requires every canonical/templated path in the
+# manifest to be a real file, so the helper touches each one in the
+# fixture root before invoking the check.
+#
+# Args: $1 = manifest YAML content, $2 = newline-separated list of
+# repo-relative paths to materialize (files for non-trailing-slash
+# entries, dirs for trailing-slash kit entries).
+run_with_fixture() {
+  local manifest_content="$1" paths="$2"
+  local fix
+  fix="$(mktemp -d "$WORKDIR/fix.XXXXXX")"
+  printf '%s' "$manifest_content" > "$fix/manifest.yml"
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    case "$p" in
+      */) mkdir -p "$fix/$p" ;;
+      *)  mkdir -p "$(dirname "$fix/$p")"; : > "$fix/$p" ;;
+    esac
+  done <<< "$paths"
+  MERGEPATH_MANIFEST_PATH="$fix/manifest.yml" MERGEPATH_REPO_ROOT="$fix" bash "$CHECK" 2>&1
+}
+
+# --- Test fixture: baseline well-formed manifest --------------------
+MIN_HEADER='version: 1
+consumers:
+  - name: example
+    repo: example-org/example
+    visibility: public
+paths:'
+
+# --- Case 1: requires: all satisfied by exact + kit-prefix coverage -
+MANIFEST_SAT="$MIN_HEADER
+  - path: scripts/foo.sh
+    type: canonical
+    consumers: all
+    requires:
+      - \"tests/test_foo.sh\"
+  - path: tests/test_foo.sh
+    type: canonical
+    consumers: all
+  - path: scripts/ci/
+    type: kit
+    consumers: all
+    requires:
+      - \"tests/test_kit_helper.sh\"
+      - \"scripts/ci/fixtures/foo.json\"
+  - path: tests/test_kit_helper.sh
+    type: canonical
+    consumers: all
+"
+PATHS_SAT="scripts/foo.sh
+tests/test_foo.sh
+tests/test_kit_helper.sh
+scripts/ci/
+scripts/ci/fixtures/foo.json"
+set +e
+out=$(run_with_fixture "$MANIFEST_SAT" "$PATHS_SAT"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_sync_manifest: PASS"; then
+  pass "Case 1: requires: satisfied by exact + kit-prefix coverage"
+else
+  fail "Case 1 unexpected (rc=$rc): $out"
+fi
+
+# --- Case 2: requires: pointing at an UNCOVERED path ----------------
+MANIFEST_UNCOV="$MIN_HEADER
+  - path: scripts/foo.sh
+    type: canonical
+    consumers: all
+    requires:
+      - \"tests/missing.sh\"
+  - path: tests/test_foo.sh
+    type: canonical
+    consumers: all
+"
+PATHS_UNCOV="scripts/foo.sh
+tests/test_foo.sh"
+set +e
+out=$(run_with_fixture "$MANIFEST_UNCOV" "$PATHS_UNCOV"); rc=$?
+set -e
+if [ "$rc" = "1" ] && \
+   echo "$out" | grep -q "requires 'tests/missing.sh' but that path is not covered"; then
+  pass "Case 2: uncovered requires fails closed with named-path diagnostic"
+else
+  fail "Case 2 unexpected (rc=$rc): $out"
+fi
+
+# --- Case 3: entry WITHOUT requires: stays valid --------------------
+MANIFEST_NOREQ="$MIN_HEADER
+  - path: scripts/foo.sh
+    type: canonical
+    consumers: all
+  - path: tests/test_foo.sh
+    type: canonical
+    consumers: all
+"
+PATHS_NOREQ="scripts/foo.sh
+tests/test_foo.sh"
+set +e
+out=$(run_with_fixture "$MANIFEST_NOREQ" "$PATHS_NOREQ"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "PASS"; then
+  pass "Case 3: missing requires: is valid (optional field)"
+else
+  fail "Case 3 unexpected (rc=$rc): $out"
+fi
+
+# --- Case 4: malformed requires: (scalar instead of sequence) ------
+MANIFEST_MAL="$MIN_HEADER
+  - path: scripts/foo.sh
+    type: canonical
+    consumers: all
+    requires: \"tests/test_foo.sh\"
+  - path: tests/test_foo.sh
+    type: canonical
+    consumers: all
+"
+PATHS_MAL="scripts/foo.sh
+tests/test_foo.sh"
+set +e
+out=$(run_with_fixture "$MANIFEST_MAL" "$PATHS_MAL"); rc=$?
+set -e
+# yq's `.requires[]` on a scalar errors OR splits per-char depending on
+# version; either way the check must exit non-zero with FAIL output.
+if [ "$rc" = "1" ] && echo "$out" | grep -q "FAIL"; then
+  pass "Case 4: scalar requires: rejected (fails closed)"
+else
+  fail "Case 4 unexpected (rc=$rc): $out"
+fi
+
+# --- Case 5: kit-prefix boundary — adjacent dir does NOT count -----
+# `scripts/ci/foo` should be covered by `scripts/ci/` kit, but
+# `scripts/cinema/foo` must NOT be covered by `scripts/ci/` (the prefix
+# match is slash-bounded).
+MANIFEST_BOUND="$MIN_HEADER
+  - path: scripts/foo.sh
+    type: canonical
+    consumers: all
+    requires:
+      - \"scripts/cinema/foo.sh\"
+  - path: scripts/ci/
+    type: kit
+    consumers: all
+"
+PATHS_BOUND="scripts/foo.sh
+scripts/ci/"
+set +e
+out=$(run_with_fixture "$MANIFEST_BOUND" "$PATHS_BOUND"); rc=$?
+set -e
+if [ "$rc" = "1" ] && \
+   echo "$out" | grep -q "requires 'scripts/cinema/foo.sh' but that path is not covered"; then
+  pass "Case 5: kit-prefix is slash-bounded (scripts/ci/ does NOT cover scripts/cinema/)"
+else
+  fail "Case 5 unexpected (rc=$rc): $out"
+fi
+
+# NOTE: a "live manifest" smoke case is intentionally absent. The
+# live invocation of check_sync_manifest in PR CI already smoke-tests
+# the live manifest; invoking it from inside this fixture suite
+# recurses through the new "run regression suite" call at the bottom
+# of check_sync_manifest. Trust the CI invocation to do the smoke.
+
+echo
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -gt 0 ]; then
+  echo "test_check_sync_manifest: FAIL ($FAIL/$TOTAL failed)"
+  exit 1
+fi
+echo "test_check_sync_manifest: PASS ($TOTAL tests)"
+exit 0

--- a/tests/test_check_sync_manifest.sh
+++ b/tests/test_check_sync_manifest.sh
@@ -187,6 +187,127 @@ else
   fail "Case 5 unexpected (rc=$rc): $out"
 fi
 
+# --- Case 6: consumer-scope-aware closure (#264 r2) ----------------
+#
+# nathanpayne-codex Phase 4b r1 on PR #294: the original closure
+# check verified that a required path was IN the manifest but did
+# NOT verify that the required path's `consumers:` covered the
+# requirer's `consumers:`. If a kit propagates to `consumers: all`
+# but a `requires:` entry points at a path with `consumers:
+# [matchline]`, the other consumers still miss the dependency at
+# lint time.
+
+# Need at least two consumers to express a non-universal subset.
+MULTI_HEADER='version: 1
+consumers:
+  - name: matchline
+    repo: org/matchline
+    visibility: public
+  - name: swipewatch
+    repo: org/swipewatch
+    visibility: public
+paths:'
+
+MANIFEST_SCOPE_GAP="$MULTI_HEADER
+  - path: scripts/ci/
+    type: kit
+    consumers: all
+    requires:
+      - \"tests/test_foo.sh\"
+  - path: tests/test_foo.sh
+    type: canonical
+    consumers:
+      - matchline
+"
+PATHS_SCOPE_GAP="scripts/ci/
+tests/test_foo.sh"
+set +e
+out=$(run_with_fixture "$MANIFEST_SCOPE_GAP" "$PATHS_SCOPE_GAP"); rc=$?
+set -e
+if [ "$rc" = "1" ] && \
+   echo "$out" | grep -q "does NOT cover the requirer" && \
+   echo "$out" | grep -qE "requirer is consumers: all|matchline"; then
+  pass "Case 6: requires: with narrower consumer scope fails closed (all → matchline gap)"
+else
+  fail "Case 6 unexpected (rc=$rc): $out"
+fi
+
+# Case 6b: explicit-list requirer with strict-subset required.
+# Both are explicit lists; one consumer is missing from required.
+MANIFEST_NAMED_GAP="$MULTI_HEADER
+  - path: scripts/foo.sh
+    type: canonical
+    consumers:
+      - matchline
+      - swipewatch
+    requires:
+      - \"tests/test_foo.sh\"
+  - path: tests/test_foo.sh
+    type: canonical
+    consumers:
+      - matchline
+"
+PATHS_NAMED_GAP="scripts/foo.sh
+tests/test_foo.sh"
+set +e
+out=$(run_with_fixture "$MANIFEST_NAMED_GAP" "$PATHS_NAMED_GAP"); rc=$?
+set -e
+if [ "$rc" = "1" ] && \
+   echo "$out" | grep -q "does NOT cover" && \
+   echo "$out" | grep -q "swipewatch"; then
+  pass "Case 6b: named-consumer-list requires: gap fails closed and names the missing consumer (swipewatch)"
+else
+  fail "Case 6b unexpected (rc=$rc): $out"
+fi
+
+# Case 7: same shape but required's consumers covers requirer's.
+# Should PASS.
+MANIFEST_SCOPE_OK="$MULTI_HEADER
+  - path: scripts/foo.sh
+    type: canonical
+    consumers:
+      - matchline
+    requires:
+      - \"tests/test_foo.sh\"
+  - path: tests/test_foo.sh
+    type: canonical
+    consumers:
+      - matchline
+      - swipewatch
+"
+PATHS_SCOPE_OK="scripts/foo.sh
+tests/test_foo.sh"
+set +e
+out=$(run_with_fixture "$MANIFEST_SCOPE_OK" "$PATHS_SCOPE_OK"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_sync_manifest: PASS"; then
+  pass "Case 7: requires: covered by superset consumer scope passes"
+else
+  fail "Case 7 unexpected (rc=$rc): $out"
+fi
+
+# Case 8: consumers: all → all (trivial universal coverage).
+MANIFEST_ALL_ALL="$MIN_HEADER
+  - path: scripts/ci/
+    type: kit
+    consumers: all
+    requires:
+      - \"tests/test_foo.sh\"
+  - path: tests/test_foo.sh
+    type: canonical
+    consumers: all
+"
+PATHS_ALL_ALL="scripts/ci/
+tests/test_foo.sh"
+set +e
+out=$(run_with_fixture "$MANIFEST_ALL_ALL" "$PATHS_ALL_ALL"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_sync_manifest: PASS"; then
+  pass "Case 8: consumers: all → all trivially passes"
+else
+  fail "Case 8 unexpected (rc=$rc): $out"
+fi
+
 # NOTE: a "live manifest" smoke case is intentionally absent. The
 # live invocation of check_sync_manifest in PR CI already smoke-tests
 # the live manifest; invoking it from inside this fixture suite


### PR DESCRIPTION
Authoring-Agent: claude

Closes the prevention half of #264. The canonical-test manifest
entries (the immediate fix for matchline's `check_hook_tests`
failure) already landed on main; the remaining work is a manifest-
level invariant that catches future closure gaps BEFORE a wave is
opened, plus a canary-first operational procedure for `--sync-all`
that catches what the invariant can't see.

Changes:

1. `.mergepath-sync.yml` — added a `requires:` field to three path
   entries whose canonical content hard-depends on other files:
     - `.github/workflows/pr-review-policy.yml` requires
       `scripts/workflow/` (the workflow shells out to the three
       parser helpers in that kit).
     - `.github/workflows/codex-p1-gate.yml` requires
       `scripts/codex-p1-gate.sh` (the workflow's only job runs
       that script directly).
     - `scripts/ci/` kit requires 20 paths covering every hard
       dependency under `scripts/ci/check_*` — paired tests,
       upstream scripts, workflows, and fixtures. Each entry has
       an inline comment naming the check_* wrapper that consumes
       it, so future maintainers can audit the closure with grep.
   Added a top-of-file comment block documenting the `requires:`
   model and the propagation-closure problem it closes.

2. `scripts/ci/check_sync_manifest` — added the closure invariant
   as a new validation pass. For each entry with `requires:`,
   asserts (a) the field is a YAML sequence (shape check via
   `(.requires | type) == "!!seq"` to dodge mikefarah/yq's silent-
   emit-nothing behavior on `.requires[]` against a scalar) and
   (b) every required path is covered by the manifest — either an
   exact entry or strictly inside a kit prefix (slash-bounded so
   `scripts/cinema/` does NOT match `scripts/ci/`). Fails closed
   with a clear named-path diagnostic on uncovered or malformed.
   Added `MERGEPATH_MANIFEST_PATH` and `MERGEPATH_REPO_ROOT` env
   overrides so the test suite can point the check at fixture
   manifests with stub repo trees. Appends a regression-test
   invocation that runs `tests/test_check_sync_manifest.sh` after
   the structural check passes (guarded by absence of the manifest-
   path env override so the test's fixture-mode invocations don't
   recurse).

3. `tests/test_check_sync_manifest.sh` — new, 5 fixture cases:
     - requires: satisfied by exact + kit-prefix coverage → PASS
     - uncovered requires: → FAIL with named-path diagnostic
     - missing requires: (optional field) → PASS
     - scalar requires: (malformed) → FAIL via shape check
     - kit-prefix slash boundary regression → FAIL on adjacent dir
   Fixture helper materializes stub files in a scratch root so the
   pre-existing path-existence check passes.

4. `scripts/sync-to-downstream.sh` — added a "Canary-first
   procedure for --sync-all" section to the script header
   documenting the one-consumer-canary procedure that catches what
   the manifest invariant can't see (consumer-specific
   `repo_lint.yml` steps, transitively-required files outside the
   manifest). Walks through the 3-step canary → fix → fan-out
   pattern with matchline as the canonical canary repo.

## Self-Review

- **Correctness**: shape check uses yq's `type` function (separate
  pass) because mikefarah/yq's `.requires[]` silently emits no
  output on a scalar rather than erroring. Without the shape check,
  a malformed `requires: "foo"` field would pass through silently.
  The slash-bounded kit-prefix match (`pp$kp/*`) is verified by
  Case 5: `scripts/ci/` does NOT match `scripts/cinema/foo`.

- **Regression risk**: low. The new check is additive — entries
  without `requires:` are unchanged. The shape-check pass returns
  cleanly when no entry has `requires:`. The structural exits in
  the existing check are unchanged. Recursion between
  check_sync_manifest and its test suite is guarded by the
  MERGEPATH_MANIFEST_PATH env-presence check.

- **Style/conventions**: matches the inline-literal pattern from
  `check_workflow_parsers` and `check_canonical_bugs_263caf3`
  (test cases use bash heredocs for fixture manifests). The
  `requires:` comment-block-per-entry convention mirrors the
  existing per-path comment style elsewhere in
  `.mergepath-sync.yml`.

- **Test coverage**: 5 cases exercise the new pass end-to-end
  including the malformed-shape rejection and the kit-prefix
  boundary regression. The live manifest is smoke-tested by
  check_sync_manifest's CI invocation (intentionally not in the
  test file — would recurse).

- **Security/dependency hygiene**: no new dependencies. The check
  still requires yq mikefarah v4+ (already required). No network
  side effects, no file writes outside the test's scratch dir.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
