### PR TITLE
fix: sweep low-risk helper nits surfaced by #234 closeout (#287)

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -353,6 +353,32 @@ jobs:
                   }
                 }
 
+                // ─────────────────────────────────────────────────
+                // Dual-violation note (#287):
+                //
+                // The two `prViolations.push(...)` blocks below can
+                // BOTH fire for a single PR — specifically, a
+                // Dependabot PR that also carries the
+                // `needs-external-review` label and merged with zero
+                // reviewer-identity approvals. In that case the audit
+                // emits both:
+                //
+                //   1. "External-review PR merged with no APPROVED
+                //      review …" (from the hadExternalLabel branch)
+                //   2. "Dependabot PR merged with no reviewer identity
+                //      approval …" (from the dependabotNeedsApproval
+                //      branch)
+                //
+                // This is INTENTIONAL, not an over-emit bug. The two
+                // policy conditions are independent: one comes from
+                // the external-review label being present at merge,
+                // the other from Dependabot's narrower clearance rule
+                // (Codex doesn't count for Dependabot — only a CLI
+                // reviewer-identity APPROVED review does). When both
+                // are simultaneously true, the audit correctly
+                // surfaces both — collapsing them into a single line
+                // would hide which gate the merge bypassed.
+                // ─────────────────────────────────────────────────
                 if (hadExternalLabel &&
                     cliApprovedReviews.length === 0 &&
                     !codexCleared &&
@@ -378,6 +404,11 @@ jobs:
                 // the Phase 4a flow, so this is just defensive
                 // against future weirdness — and reuses the
                 // cliApprovedReviews array computed above.
+                //
+                // See the dual-violation note above: a Dependabot PR
+                // also carrying `needs-external-review` will trip
+                // both pushes on the same iteration. By design — the
+                // two pushes report independent policy conditions.
                 if (dependabotNeedsApproval && cliApprovedReviews.length === 0) {
                   prViolations.push(
                     'Dependabot PR merged with no reviewer identity approval (auto-merge approval missing or removed)'

--- a/scripts/gh-projects/README.md
+++ b/scripts/gh-projects/README.md
@@ -75,14 +75,17 @@ Valid status names are whatever options the Project's `Status` field has — typ
 ### Set the Project README
 
 ```bash
-gh project edit <N> --owner <owner> --readme "$(cat path/to/plan.md)"
+gh project edit <N> --owner <owner> --readme "$(cat "path/to/plan.md")"
 ```
 
 Or from a driver that has sourced `lib.sh`:
 
 ```bash
-set_project_readme ~/.claude/plans/my-initiative.md
+set_project_readme "$HOME/.claude/plans/my-initiative.md"
 ```
+
+(Use `"$HOME/..."` or `"~/path/..."` with double quotes around any path argument
+so a directory name with spaces — e.g. `~/My Plans/...` — survives word-splitting.)
 
 ## Placeholder conventions in body files
 

--- a/scripts/request-label-removal.sh
+++ b/scripts/request-label-removal.sh
@@ -44,6 +44,28 @@ set -eo pipefail
 
 ALLOWED_LABELS=(needs-external-review needs-human-review policy-violation)
 
+# Escape a string for embedding inside an AppleScript double-quoted
+# literal. See the inline call site below for the full rationale on
+# escape ordering; the function is hoisted up here so unit tests can
+# `source` this script (with MERGEPATH_REQUEST_LABEL_REMOVAL_LIB=1) and
+# call it directly without firing the main flow.
+applescript_escape() {
+  local s="$1"
+  s=${s//\\/\\\\}        # \  -> \\          (must be FIRST)
+  s=${s//\"/\\\"}        # "  -> \"
+  s=${s//$'\n'/\\n}      # LF -> \n
+  s=${s//$'\r'/\\r}      # CR -> \r
+  s=${s//$'\t'/\\t}      # TAB -> \t
+  printf '%s' "$s"
+}
+
+# Library mode: when sourced by a test harness with this env var set,
+# expose helper functions only and skip the main flow (which would
+# error on the missing positional PR#).
+if [ "${MERGEPATH_REQUEST_LABEL_REMOVAL_LIB:-0}" = "1" ]; then
+  return 0 2>/dev/null || true
+fi
+
 usage() {
   cat <<'EOF' >&2
 Usage: scripts/request-label-removal.sh <PR#> <label> [--reason <text>] [--repo owner/name]
@@ -161,9 +183,12 @@ fi
 echo "Posted label-removal request on $PR_URL"
 
 if [ -n "${MERGEPATH_NOTIFY_IMESSAGE_TO:-}" ]; then
+  # `applescript_escape` is defined at the top of this file. The
+  # string transits both shell and AppleScript, so the escape order
+  # is load-bearing — see the helper definition for full rationale.
   IMSG_BODY="Mergepath: PR #$PR_NUM blocked on '$LABEL' label. Clear when ready: $PR_URL"
-  IMSG_BODY_ESC=${IMSG_BODY//\"/\\\"}
-  TARGET_ESC=${MERGEPATH_NOTIFY_IMESSAGE_TO//\"/\\\"}
+  IMSG_BODY_ESC=$(applescript_escape "$IMSG_BODY")
+  TARGET_ESC=$(applescript_escape "$MERGEPATH_NOTIFY_IMESSAGE_TO")
   if osascript -e "tell application \"Messages\" to send \"$IMSG_BODY_ESC\" to buddy \"$TARGET_ESC\" of (service 1 whose service type is iMessage)" >/dev/null 2>&1; then
     echo "Notified $MERGEPATH_NOTIFY_IMESSAGE_TO via iMessage"
   else

--- a/tests/test_label_removal_guard.sh
+++ b/tests/test_label_removal_guard.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# tests/test_label_removal_guard.sh
+#
+# Unit tests for scripts/hooks/label-removal-guard.sh — the PreToolUse
+# hook that blocks `gh pr edit --remove-label / --add-label` for the
+# human-action labels (needs-external-review, needs-human-review,
+# policy-violation).
+#
+# Coverage focus is the consolidated `gh ... pr edit` detection plus
+# the `-R` / `--repo` interspersed-argument cases (#287). Earlier
+# revisions of the hook (#172 → #271 → #277) used multiple `case` glob
+# patterns to handle different positions of `-R` / `--repo`; the
+# current adjacency-anchored regex (`gh.*pr[[:space:]]+edit`) plus a
+# whole-token walk subsumes those variants. These tests prove the
+# simplified form still catches every position the older patterns
+# explicitly enumerated.
+#
+# Hook contract: reads a JSON envelope on stdin (PreToolUse passes
+# `{tool_input: {command: "..."}}`). Tokenizes with shlex. Exits 0 to
+# allow, 2 to block.
+#
+# Bash 3.2 portable. Mirrors the shape of tests/test_gh_pr_guard.sh.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$ROOT/scripts/hooks/label-removal-guard.sh"
+
+[[ -x "$HOOK" ]] || { echo "missing or non-executable $HOOK" >&2; exit 1; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "SKIP: python3 not available (label-removal-guard.sh requires python3 for tokenization)" >&2
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not available (test builds JSON payloads with jq)" >&2
+  exit 0
+fi
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/label-removal-guard-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Run the hook with the given command. Returns the hook's exit code
+# (no STDERR capture — assert_block_blocked / assert_allow only care
+# about the code).
+run_hook() {
+  local cmd="$1"
+  local payload
+  payload=$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}')
+  bash "$HOOK" <<<"$payload"
+}
+
+# Helper assertions. Each takes a description + command, runs the hook,
+# and tallies PASS/FAIL according to the expected exit code.
+assert_blocked() {
+  local desc="$1"
+  local cmd="$2"
+  local rc=0
+  run_hook "$cmd" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq 2 ]; then
+    pass "$desc"
+  else
+    fail "$desc (expected exit 2, got $rc)"
+  fi
+}
+
+assert_allowed() {
+  local desc="$1"
+  local cmd="$2"
+  local rc=0
+  run_hook "$cmd" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    pass "$desc"
+  else
+    fail "$desc (expected exit 0, got $rc)"
+  fi
+}
+
+# ─── Baseline: the bare form blocks for each prohibited label ───────
+assert_blocked "baseline: --remove-label needs-external-review (bare)" \
+  "gh pr edit 1 --remove-label needs-external-review"
+assert_blocked "baseline: --remove-label needs-human-review (bare)" \
+  "gh pr edit 1 --remove-label needs-human-review"
+assert_blocked "baseline: --remove-label policy-violation (bare)" \
+  "gh pr edit 1 --remove-label policy-violation"
+assert_blocked "baseline: --add-label policy-violation (bare)" \
+  "gh pr edit 1 --add-label policy-violation"
+
+# ─── -R / --repo interspersed BEFORE `pr edit` ──────────────────────
+# gh accepts a global -R/--repo before the subcommand. The simplified
+# adjacency-anchored regex (`gh.*pr[[:space:]]+edit`) plus the
+# post-tokenize token walk must still catch every position.
+assert_blocked "global -R before pr: gh -R owner/repo pr edit ... --remove-label needs-external-review" \
+  "gh -R nathanjohnpayne/mergepath pr edit 1 --remove-label needs-external-review"
+assert_blocked "global --repo before pr: gh --repo owner/repo pr edit ... --remove-label needs-human-review" \
+  "gh --repo nathanjohnpayne/mergepath pr edit 1 --remove-label needs-human-review"
+assert_blocked "global --repo= form: gh --repo=owner/repo pr edit ... --remove-label policy-violation" \
+  "gh --repo=nathanjohnpayne/mergepath pr edit 1 --remove-label policy-violation"
+
+# ─── -R / --repo interspersed AFTER `pr edit` ───────────────────────
+# gh also accepts the repo selector after the subcommand (the more
+# common form in CI scripts).
+assert_blocked "post-edit -R: gh pr edit 1 -R owner/repo --remove-label needs-external-review" \
+  "gh pr edit 1 -R nathanjohnpayne/mergepath --remove-label needs-external-review"
+assert_blocked "post-edit --repo: gh pr edit 1 --repo owner/repo --remove-label needs-human-review" \
+  "gh pr edit 1 --repo nathanjohnpayne/mergepath --remove-label needs-human-review"
+assert_blocked "post-edit --repo before PR#: gh pr edit --repo owner/repo 1 --remove-label policy-violation" \
+  "gh pr edit --repo nathanjohnpayne/mergepath 1 --remove-label policy-violation"
+
+# ─── -R / --repo with --remove-label= flag-value syntax ─────────────
+assert_blocked "post-edit -R + --remove-label= form" \
+  "gh pr edit 1 -R owner/repo --remove-label=needs-external-review"
+assert_blocked "pre-edit --repo + --remove-label= form" \
+  "gh --repo owner/repo pr edit 1 --remove-label=policy-violation"
+
+# ─── -R / --repo with comma-separated label list ────────────────────
+# Per the existing comma-split logic, each segment is checked. A
+# prohibited label hiding in a multi-label remove must still block,
+# regardless of where -R appears.
+assert_blocked "comma-list with prohibited segment, -R after edit" \
+  "gh pr edit 1 -R owner/repo --remove-label foo,needs-external-review,bar"
+assert_blocked "comma-list with prohibited segment, --repo before pr" \
+  "gh --repo owner/repo pr edit 1 --remove-label foo,policy-violation"
+
+# ─── Allow paths: -R / --repo present, non-prohibited label ─────────
+# The simplified pattern must not over-block — `gh pr edit` with a
+# non-prohibited label, with -R / --repo in either position, stays
+# allowed.
+assert_allowed "allow: gh pr edit ... --remove-label some-unrelated-label" \
+  "gh pr edit 1 --remove-label some-unrelated-label"
+assert_allowed "allow: -R before pr, unrelated remove" \
+  "gh -R owner/repo pr edit 1 --remove-label some-unrelated-label"
+assert_allowed "allow: --repo after edit, unrelated remove" \
+  "gh pr edit 1 --repo owner/repo --remove-label some-unrelated-label"
+assert_allowed "allow: --add-label needs-foo (not in prohibited set)" \
+  "gh pr edit 1 --add-label needs-foo"
+
+# ─── Allow paths: non-edit subcommands with -R / --repo ─────────────
+# `gh pr view`, `gh pr create` etc. must never be blocked by this
+# hook, regardless of where -R lives.
+assert_allowed "allow: gh -R owner/repo pr view 1" \
+  "gh -R owner/repo pr view 1"
+assert_allowed "allow: gh --repo owner/repo pr create --title x --body y" \
+  "gh --repo owner/repo pr create --title x --body y"
+assert_allowed "allow: gh pr list --repo owner/repo" \
+  "gh pr list --repo owner/repo"
+
+# ─── Shell-expansion guard (#172): still blocked under -R / --repo ──
+assert_blocked "expansion under -R: --remove-label \"\$BLOCK_LABEL\"" \
+  'gh -R owner/repo pr edit 1 --remove-label "$BLOCK_LABEL"'
+assert_blocked "expansion under --repo: --remove-label \`echo policy-violation\`" \
+  'gh pr edit 1 --repo owner/repo --remove-label `echo policy-violation`'
+
+echo
+echo "Total: $((PASS + FAIL)) — PASS: $PASS, FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_request_label_removal_escape.sh
+++ b/tests/test_request_label_removal_escape.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# tests/test_request_label_removal_escape.sh
+#
+# Unit tests for the AppleScript-escape helper in
+# scripts/request-label-removal.sh (#287).
+#
+# The helper escapes a string for embedding inside an AppleScript
+# double-quoted literal that is itself wrapped in a shell-double-quoted
+# `osascript -e "..."` argument. The previous implementation only
+# escaped double quotes, which left backslashes and newlines free to
+# corrupt the AppleScript invocation (a backslash-bearing reason
+# string would turn the next character into an AppleScript escape; a
+# newline would terminate the source line and break parsing).
+#
+# Escape order is load-bearing:
+#   1. Backslashes FIRST  (\  -> \\)   so later substitutions' \
+#      sequences aren't re-escaped
+#   2. Double quotes      ("  -> \")
+#   3. Newlines           (LF -> \n)
+#   4. Carriage returns   (CR -> \r)
+#   5. Tabs               (TAB -> \t)
+#
+# We source the script in library mode (MERGEPATH_REQUEST_LABEL_REMOVAL_LIB=1)
+# so the helper function is in scope without firing the main flow.
+#
+# Bash 3.2 portable.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/request-label-removal.sh"
+
+[[ -r "$SCRIPT" ]] || { echo "missing $SCRIPT" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Source in library mode. This must run in a subshell-free context so
+# the function lands in the current scope, but the library-mode `return`
+# in the script only works when this file is itself executed via
+# `bash tests/test_request_label_removal_escape.sh` (which we are).
+# shellcheck disable=SC1090
+MERGEPATH_REQUEST_LABEL_REMOVAL_LIB=1 source "$SCRIPT"
+
+if ! declare -F applescript_escape >/dev/null; then
+  echo "FAIL: applescript_escape not defined after sourcing $SCRIPT" >&2
+  exit 1
+fi
+
+assert_eq() {
+  local desc="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass "$desc"
+  else
+    fail "$desc"
+    printf '  expected: %q\n  actual:   %q\n' "$expected" "$actual" >&2
+  fi
+}
+
+# ─── Baseline: an empty / plain string is unchanged ─────────────────
+assert_eq "empty string" "" "$(applescript_escape "")"
+assert_eq "plain ASCII" "hello world" "$(applescript_escape "hello world")"
+
+# ─── Double quote: " -> \" ──────────────────────────────────────────
+assert_eq 'double quote → \"' \
+  'say \"hi\"' \
+  "$(applescript_escape 'say "hi"')"
+
+# ─── Backslash: \ -> \\ ─────────────────────────────────────────────
+# Order-matters check: a lone backslash must become exactly two
+# backslashes — not four (which would happen if a later substitution
+# re-escaped the just-injected backslashes).
+assert_eq 'backslash → \\' \
+  'a\\b' \
+  "$(applescript_escape 'a\b')"
+
+# ─── Backslash + quote (combined) ───────────────────────────────────
+# Input:    a\"b      (raw: backslash, double quote, b)
+# Step 1:   a\\"b     (escape backslash)
+# Step 2:   a\\\"b    (escape double quote)
+# Expected: a\\\"b
+assert_eq 'backslash THEN quote → \\\"' \
+  'a\\\"b' \
+  "$(applescript_escape 'a\"b')"
+
+# ─── Newline: LF -> \n ──────────────────────────────────────────────
+# The input contains a raw newline; the output should contain the
+# two-character escape sequence `\n` (backslash, n), NOT a literal
+# newline.
+NL_INPUT=$'line1\nline2'
+assert_eq 'newline → \n' \
+  'line1\nline2' \
+  "$(applescript_escape "$NL_INPUT")"
+
+# ─── Carriage return: CR -> \r ──────────────────────────────────────
+CR_INPUT=$'a\rb'
+assert_eq 'carriage return → \r' \
+  'a\rb' \
+  "$(applescript_escape "$CR_INPUT")"
+
+# ─── Tab: TAB -> \t ─────────────────────────────────────────────────
+TAB_INPUT=$'col1\tcol2'
+assert_eq 'tab → \t' \
+  'col1\tcol2' \
+  "$(applescript_escape "$TAB_INPUT")"
+
+# ─── The headline mixed case from the issue ─────────────────────────
+# A reason string containing backslashes, double quotes, AND newlines
+# — the exact failure mode the harden was meant to close.
+#
+# Input:  Path C:\Users\foo failed: said "no" \nthen quit
+# (literal raw string: backslashes, embedded double quotes, AND a
+# literal newline character).
+#
+# Step-by-step:
+#   raw:      'Path C:\Users\foo failed: said "no"' + LF + 'then quit'
+#   step 1 (\ → \\):
+#             'Path C:\\Users\\foo failed: said "no"' + LF + 'then quit'
+#   step 2 (" → \"):
+#             'Path C:\\Users\\foo failed: said \"no\"' + LF + 'then quit'
+#   step 3 (LF → \n):
+#             'Path C:\\Users\\foo failed: said \"no\"\nthen quit'
+MIXED_INPUT=$'Path C:\\Users\\foo failed: said "no"\nthen quit'
+MIXED_EXPECTED='Path C:\\Users\\foo failed: said \"no\"\nthen quit'
+assert_eq 'mixed: backslash + quote + newline (the headline case)' \
+  "$MIXED_EXPECTED" \
+  "$(applescript_escape "$MIXED_INPUT")"
+
+# ─── Regression: escape ordering ────────────────────────────────────
+# If the implementation escaped quotes BEFORE backslashes, then for
+# input `"\` (quote, backslash):
+#   wrong order:  step 1 (" → \"):  `\"\`
+#                 step 2 (\ → \\):  `\\\"\\`  ← four chars including double-escape
+# The correct ordering yields `\"\\` (3 chars: backslash-quote,
+# backslash-backslash). Pin this exact output to catch any future
+# reordering.
+assert_eq 'order: input "\\ → \\"\\\\ (backslash escaped after quote)' \
+  '\"\\' \
+  "$(applescript_escape '"\')"
+
+# ─── No-op safety: a string with only safe characters ───────────────
+assert_eq 'safe chars unchanged: phone-number target' \
+  "+15551234567" \
+  "$(applescript_escape "+15551234567")"
+
+echo
+echo "Total: $((PASS + FAIL)) — PASS: $PASS, FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Sweep four of the five low-risk helper nits the codex 2026-05-13
unresolved-feedback rollup (#234) closed without addressing. The
fifth bullet (scripts/op-preflight.sh repair-recipe quoting) is
intentionally SKIPPED in this commit — see Self-Review for the
rationale tied to in-flight PR #293 / issue #284.

Fixes per file:

- scripts/gh-projects/README.md:84
    Quote the `set_project_readme` path example so a plan path that
    contains spaces survives word-splitting. Switched to
    `"$HOME/.claude/plans/my-initiative.md"` and added a short
    follow-up note explaining the convention. Same fix applied to
    the adjacent `gh project edit ... --readme "$(cat path/to/plan.md)"`
    example on line 78.

- scripts/hooks/label-removal-guard.sh
    The redundant `*gh*pr*edit*` scatter pattern was already
    consolidated in #277 into the adjacency-anchored regex
    `gh.*pr[[:space:]]+edit` plus a whole-token walk. No code change
    needed. Added tests/test_label_removal_guard.sh (23 cases) as
    regression coverage proving the simplified form catches every
    `-R` / `--repo` interspersed-argument case the older multi-glob
    enumeration handled — pre-pr position, post-edit position,
    `--repo=value` form, comma-separated label lists, shell-expansion
    guards. Also covers the allow paths so the simplified pattern
    doesn't over-block.

- scripts/request-label-removal.sh:185-197
    Harden the AppleScript escaping in the iMessage notification
    path. Previous form only escaped `"`; a reason string containing
    a backslash or newline would either smuggle an unintended
    AppleScript escape sequence or terminate the source line. New
    `applescript_escape` helper escapes in the order required for
    correctness: backslashes FIRST (so later substitutions don't
    re-escape the just-injected `\\`), then double quotes, then LF
    → `\n`, CR → `\r`, TAB → `\t`. Function is hoisted to the top
    of the file with a library-mode source guard
    (`MERGEPATH_REQUEST_LABEL_REMOVAL_LIB=1`) so the unit test can
    call it directly without firing the main flow. Added
    tests/test_request_label_removal_escape.sh (11 cases) covering
    the empty/plain baselines, each escape independently, the
    headline mixed-case (backslash + quote + newline together), and
    a load-bearing ordering regression pinning the exact two-step
    transform on input `"\`.

- .github/workflows/pr-audit.yml:356-415
    A Dependabot PR that also carries `needs-external-review` and
    merged with zero reviewer-identity approvals trips BOTH
    `prViolations.push(...)` calls in Check 2 on a single
    iteration. Added a comment block above the first push
    documenting that this is intentional — the two conditions are
    independent policy gates and collapsing them would hide which
    gate the merge bypassed — plus a back-reference comment above
    the second push pointing at the explanation.

- scripts/op-preflight.sh — NOT TOUCHED. (See Self-Review.)

Tests run locally:
  tests/test_label_removal_guard.sh         23 passed
  tests/test_request_label_removal_escape.sh 11 passed
  tests/test_gh_pr_guard.sh                 16 passed (no regression)
  tests/test_gh_as_author.sh                13 passed (no regression)
  bash -n on all touched shell files: clean
  yq parses pr-audit.yml: clean

Closes #287

Authoring-Agent: claude

## Self-Review

- Correctness: each fix is local and additive. The README quoting is
  a doc-only change. The AppleScript escape helper has unit-test
  coverage for the headline mixed case AND a regression-pinning
  ordering test (input `"\` must produce the exact 3-char output
  `\"\\` — pinning this prevents a future refactor from reordering
  the escape steps and re-introducing the double-escape bug). The
  pr-audit.yml change is comment-only (no behavior change, no risk
  to the cron). The label-removal-guard test file is new; it
  exercises the existing hook without modifying it.

- Regression risk: low. No production code path changes besides the
  iMessage osascript invocation, which previously failed silently
  on backslash/newline-bearing inputs and now succeeds on them. The
  hook's source-of-truth code is untouched — only test coverage was
  added. The pr-audit.yml diff is pure comments and cannot change
  cron output.

- Style: function shape and comment density match the surrounding
  conventions in scripts/hooks/gh-pr-guard.sh and
  scripts/request-label-removal.sh. Test files mirror the shape of
  tests/test_gh_pr_guard.sh per the issue's "follow the pattern from
  tests/test_gh_pr_guard.sh" instruction.

- Test coverage: 34 new test cases across two test files. Both pass
  locally. The headline AppleScript escape test asserts on the exact
  output a future regression would change.

- Security / dependency hygiene: no new dependencies. The library-
  mode source guard adds one env-var check (an opt-in flag a test
  harness sets); it cannot be triggered by an unauthenticated caller
  because the env var is not read from any external surface.

- Scope deviation — scripts/op-preflight.sh bullet SKIPPED. The
  issue body lists five fixes; the fourth ("Quote `$expected` in the
  op-preflight.sh emitted repair command") is intentionally not
  addressed in this commit. PR #293 (which closes issue #284) is in
  flight and REPLACES the entire `warn_active_account_mismatch`
  function in scripts/op-preflight.sh with auto-restore behavior —
  the unquoted `$expected` lives inside the lines #293 deletes. The
  task-runner caller flagged the overlap explicitly and instructed
  to skip the bullet. After #293 lands, if any analogue of the
  repair-recipe survives in the new auto-restore code path, a
  follow-up commit can quote it then.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
