### PR TITLE
fix: deploy strict-bash + dirty-tree guard + portable mktemp (#286)

### DIFF
--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -142,6 +142,14 @@ jobs:
         # added by #256 P2.
         run: ./scripts/ci/check_coderabbit_config_tests
 
+      - name: check_mktemp_portability
+        # Regression guard for mergepath#286. Hard-fails on any
+        # tracked shell file using the BSD-only `mktemp -t <prefix>`
+        # form, which GNU coreutils mktemp rejects (XXXXXX required).
+        # Closes the re-introduction surface that the closed-review
+        # backlog sweep on #286 caught.
+        run: ./scripts/ci/check_mktemp_portability
+
       - name: check_governance_files
         run: |
           MISSING=0

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -559,12 +559,20 @@ scripts/deploy.sh --skip-cf-purge
 scripts/deploy.sh --force
 ```
 
-The guards (see [mergepath#77](https://github.com/nathanjohnpayne/mergepath/issues/77) for the incident that motivated them):
+The guards (see [mergepath#77](https://github.com/nathanjohnpayne/mergepath/issues/77) for the incident that motivated them; the dirty-tree guard was added in [mergepath#286](https://github.com/nathanjohnpayne/mergepath/issues/286) after a closed-review backlog sweep):
 
 1. **Current branch must be `main`.** Deploys should ship the reviewed, merged state of the project, not a worktree's in-progress branch.
 2. **Local `main` must not be behind `origin/main`.** After `git fetch`, `git rev-list --count HEAD..origin/main` must be 0. Otherwise the deploy refuses.
+3. **Working tree must be clean.** `git status --porcelain` must return empty — no modified, staged, or untracked paths. A dirty tree means the deploy would ship whatever the in-progress edits compile to, which diverges from the merged-on-main state reviewers signed off on (same failure class as #77).
 
-Both guards can be bypassed with `--force` for break-glass scenarios. Never use `--force` during routine deploys.
+Guards 1 and 2 are bypassed with `--force`. Guard 3 is bypassed by the dedicated env var `DEPLOY_ALLOW_DIRTY=1` — kept separate from `--force` so the override is deliberate, audit-greppable, and `--force` doesn't accidentally subsume the dirty-tree check:
+
+```bash
+# Break-glass: deploy with uncommitted changes (NEVER for routine deploys)
+DEPLOY_ALLOW_DIRTY=1 scripts/deploy.sh
+```
+
+When the override is used, the script logs the dirty paths to stderr under a `⚠️  DEPLOY_ALLOW_DIRTY=1` banner so the deviation is visible in the deploy transcript. Never use `--force` or `DEPLOY_ALLOW_DIRTY=1` during routine deploys.
 
 Cloudflare cache purge runs when `CF_API_TOKEN` and `CF_ZONE_ID` are set in the environment. `CF_API_TOKEN` is sourced automatically by `scripts/op-preflight.sh --mode deploy` (or `--mode all`) from the shared "All Domains — Cache Purge API token" 1Password item — no `op read` needed in your shell. `CF_ZONE_ID` is per-repo; each downstream consumer sets its own zone ID (e.g., in the repo's bootstrap or as a hardcoded value in its `scripts/deploy.sh` wrapper) since one CF token covers all domains but each domain has its own zone. Without both variables the purge step no-ops with a clear log line.
 

--- a/scripts/ci/check_mktemp_portability
+++ b/scripts/ci/check_mktemp_portability
@@ -86,8 +86,9 @@ VIOLATION_LIST=""
 
 # The pattern targets `mktemp` followed by zero or more whitespace-
 # separated short-option clusters, ending in a cluster that contains
-# `-t` (either bare `-t` OR a compact combined form like `-dt`),
-# followed by a bare-token prefix arg.
+# `-t` (bare `-t` OR a compact combined form like `-dt`), followed
+# by a prefix-like argument — bare token, quoted string, OR variable
+# expansion.
 #
 # The cluster regex `-[a-zA-Z]*t` matches:
 #   - bare `-t`                  (zero leading letters, then 't')
@@ -96,21 +97,32 @@ VIOLATION_LIST=""
 # so `t` must be the LAST char of the flag cluster — hence the trailing
 # `t` anchor in the regex.
 #
+# Prefix-argument alternation (#286 r3 — nathanpayne-codex Phase 4b
+# finding: r2 regex required a bare identifier as the prefix-arg, so
+# quoted forms like `mktemp -t "prefix"` and variable forms like
+# `mktemp -t "$prefix"` slipped through. r3 extends the alternation):
+#   - "..."   double-quoted bare-name (no slashes inside — slashes
+#             would indicate the portable template form)
+#   - '...'   single-quoted bare-name
+#   - $VAR    $-prefixed variable expansion (with or without braces)
+#   - bare    identifier (existing coverage)
+#
 # Examples this matches (BAD):
 #   mktemp -t myprefix
 #   mktemp -d -t mergepath-sim
-#   mktemp -dt myprefix            (#286 r2 — nathanpayne-codex Phase
-#                                    4b finding: the prior regex required
-#                                    a separate `-t` token, missing the
-#                                    compact combined form.)
-#   mktemp -Pdt myprefix           (any leading flags before the t)
+#   mktemp -dt myprefix
+#   mktemp -Pdt myprefix
+#   mktemp -t "prefix"             (r3: quoted bare-name)
+#   mktemp -t 'prefix'             (r3: single-quoted bare-name)
+#   mktemp -t "$prefix"            (r3: quoted variable expansion)
+#   mktemp -t ${prefix}            (r3: bare variable expansion)
 #
 # Examples this DOES NOT match (GOOD):
-#   mktemp -d "${TMPDIR:-/tmp}/mergepath-sim.XXXXXX"
-#   mktemp /tmp/foo.XXXXXX
-#   mktemp --tmpdir name.XXXXXX
-#   mktemp -d   (no -t, no prefix-as-bare-token)
-PATTERN='mktemp([[:space:]]+-[a-zA-Z]+)*[[:space:]]+-[a-zA-Z]*t[[:space:]]+[A-Za-z_][A-Za-z0-9_.-]*'
+#   mktemp -d "${TMPDIR:-/tmp}/mergepath-sim.XXXXXX"  (slashes in quote)
+#   mktemp "/tmp/foo.XXXXXX"                          (no -t)
+#   mktemp --tmpdir name.XXXXXX                       (no -t flag)
+#   mktemp -d                                         (no -t, no prefix-arg)
+PATTERN='mktemp([[:space:]]+-[a-zA-Z]+)*[[:space:]]+-[a-zA-Z]*t[[:space:]]+("[^"/]*"|'"'"'[^'"'"'/]*'"'"'|\$\{?[A-Za-z_][A-Za-z0-9_]*\}?|[A-Za-z_][A-Za-z0-9_.-]*)'
 
 while IFS= read -r file; do
   [[ -z "$file" ]] && continue

--- a/scripts/ci/check_mktemp_portability
+++ b/scripts/ci/check_mktemp_portability
@@ -26,25 +26,41 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-cd "$REPO_ROOT"
+# MERGEPATH_MKTEMP_SCAN_ROOT env override so tests/test_check_mktemp_portability.sh
+# can point the check at fixture trees. When set, file enumeration uses
+# `find` over that root (no git involvement); otherwise the default path
+# uses `git ls-files` over $REPO_ROOT.
+SCAN_ROOT="${MERGEPATH_MKTEMP_SCAN_ROOT:-$REPO_ROOT}"
+cd "$SCAN_ROOT"
 
-# git ls-files: tracked files only. -z + NUL-delim handles paths with
-# spaces. We restrict to *.sh first and additionally include any
-# tracked file whose first line is a bash/sh shebang.
 TMPFILE="$(mktemp "${TMPDIR:-/tmp}/check-mktemp-portability.XXXXXX")"
 trap 'rm -f "$TMPFILE"' EXIT
 
-# Collect candidate files.
-while IFS= read -r -d '' f; do
-  case "$f" in
-    *.sh) echo "$f" >> "$TMPFILE" ;;
-    *)
-      # Cheap shebang sniff. Only the first line is read.
-      head -n1 -- "$f" 2>/dev/null | grep -qE '^#!.*(bash|/sh)( |$)' \
-        && echo "$f" >> "$TMPFILE"
-      ;;
-  esac
-done < <(git ls-files -z)
+# Collect candidate files. Two modes:
+#   - default: git ls-files (tracked-files-only over a real repo)
+#   - test:    find over the scan root (no git index assumed)
+if [[ -n "${MERGEPATH_MKTEMP_SCAN_ROOT:-}" ]]; then
+  while IFS= read -r -d '' f; do
+    rel="${f#./}"
+    case "$rel" in
+      *.sh) echo "$rel" >> "$TMPFILE" ;;
+      *)
+        head -n1 -- "$f" 2>/dev/null | grep -qE '^#!.*(bash|/sh)( |$)' \
+          && echo "$rel" >> "$TMPFILE"
+        ;;
+    esac
+  done < <(find . -type f -print0)
+else
+  while IFS= read -r -d '' f; do
+    case "$f" in
+      *.sh) echo "$f" >> "$TMPFILE" ;;
+      *)
+        head -n1 -- "$f" 2>/dev/null | grep -qE '^#!.*(bash|/sh)( |$)' \
+          && echo "$f" >> "$TMPFILE"
+        ;;
+    esac
+  done < <(git ls-files -z)
+fi
 
 # Self-exclusion: skip this script (its comments necessarily mention
 # the forbidden form for documentation) and the script that owns the
@@ -55,20 +71,32 @@ VIOLATIONS=0
 VIOLATION_LIST=""
 
 # The pattern targets `mktemp` followed by zero or more whitespace-
-# separated options (`-d` and friends) and then `-t <prefix>` where
-# the prefix is a bare token: starts with a letter/underscore and
-# contains no slash or quote. This is exactly the BSD short form.
+# separated short-option clusters, ending in a cluster that contains
+# `-t` (either bare `-t` OR a compact combined form like `-dt`),
+# followed by a bare-token prefix arg.
+#
+# The cluster regex `-[a-zA-Z]*t` matches:
+#   - bare `-t`                  (zero leading letters, then 't')
+#   - compact `-dt`, `-Pt`, etc. (one or more leading letters, then 't')
+# In BSD getopt semantics `-t` consumes the next arg as the prefix,
+# so `t` must be the LAST char of the flag cluster — hence the trailing
+# `t` anchor in the regex.
 #
 # Examples this matches (BAD):
 #   mktemp -t myprefix
 #   mktemp -d -t mergepath-sim
-#   mktemp -dt myprefix
+#   mktemp -dt myprefix            (#286 r2 — nathanpayne-codex Phase
+#                                    4b finding: the prior regex required
+#                                    a separate `-t` token, missing the
+#                                    compact combined form.)
+#   mktemp -Pdt myprefix           (any leading flags before the t)
 #
 # Examples this DOES NOT match (GOOD):
 #   mktemp -d "${TMPDIR:-/tmp}/mergepath-sim.XXXXXX"
 #   mktemp /tmp/foo.XXXXXX
 #   mktemp --tmpdir name.XXXXXX
-PATTERN='mktemp([[:space:]]+-[a-zA-Z]+)*[[:space:]]+-t[[:space:]]+[A-Za-z_][A-Za-z0-9_.-]*'
+#   mktemp -d   (no -t, no prefix-as-bare-token)
+PATTERN='mktemp([[:space:]]+-[a-zA-Z]+)*[[:space:]]+-[a-zA-Z]*t[[:space:]]+[A-Za-z_][A-Za-z0-9_.-]*'
 
 while IFS= read -r file; do
   [[ -z "$file" ]] && continue
@@ -114,6 +142,19 @@ Offending files (path + line numbers):
 EOF
   printf '%s' "$VIOLATION_LIST" >&2
   exit 1
+fi
+
+# Run the regression test suite if present. Guarded by absence of
+# MERGEPATH_MKTEMP_SCAN_ROOT so the test harness's fixture-mode
+# invocations (which set that env) don't recurse back through the
+# test suite. Same recursion-guard pattern as check_sync_manifest.
+TEST_SUITE="$REPO_ROOT/tests/test_check_mktemp_portability.sh"
+if [[ -z "${MERGEPATH_MKTEMP_SCAN_ROOT:-}" ]] && [[ -x "$TEST_SUITE" ]]; then
+  echo "check_mktemp_portability: running regression test suite"
+  if ! bash "$TEST_SUITE"; then
+    echo "check_mktemp_portability: FAIL (regression test suite failed)"
+    exit 1
+  fi
 fi
 
 echo "check_mktemp_portability: PASS"

--- a/scripts/ci/check_mktemp_portability
+++ b/scripts/ci/check_mktemp_portability
@@ -62,10 +62,24 @@ else
   done < <(git ls-files -z)
 fi
 
-# Self-exclusion: skip this script (its comments necessarily mention
-# the forbidden form for documentation) and the script that owns the
-# regression test for #286's mktemp story.
+# Self-exclusion: skip files that LEGITIMATELY contain the BSD-only
+# form as part of their own purpose (documentation, regression test
+# fixtures). Without this set, the check false-flags itself and its
+# own paired test for #286 r3 — nathanpayne-codex Phase 4b finding:
+# the new tests/test_check_mktemp_portability.sh writes heredoc
+# fixtures containing `mktemp -dt mergepath-bad` (the BAD pattern
+# the regex is supposed to catch), and the check scans those
+# fixture strings and flags them.
+#
+# This script: its comments document the forbidden form by name.
+# The paired test file: its heredocs contain the forbidden form
+# AS FIXTURES — the regex catching them inside heredocs is exactly
+# the false positive r3 closes.
 SELF_REL="scripts/ci/check_mktemp_portability"
+EXCLUDE_PATHS=(
+  "scripts/ci/check_mktemp_portability"
+  "tests/test_check_mktemp_portability.sh"
+)
 
 VIOLATIONS=0
 VIOLATION_LIST=""
@@ -100,7 +114,15 @@ PATTERN='mktemp([[:space:]]+-[a-zA-Z]+)*[[:space:]]+-[a-zA-Z]*t[[:space:]]+[A-Za
 
 while IFS= read -r file; do
   [[ -z "$file" ]] && continue
-  [[ "$file" == "$SELF_REL" ]] && continue
+  # Skip any path on the self-exclusion list (docs + regression
+  # fixtures that legitimately reference the BSD form). Keep the
+  # SELF_REL variable above as the primary self-skip for readability;
+  # EXCLUDE_PATHS extends it to the paired test file.
+  skip_file=0
+  for ex in "${EXCLUDE_PATHS[@]}"; do
+    if [[ "$file" == "$ex" ]]; then skip_file=1; break; fi
+  done
+  [[ "$skip_file" -eq 1 ]] && continue
   # Filter out:
   #   - comment lines (leading-whitespace `#` — both documentation
   #     comments and shebangs)

--- a/scripts/ci/check_mktemp_portability
+++ b/scripts/ci/check_mktemp_portability
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check_mktemp_portability
+#
+# Regression guard for mergepath#286. Hard-fails on any tracked shell
+# file that uses the BSD-only `mktemp -t <prefix>` short form. GNU
+# coreutils mktemp requires an explicit `XXXXXX` placeholder in the
+# template and exits non-zero on `mktemp -t name`, so the BSD form
+# silently breaks any Linux CI that reaches it (and any portable
+# tooling that mixes platforms). The portable form is
+# `mktemp -d "${TMPDIR:-/tmp}/<prefix>.XXXXXX"` (and the equivalent
+# without `-d` for a single file).
+#
+# Scope:
+#   - Tracked files only (no node_modules / dist / generated noise).
+#   - Limited to *.sh files and any other tracked shell-shebanged
+#     script under tests/, scripts/, and the repo root. The matcher
+#     is intentionally conservative: it only flags forms where the
+#     argument after `-t` is a bare token (no slash, no quote), which
+#     is exactly the BSD-style "name prefix" form.
+#
+# Exit codes:
+#   0 — no `mktemp -t <prefix>` occurrences found.
+#   1 — at least one occurrence found; paths + line numbers printed.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+cd "$REPO_ROOT"
+
+# git ls-files: tracked files only. -z + NUL-delim handles paths with
+# spaces. We restrict to *.sh first and additionally include any
+# tracked file whose first line is a bash/sh shebang.
+TMPFILE="$(mktemp "${TMPDIR:-/tmp}/check-mktemp-portability.XXXXXX")"
+trap 'rm -f "$TMPFILE"' EXIT
+
+# Collect candidate files.
+while IFS= read -r -d '' f; do
+  case "$f" in
+    *.sh) echo "$f" >> "$TMPFILE" ;;
+    *)
+      # Cheap shebang sniff. Only the first line is read.
+      head -n1 -- "$f" 2>/dev/null | grep -qE '^#!.*(bash|/sh)( |$)' \
+        && echo "$f" >> "$TMPFILE"
+      ;;
+  esac
+done < <(git ls-files -z)
+
+# Self-exclusion: skip this script (its comments necessarily mention
+# the forbidden form for documentation) and the script that owns the
+# regression test for #286's mktemp story.
+SELF_REL="scripts/ci/check_mktemp_portability"
+
+VIOLATIONS=0
+VIOLATION_LIST=""
+
+# The pattern targets `mktemp` followed by zero or more whitespace-
+# separated options (`-d` and friends) and then `-t <prefix>` where
+# the prefix is a bare token: starts with a letter/underscore and
+# contains no slash or quote. This is exactly the BSD short form.
+#
+# Examples this matches (BAD):
+#   mktemp -t myprefix
+#   mktemp -d -t mergepath-sim
+#   mktemp -dt myprefix
+#
+# Examples this DOES NOT match (GOOD):
+#   mktemp -d "${TMPDIR:-/tmp}/mergepath-sim.XXXXXX"
+#   mktemp /tmp/foo.XXXXXX
+#   mktemp --tmpdir name.XXXXXX
+PATTERN='mktemp([[:space:]]+-[a-zA-Z]+)*[[:space:]]+-t[[:space:]]+[A-Za-z_][A-Za-z0-9_.-]*'
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  [[ "$file" == "$SELF_REL" ]] && continue
+  # Filter out:
+  #   - comment lines (leading-whitespace `#` — both documentation
+  #     comments and shebangs)
+  #   - lines where the `mktemp -t name` reference is INSIDE a quoted
+  #     string fed to grep / awk / sed (these are tests asserting the
+  #     bad form is NOT present in another script; flagging them
+  #     would force the check to know which strings are docs vs.
+  #     real invocations, an unwinnable game).
+  # The second filter is intentionally narrow: it requires the
+  # occurrence to be preceded by a non-quote-immediately-before
+  # context. The regex anchors `mktemp` at a word boundary that
+  # is not immediately preceded by `"` or `'`.
+  matches="$(grep -nE "$PATTERN" -- "$file" \
+    | grep -vE '^[0-9]+:[[:space:]]*#' \
+    | grep -vE "[\"']mktemp[[:space:]]" \
+    || true)"
+  if [[ -n "$matches" ]]; then
+    VIOLATIONS=$((VIOLATIONS + 1))
+    VIOLATION_LIST+="$file"$'\n'"$matches"$'\n\n'
+  fi
+done < "$TMPFILE"
+
+if [[ $VIOLATIONS -gt 0 ]]; then
+  cat >&2 <<EOF
+check_mktemp_portability: FAIL
+
+Found $VIOLATIONS file(s) using the BSD-only \`mktemp -t <prefix>\` form.
+GNU coreutils mktemp requires an explicit \`XXXXXX\` placeholder and
+exits non-zero on the BSD short form, so this break Linux CI and any
+portable tooling that mixes platforms.
+
+Replace with the portable form:
+
+    mktemp -d "\${TMPDIR:-/tmp}/<prefix>.XXXXXX"
+    mktemp    "\${TMPDIR:-/tmp}/<prefix>.XXXXXX"  # for a single file
+
+Offending files (path + line numbers):
+
+EOF
+  printf '%s' "$VIOLATION_LIST" >&2
+  exit 1
+fi
+
+echo "check_mktemp_portability: PASS"
+exit 0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,17 +3,23 @@ set -euo pipefail
 
 # Canonical deploy wrapper for projects that use op-firebase-deploy.
 #
-# Enforces two guards before calling the deploy chain:
+# Enforces three guards before calling the deploy chain:
 #   1. Current branch is `main`.
 #   2. Local `main` is not behind `origin/main`.
+#   3. The working tree is clean (no modified or staged paths).
 #
-# These two guards together prevent the stale-worktree class of deploy
+# These three guards together prevent the stale-worktree class of deploy
 # (documented in https://github.com/nathanjohnpayne/mergepath/issues/77):
-# an agent working in a feature branch or stale worktree accidentally
-# deploying a dist/ output that reflects an older state of main.
+# an agent working in a feature branch, stale worktree, or with
+# uncommitted in-progress edits accidentally deploying a dist/ output
+# that does not match what reviewers have seen merged on main.
 #
 # After the guards pass, the script:
 #   - Builds (default: `npm run build`; configurable via $BUILD_CMD).
+#     The build command is run under `bash -euo pipefail -c --` so a
+#     compound command (e.g. `npm run lint && npm run build`) fails
+#     closed if any step errors, rather than masking earlier failures
+#     behind the exit code of the final segment.
 #   - Deploys (`op-firebase-deploy`; any arguments after `--` are passed
 #     through, e.g. `--only hosting`).
 #   - Purges Cloudflare cache (if CF_API_TOKEN + CF_ZONE_ID are set).
@@ -26,10 +32,13 @@ set -euo pipefail
 #   scripts/deploy.sh --skip-cf-purge       # skip the Cloudflare purge step
 #
 # Environment:
-#   BUILD_CMD     Build command (default: "npm run build").
-#   CF_API_TOKEN  Cloudflare API token with Purge Cache permission.
-#                 Typical source: 1Password (op read ...).
-#   CF_ZONE_ID    Cloudflare zone ID for the project domain.
+#   BUILD_CMD            Build command (default: "npm run build").
+#   CF_API_TOKEN         Cloudflare API token with Purge Cache permission.
+#                        Typical source: 1Password (op read ...).
+#   CF_ZONE_ID           Cloudflare zone ID for the project domain.
+#   DEPLOY_ALLOW_DIRTY   Set to "1" to bypass the clean-working-tree guard.
+#                        Break-glass only — never set during routine deploys.
+#                        See DEPLOYMENT.md § Deploy guards.
 #
 # See DEPLOYMENT.md § Deploy flow for full documentation.
 
@@ -110,17 +119,62 @@ EOF
   fi
 fi
 
+# Guard 3: working tree must be clean
+#
+# `git status --porcelain` prints one line per modified, staged, or
+# untracked path and is empty when the worktree matches HEAD with the
+# index. Deploying from a dirty tree silently ships whatever the
+# in-progress edits compile to — that diverges from the merged-on-main
+# state that reviewers signed off on (same failure class as #77).
+#
+# Break-glass override: DEPLOY_ALLOW_DIRTY=1 (env var, not a flag, so
+# `--force` doesn't accidentally subsume this guard — keeping the
+# override deliberate and audit-greppable). Logged with a clear ⚠️
+# trail when used.
+DIRTY="$(git status --porcelain)"
+if [[ -n "$DIRTY" ]]; then
+  if [[ "${DEPLOY_ALLOW_DIRTY:-0}" == "1" ]]; then
+    echo "⚠️  DEPLOY_ALLOW_DIRTY=1: deploying with uncommitted changes:" >&2
+    printf '%s\n' "$DIRTY" >&2
+  else
+    cat >&2 <<EOF
+Refusing to deploy: working tree is dirty.
+
+Modified / staged / untracked paths:
+$DIRTY
+
+Commit, stash, or revert these before deploying so the deploy reflects
+the merged-on-main state that reviewers approved (see mergepath#77 for
+the class of failure this guard closes).
+
+To override (break-glass only): DEPLOY_ALLOW_DIRTY=1 scripts/deploy.sh
+EOF
+    exit 1
+  fi
+fi
+
 # Step 1: Build
 if [[ "$BUILD_SKIP" == "true" ]]; then
   echo ">> Skipping build (--skip-build)"
 else
   BUILD_CMD="${BUILD_CMD:-npm run build}"
   echo ">> Building: $BUILD_CMD"
-  # Use `bash -c --` so BUILD_CMD is parsed as a shell command string
-  # in a controlled subshell rather than `eval`'d in the current
-  # shell. Cheap defense against environment injection from whatever
-  # source populated BUILD_CMD.
-  bash -c -- "$BUILD_CMD"
+  # Use `bash -euo pipefail -c --` so BUILD_CMD is parsed as a shell
+  # command string in a controlled subshell rather than `eval`'d in
+  # the current shell (cheap defense against environment injection
+  # from whatever source populated BUILD_CMD), AND so compound
+  # commands fail closed:
+  #   - `set -e`: any failing step aborts the subshell.
+  #   - `set -u`: unset variables are an error (catches typos in
+  #     BUILD_CMD that would otherwise silently expand to empty).
+  #   - `set -o pipefail`: a failing step in a pipeline is preserved,
+  #     not masked by the success of the final stage.
+  # Without these flags, a BUILD_CMD like `npm run lint && npm run
+  # build` would still fail if lint failed (because && short-circuits)
+  # — but `npm run lint; npm run build` would mask the lint failure
+  # behind the build's exit code, and `npm run build | tee log.txt`
+  # would only surface tee's exit code. Strict-bash closes both.
+  bash -euo pipefail -c -- "$BUILD_CMD"
 fi
 
 # Step 2: Deploy

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -179,7 +179,17 @@ fi
 
 # Step 2: Deploy
 echo ">> Deploying via op-firebase-deploy"
-op-firebase-deploy "${DEPLOY_ARGS[@]}"
+# Bash 3.2 + `set -u`: expanding an empty `${DEPLOY_ARGS[@]}` aborts
+# with "DEPLOY_ARGS[@]: unbound variable" when no trailing deploy
+# args were appended (e.g. `deploy.sh --force --skip-build
+# --skip-cf-purge` with nothing after `--`). The `${ARR[@]+"${ARR[@]}"}`
+# idiom expands to the array contents only when the array has been
+# ASSIGNED — DEPLOY_ARGS=() at parse time qualifies as assigned, so
+# this expansion is always defined regardless of length. Bash 4+
+# tolerates the bare form; Bash 3.2 (still the macOS system shell)
+# does not. nathanpayne-codex Phase 4b r3 on PR #296 reproduced
+# the abort with `--force --skip-build --skip-cf-purge` under bash 3.2.
+op-firebase-deploy ${DEPLOY_ARGS[@]+"${DEPLOY_ARGS[@]}"}
 
 # Step 3: Cloudflare cache purge (optional)
 if [[ "$CF_PURGE_SKIP" == "true" ]]; then

--- a/scripts/policy-sim.sh
+++ b/scripts/policy-sim.sh
@@ -22,7 +22,13 @@ TEMPLATE="$REPO_ROOT/mergepath/playground/index.html"
 # file inside with its extension intact; the dir name carries
 # uniqueness, the filename carries the .html so `open` picks the
 # right handler.
-OUT_DIR="$(mktemp -d -t mergepath-sim)"
+#
+# Use the portable `mktemp -d "$TMPDIR/name.XXXXXX"` form rather
+# than `mktemp -d -t name`: BSD mktemp treats `-t` as a prefix and
+# auto-appends a template, but GNU coreutils requires an explicit
+# `XXXXXX` placeholder and exits non-zero without one. The portable
+# form works on both. See mergepath#286.
+OUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mergepath-sim.XXXXXX")"
 OUT="$OUT_DIR/mergepath.html"
 
 for bin in gh jq python3; do
@@ -41,8 +47,8 @@ echo "Fetching last $LIMIT merged PRs via gh..."
 
 # PRs payload is intermediate; same trailing-X constraint, same
 # fix. The trap only cleans up this file — OUT stays so the browser
-# can open it.
-PRS_DIR="$(mktemp -d -t mergepath-prs)"
+# can open it. Portable `mktemp -d "$TMPDIR/name.XXXXXX"` per #286.
+PRS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mergepath-prs.XXXXXX")"
 PRS_FILE="$PRS_DIR/prs.json"
 trap 'rm -rf "$PRS_DIR"' EXIT
 

--- a/scripts/worktree-cleanup.sh
+++ b/scripts/worktree-cleanup.sh
@@ -214,8 +214,14 @@ worktree_records() {
 }
 
 # ── Gather state ──────────────────────────────────────────────────────
-GONE_FILE=$(mktemp -t wcleanup-gone.XXXXXX)
-REC_FILE=$(mktemp -t wcleanup-rec.XXXXXX)
+# Portable mktemp template (#286 r5): BSD-only `mktemp -t <prefix>`
+# fails closed on GNU coreutils because the template lacks `XXXXXX`
+# placeholders in the right position. The portable form below works
+# on both. Caught by check_mktemp_portability once that check landed
+# from #286 — this fix closes the cross-PR gap (#298 merged the
+# bad form before #286's check was wired into CI).
+GONE_FILE=$(mktemp "${TMPDIR:-/tmp}/wcleanup-gone.XXXXXX")
+REC_FILE=$(mktemp "${TMPDIR:-/tmp}/wcleanup-rec.XXXXXX")
 trap 'rm -f "$GONE_FILE" "$REC_FILE"' EXIT
 
 gone_branches >"$GONE_FILE"

--- a/tests/test_check_mktemp_portability.sh
+++ b/tests/test_check_mktemp_portability.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# tests/test_check_mktemp_portability.sh
+#
+# Unit tests for scripts/ci/check_mktemp_portability. The check is a
+# repo-wide grep; tests pivot it onto fixture files in a scratch dir
+# via MERGEPATH_MKTEMP_SCAN_ROOT, then assert the violation detection.
+#
+# The compact-flag form (`mktemp -dt prefix`) is the specific
+# regression #286 r2 closes per nathanpayne-codex Phase 4b.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK="$ROOT/scripts/ci/check_mktemp_portability"
+
+[[ -x "$CHECK" ]] || { echo "missing or non-executable $CHECK" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/check-mktemp-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Helper: build a fixture file at a relative path under WORKDIR and
+# run the check via MERGEPATH_MKTEMP_SCAN_ROOT. Returns the check's
+# exit code via the OUT/RC vars.
+run_check_on_fixture() {
+  local rel="$1" content="$2"
+  local dir
+  dir="$WORKDIR/$(dirname "$rel")"
+  mkdir -p "$dir"
+  printf '%s' "$content" > "$WORKDIR/$rel"
+  chmod +x "$WORKDIR/$rel"
+  set +e
+  OUT=$(MERGEPATH_MKTEMP_SCAN_ROOT="$WORKDIR" bash "$CHECK" 2>&1)
+  RC=$?
+  set -e
+}
+
+# Case 1: clean fixture (uses portable mktemp form) → PASS
+run_check_on_fixture "clean.sh" '#!/usr/bin/env bash
+foo=$(mktemp -d "${TMPDIR:-/tmp}/clean.XXXXXX")
+'
+if [ "$RC" = "0" ] && echo "$OUT" | grep -q "PASS"; then
+  pass "clean fixture (portable form): exits 0 with PASS"
+else
+  fail "clean fixture: rc=$RC out=$OUT"
+fi
+rm -f "$WORKDIR/clean.sh"
+
+# Case 2: BSD bare-t form → FAIL
+run_check_on_fixture "bad-bare-t.sh" '#!/usr/bin/env bash
+foo=$(mktemp -t mergepath-bad)
+'
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "FAIL"; then
+  pass "bare -t form: caught (BSD-incompatible)"
+else
+  fail "bare -t form: rc=$RC out=$OUT"
+fi
+rm -f "$WORKDIR/bad-bare-t.sh"
+
+# Case 3: BSD -d -t form → FAIL
+run_check_on_fixture "bad-d-then-t.sh" '#!/usr/bin/env bash
+foo=$(mktemp -d -t mergepath-bad)
+'
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "FAIL"; then
+  pass "-d -t (separate) form: caught"
+else
+  fail "-d -t form: rc=$RC out=$OUT"
+fi
+rm -f "$WORKDIR/bad-d-then-t.sh"
+
+# Case 4 (#286 r2): compact -dt form → FAIL. This is the specific
+# regression nathanpayne-codex flagged — the prior regex missed it.
+run_check_on_fixture "bad-compact-dt.sh" '#!/usr/bin/env bash
+foo=$(mktemp -dt mergepath-bad)
+'
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "FAIL"; then
+  pass "compact -dt form: caught (#286 r2 regression)"
+else
+  fail "compact -dt form: rc=$RC out=$OUT  (regex did not catch combined -dt)"
+fi
+rm -f "$WORKDIR/bad-compact-dt.sh"
+
+# Case 5: compact -Pdt form (any leading flags before t) → FAIL
+run_check_on_fixture "bad-compact-pdt.sh" '#!/usr/bin/env bash
+foo=$(mktemp -Pdt mergepath-bad)
+'
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "FAIL"; then
+  pass "compact -Pdt form: caught (any flags before t)"
+else
+  fail "compact -Pdt form: rc=$RC out=$OUT"
+fi
+rm -f "$WORKDIR/bad-compact-pdt.sh"
+
+# Case 6: mktemp -d alone (no -t, no prefix-as-bare-token) → PASS.
+# Regression net: don't false-flag `-d` only.
+run_check_on_fixture "clean-d-only.sh" '#!/usr/bin/env bash
+foo=$(mktemp -d "/tmp/keep.XXXXXX")
+'
+if [ "$RC" = "0" ] && echo "$OUT" | grep -q "PASS"; then
+  pass "-d only with quoted template: passes"
+else
+  fail "-d only: rc=$RC out=$OUT"
+fi
+rm -f "$WORKDIR/clean-d-only.sh"
+
+# Case 7: comment line referencing `mktemp -t foo` (docs/banner) → PASS.
+# The check filters comment lines.
+run_check_on_fixture "comment-mention.sh" '#!/usr/bin/env bash
+# Never use: mktemp -t legacy-bsd-form
+foo=$(mktemp -d "/tmp/safe.XXXXXX")
+'
+if [ "$RC" = "0" ] && echo "$OUT" | grep -q "PASS"; then
+  pass "comment-line mention of -t: not flagged"
+else
+  fail "comment-line mention: rc=$RC out=$OUT"
+fi
+rm -f "$WORKDIR/comment-mention.sh"
+
+echo
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -gt 0 ]; then
+  echo "test_check_mktemp_portability: FAIL ($FAIL/$TOTAL failed)"
+  exit 1
+fi
+echo "test_check_mktemp_portability: PASS ($TOTAL tests)"
+exit 0

--- a/tests/test_check_mktemp_portability.sh
+++ b/tests/test_check_mktemp_portability.sh
@@ -120,6 +120,77 @@ else
 fi
 rm -f "$WORKDIR/comment-mention.sh"
 
+# Case 8 (#286 r3): double-quoted bare-name prefix.
+run_check_on_fixture "bad-quoted-bare.sh" '#!/usr/bin/env bash
+foo=$(mktemp -t "prefix")
+'
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "FAIL"; then
+  pass "double-quoted bare prefix: caught (#286 r3)"
+else
+  fail "double-quoted bare prefix: rc=$RC out=$OUT"
+fi
+rm -f "$WORKDIR/bad-quoted-bare.sh"
+
+# Case 9: single-quoted bare-name prefix.
+run_check_on_fixture "bad-squoted-bare.sh" '#!/usr/bin/env bash
+foo=$(mktemp -t '"'"'prefix'"'"')
+'
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "FAIL"; then
+  pass "single-quoted bare prefix: caught"
+else
+  fail "single-quoted bare prefix: rc=$RC out=$OUT"
+fi
+rm -f "$WORKDIR/bad-squoted-bare.sh"
+
+# Case 10: double-quoted variable expansion prefix.
+run_check_on_fixture "bad-quoted-var.sh" '#!/usr/bin/env bash
+prefix=foo
+foo=$(mktemp -t "$prefix")
+'
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "FAIL"; then
+  pass "double-quoted variable prefix: caught (#286 r3)"
+else
+  fail "double-quoted variable prefix: rc=$RC out=$OUT"
+fi
+rm -f "$WORKDIR/bad-quoted-var.sh"
+
+# Case 11: bare variable expansion prefix.
+run_check_on_fixture "bad-bare-var.sh" '#!/usr/bin/env bash
+prefix=foo
+foo=$(mktemp -t $prefix)
+'
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "FAIL"; then
+  pass "bare variable prefix: caught"
+else
+  fail "bare variable prefix: rc=$RC out=$OUT"
+fi
+rm -f "$WORKDIR/bad-bare-var.sh"
+
+# Case 12: braced variable expansion prefix.
+run_check_on_fixture "bad-braced-var.sh" '#!/usr/bin/env bash
+prefix=foo
+foo=$(mktemp -t ${prefix})
+'
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "FAIL"; then
+  pass "braced variable prefix: caught"
+else
+  fail "braced variable prefix: rc=$RC out=$OUT"
+fi
+rm -f "$WORKDIR/bad-braced-var.sh"
+
+# Case 13: portable quoted template (slashes inside quote) → PASS.
+# This is the SHAPE we explicitly do NOT want to flag, even though
+# it contains the literal `mktemp -t "..."` substring.
+run_check_on_fixture "clean-quoted-template.sh" '#!/usr/bin/env bash
+foo=$(mktemp -d "${TMPDIR:-/tmp}/safe.XXXXXX")
+'
+if [ "$RC" = "0" ] && echo "$OUT" | grep -q "PASS"; then
+  pass "portable quoted template (slashes inside quotes): not flagged"
+else
+  fail "portable quoted template: rc=$RC out=$OUT"
+fi
+rm -f "$WORKDIR/clean-quoted-template.sh"
+
 echo
 TOTAL=$((PASS + FAIL))
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_deploy.sh
+++ b/tests/test_deploy.sh
@@ -176,12 +176,9 @@ ERR3="$WORKDIR/case3.err"
 : >"$WORKDIR/ofd-calls.log"
 
 set +e
-# Pass an arg through `--` (`--only hosting`) so DEPLOY_ARGS is
-# non-empty when the script reaches `op-firebase-deploy
-# "${DEPLOY_ARGS[@]}"`. macOS bash 3.2 treats empty array expansion
-# under `set -u` as an unbound-variable error — that's a pre-existing
-# quirk in deploy.sh independent of #286 and out of scope for this
-# test; non-empty args sidestep it cleanly.
+# Pass trailing args through `--` (`--only hosting`) to exercise the
+# non-empty DEPLOY_ARGS path. The empty-DEPLOY_ARGS path is exercised
+# separately in Case 4 below (#286 r3 regression).
 PATH="$STUB_DIR:$PATH" \
 OFD_LOG="$WORKDIR/ofd-calls.log" \
 DEPLOY_ALLOW_DIRTY=1 \
@@ -200,6 +197,45 @@ elif ! grep -q 'op-firebase-deploy' "$WORKDIR/ofd-calls.log"; then
   fail "allow-dirty: deploy.sh did not reach the op-firebase-deploy step despite the override."
 else
   pass "allow-dirty: DEPLOY_ALLOW_DIRTY=1 override permits deploy, logs the banner, reaches the deploy step."
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4 (#286 r3 — nathanpayne-codex Phase 4b finding): empty
+# DEPLOY_ARGS must NOT trip the bash 3.2 unbound-variable abort.
+# Invoke `deploy.sh --force --skip-build --skip-cf-purge` with NO
+# trailing `-- <args>`; the script reaches the op-firebase-deploy
+# step with DEPLOY_ARGS=(). Pre-fix: aborts with `DEPLOY_ARGS[@]:
+# unbound variable`. Post-fix: expansion is `${ARR[@]+"${ARR[@]}"}`
+# which is empty-safe under `set -u`.
+# ---------------------------------------------------------------------------
+REPO4="$WORKDIR/case4-empty-args-repo"
+mkdir -p "$REPO4"
+( cd "$REPO4" && git init -q -b main && git config user.email a@b.c && git config user.name a && \
+  echo init >README.md && git add README.md && git commit -q -m init )
+
+OUT4="$WORKDIR/case4.out"
+ERR4="$WORKDIR/case4.err"
+: >"$WORKDIR/ofd-calls-4.log"
+
+set +e
+PATH="$STUB_DIR:$PATH" \
+OFD_LOG="$WORKDIR/ofd-calls-4.log" \
+  bash -c "cd '$REPO4' && bash '$SCRIPT' --force --skip-build --skip-cf-purge" \
+  >"$OUT4" 2>"$ERR4"
+RC4=$?
+set -e
+
+if grep -q 'unbound variable' "$ERR4" 2>/dev/null; then
+  fail "empty-args: deploy.sh aborted with 'unbound variable' (#286 r3 regression)."
+  cat "$ERR4" >&2
+elif [[ $RC4 -ne 0 ]]; then
+  fail "empty-args: deploy.sh returned $RC4 (expected 0). stderr was:"
+  cat "$ERR4" >&2
+elif ! grep -q 'op-firebase-deploy' "$WORKDIR/ofd-calls-4.log"; then
+  fail "empty-args: deploy.sh did not reach the op-firebase-deploy step."
+  cat "$ERR4" >&2
+else
+  pass "empty-args: deploy.sh with no trailing DEPLOY_ARGS reaches op-firebase-deploy without unbound-variable abort"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_deploy.sh
+++ b/tests/test_deploy.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# tests/test_deploy.sh
+#
+# Unit tests for scripts/deploy.sh. Covers the two guards added /
+# tightened by mergepath#286:
+#
+#   1. Strict-bash BUILD_CMD invocation.
+#      The script must run BUILD_CMD under `bash -euo pipefail -c --`
+#      rather than plain `bash -c --`. The regression case is a
+#      compound command like `false; echo should-not-run`: the old
+#      form returns 0 (last segment succeeds), masking the failure;
+#      the strict form aborts on `false`. We assert non-zero exit AND
+#      that the second segment never wrote its stdout.
+#
+#   2. Clean-working-tree guard.
+#      With a dirty fixture worktree, the script must exit non-zero,
+#      print the dirty-tree diagnostic, and list the modified path.
+#      With DEPLOY_ALLOW_DIRTY=1, the same dirty fixture must allow
+#      the deploy to proceed (we assert by reaching the shimmed
+#      op-firebase-deploy step).
+#
+# Strategy: build a self-contained fixture git repo per test, run
+# scripts/deploy.sh inside it with --force (to bypass guards 1+2 —
+# branch + freshness — which depend on `origin/main` we don't want
+# to set up) and --skip-cf-purge. Where the test needs the script
+# to reach the deploy step, PATH-shim `op-firebase-deploy` so the
+# script's `op-firebase-deploy "${DEPLOY_ARGS[@]}"` succeeds.
+#
+# Bash 3.2 portable.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/deploy.sh"
+
+[[ -x "$SCRIPT" ]] || { echo "missing or non-executable $SCRIPT" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/test-deploy.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Build a PATH shim that supplies a stub `op-firebase-deploy` so the
+# script can reach its deploy step in success cases. The shim records
+# its invocation to a per-test log so we can assert reachability.
+# ---------------------------------------------------------------------------
+STUB_DIR="$WORKDIR/stub-bin"
+mkdir -p "$STUB_DIR"
+
+cat >"$STUB_DIR/op-firebase-deploy" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-op-firebase-deploy: invoked with args: $*" >&2
+: "${OFD_LOG:?OFD_LOG must be set by the test}"
+{
+  printf 'op-firebase-deploy'
+  for a in "$@"; do printf '\t%s' "$a"; done
+  printf '\n'
+} >> "$OFD_LOG"
+exit 0
+STUB
+chmod +x "$STUB_DIR/op-firebase-deploy"
+
+# Helper: build a throwaway git repo on a non-main branch with one
+# committed file. Caller sets the working dir's dirty/clean state.
+init_fixture_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  (
+    cd "$repo"
+    git init --quiet -b feature/deploy-test
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    git config commit.gpgsign false
+    echo "initial" > README.md
+    git add README.md
+    git commit --quiet -m "initial"
+  )
+}
+
+# Run scripts/deploy.sh inside a fixture repo with sensible defaults.
+# Args after `--` are passed to the script.
+run_deploy() {
+  local repo="$1"; shift
+  (
+    cd "$repo"
+    PATH="$STUB_DIR:$PATH" \
+      OFD_LOG="$WORKDIR/ofd-calls.log" \
+      bash "$SCRIPT" "$@"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: BUILD_CMD='false; echo should-not-run' fails closed under
+# strict-bash invocation.
+# ---------------------------------------------------------------------------
+REPO1="$WORKDIR/case1-strict-bash"
+init_fixture_repo "$REPO1"
+OUT1="$WORKDIR/case1.out"
+ERR1="$WORKDIR/case1.err"
+: >"$WORKDIR/ofd-calls.log"
+
+set +e
+PATH="$STUB_DIR:$PATH" \
+OFD_LOG="$WORKDIR/ofd-calls.log" \
+BUILD_CMD='false; echo should-not-run' \
+  bash -c "cd '$REPO1' && bash '$SCRIPT' --force --skip-cf-purge" \
+  >"$OUT1" 2>"$ERR1"
+RC1=$?
+set -e
+
+if [[ $RC1 -eq 0 ]]; then
+  fail "strict-bash: deploy.sh returned 0 with BUILD_CMD='false; echo should-not-run' — the OLD masking behavior is still live."
+# Grep only for a LINE that is exactly 'should-not-run' (the
+# `echo should-not-run` output), not any line containing the
+# string — the script's own `>> Building: false; echo should-not-run`
+# diagnostic echoes BUILD_CMD itself and would false-positive a
+# substring match.
+elif grep -qE '^should-not-run$' "$OUT1" "$ERR1" 2>/dev/null; then
+  fail "strict-bash: deploy.sh ran the second segment of the compound command (output contains a bare 'should-not-run' line). Strict-bash should abort on 'false'."
+elif grep -q 'op-firebase-deploy' "$WORKDIR/ofd-calls.log"; then
+  fail "strict-bash: deploy.sh reached the op-firebase-deploy step despite the failing build — build failure was masked."
+else
+  pass "strict-bash: compound BUILD_CMD with leading false fails closed (rc=$RC1, no bare 'should-not-run' line, no deploy)."
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: Clean-working-tree guard rejects a dirty fixture worktree.
+# ---------------------------------------------------------------------------
+REPO2="$WORKDIR/case2-dirty-tree"
+init_fixture_repo "$REPO2"
+# Introduce a dirty edit so git status --porcelain reports a modified path.
+echo "uncommitted change" >> "$REPO2/README.md"
+
+OUT2="$WORKDIR/case2.out"
+ERR2="$WORKDIR/case2.err"
+: >"$WORKDIR/ofd-calls.log"
+
+set +e
+PATH="$STUB_DIR:$PATH" \
+OFD_LOG="$WORKDIR/ofd-calls.log" \
+  bash -c "cd '$REPO2' && bash '$SCRIPT' --force --skip-cf-purge --skip-build" \
+  >"$OUT2" 2>"$ERR2"
+RC2=$?
+set -e
+
+if [[ $RC2 -eq 0 ]]; then
+  fail "dirty-tree: deploy.sh returned 0 from a dirty worktree. Guard 3 missing or non-enforcing."
+elif ! grep -q 'working tree is dirty' "$ERR2"; then
+  fail "dirty-tree: deploy.sh exited non-zero (rc=$RC2) but did not print the 'working tree is dirty' diagnostic to stderr. stderr was:"
+  cat "$ERR2" >&2
+elif ! grep -q 'README.md' "$ERR2"; then
+  fail "dirty-tree: deploy.sh did not list the modified path (README.md) in its diagnostic. stderr was:"
+  cat "$ERR2" >&2
+elif grep -q 'op-firebase-deploy' "$WORKDIR/ofd-calls.log"; then
+  fail "dirty-tree: deploy.sh reached the op-firebase-deploy step from a dirty worktree."
+else
+  pass "dirty-tree: deploy.sh exits non-zero with a clear diagnostic and the dirty paths listed (rc=$RC2)."
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3: DEPLOY_ALLOW_DIRTY=1 break-glass override lets the dirty
+# fixture worktree deploy. We use --skip-build so the test doesn't
+# depend on `npm` being installed, and check that the shimmed
+# op-firebase-deploy was reached.
+# ---------------------------------------------------------------------------
+REPO3="$WORKDIR/case3-allow-dirty"
+init_fixture_repo "$REPO3"
+echo "another uncommitted change" >> "$REPO3/README.md"
+
+OUT3="$WORKDIR/case3.out"
+ERR3="$WORKDIR/case3.err"
+: >"$WORKDIR/ofd-calls.log"
+
+set +e
+# Pass an arg through `--` (`--only hosting`) so DEPLOY_ARGS is
+# non-empty when the script reaches `op-firebase-deploy
+# "${DEPLOY_ARGS[@]}"`. macOS bash 3.2 treats empty array expansion
+# under `set -u` as an unbound-variable error — that's a pre-existing
+# quirk in deploy.sh independent of #286 and out of scope for this
+# test; non-empty args sidestep it cleanly.
+PATH="$STUB_DIR:$PATH" \
+OFD_LOG="$WORKDIR/ofd-calls.log" \
+DEPLOY_ALLOW_DIRTY=1 \
+  bash -c "cd '$REPO3' && bash '$SCRIPT' --force --skip-build --skip-cf-purge -- --only hosting" \
+  >"$OUT3" 2>"$ERR3"
+RC3=$?
+set -e
+
+if [[ $RC3 -ne 0 ]]; then
+  fail "allow-dirty: deploy.sh returned $RC3 with DEPLOY_ALLOW_DIRTY=1 from a dirty worktree. Override is broken. stderr was:"
+  cat "$ERR3" >&2
+elif ! grep -q 'DEPLOY_ALLOW_DIRTY=1' "$ERR3"; then
+  fail "allow-dirty: deploy.sh did not log the DEPLOY_ALLOW_DIRTY=1 override banner to stderr. stderr was:"
+  cat "$ERR3" >&2
+elif ! grep -q 'op-firebase-deploy' "$WORKDIR/ofd-calls.log"; then
+  fail "allow-dirty: deploy.sh did not reach the op-firebase-deploy step despite the override."
+else
+  pass "allow-dirty: DEPLOY_ALLOW_DIRTY=1 override permits deploy, logs the banner, reaches the deploy step."
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "test_deploy.sh: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/test_mergepath_playground.sh
+++ b/tests/test_mergepath_playground.sh
@@ -12,7 +12,11 @@ SCRIPT="$ROOT/scripts/policy-sim.sh"
 # macOS mktemp only substitutes trailing Xs — `name.XXXXXX.js`
 # would work once and then fail with "File exists". Use a temp
 # directory and place fixed-name files inside.
-TMPDIR_SAFE="$(mktemp -d -t mergepath-test)"
+#
+# Use the portable `mktemp -d "$TMPDIR/name.XXXXXX"` form rather
+# than `mktemp -d -t name`: GNU coreutils requires an explicit
+# `XXXXXX` placeholder. See mergepath#286.
+TMPDIR_SAFE="$(mktemp -d "${TMPDIR:-/tmp}/mergepath-test.XXXXXX")"
 CHECK_FILE="$TMPDIR_SAFE/extracted.js"
 
 cleanup() {

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -26,7 +26,7 @@ fi
 
 [[ -x "$SCRIPT" ]] || { echo "missing or non-executable $SCRIPT" >&2; exit 1; }
 
-WORKDIR="$(mktemp -d -t sync-to-downstream-test)"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/sync-to-downstream-test.XXXXXX")"
 trap 'rm -rf "$WORKDIR"' EXIT
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closed-review backlog sweep on #286 surfaced three residual gaps left
from the deploy + playground stories. Patch all three plus a
structural regression check to prevent the mktemp form from coming
back.

Authoring-Agent: claude

1. scripts/deploy.sh — strict-bash BUILD_CMD invocation.

   Old: `bash -c -- "$BUILD_CMD"`.  A compound BUILD_CMD like
   `npm run lint; npm run build` masks lint failure behind the build's
   exit code; `npm run build | tee log` masks build failure behind
   tee's success. Both are silently broken deploys.

   New: `bash -euo pipefail -c -- "$BUILD_CMD"`. set -e aborts on the
   first failing simple command; set -u catches typos that would
   silently expand to empty; pipefail preserves a failing step's exit
   code through a pipeline. Verified regression case:

     BUILD_CMD='false; echo should-not-run' scripts/deploy.sh ...

   Under the old form, the script printed 'should-not-run' and
   reached op-firebase-deploy with rc=0. Under the new form, the
   subshell aborts on `false` and the script exits non-zero before
   reaching deploy. Covered by tests/test_deploy.sh case 1.

2. scripts/deploy.sh — clean-working-tree guard (guard 3).

   Before build/deploy, run `git status --porcelain`. If non-empty,
   list the modified/staged/untracked paths and exit non-zero with
   the diagnostic "Refusing to deploy: working tree is dirty.".
   Closes the same #77 failure class for in-progress local edits:
   a dirty tree ships whatever the WIP edits compile to, which
   diverges from the merged-on-main state reviewers approved.

   Break-glass override: DEPLOY_ALLOW_DIRTY=1 (env var, not a CLI
   flag, kept separate from --force so the override is deliberate
   and audit-greppable, and --force can never accidentally subsume
   it). When used, the script logs a ⚠️ DEPLOY_ALLOW_DIRTY=1 banner
   plus the dirty paths to stderr so the deviation is visible in the
   deploy transcript. Documented in DEPLOYMENT.md § Deploy guards
   and in the script header. Covered by tests/test_deploy.sh cases
   2 (rejects dirty) and 3 (allows under override, logs banner,
   reaches deploy step).

3. scripts/policy-sim.sh + tests/test_mergepath_playground.sh +
   tests/test_sync_to_downstream.sh — portable mktemp.

   BSD-only `mktemp -d -t <prefix>` form was reintroduced in three
   tracked scripts. GNU coreutils mktemp requires an explicit
   `XXXXXX` placeholder in the template and exits non-zero on the
   short form, so every Linux CI runner that reaches these scripts
   fails the line. Replaced with the portable form:

     mktemp -d "${TMPDIR:-/tmp}/<prefix>.XXXXXX"

   which works on both BSD/macOS and GNU/Linux. Three call sites
   fixed: scripts/policy-sim.sh:31 (OUT_DIR), :51 (PRS_DIR);
   tests/test_mergepath_playground.sh:19 (TMPDIR_SAFE);
   tests/test_sync_to_downstream.sh:29 (WORKDIR).

4. scripts/ci/check_mktemp_portability — structural regression guard.

   New CI check that hard-fails on any tracked shell file using the
   BSD-only `mktemp -t <prefix>` short form. Scans git-tracked
   *.sh + bash/sh-shebanged files, skips comment lines (so the
   docs in this PR don't false-positive) and quoted strings fed
   to grep/awk/sed (so existing tests that assert the bad form is
   absent in OTHER scripts don't false-positive either). The match
   regex is intentionally narrow — only flags the BSD shape
   (`-t bare-token`), not the portable `mktemp dir/name.XXXXXX`
   form.

   Wired into .github/workflows/repo_lint.yml between
   check_coderabbit_config_tests and check_governance_files. Verified
   against a synthetic violation in a throwaway repo (exits 1 with
   path + line number) and against the real repo after fix (exits 0).

5. tests/test_deploy.sh — new.

   Three cases against a self-contained git fixture per case
   (no remote; uses --force to skip guards 1+2 since the test's
   purpose is to exercise build + guard 3). PATH-shims
   op-firebase-deploy so the script can reach its deploy step in
   the positive case. All three pass locally.

Touched files outside the strict #286 whitelist:

- tests/test_sync_to_downstream.sh — one-line mktemp fix. In scope
  for "Grep the file for ALL mktemp -t occurrences and fix every
  one"; the check_mktemp_portability guard would otherwise fail CI
  on the repo as-is.

Test results (local):

  bash tests/test_deploy.sh                  → 3 passed, 0 failed
  bash tests/test_mergepath_playground.sh    → OK
  bash tests/test_sync_to_downstream.sh      → PASS
  bash tests/test_sync_overrides.sh          → 31 passed, 0 failed
  ./scripts/ci/check_mktemp_portability      → PASS
  ./scripts/ci/check_spec_test_alignment     → PASS
  ./scripts/ci/check_required_root_files     → PASS
  ./scripts/ci/check_workflow_parsers        → PASS (29 tests)

## Self-Review

- **Correctness.** The strict-bash change is the minimum invariant
  preserving change (still `bash -c --`, just with the safety flags
  set). The dirty guard uses `git status --porcelain` which is the
  documented stable porcelain (v1) — non-empty IFF the tree has
  modified/staged/untracked content. The portable mktemp form is
  what coreutils' own docs recommend.

- **Regression risk.** The strict-bash flip changes the exit code
  surface of BUILD_CMD: anything that previously masked a failure
  will now fail loudly. That's the point — it's an opt-out class of
  failure being closed, not an opt-in capability being added.
  Existing BUILD_CMD values like `npm run build` are single
  commands and behave identically. Compound BUILD_CMDs that
  intentionally allowed failure are extremely unlikely in practice
  (deploys want zero tolerance for build failure) but are still
  expressible via `bash -c 'cmd_that_may_fail || true'` if needed.

- **Style.** Comments cite issue numbers (#77 for the worktree
  story, #286 for this sweep). Override behavior is documented in
  both the script header AND DEPLOYMENT.md so neither path leaves
  a user confused about the env-var-vs-flag split. The new CI
  check follows the same shape as the other scripts/ci/check_*
  files (set -euo pipefail, REPO_ROOT resolution via BASH_SOURCE,
  prefixed `check_<name>: PASS|FAIL` final line, no external deps
  beyond git + grep).

- **Test coverage.** Three deploy cases (one strict-bash + two
  dirty-tree branches), the structural mktemp check both as a
  positive test (no violations in current repo) and verified
  against a synthetic violation in a throwaway repo. The existing
  test_mergepath_playground.sh assertions (`mktemp -d` present, no
  `mktemp ... .ext)` short form) still hold after the change.

- **Security / dependency hygiene.** No new external deps. The
  DEPLOY_ALLOW_DIRTY override is env-var only and the script's
  invocation chain doesn't propagate it to children (no `export`),
  so an op-firebase-deploy sub-call can't see it and act on it.
  No new network calls. The deploy script still runs build
  commands as the invoking user with no privilege escalation.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
