### PR TITLE
feat: op-firebase-setup --provision-sa-key + rank-1 resolver test (#154 close-out)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -252,14 +252,14 @@ This creates `firebase.json` and `.firebaserc`. Commit both.
 ### 4. Set up the deployer service account
 
 ```bash
-op-firebase-setup {project-id}
+op-firebase-setup {project-id} --provision-sa-key
 ```
 
-See [First-Time Setup](#first-time-setup) for details. This creates the `firebase-deployer` service account, grants the necessary deploy roles, and configures impersonation as a fallback path.
+See [First-Time Setup](#first-time-setup) for details. This creates the `firebase-deployer` service account, grants the necessary deploy roles, configures impersonation as a fallback path, and (with `--provision-sa-key`) mints the deployer SA key and uploads it to `op://Firebase/{project-id} — Firebase Deployer SA Key`. The flag is opt-in; without it, the script does impersonation-only setup and leaves SA-key provisioning as a documented manual step.
 
 ### 5. Provision the Firebase-vault SA key (preferred default)
 
-After `op-firebase-setup` runs, follow [§ Secrets Management → Provisioning the Firebase-vault SA key](#provisioning-the-firebase-vault-sa-key) to materialize the SA key into the 1Password Firebase vault. This is the **preferred default** credential for routine deploys (interactive + CI) per #154 — it avoids the recurring `firebase login --reauth` friction (#137) caused by RAPT/refresh-token expiry on the shared 1Password ADC.
+If you ran step 4 with `--provision-sa-key`, the SA key is already in 1Password and you can skip to step 6. Otherwise, follow [§ Secrets Management → Provisioning the Firebase-vault SA key](#provisioning-the-firebase-vault-sa-key) to materialize the SA key — the doc-block procedure is functionally identical to what `--provision-sa-key` runs inside the setup script. The SA key is the **preferred default** credential for routine deploys (interactive + CI) per #154 — it avoids the recurring `firebase login --reauth` friction (#137) caused by RAPT/refresh-token expiry on the shared 1Password ADC.
 
 Impersonation remains as a fallback path; it kicks in when the project SA key isn't provisioned yet.
 
@@ -701,7 +701,20 @@ Each project's SA key is stored in the 1Password **Firebase** vault with the nam
 
 ### Provisioning the Firebase-vault SA key
 
-Run once per Firebase project, after `op-firebase-setup` has created the `firebase-deployer` service account:
+Run once per Firebase project. The preferred path is the `--provision-sa-key` flag on the setup script — it mints the key, uploads it, and wipes the local tempfile in a single attended invocation:
+
+```bash
+op-firebase-setup {project-id} --provision-sa-key
+
+# Verify: a routine deploy should now log
+# "[op-firebase-deploy] source credential: project Firebase-vault SA key (...)"
+# and run without prompting for firebase login --reauth.
+op-firebase-deploy --only hosting   # or whatever target
+```
+
+The flag is opt-in (preserves the prior impersonation-only setup behavior for callers who want it), refuses to overwrite an existing 1Password item with the canonical title (rotate via the [§ Rotating a Firebase deploy SA key](#rotating-a-firebase-deploy-sa-key) procedure instead), and short-circuits early with a clear error if the 1Password CLI is not on PATH.
+
+If you cannot use the flag (older `op-firebase-setup` on PATH, debugging the steps individually, or operating against a setup that already ran without provisioning), the manual procedure below is functionally identical to what the flag runs internally:
 
 ```bash
 PROJECT_ID="{project-id}"
@@ -885,3 +898,10 @@ and the `GOOGLE_APPLICATION_CREDENTIALS` export resumes normally.
 **2026-05-15: Deploy credential precedence updated.** Project Firebase-vault SA keys
 are now the default for `op-firebase-deploy`. See #154 / #211 for implementation
 history; live consumer verification on matchline pending (#211 close-out).
+
+**2026-05-15: `op-firebase-setup --provision-sa-key` flag added.** The setup script
+now optionally mints the deployer SA key and uploads it to
+`op://Firebase/{project-id} — Firebase Deployer SA Key` as part of the same
+attended invocation, folding the previously-manual DEPLOYMENT.md procedure into
+the script. Opt-in to preserve the prior impersonation-only behavior contract.
+See #154 close-out.

--- a/scripts/ci/check_op_firebase_deploy_integration
+++ b/scripts/ci/check_op_firebase_deploy_integration
@@ -27,6 +27,9 @@
 # Cases covered (resolver precedence per the script source's comment
 # block at `resolve_source_cred_file`):
 #
+#   0. genuinely user-supplied GOOGLE_APPLICATION_CREDENTIALS (NOT
+#      preflight-injected) → rank 1 wins
+#        log: "source credential: explicit GOOGLE_APPLICATION_CREDENTIALS ..."
 #   1. project SA key present → rank 2 wins
 #        log: "source credential: project Firebase-vault SA key ..."
 #   2. project SA absent + preflight ADC present → rank 3 wins
@@ -36,6 +39,16 @@
 #        log: "source credential: shared 1Password ADC ..."
 #   4. all op sources absent + local ADC file present → rank 5 wins
 #        log: "source credential: local ADC file ..."
+#
+# Not covered (deliberate): the usability-fallback walk (rank-N
+# unusable → fall through to N+1). The script short-circuits
+# `source_cred_is_usable` to "usable" for `type == "service_account"`
+# credentials (see scripts/firebase/op-firebase-deploy line ~244), so
+# triggering the fallback path requires an `authorized_user`-shaped
+# JSON whose refresh-token call to oauth2.googleapis.com fails. That
+# introduces a real outbound-network dependency that's not safe to
+# rely on under hermetic CI; the behavior is exercised by #211's
+# live consumer-repo verification instead.
 #
 # Each case asserts:
 #   (a) the source-credential log line on stderr matches the expected
@@ -215,6 +228,186 @@ STUB
   fi
 }
 
+# Variant of run_case that sources case-env.sh before invoking the script.
+# Lets us pass GOOGLE_APPLICATION_CREDENTIALS / OP_PREFLIGHT_ADC_TMPFILE
+# through env -i without clobbering them.
+run_case_with_env() {
+  local case_name="$1"
+  local expected_log_substring="$2"
+  local project="$3"
+  local provision="$4"
+  local case_dir="$SCRATCH_ROOT/$case_name"
+  local bin_dir="$case_dir/bin"
+  local tmp_dir="$case_dir/tmp"
+  local home_dir="$case_dir/home"
+
+  mkdir -p "$bin_dir" "$tmp_dir" "$home_dir/.config/gcloud"
+
+  cat >"$case_dir/.firebaserc" <<JSON
+{ "projects": { "default": "$project" } }
+JSON
+
+  cat >"$bin_dir/firebase" <<'STUB'
+#!/usr/bin/env bash
+echo "[stub-firebase] called with: $*" >&2
+exit 0
+STUB
+  chmod +x "$bin_dir/firebase"
+
+  cat >"$bin_dir/gcloud" <<'STUB'
+#!/usr/bin/env bash
+echo "[stub-gcloud] called with: $*" >&2
+exit 0
+STUB
+  chmod +x "$bin_dir/gcloud"
+
+  "$provision" "$case_dir" "$bin_dir" "$tmp_dir" "$home_dir" "$project"
+
+  local stderr_log="$case_dir/stderr.log"
+  local stdout_log="$case_dir/stdout.log"
+  local rc=0
+
+  # Wrap the invocation: source case-env.sh (if it exists), then exec
+  # the script. We still use env -i to enforce a hermetic baseline.
+  cat >"$case_dir/runner.sh" <<RUNNER
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$case_dir"
+if [ -f "$case_dir/case-env.sh" ]; then
+  # shellcheck disable=SC1090
+  source "$case_dir/case-env.sh"
+fi
+exec "$DEPLOY_SCRIPT"
+RUNNER
+  chmod +x "$case_dir/runner.sh"
+
+  (
+    env -i \
+      PATH="$bin_dir:$PYTHON3_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+      HOME="$home_dir" \
+      TMPDIR="$tmp_dir" \
+      "$case_dir/runner.sh" \
+      >"$stdout_log" 2>"$stderr_log"
+  ) || rc=$?
+
+  local check_passed=true
+
+  if [ "$rc" -ne 0 ]; then
+    echo "  FAIL: $case_name — script exited rc=$rc (expected 0)"
+    echo "    stderr:"
+    sed 's/^/      /' "$stderr_log" >&2 || true
+    check_passed=false
+  fi
+
+  if ! grep -qF "$expected_log_substring" "$stderr_log"; then
+    echo "  FAIL: $case_name — stderr missing expected source-cred log"
+    echo "    expected substring: $expected_log_substring"
+    echo "    actual stderr:"
+    sed 's/^/      /' "$stderr_log" >&2 || true
+    check_passed=false
+  fi
+
+  # Tempfile cleanup: the script-written tempfiles (gcp-impersonated-*,
+  # firebase-sa-*, gcp-adc-*) must be gone. Note that for cases that
+  # pre-provision their own credentials (preflight ADC, explicit GAC),
+  # those harness-written files are allowed to survive — only files
+  # matching the script's mktemp patterns are checked.
+  local lingering
+  lingering="$(find "$tmp_dir" -type f 2>/dev/null | grep -E 'gcp-(adc|impersonated)-|firebase-sa-' || true)"
+  if [ -n "$lingering" ]; then
+    echo "  FAIL: $case_name — tempfiles leaked under $tmp_dir:"
+    echo "$lingering" | sed 's/^/      /' >&2
+    check_passed=false
+  fi
+
+  if $check_passed; then
+    echo "  PASS: $case_name — log='$expected_log_substring', tempfiles cleaned"
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ----------------------------------------------------------------------
+# Case 0 — genuinely user-supplied GOOGLE_APPLICATION_CREDENTIALS
+#          (NOT preflight-injected) → rank 1 wins
+# ----------------------------------------------------------------------
+# Distinguishes a human-set env var from preflight's tempfile by setting
+# GOOGLE_APPLICATION_CREDENTIALS WITHOUT also setting OP_PREFLIGHT_ADC_TMPFILE.
+# The resolver's `is_preflight_injected` check requires both to be set
+# AND equal; with only GAC set, rank 1 wins and the script reports the
+# explicit override. Even if a project SA key is reachable via `op`,
+# rank 1 short-circuits the resolver before rank 2 runs (this case
+# verifies that ordering by leaving `op` reachable — if rank 2 ever
+# slipped above rank 1, the assertion would fail on the log line).
+# ----------------------------------------------------------------------
+provision_explicit_gac() {
+  local case_dir="$1" bin_dir="$2" tmp_dir="$3" home_dir="$4" project="$5"
+
+  # Provision an explicit credential file in a non-preflight location.
+  # The path lives under $tmp_dir so the cleanup-leak assertion still
+  # works — but the file itself is owned by the test harness and
+  # allowed to survive (we filter the leak grep to the script's mktemp
+  # patterns, not our pre-provisioned files).
+  local explicit_path="$tmp_dir/explicit-gac.json"
+  write_fake_sa_key "$explicit_path" \
+    "explicit-override@${project}.iam.gserviceaccount.com"
+
+  # Provision a project SA key that WOULD win at rank 2 if rank 1
+  # didn't fire. The assertion that the log line says "explicit
+  # GOOGLE_APPLICATION_CREDENTIALS" (not "project Firebase-vault SA
+  # key") is what proves rank 1 outranks rank 2.
+  local sa_payload_dir="$case_dir/op-payloads"
+  mkdir -p "$sa_payload_dir"
+  write_fake_sa_key "$sa_payload_dir/project-sa.json" \
+    "firebase-deployer@${project}.iam.gserviceaccount.com"
+
+  cat >"$bin_dir/op" <<STUB
+#!/usr/bin/env bash
+case "\$1" in
+  document)
+    shift
+    if [ "\$1" = "get" ]; then
+      shift
+      out_path=""
+      while [ \$# -gt 0 ]; do
+        if [ "\$1" = "--out-file" ]; then
+          shift; out_path="\$1"
+        fi
+        shift || true
+      done
+      if [ -n "\$out_path" ]; then
+        cp "$sa_payload_dir/project-sa.json" "\$out_path"
+        exit 0
+      fi
+      exit 1
+    fi
+    exit 1
+    ;;
+  read)
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$bin_dir/op"
+
+  # GAC set; OP_PREFLIGHT_ADC_TMPFILE deliberately UNSET → not
+  # preflight-injected → rank 1 fires.
+  cat >"$case_dir/case-env.sh" <<ENV
+export GOOGLE_APPLICATION_CREDENTIALS="$explicit_path"
+unset OP_PREFLIGHT_ADC_TMPFILE
+ENV
+}
+
+run_case_with_env \
+  "case0_explicit_gac_override" \
+  "source credential: explicit GOOGLE_APPLICATION_CREDENTIALS" \
+  "merge-path-test" \
+  provision_explicit_gac
+
 # ----------------------------------------------------------------------
 # Case 1 — project SA key present (rank 2 wins)
 # ----------------------------------------------------------------------
@@ -302,106 +495,6 @@ STUB
 export GOOGLE_APPLICATION_CREDENTIALS="$preflight_path"
 export OP_PREFLIGHT_ADC_TMPFILE="$preflight_path"
 ENV
-}
-
-# Variant of run_case that sources case-env.sh before invoking the script.
-# Lets us pass GOOGLE_APPLICATION_CREDENTIALS / OP_PREFLIGHT_ADC_TMPFILE
-# through env -i without clobbering them.
-run_case_with_env() {
-  local case_name="$1"
-  local expected_log_substring="$2"
-  local project="$3"
-  local provision="$4"
-  local case_dir="$SCRATCH_ROOT/$case_name"
-  local bin_dir="$case_dir/bin"
-  local tmp_dir="$case_dir/tmp"
-  local home_dir="$case_dir/home"
-
-  mkdir -p "$bin_dir" "$tmp_dir" "$home_dir/.config/gcloud"
-
-  cat >"$case_dir/.firebaserc" <<JSON
-{ "projects": { "default": "$project" } }
-JSON
-
-  cat >"$bin_dir/firebase" <<'STUB'
-#!/usr/bin/env bash
-echo "[stub-firebase] called with: $*" >&2
-exit 0
-STUB
-  chmod +x "$bin_dir/firebase"
-
-  cat >"$bin_dir/gcloud" <<'STUB'
-#!/usr/bin/env bash
-echo "[stub-gcloud] called with: $*" >&2
-exit 0
-STUB
-  chmod +x "$bin_dir/gcloud"
-
-  "$provision" "$case_dir" "$bin_dir" "$tmp_dir" "$home_dir" "$project"
-
-  local stderr_log="$case_dir/stderr.log"
-  local stdout_log="$case_dir/stdout.log"
-  local rc=0
-
-  # Wrap the invocation: source case-env.sh (if it exists), then exec
-  # the script. We still use env -i to enforce a hermetic baseline.
-  cat >"$case_dir/runner.sh" <<RUNNER
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$case_dir"
-if [ -f "$case_dir/case-env.sh" ]; then
-  # shellcheck disable=SC1090
-  source "$case_dir/case-env.sh"
-fi
-exec "$DEPLOY_SCRIPT"
-RUNNER
-  chmod +x "$case_dir/runner.sh"
-
-  (
-    env -i \
-      PATH="$bin_dir:$PYTHON3_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
-      HOME="$home_dir" \
-      TMPDIR="$tmp_dir" \
-      "$case_dir/runner.sh" \
-      >"$stdout_log" 2>"$stderr_log"
-  ) || rc=$?
-
-  local check_passed=true
-
-  if [ "$rc" -ne 0 ]; then
-    echo "  FAIL: $case_name — script exited rc=$rc (expected 0)"
-    echo "    stderr:"
-    sed 's/^/      /' "$stderr_log" >&2 || true
-    check_passed=false
-  fi
-
-  if ! grep -qF "$expected_log_substring" "$stderr_log"; then
-    echo "  FAIL: $case_name — stderr missing expected source-cred log"
-    echo "    expected substring: $expected_log_substring"
-    echo "    actual stderr:"
-    sed 's/^/      /' "$stderr_log" >&2 || true
-    check_passed=false
-  fi
-
-  # Tempfile cleanup: the script-written tempfiles (gcp-impersonated-*,
-  # firebase-sa-*, gcp-adc-*) must be gone. Note that for the preflight
-  # case, the preflight-adc.json file is provisioned BY THE TEST (not
-  # the script) and is allowed to survive — only files matching the
-  # script's mktemp patterns are checked.
-  local lingering
-  lingering="$(find "$tmp_dir" -type f 2>/dev/null | grep -E 'gcp-(adc|impersonated)-|firebase-sa-' || true)"
-  if [ -n "$lingering" ]; then
-    echo "  FAIL: $case_name — tempfiles leaked under $tmp_dir:"
-    echo "$lingering" | sed 's/^/      /' >&2
-    check_passed=false
-  fi
-
-  if $check_passed; then
-    echo "  PASS: $case_name — log='$expected_log_substring', tempfiles cleaned"
-    PASS=$((PASS + 1))
-  else
-    FAIL=$((FAIL + 1))
-  fi
 }
 
 run_case_with_env \

--- a/scripts/firebase/op-firebase-setup
+++ b/scripts/firebase/op-firebase-setup
@@ -177,16 +177,59 @@ if $PROVISION_SA_KEY; then
     # exit. The trap is scoped to this branch — installing it at the
     # top of the script would surprise callers in the impersonation-
     # only path (they have no tempfile to clean up).
+    #
+    # Trap also revokes the just-minted GCP key if the 1Password
+    # upload fails partway through. Without revoke-on-failure, a
+    # transient `op document create` error (stale auth, vault perms,
+    # network) would leave an active deployer-SA key in IAM that
+    # nothing local references — the tempfile gets wiped by the trap
+    # and the key is orphaned. Repeated failed provisioning runs
+    # would eventually hit GCP's 10-keys-per-SA limit and block all
+    # future minting. (codex P1 r1 on PR #302.)
     umask 077
     KEY_PATH="$(mktemp "${TMPDIR:-/tmp}/firebase-sa-key-XXXXXX.json")"
-    cleanup_key_tempfile() { rm -f "$KEY_PATH"; }
-    trap cleanup_key_tempfile EXIT
+    KEY_ID=""
+    UPLOAD_OK=false
+    cleanup_provision() {
+      local rc=$?
+      if ! $UPLOAD_OK && [ -n "$KEY_ID" ]; then
+        echo "Revoking just-minted key $KEY_ID (1Password upload did not complete)..." >&2
+        # Best-effort revoke. If the revoke itself fails (auth lost,
+        # network drop, IAM policy denial), surface the orphan KEY_ID
+        # for manual cleanup rather than silently swallowing the loss.
+        if ! gcloud iam service-accounts keys delete "$KEY_ID" \
+             --iam-account="$SA_EMAIL" \
+             --project="$PROJECT" \
+             --quiet 2>&1; then
+          echo "WARNING: Failed to revoke key $KEY_ID on $SA_EMAIL." >&2
+          echo "Manually revoke with:" >&2
+          echo "  gcloud iam service-accounts keys delete $KEY_ID \\" >&2
+          echo "    --iam-account=$SA_EMAIL --project=$PROJECT" >&2
+        else
+          echo "Revoked $KEY_ID." >&2
+        fi
+      fi
+      rm -f "$KEY_PATH"
+      return $rc
+    }
+    trap cleanup_provision EXIT
 
     echo "Minting SA key (requires iam.serviceAccountKeyAdmin on $PROJECT)..."
     gcloud iam service-accounts keys create "$KEY_PATH" \
       --iam-account="$SA_EMAIL" \
       --project="$PROJECT" \
       --quiet
+
+    # Capture the minted key's private_key_id so the trap can revoke
+    # it if upload fails. If extraction errors (malformed JSON, etc.),
+    # KEY_ID stays empty and the trap surfaces the orphan for manual
+    # cleanup rather than guessing at a key ID.
+    KEY_ID="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('private_key_id',''))" "$KEY_PATH" 2>/dev/null || true)"
+    if [ -z "$KEY_ID" ]; then
+      echo "WARNING: Could not extract private_key_id from minted SA key file." >&2
+      echo "If the upload below fails, manually list + revoke recent keys with:" >&2
+      echo "  gcloud iam service-accounts keys list --iam-account=$SA_EMAIL --project=$PROJECT" >&2
+    fi
 
     echo "Uploading to op://Firebase/$SA_KEY_OP_TITLE..."
     # `op document create` reads the file from disk. The title is
@@ -196,7 +239,10 @@ if $PROVISION_SA_KEY; then
       --vault Firebase \
       --title "$SA_KEY_OP_TITLE" >/dev/null
 
-    # Explicit wipe (the trap will also fire). Belt-and-braces.
+    UPLOAD_OK=true
+
+    # Explicit wipe (the trap will also fire on EXIT, but doing it
+    # eagerly here narrows the on-disk-key window).
     rm -f "$KEY_PATH"
     trap - EXIT
     echo "SA key uploaded and local tempfile wiped."

--- a/scripts/firebase/op-firebase-setup
+++ b/scripts/firebase/op-firebase-setup
@@ -1,14 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Set up keyless Firebase deploy auth for any project.
-# Creates a deployer service account, grants deploy roles, grants the current
-# principal permission to impersonate it, and creates a dedicated gcloud config
-# with explicit quota attribution for the target project.
+# Set up Firebase deploy auth for any project.
+#
+# Default behavior creates a deployer service account, grants deploy
+# roles, grants the current principal permission to impersonate it,
+# and creates a dedicated gcloud config with explicit quota
+# attribution for the target project. This is the keyless
+# impersonation path — historically the only path this script set up.
+#
+# With `--provision-sa-key`, the script also mints a JSON key for the
+# deployer SA, uploads it to the 1Password Firebase vault as
+# `op://Firebase/{project-id} — Firebase Deployer SA Key`, and wipes
+# the local copy. The SA key is the standard day-to-day deploy
+# credential per DEPLOYMENT.md § Deploy credential precedence
+# (canonical) (#154). Provisioning is opt-in to preserve the prior
+# behavior contract and to keep key minting an explicit human
+# decision — see DEPLOYMENT.md § Secrets Management for the trade-off.
 #
 # Usage:
-#   op-firebase-setup                    # auto-detect project from .firebaserc
-#   op-firebase-setup my-project-id      # explicit project ID
+#   op-firebase-setup                              # auto-detect project, impersonation only
+#   op-firebase-setup my-project-id                # explicit project ID, impersonation only
+#   op-firebase-setup --provision-sa-key           # also mint + upload SA key to 1Password
+#   op-firebase-setup my-project --provision-sa-key
 
 SA_NAME="firebase-deployer"
 MEMBER_EMAIL="${FIREBASE_IMPERSONATION_MEMBER:-}"
@@ -21,18 +35,50 @@ ROLES=(
 )
 
 PROJECT=""
-if [[ "${1:-}" != "" ]]; then
-  PROJECT="$1"
-elif [[ -f .firebaserc ]]; then
-  PROJECT="$(python3 -c "import json; print(json.load(open('.firebaserc'))['projects']['default'])")"
-else
-  echo "Error: No project specified and no .firebaserc found." >&2
-  echo "Usage: op-firebase-setup [project-id]" >&2
-  exit 1
+PROVISION_SA_KEY=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --provision-sa-key)
+      PROVISION_SA_KEY=true
+      ;;
+    --no-provision-sa-key)
+      PROVISION_SA_KEY=false
+      ;;
+    --help|-h)
+      sed -n '3,25p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    --*)
+      echo "Error: unknown flag: $arg" >&2
+      echo "Usage: op-firebase-setup [project-id] [--provision-sa-key]" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -z "$PROJECT" ]]; then
+        PROJECT="$arg"
+      else
+        echo "Error: unexpected positional argument: $arg" >&2
+        echo "Usage: op-firebase-setup [project-id] [--provision-sa-key]" >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$PROJECT" ]]; then
+  if [[ -f .firebaserc ]]; then
+    PROJECT="$(python3 -c "import json; print(json.load(open('.firebaserc'))['projects']['default'])")"
+  else
+    echo "Error: No project specified and no .firebaserc found." >&2
+    echo "Usage: op-firebase-setup [project-id] [--provision-sa-key]" >&2
+    exit 1
+  fi
 fi
 
 SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
 CONFIG_NAME="${PROJECT}"
+SA_KEY_OP_TITLE="${PROJECT} — Firebase Deployer SA Key"
 
 if [[ -z "${MEMBER_EMAIL}" ]]; then
   MEMBER_EMAIL="$(gcloud config get-value account 2>/dev/null || true)"
@@ -44,11 +90,25 @@ if [[ -z "${MEMBER_EMAIL}" ]]; then
   exit 1
 fi
 
+# Preflight 1Password CLI availability when SA-key provisioning is
+# requested. Fail fast so the user doesn't get through the IAM setup
+# and then discover the upload can't run.
+if $PROVISION_SA_KEY && ! command -v op >/dev/null 2>&1; then
+  echo "Error: --provision-sa-key requires the 1Password CLI (op) on PATH." >&2
+  echo "Install op (https://1password.com/downloads/command-line/) or re-run without --provision-sa-key." >&2
+  exit 1
+fi
+
 echo ""
 echo "Project:           $PROJECT"
 echo "Service account:   $SA_EMAIL"
 echo "Impersonation via: user:${MEMBER_EMAIL}"
 echo "gcloud config:     $CONFIG_NAME"
+if $PROVISION_SA_KEY; then
+  echo "Provision SA key:  yes (upload to op://Firebase/$SA_KEY_OP_TITLE)"
+else
+  echo "Provision SA key:  no (impersonation only; pass --provision-sa-key to mint + upload)"
+fi
 echo ""
 
 # 1. Enable IAMCredentials API for impersonation
@@ -97,10 +157,65 @@ gcloud config set auth/impersonate_service_account "$SA_EMAIL" --configuration="
 gcloud config set billing/quota_project "$PROJECT" --configuration="$CONFIG_NAME" >/dev/null
 echo "Configured gcloud impersonation and quota attribution for $CONFIG_NAME."
 
+# 6. (Optional) Mint and upload the deployer SA key to 1Password.
+#    Implements the previously-manual procedure documented under
+#    DEPLOYMENT.md § Provisioning the Firebase-vault SA key, gated
+#    behind --provision-sa-key so existing setup runs are unchanged.
+if $PROVISION_SA_KEY; then
+  echo ""
+  echo "Provisioning Firebase-vault SA key (--provision-sa-key)..."
+
+  # If an item with the canonical title already exists, refuse to
+  # double-provision silently. Operators rotating a key should follow
+  # the rotation procedure (DEPLOYMENT.md § Rotating a Firebase deploy
+  # SA key), not re-run setup.
+  if op item get "$SA_KEY_OP_TITLE" --vault Firebase >/dev/null 2>&1; then
+    echo "Skipping SA-key provisioning: item already exists in op://Firebase/$SA_KEY_OP_TITLE." >&2
+    echo "To rotate, follow DEPLOYMENT.md § Rotating a Firebase deploy SA key." >&2
+  else
+    # Mint into a chmod-600 tempfile we delete unconditionally on
+    # exit. The trap is scoped to this branch — installing it at the
+    # top of the script would surprise callers in the impersonation-
+    # only path (they have no tempfile to clean up).
+    umask 077
+    KEY_PATH="$(mktemp "${TMPDIR:-/tmp}/firebase-sa-key-XXXXXX.json")"
+    cleanup_key_tempfile() { rm -f "$KEY_PATH"; }
+    trap cleanup_key_tempfile EXIT
+
+    echo "Minting SA key (requires iam.serviceAccountKeyAdmin on $PROJECT)..."
+    gcloud iam service-accounts keys create "$KEY_PATH" \
+      --iam-account="$SA_EMAIL" \
+      --project="$PROJECT" \
+      --quiet
+
+    echo "Uploading to op://Firebase/$SA_KEY_OP_TITLE..."
+    # `op document create` reads the file from disk. The title is
+    # exactly what materialize_firebase_vault_sa_key in op-firebase-
+    # deploy reads — keep them in sync.
+    op document create "$KEY_PATH" \
+      --vault Firebase \
+      --title "$SA_KEY_OP_TITLE" >/dev/null
+
+    # Explicit wipe (the trap will also fire). Belt-and-braces.
+    rm -f "$KEY_PATH"
+    trap - EXIT
+    echo "SA key uploaded and local tempfile wiped."
+  fi
+fi
+
 echo ""
 echo "Setup complete."
 echo ""
 echo "Next steps:"
 echo "  gcloud config configurations activate $CONFIG_NAME"
-echo "  op-firebase-deploy      # keyless deploy via impersonation"
+if $PROVISION_SA_KEY; then
+  echo "  op-firebase-deploy      # uses project Firebase-vault SA key (rank 2)"
+else
+  echo "  op-firebase-deploy      # uses keyless impersonation (no SA key provisioned)"
+  echo ""
+  echo "  To switch to the stable SA-key-first deploy path (recommended for"
+  echo "  routine deploys — avoids the #137 firebase login --reauth churn),"
+  echo "  re-run with --provision-sa-key, or follow DEPLOYMENT.md"
+  echo "  § Provisioning the Firebase-vault SA key."
+fi
 echo ""


### PR DESCRIPTION
Closes the two remaining code-side gaps from #154's [close-out plan-update](https://github.com/nathanjohnpayne/mergepath/issues/154#issuecomment-2895341760):

1. **`op-firebase-setup --provision-sa-key`.** The setup script now optionally mints the deployer SA key and uploads it to `op://Firebase/{project-id} — Firebase Deployer SA Key` inside the same attended invocation, folding the previously-manual `DEPLOYMENT.md` block into the script. Opt-in so the prior impersonation-only contract is preserved. Refuses to overwrite an existing 1Password item with the canonical title (rotation is a separate procedure per `DEPLOYMENT.md § Rotating a Firebase deploy SA key`).

2. **Rank-1 resolver test.** `scripts/ci/check_op_firebase_deploy_integration` gains Case 0 for genuinely user-supplied `GOOGLE_APPLICATION_CREDENTIALS`. The case provisions a project SA key that WOULD win at rank 2 if rank 1 didn't fire — so the assertion on the "explicit GOOGLE_APPLICATION_CREDENTIALS" log line proves the ordering, not just that rank 1 produces *some* log. The usability-fallback walk is documented as deliberately excluded (SA-shortcut + outbound-network requirement makes deterministic CI coverage impractical; #211 live verification exercises it).

3. **DEPLOYMENT.md.** § First-Time Setup step 4-5 + § Provisioning the Firebase-vault SA key + Changelog updated to lead with the flag.

Authoring-Agent: claude

## Test plan

- [x] `MERGEPATH_RUN_INTEGRATION=1 bash scripts/ci/check_op_firebase_deploy_integration` — 5/5 cases pass locally
- [x] `bash -n scripts/firebase/op-firebase-setup` — clean
- [x] `bash scripts/ci/check_ci_scripts_wired` — 33 check_* scripts, all wired or exempt (integration check stays WIRED-EXEMPT)
- [x] `bash scripts/ci/check_mktemp_portability` — clean (setup script uses portable `mktemp "${TMPDIR:-/tmp}/firebase-sa-key-XXXXXX.json"` form, no `mktemp -t`)
- [x] `bash scripts/ci/check_sync_manifest` — clean
- [ ] CI: required workflows pass
- [ ] Live `op-firebase-setup --provision-sa-key` run on a real consumer repo (deferred to #211 — needs the same human-attended verification window)

## Self-Review

**Correctness.** Smoke test exercises all 5 ranks end-to-end with shimmed `op`/`firebase`/`gcloud`. Rank 1 case has a project SA key reachable via `op`, which would win at rank 2 — the log-line assertion proves rank 1 outranks rank 2.

**Regression risk.** Low. `op-firebase-setup` without flags is behavior-identical to the prior version — same 5 IAM steps, same exit codes, same "Next steps:" output (with a more helpful nudge about the SA-key option). `--provision-sa-key` short-circuits with a clear error if `op` is missing (preflight check, before any IAM work) and refuses to clobber an existing 1Password item. Integration check gains a case; existing 4 cases unchanged.

**Style.** Matches surrounding scripts: `set -euo pipefail`, `umask 077` for tempfiles, trap-on-EXIT cleanup, portable `mktemp`. Argument parser handles `--help`, unknown flags fail closed, single positional project ID. Logged source-credential descriptor format unchanged.

**Test coverage.** Rank 1 now covered. Ranks 2-5 still covered. Usability-fallback walk explicitly documented as out-of-scope for hermetic CI and reserved for #211 live verification.

**Security/dependency hygiene.** No new dependencies. SA-key provisioning path uses `umask 077` for the tempfile, scopes the cleanup trap to the provisioning branch only (avoids surprising the impersonation-only path), runs an explicit `rm -f` after upload, and clears the trap afterward (belt-and-braces). Refuses to overwrite an existing 1Password item — accidental re-runs can't shadow a rotated key. `op-firebase-deploy`'s resolver is unchanged.

Refs #154, #211.
