### PR TITLE
[codex] Resolve closed-review backlog findings

### DIFF
--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -290,12 +290,21 @@ assert_eq "classify_phase_4b: a present-but-unrecognized value is invalid" "inva
 
 # Fixture: verify end-to-end against the actual review-policy.yml so a
 # typo in the schema-doc example doesn't pass the unit fixtures while
-# breaking the real read. A missing field is accepted as valid (the
-# documented fallback-only default) per classify_phase_4b — this check
-# ships in the propagated kit and must not hard-fail a consumer repo
-# that simply hasn't opted into phase_4b_default yet (#264).
-got=$(awk -v field="phase_4b_default" "$policy_field_awk" "$ROOT/.github/review-policy.yml")
-if [ "$(classify_phase_4b "$got")" = "valid" ]; then
+# breaking the real read. A missing field is accepted as valid ONLY
+# when the key is truly absent from the real file; mergepath's own
+# policy sets the key, so an empty parser result there is a regression
+# rather than the fallback-only migration case (#300).
+real_policy="$ROOT/.github/review-policy.yml"
+real_has_phase_4b_default=0
+if grep -Eq '^phase_4b_default[[:space:]]*:' "$real_policy"; then
+  real_has_phase_4b_default=1
+fi
+
+got=$(awk -v field="phase_4b_default" "$policy_field_awk" "$real_policy")
+if [ -z "$got" ] && [ "$real_has_phase_4b_default" -eq 1 ]; then
+  fail=$((fail + 1))
+  echo "  FAIL: real .github/review-policy.yml contains phase_4b_default, but policy_field returned empty" >&2
+elif [ "$(classify_phase_4b "$got")" = "valid" ]; then
   pass=$((pass + 1))
   if [ -z "$got" ]; then
     echo "  PASS: real .github/review-policy.yml has no phase_4b_default (valid — defaults to fallback-only)"

--- a/scripts/gh-projects/README.md
+++ b/scripts/gh-projects/README.md
@@ -141,7 +141,7 @@ Companion one-shot, non-idempotent driver that adds new children to **existing**
 - A phase scope expands mid-flight
 - A mid-phase discovery needs its own ticket
 
-Same `lib.sh` helpers — no library changes. The driver fetches existing parent numbers (or accepts them as args), prep_body's sibling references, calls `create_child` + `link_sub_issue` for each new child, then adds to the Project. The reference implementation lives in nathanpaynedotcom (`scripts/gh-projects/examples/matchline/additions/add-plan-refinements.sh` on the `matchline/issue-driver` branch — promoted in [nathanpaynedotcom#263](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/263)).
+Same `lib.sh` helpers — no library changes. The driver fetches existing parent numbers (or accepts them as args), prep_body's sibling references, calls `create_child` + `link_sub_issue` for each new child, then adds to the Project. The reference implementation lives in nathanpaynedotcom on `main`: [`scripts/gh-projects/examples/matchline/additions/add-plan-refinements.sh`](https://github.com/nathanjohnpayne/nathanpaynedotcom/blob/main/scripts/gh-projects/examples/matchline/additions/add-plan-refinements.sh), promoted in [nathanpaynedotcom#263](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/263).
 
 ### Picking which to write
 

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -485,10 +485,10 @@ restore_active_account_or_warn() {
       echo "#   Result:   switch returned 0 but active is still '$verify'." >&2
       echo "#             The switch silently no-op'd (corrupt hosts.yml," >&2
       echo "#             mock gh, concurrent switch race). Run" >&2
-      echo "#             'gh auth switch -u $expected' manually to recover." >&2
+      echo "#             gh auth switch -u '$expected' manually to recover." >&2
     fi
   else
-    echo "#   Result:   gh auth switch -u $expected FAILED." >&2
+    echo "#   Result:   gh auth switch -u '$expected' FAILED." >&2
     echo "#             Is $expected in the keyring? Run 'gh auth login'" >&2
     echo "#             once for that identity, then re-run preflight." >&2
   fi


### PR DESCRIPTION
Authoring-Agent: codex

## Summary
- tighten `check_workflow_parsers` so mergepath's real `.github/review-policy.yml` fails if the present `phase_4b_default` key parses as empty
- update the gh-projects additions-driver reference to the merged file on `nathanpaynedotcom` `main` instead of the deleted `matchline/issue-driver` branch
- quote the active-account recovery command in the current `op-preflight.sh` warning text

## Issue #300 validation
The remaining raw sweep findings were checked against current `origin/main`. These were already addressed before this branch: `op-preflight.sh` active-account detection, `codex-review-check.sh` Authoring-Agent parsing, `audit-branch-protection.sh` ruleset scoping and `~ALL` handling, `op-firebase-deploy` fallback after unusable preflight ADC, `label-removal-guard.sh` command matching, `request-label-removal.sh` AppleScript escaping, and the gh-projects path-quoting example.

This PR fixes the still-actionable parser regression guard and stale external README reference, plus the small preflight command-quoting polish.

Closes #300

## Self-Review
- Correctness: verified the changed parser guard now distinguishes a genuinely absent `phase_4b_default` from a present key that parsed empty.
- Regression risk: limited to one CI check assertion, one README reference, and two user-facing preflight echo strings.
- Style/conventions: follows existing shell-test style and keeps the README update in the existing section.
- Test coverage: ran the targeted local checks listed below, including the policy parser, review-policy, label guard, preflight, and deploy resolver suites.
- Security/dependency hygiene: no dependency, secret, or credential handling changes; the optional deploy resolver check used local shims only.

## Validation
- `bash -n scripts/ci/check_workflow_parsers scripts/op-preflight.sh scripts/hooks/label-removal-guard.sh scripts/request-label-removal.sh scripts/audit-branch-protection.sh scripts/firebase/op-firebase-deploy scripts/codex-review-check.sh`
- `scripts/ci/check_workflow_parsers`
- `tests/test_audit_branch_protection.sh`
- `tests/test_request_label_removal_escape.sh`
- `tests/test_label_removal_guard.sh`
- `scripts/ci/check_canonical_bugs_263caf3`
- `MERGEPATH_RUN_INTEGRATION=1 bash scripts/ci/check_op_firebase_deploy_integration`
- `tests/test_op_preflight_check.sh`
- `scripts/ci/check_op_preflight_contract`
- `git diff --check`
