### PR TITLE
feat: daily deferred-feedback rollup workflow + classifier (#299 v1)

### DIFF
--- a/.github/workflows/daily-feedback-rollup.yml
+++ b/.github/workflows/daily-feedback-rollup.yml
@@ -1,0 +1,90 @@
+name: Daily deferred-feedback rollup
+
+# Daily end-of-day rollup of bot-review threads that were resolved on
+# yesterday's PRs without an associated fix commit or substantive
+# reply. Complements weekly-feedback-sweep.yml (which catches
+# longer-tail residuals on still-open PRs); this catches the
+# deferred-and-forgotten class while the agent's context is still
+# fresh. See mergepath#299.
+#
+# Auth model:
+#   - Same-repo reads + writes. GITHUB_TOKEN works for both, but
+#     REVIEWER_ASSIGNMENT_TOKEN (the nathanpayne-claude PAT already
+#     wired for weekly sweep) keeps the issue byline showing the
+#     agent identity instead of github-actions[bot].
+#
+# Idempotency:
+#   - daily-feedback-rollup.sh's self-throttling appends to the
+#     most-recently-opened track issue if that issue has ≥ N
+#     unchecked items, rather than opening a new one every day.
+#     v1 dedupe-against-prior-triaged-items is a documented follow-up.
+#   - Re-running on the same day for the same window posts a second
+#     issue (NOT idempotent yet — also a documented follow-up).
+
+on:
+  schedule:
+    # 55 23 * * *: 23:55 UTC daily = 4:55pm Pacific / 7:55pm Eastern,
+    # late enough to capture the day's merges but before the working-
+    # memory rolls over for that day's agent sessions.
+    - cron: '55 23 * * *'
+  workflow_dispatch:
+    inputs:
+      since:
+        description: 'Window start (YYYY-MM-DD, UTC). Default: yesterday.'
+        required: false
+      until:
+        description: 'Window end (YYYY-MM-DD, UTC). Default: today.'
+        required: false
+      dry_run:
+        description: 'If true, print NDJSON to logs and skip issue mutation.'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  rollup:
+    name: Classify + post rollup issues
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Ensure jq + gh present
+        run: |
+          for dep in gh jq shasum; do
+            if ! command -v "$dep" >/dev/null 2>&1; then
+              echo "ERROR: $dep not installed on runner" >&2
+              exit 1
+            fi
+          done
+
+      - name: Run rollup
+        env:
+          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "ERROR: REVIEWER_ASSIGNMENT_TOKEN secret is empty. Daily rollup cannot run without a cross-repo-capable PAT." >&2
+            echo "       Set the secret in repo Settings → Secrets and variables → Actions." >&2
+            exit 1
+          fi
+
+          ARGS=()
+          if [ -n "${{ github.event.inputs.since }}" ]; then
+            ARGS+=(--since "${{ github.event.inputs.since }}")
+          fi
+          if [ -n "${{ github.event.inputs.until }}" ]; then
+            ARGS+=(--until "${{ github.event.inputs.until }}")
+          fi
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+
+          chmod +x scripts/daily-feedback-rollup.sh
+          scripts/daily-feedback-rollup.sh "${ARGS[@]+"${ARGS[@]}"}"

--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -99,6 +99,15 @@ jobs:
       - name: check_codex_scripts
         run: ./scripts/ci/check_codex_scripts
 
+      - name: check_daily_feedback_rollup
+        # Pure-function helpers + a 3-case shimmed --dry-run smoke
+        # over scripts/daily-feedback-rollup.sh (#299 v1 slice).
+        # Hermetic — uses a gh stub + canned GraphQL fixture; no
+        # network. The full rollup integration (actually firing the
+        # workflow against live PRs) is exercised once daily via
+        # the cron in .github/workflows/daily-feedback-rollup.yml.
+        run: ./scripts/ci/check_daily_feedback_rollup
+
       - name: check_canonical_bugs_263caf3
         # Regression coverage for two nathanpayne-codex Phase 4b
         # findings on the 263caf3 propagation wave:

--- a/scripts/ci/check_daily_feedback_rollup
+++ b/scripts/ci/check_daily_feedback_rollup
@@ -80,7 +80,8 @@ cat >"$FIXTURES/threads.json" <<'JSON'
         "headRefOid": "head_sha_xxxxxxxxxxxxxxxxxxxxxx",
         "commits": {
           "nodes": [
-            { "commit": { "oid": "head_sha_xxxxxxxxxxxxxxxxxxxxxx", "authoredDate": "2026-05-15T10:00:00Z", "author": { "user": { "login": "nathanjohnpayne" } } } }
+            { "commit": { "oid": "commit_early_xxxxxxxxxxxxxxxxxxx", "authoredDate": "2026-05-15T07:00:00Z", "author": { "user": { "login": "nathanjohnpayne" } } } },
+            { "commit": { "oid": "head_sha_xxxxxxxxxxxxxxxxxxxxxx", "authoredDate": "2026-05-15T07:30:00Z", "author": { "user": { "login": "nathanjohnpayne" } } } }
           ]
         },
         "reviewThreads": {
@@ -176,9 +177,29 @@ cat >"$FIXTURES/threads.json" <<'JSON'
                     "databaseId": 6,
                     "author": { "login": "chatgpt-codex-connector[bot]" },
                     "body": "**![P1 Badge]** Stale finding — original commit was force-pushed away.",
-                    "createdAt": "2026-05-15T07:00:00Z",
+                    "createdAt": "2026-05-15T08:30:00Z",
                     "originalCommit": { "oid": "DEADBEEF_not_in_commits_list" },
                     "url": "https://github.com/owner/repo/pull/999#discussion_r6"
+                  }
+                ]
+              }
+            },
+            {
+              "id": "PRT_thread_e",
+              "isResolved": true,
+              "isOutdated": false,
+              "path": "scripts/e.sh",
+              "line": 50,
+              "originalLine": 50,
+              "comments": {
+                "nodes": [
+                  {
+                    "databaseId": 7,
+                    "author": { "login": "chatgpt-codex-connector[bot]" },
+                    "body": "**![P1 Badge]** Race condition addressed by a later fix-commit, no reply or tag.",
+                    "createdAt": "2026-05-15T05:00:00Z",
+                    "originalCommit": { "oid": "commit_early_xxxxxxxxxxxxxxxxxxx" },
+                    "url": "https://github.com/owner/repo/pull/999#discussion_r7"
                   }
                 ]
               }
@@ -264,7 +285,7 @@ fi
 # Assertions on the NDJSON output.
 LINES=$(wc -l < "$OUT_FILE" | tr -d ' ')
 if [ "$LINES" -ne 2 ]; then
-  echo "FAIL: expected 2 NDJSON lines (A substantive + C polish; B reply-skipped, D stale-skipped), got $LINES" >&2
+  echo "FAIL: expected 2 NDJSON lines (A substantive + C polish; B reply-skipped, D stale-skipped, E fix-skipped), got $LINES" >&2
   cat "$OUT_FILE" >&2
   echo "  stderr:" >&2
   sed 's/^/    /' "$ERR_FILE" >&2
@@ -303,6 +324,17 @@ if grep -q '"thread_id":"PRT_thread_d"' "$OUT_FILE"; then
   exit 1
 fi
 
+# Thread E — must be FILTERED (addressed-via-fix: agent-author
+# commits at 07:00 + 07:30 are both AFTER the comment's createdAt of
+# 05:00). Validates the per-PR fix-commit heuristic that closes the
+# codex P1 r1 finding on this PR. The other threads' createdAts
+# (08:00+) are AFTER both commits, so the fix-gate doesn't fire for
+# them — keeping the substantive/polish routing assertions intact.
+if grep -q '"thread_id":"PRT_thread_e"' "$OUT_FILE"; then
+  echo "FAIL: thread E (addressed-via-fix: agent commit after comment) should be filtered out" >&2
+  exit 1
+fi
+
 # Thread C — polish (P3, tagged nitpick-noted)
 if ! grep -q '"thread_id":"PRT_thread_c"' "$OUT_FILE"; then
   echo "FAIL: thread C (tagged nitpick-noted P3) missing from output" >&2
@@ -326,5 +358,5 @@ if ! grep -oE '"item_id":"[a-f0-9]{12}"' "$OUT_FILE" | head -1 >/dev/null; then
   exit 1
 fi
 
-echo "check_daily_feedback_rollup: PASS (unit tests + 4-case --dry-run smoke)"
+echo "check_daily_feedback_rollup: PASS (unit tests + 5-case --dry-run smoke)"
 exit 0

--- a/scripts/ci/check_daily_feedback_rollup
+++ b/scripts/ci/check_daily_feedback_rollup
@@ -78,7 +78,11 @@ cat >"$FIXTURES/threads.json" <<'JSON'
     "repository": {
       "pullRequest": {
         "headRefOid": "head_sha_xxxxxxxxxxxxxxxxxxxxxx",
-        "commits": { "nodes": [] },
+        "commits": {
+          "nodes": [
+            { "commit": { "oid": "head_sha_xxxxxxxxxxxxxxxxxxxxxx", "authoredDate": "2026-05-15T10:00:00Z", "author": { "user": { "login": "nathanjohnpayne" } } } }
+          ]
+        },
         "reviewThreads": {
           "totalCount": 3,
           "pageInfo": { "hasNextPage": false, "endCursor": null },
@@ -155,6 +159,26 @@ cat >"$FIXTURES/threads.json" <<'JSON'
                     "createdAt": "2026-05-15T09:30:00Z",
                     "originalCommit": null,
                     "url": "https://github.com/owner/repo/pull/999#discussion_r5"
+                  }
+                ]
+              }
+            },
+            {
+              "id": "PRT_thread_d",
+              "isResolved": true,
+              "isOutdated": true,
+              "path": "scripts/d.sh",
+              "line": 40,
+              "originalLine": 40,
+              "comments": {
+                "nodes": [
+                  {
+                    "databaseId": 6,
+                    "author": { "login": "chatgpt-codex-connector[bot]" },
+                    "body": "**![P1 Badge]** Stale finding — original commit was force-pushed away.",
+                    "createdAt": "2026-05-15T07:00:00Z",
+                    "originalCommit": { "oid": "DEADBEEF_not_in_commits_list" },
+                    "url": "https://github.com/owner/repo/pull/999#discussion_r6"
                   }
                 ]
               }
@@ -240,7 +264,7 @@ fi
 # Assertions on the NDJSON output.
 LINES=$(wc -l < "$OUT_FILE" | tr -d ' ')
 if [ "$LINES" -ne 2 ]; then
-  echo "FAIL: expected 2 NDJSON lines, got $LINES" >&2
+  echo "FAIL: expected 2 NDJSON lines (A substantive + C polish; B reply-skipped, D stale-skipped), got $LINES" >&2
   cat "$OUT_FILE" >&2
   echo "  stderr:" >&2
   sed 's/^/    /' "$ERR_FILE" >&2
@@ -268,6 +292,17 @@ if grep -q '"thread_id":"PRT_thread_b"' "$OUT_FILE"; then
   exit 1
 fi
 
+# Thread D — must be FILTERED (stale-head: originalCommit not in
+# commits.nodes). Locks in the regression fix: the prior naive
+# `orig_commit != head_oid` check would have incorrectly classified
+# Thread A (whose originalCommit matches headRefOid) as in-history
+# AND Thread D as stale; the new membership check produces the same
+# result for D but stops mis-classifying intermediate-commit threads.
+if grep -q '"thread_id":"PRT_thread_d"' "$OUT_FILE"; then
+  echo "FAIL: thread D (stale-head, originalCommit not in commits list) should be filtered out" >&2
+  exit 1
+fi
+
 # Thread C — polish (P3, tagged nitpick-noted)
 if ! grep -q '"thread_id":"PRT_thread_c"' "$OUT_FILE"; then
   echo "FAIL: thread C (tagged nitpick-noted P3) missing from output" >&2
@@ -291,5 +326,5 @@ if ! grep -oE '"item_id":"[a-f0-9]{12}"' "$OUT_FILE" | head -1 >/dev/null; then
   exit 1
 fi
 
-echo "check_daily_feedback_rollup: PASS (unit tests + 3-case --dry-run smoke)"
+echo "check_daily_feedback_rollup: PASS (unit tests + 4-case --dry-run smoke)"
 exit 0

--- a/scripts/ci/check_daily_feedback_rollup
+++ b/scripts/ci/check_daily_feedback_rollup
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# check_daily_feedback_rollup
+#
+# Structural check for scripts/daily-feedback-rollup.sh (mergepath#299).
+#
+# Two layers:
+#
+#   1. Run the paired unit tests in tests/test_daily_feedback_rollup.sh
+#      (pure-function coverage of classify_severity / severity_to_track
+#      / item_id_for / extract_tag_class / tag_class_action /
+#      is_agent_author / body_excerpt — 46 cases as of this writing).
+#
+#   2. Run the rollup script's `--dry-run` mode against a `gh`-shimmed
+#      scratch environment with canned fixture responses. Asserts the
+#      end-to-end classification + routing path produces the expected
+#      NDJSON items.
+#
+# Both layers run under hermetic PATH so the script's gh / jq / shasum
+# calls resolve to the shim or to the runner's tools rather than a
+# user-installed alternative.
+#
+# Bash 3.2 compatible (macOS default + ubuntu-latest).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/daily-feedback-rollup.sh"
+UNIT_TEST="$ROOT/tests/test_daily_feedback_rollup.sh"
+
+[ -x "$SCRIPT" ] || { echo "missing or non-executable $SCRIPT" >&2; exit 1; }
+[ -x "$UNIT_TEST" ] || { echo "missing or non-executable $UNIT_TEST" >&2; exit 1; }
+
+# ---------------------------------------------------------------------
+# Layer 1 — unit tests
+# ---------------------------------------------------------------------
+
+echo "check_daily_feedback_rollup: running unit tests"
+if ! bash "$UNIT_TEST" >&2; then
+  echo "check_daily_feedback_rollup: FAIL — unit tests did not pass" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------
+# Layer 2 — shimmed integration smoke
+# ---------------------------------------------------------------------
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/check-daily-feedback-XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+BIN="$WORKDIR/bin"
+mkdir -p "$BIN"
+FIXTURES="$WORKDIR/fixtures"
+mkdir -p "$FIXTURES"
+
+# ----- Fixture: one merged PR with three resolved threads -----
+#
+# Thread A: chatgpt-codex-connector P1 finding, no fix, no reply →
+#   classify as deferred-untagged, route to substantive.
+# Thread B: coderabbitai Nitpick, agent posted a 50-char substantive
+#   reply → classify as addressed-via-reply, skip.
+# Thread C: chatgpt-codex-connector P3 with a `[mergepath-resolve:
+#   nitpick-noted]` reply → tagged, route to polish.
+
+cat >"$FIXTURES/prs.json" <<'JSON'
+[
+  {
+    "number": 999,
+    "title": "test PR",
+    "url": "https://github.com/owner/repo/pull/999",
+    "mergedAt": "2026-05-15T12:00:00Z"
+  }
+]
+JSON
+
+cat >"$FIXTURES/threads.json" <<'JSON'
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "headRefOid": "head_sha_xxxxxxxxxxxxxxxxxxxxxx",
+        "commits": { "nodes": [] },
+        "reviewThreads": {
+          "totalCount": 3,
+          "pageInfo": { "hasNextPage": false, "endCursor": null },
+          "nodes": [
+            {
+              "id": "PRT_thread_a",
+              "isResolved": true,
+              "isOutdated": false,
+              "path": "scripts/a.sh",
+              "line": 10,
+              "originalLine": 10,
+              "comments": {
+                "nodes": [
+                  {
+                    "databaseId": 1,
+                    "author": { "login": "chatgpt-codex-connector[bot]" },
+                    "body": "**![P1 Badge]** Critical race condition. Fix before merge.",
+                    "createdAt": "2026-05-15T08:00:00Z",
+                    "originalCommit": { "oid": "head_sha_xxxxxxxxxxxxxxxxxxxxxx" },
+                    "url": "https://github.com/owner/repo/pull/999#discussion_r1"
+                  }
+                ]
+              }
+            },
+            {
+              "id": "PRT_thread_b",
+              "isResolved": true,
+              "isOutdated": false,
+              "path": "scripts/b.sh",
+              "line": 20,
+              "originalLine": 20,
+              "comments": {
+                "nodes": [
+                  {
+                    "databaseId": 2,
+                    "author": { "login": "coderabbitai[bot]" },
+                    "body": "_🧹 Nitpick (assertive)_ minor style suggestion here.",
+                    "createdAt": "2026-05-15T08:10:00Z",
+                    "originalCommit": { "oid": "head_sha_xxxxxxxxxxxxxxxxxxxxxx" },
+                    "url": "https://github.com/owner/repo/pull/999#discussion_r2"
+                  },
+                  {
+                    "databaseId": 3,
+                    "author": { "login": "nathanpayne-claude" },
+                    "body": "Acknowledged — addressed in commit abc1234 with the renamed variable per the suggestion.",
+                    "createdAt": "2026-05-15T09:00:00Z",
+                    "originalCommit": null,
+                    "url": "https://github.com/owner/repo/pull/999#discussion_r3"
+                  }
+                ]
+              }
+            },
+            {
+              "id": "PRT_thread_c",
+              "isResolved": true,
+              "isOutdated": false,
+              "path": "scripts/c.sh",
+              "line": 30,
+              "originalLine": 30,
+              "comments": {
+                "nodes": [
+                  {
+                    "databaseId": 4,
+                    "author": { "login": "chatgpt-codex-connector[bot]" },
+                    "body": "**![P3 Badge]** Polish suggestion — consider extracting a helper.",
+                    "createdAt": "2026-05-15T08:20:00Z",
+                    "originalCommit": { "oid": "head_sha_xxxxxxxxxxxxxxxxxxxxxx" },
+                    "url": "https://github.com/owner/repo/pull/999#discussion_r4"
+                  },
+                  {
+                    "databaseId": 5,
+                    "author": { "login": "nathanpayne-claude" },
+                    "body": "[mergepath-resolve: nitpick-noted] Noted; not worth a refactor for a one-line helper.",
+                    "createdAt": "2026-05-15T09:30:00Z",
+                    "originalCommit": null,
+                    "url": "https://github.com/owner/repo/pull/999#discussion_r5"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+JSON
+
+# ----- gh shim — dispatches on argv -----
+cat >"$BIN/gh" <<STUB
+#!/usr/bin/env bash
+# Minimal gh stub for check_daily_feedback_rollup. Only the calls the
+# rollup script makes in --dry-run mode are handled.
+case "\$1" in
+  repo)
+    # gh repo view --json owner,name --jq ...
+    printf '%s\n' "owner/repo"
+    exit 0
+    ;;
+  pr)
+    # gh pr list ...
+    cat "$FIXTURES/prs.json"
+    exit 0
+    ;;
+  api)
+    # gh api graphql -f query='...' -F owner=... -F name=... -F pr=999
+    # (we don't introspect the query — just return the fixture)
+    cat "$FIXTURES/threads.json"
+    exit 0
+    ;;
+  *)
+    echo "[gh-stub] unhandled: \$*" >&2
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "$BIN/gh"
+
+# Capture python3/jq/shasum locations so the hermetic PATH below
+# resolves them. python3 isn't used by the rollup script directly but
+# shasum is.
+PYTHON3_DIR="$(cd "$(dirname "$(command -v python3 2>/dev/null || echo /bin/true)")" && pwd -P 2>/dev/null || echo /usr/bin)"
+JQ_DIR="$(cd "$(dirname "$(command -v jq)")" && pwd -P)"
+SHASUM_DIR="$(cd "$(dirname "$(command -v shasum)")" && pwd -P)"
+
+# Build a PATH that includes the shim, the runner tool paths, and the
+# minimal system dirs. env -i strips everything else.
+STUB_PATH="$BIN:$JQ_DIR:$SHASUM_DIR"
+if [ "$PYTHON3_DIR" != "/usr/bin" ]; then
+  STUB_PATH="$STUB_PATH:$PYTHON3_DIR"
+fi
+STUB_PATH="$STUB_PATH:/usr/bin:/bin:/usr/sbin:/sbin"
+
+echo "check_daily_feedback_rollup: running --dry-run against fixture"
+
+OUT_FILE="$WORKDIR/dry-run.ndjson"
+ERR_FILE="$WORKDIR/dry-run.err"
+
+set +e
+env -i \
+  PATH="$STUB_PATH" \
+  HOME="$WORKDIR" \
+  TMPDIR="$WORKDIR" \
+  GH_TOKEN="stub-token" \
+  REPO="owner/repo" \
+  ROLLUP_AGENT_AUTHORS="nathanjohnpayne:nathanpayne-claude" \
+  "$SCRIPT" --dry-run --since 2026-05-15 --until 2026-05-16 \
+  >"$OUT_FILE" 2>"$ERR_FILE"
+RC=$?
+set -e
+
+if [ "$RC" -ne 0 ]; then
+  echo "FAIL: --dry-run exited rc=$RC" >&2
+  echo "  stderr:" >&2
+  sed 's/^/    /' "$ERR_FILE" >&2 || true
+  exit 1
+fi
+
+# Assertions on the NDJSON output.
+LINES=$(wc -l < "$OUT_FILE" | tr -d ' ')
+if [ "$LINES" -ne 2 ]; then
+  echo "FAIL: expected 2 NDJSON lines, got $LINES" >&2
+  cat "$OUT_FILE" >&2
+  echo "  stderr:" >&2
+  sed 's/^/    /' "$ERR_FILE" >&2
+  exit 1
+fi
+
+# Thread A — substantive (P1, untagged)
+if ! grep -q '"thread_id":"PRT_thread_a"' "$OUT_FILE"; then
+  echo "FAIL: thread A (P1 untagged) missing from output" >&2
+  cat "$OUT_FILE" >&2
+  exit 1
+fi
+if ! grep '"thread_id":"PRT_thread_a"' "$OUT_FILE" | grep -q '"track":"substantive"'; then
+  echo "FAIL: thread A should route to substantive (P1)" >&2
+  exit 1
+fi
+if ! grep '"thread_id":"PRT_thread_a"' "$OUT_FILE" | grep -q '"severity":"P1"'; then
+  echo "FAIL: thread A should classify as P1" >&2
+  exit 1
+fi
+
+# Thread B — must be FILTERED (substantive reply from agent)
+if grep -q '"thread_id":"PRT_thread_b"' "$OUT_FILE"; then
+  echo "FAIL: thread B (addressed-via-reply) should be filtered out" >&2
+  exit 1
+fi
+
+# Thread C — polish (P3, tagged nitpick-noted)
+if ! grep -q '"thread_id":"PRT_thread_c"' "$OUT_FILE"; then
+  echo "FAIL: thread C (tagged nitpick-noted P3) missing from output" >&2
+  cat "$OUT_FILE" >&2
+  exit 1
+fi
+if ! grep '"thread_id":"PRT_thread_c"' "$OUT_FILE" | grep -q '"track":"polish"'; then
+  echo "FAIL: thread C should route to polish (P3)" >&2
+  exit 1
+fi
+if ! grep '"thread_id":"PRT_thread_c"' "$OUT_FILE" | grep -q '"tag_note":"tagged: nitpick-noted"'; then
+  echo "FAIL: thread C should carry the canonical tag note" >&2
+  grep '"thread_id":"PRT_thread_c"' "$OUT_FILE" >&2
+  exit 1
+fi
+
+# Stable item IDs must be present + 12 chars
+if ! grep -oE '"item_id":"[a-f0-9]{12}"' "$OUT_FILE" | head -1 >/dev/null; then
+  echo "FAIL: item_id markers missing or wrong shape" >&2
+  cat "$OUT_FILE" >&2
+  exit 1
+fi
+
+echo "check_daily_feedback_rollup: PASS (unit tests + 3-case --dry-run smoke)"
+exit 0

--- a/scripts/daily-feedback-rollup.sh
+++ b/scripts/daily-feedback-rollup.sh
@@ -500,7 +500,36 @@ if $DRY_RUN; then
   if [ -s "$POLISH_NDJSON" ]; then
     cat "$POLISH_NDJSON"
   fi
+  # Dry-run still surfaces per-PR failures via exit code so the
+  # operator inspecting `--dry-run` output sees the same "this run
+  # is incomplete" signal a non-dry run would emit.
+  if [ "$FAILED_PR_COUNT" -gt 0 ]; then
+    echo "daily-feedback-rollup: WARN — $FAILED_PR_COUNT PR(s) failed to fetch threads in this dry run (PRs: $FAILED_PR_LIST)." >&2
+    exit 2
+  fi
   exit 0
+fi
+
+# ---------------------------------------------------------------------
+# Atomicity gate — abort BEFORE posting if any per-PR fetch failed.
+# ---------------------------------------------------------------------
+#
+# Posting partial rollups and then exiting 2 is worse than not posting
+# at all: with v1 dedupe-against-prior-rollups deferred, the operator's
+# retry on the same --since/--until window would create a duplicate
+# (or overlapping) rollup issue, doubling triage cost. Total atomicity
+# — either all-or-nothing — keeps the rollup-output contract intact.
+#
+# The operator's recovery path: retry the same `workflow_dispatch
+# --since X --until X` invocation once the API recovers. The classifier
+# is stateless and idempotent w.r.t. inputs, so the retry produces
+# the complete window's data exactly once.
+#
+# (codex Phase 4b r2 on PR #303.)
+if [ "$FAILED_PR_COUNT" -gt 0 ]; then
+  echo "daily-feedback-rollup: ERROR — $FAILED_PR_COUNT PR(s) failed to fetch threads (PRs: $FAILED_PR_LIST)." >&2
+  echo "daily-feedback-rollup: Aborting WITHOUT posting any rollup issues. Re-run with the same --since/--until once the API recovers to produce a complete rollup." >&2
+  exit 2
 fi
 
 # ---------------------------------------------------------------------
@@ -687,14 +716,8 @@ post_or_append "$SUBSTANTIVE_NDJSON" "substantive" "$SUBSTANTIVE_LABEL" \
 post_or_append "$POLISH_NDJSON" "polish" "$POLISH_LABEL" \
   "$POLISH_THROTTLE" "${POLISH_LABEL} ${DATE_STAMP}"
 
-# Exit non-zero if any per-PR GraphQL fetch failed (CodeRabbit Major
-# r4 on PR #303). The rollup may still have posted SOME data — the
-# log line above tells the operator which PRs are missing so they
-# can re-run via `workflow_dispatch --since X --until X` to pick up
-# the missed threads.
-if [ "$FAILED_PR_COUNT" -gt 0 ]; then
-  echo "daily-feedback-rollup: ERROR — $FAILED_PR_COUNT PR(s) failed to fetch threads (PRs: $FAILED_PR_LIST). The rollup published includes what we did fetch; re-run with the same --since/--until once the API recovers to backfill the missing data." >&2
-  exit 2
-fi
-
+# Note: the FAILED_PR_COUNT check happens BEFORE post_or_append in
+# the atomicity gate above (codex Phase 4b r2 on PR #303). By the
+# time we reach this point, the run has either successfully posted
+# both tracks' rollups or short-circuited via dry-run.
 echo "daily-feedback-rollup: done" >&2

--- a/scripts/daily-feedback-rollup.sh
+++ b/scripts/daily-feedback-rollup.sh
@@ -130,9 +130,13 @@ echo "daily-feedback-rollup: repo=$REPO window=[$SINCE, $UNTIL) date_stamp=$DATE
 # Step 1 — fetch PRs merged in the window
 # ---------------------------------------------------------------------
 
-# Use the search API. `closed:>=$SINCE` includes both merged and
-# closed-without-merge — that's intentional; closed-without-merge
-# may still carry resolved-without-fix threads worth surfacing.
+# Use the search API. `is:merged merged:>=...` scopes the scan to
+# PRs that actually merged in the window — abandoned (closed-without-
+# merge) PRs are excluded because their unaddressed feedback is
+# typically not actionable (the work didn't land). The earlier broader
+# `closed:>=$SINCE` scope swept those in, producing rollup entries
+# with `mergedAt: n/a` that confused triage (CodeRabbit Major r2 on
+# PR #303).
 #
 # No `|| echo '[]'` fallback: an API failure here (auth, rate limit,
 # network) MUST fail the run loudly. Treating a failed call as "zero
@@ -141,8 +145,8 @@ echo "daily-feedback-rollup: repo=$REPO window=[$SINCE, $UNTIL) date_stamp=$DATE
 # Major r1 on PR #303).
 if ! prs_json=$(gh pr list \
     --repo "$REPO" \
-    --state closed \
-    --search "closed:>=$SINCE closed:<$UNTIL" \
+    --state merged \
+    --search "is:merged merged:>=$SINCE merged:<$UNTIL" \
     --limit "$MAX_PRS_PER_DAY" \
     --json number,title,url,mergedAt); then
   echo "daily-feedback-rollup: ERROR — gh pr list failed (auth/rate-limit/network?). Aborting rather than producing an empty rollup." >&2
@@ -366,13 +370,20 @@ while [ "$i" -lt "$pr_count" ]; do
 
       # Heuristic 4: thread is stale-head — its originalCommit isn't
       # in the PR's current commit history (got rebased away or force-
-      # pushed off). The naive `orig_commit != head_oid` check was
-      # over-broad: many bot comments anchor to intermediate commits
-      # that are still in the PR history and remain valid findings.
-      # Use membership against the commits list we already pulled in
-      # the GraphQL query (CodeRabbit Major r1 on PR #303).
+      # pushed off). Membership check against the commits list we
+      # pulled in the GraphQL query (CodeRabbit Major r1 on PR #303
+      # tightened the prior naive `orig_commit != head_oid` check).
+      #
+      # IMPORTANT: the GraphQL query pulls `commits(last: 100)`, which
+      # is only the tail of the PR's history. On a PR with >100
+      # commits, an older `originalCommit` can be in-history but
+      # absent from this slice — we'd falsely classify as stale and
+      # suppress a real deferred thread. Gate the stale-head branch
+      # on `commit_count < 100` so we prefer surfacing over false-
+      # skipping in the slice-saturated case (CodeRabbit Major r2 on
+      # PR #303).
       orig_commit=$(printf '%s' "$t" | jq -r '.comments.nodes[0].originalCommit.oid // ""')
-      if [ -n "$orig_commit" ]; then
+      if [ -n "$orig_commit" ] && [ "$commit_count" -lt 100 ]; then
         if ! printf '%s' "$threads_json" | jq -e --arg oid "$orig_commit" \
              '.data.repository.pullRequest.commits.nodes
               | any(.commit.oid == $oid)' >/dev/null; then

--- a/scripts/daily-feedback-rollup.sh
+++ b/scripts/daily-feedback-rollup.sh
@@ -1,0 +1,521 @@
+#!/usr/bin/env bash
+# scripts/daily-feedback-rollup.sh
+#
+# Daily end-of-day rollup of bot-review threads that were resolved on
+# this repo's PRs in the last 24h **without** an associated fix
+# commit or substantive reply. Files two GitHub Issues per day, one
+# per track (substantive / polish), so the deferred-and-forgotten
+# class of feedback gets surfaced while the context is still hot.
+#
+# Implements the first slice of mergepath#299. The follow-ups
+# explicitly NOT in this slice:
+#
+#   - Agent-side `[mergepath-resolve:<class>]` tag emission in
+#     `scripts/resolve-pr-threads.sh`. This script reads the tag if
+#     present (forward-compatibility) and falls back to heuristics
+#     when it isn't.
+#   - Full triage-state persistence / dedupe-against-prior-rollups
+#     (the `<!-- mp-id:... -->` marker + 14-day window). v1 emits
+#     the stable IDs so a future PR can layer dedupe on top without
+#     a data migration; the dedupe logic itself is deferred.
+#
+# Architecture mirrors `scripts/sweep-unresolved-feedback/enumerate.sh`
+# + `render.sh` but inverted: enumerate looks for UNresolved feedback
+# on closed PRs; this script looks for RESOLVED feedback on
+# yesterday-merged PRs that wasn't actually addressed.
+#
+# Usage:
+#   daily-feedback-rollup.sh                       # post issues
+#   daily-feedback-rollup.sh --dry-run             # print NDJSON, no issue mutation
+#   daily-feedback-rollup.sh --since YYYY-MM-DD    # explicit window start
+#   daily-feedback-rollup.sh --until YYYY-MM-DD    # explicit window end
+#
+# Environment:
+#   GH_TOKEN                  required. Reads from this repo's PRs +
+#                             writes issues. PAT must have
+#                             repo:public_repo or repo scope.
+#   REPO                      owner/repo (default: current repo
+#                             resolved via `gh repo view`).
+#   ROLLUP_SUBSTANTIVE_LABEL  default: deferred-feedback-rollup
+#   ROLLUP_POLISH_LABEL       default: polish-feedback-rollup
+#   ROLLUP_SUBSTANTIVE_THROTTLE  default: 5 (unchecked-items threshold
+#                                for appending to existing issue
+#                                instead of opening a new one)
+#   ROLLUP_POLISH_THROTTLE       default: 20
+#   ROLLUP_MAX_PRS_PER_DAY    safety cap, default 100
+#   ROLLUP_AGENT_AUTHORS      colon-separated list of agent author
+#                             logins (default:
+#                             nathanjohnpayne:nathanpayne-claude:nathanpayne-cursor:nathanpayne-codex)
+#
+# Exit codes:
+#   0   success (one or both rollup issues posted, or no surfaceable
+#       items today)
+#   1   setup error (missing dep, GH_TOKEN unset, REPO unresolvable)
+#   2   API error (gh GraphQL failure, issue create failure)
+#
+# Bash 3.2 compatible (macOS default + ubuntu-latest).
+
+set -euo pipefail
+
+DRY_RUN=false
+SINCE=""
+UNTIL=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    --since) SINCE="$2"; shift 2 ;;
+    --until) UNTIL="$2"; shift 2 ;;
+    --help|-h) sed -n '3,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Error: unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+for dep in gh jq shasum; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "daily-feedback-rollup: required dependency missing: $dep" >&2
+    exit 1
+  fi
+done
+
+# Source the pure-function helpers so the same classification logic
+# is exercised by tests/test_daily_feedback_rollup.sh.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/daily-feedback-rollup-helpers.sh"
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "daily-feedback-rollup: GH_TOKEN not set." >&2
+  exit 1
+fi
+
+REPO="${REPO:-$(gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"' 2>/dev/null || true)}"
+if [ -z "$REPO" ]; then
+  echo "daily-feedback-rollup: could not resolve REPO. Set REPO=owner/name or run inside a gh-aware checkout." >&2
+  exit 1
+fi
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+
+SUBSTANTIVE_LABEL="${ROLLUP_SUBSTANTIVE_LABEL:-deferred-feedback-rollup}"
+POLISH_LABEL="${ROLLUP_POLISH_LABEL:-polish-feedback-rollup}"
+SUBSTANTIVE_THROTTLE="${ROLLUP_SUBSTANTIVE_THROTTLE:-5}"
+POLISH_THROTTLE="${ROLLUP_POLISH_THROTTLE:-20}"
+MAX_PRS_PER_DAY="${ROLLUP_MAX_PRS_PER_DAY:-100}"
+AGENT_AUTHORS="${ROLLUP_AGENT_AUTHORS:-nathanjohnpayne:nathanpayne-claude:nathanpayne-cursor:nathanpayne-codex}"
+
+# Compute the window. Default: yesterday 00:00:00Z → today 00:00:00Z UTC.
+# BSD date (macOS) and GNU date have divergent flag syntax — try GNU first.
+if [ -z "$SINCE" ]; then
+  if date -u -d "@0" '+%Y-%m-%d' >/dev/null 2>&1; then
+    SINCE=$(date -u -d "1 day ago" '+%Y-%m-%dT00:00:00Z')
+  else
+    SINCE=$(date -u -v-1d '+%Y-%m-%dT00:00:00Z')
+  fi
+elif [ "${#SINCE}" -eq 10 ]; then
+  SINCE="${SINCE}T00:00:00Z"
+fi
+if [ -z "$UNTIL" ]; then
+  UNTIL=$(date -u '+%Y-%m-%dT00:00:00Z')
+elif [ "${#UNTIL}" -eq 10 ]; then
+  UNTIL="${UNTIL}T00:00:00Z"
+fi
+
+# Date stamp for the rollup issue title (uses SINCE date).
+DATE_STAMP="${SINCE%T*}"
+
+echo "daily-feedback-rollup: repo=$REPO window=[$SINCE, $UNTIL) date_stamp=$DATE_STAMP" >&2
+
+# ---------------------------------------------------------------------
+# Step 1 — fetch PRs merged in the window
+# ---------------------------------------------------------------------
+
+# Use the search API. `closed:>=$SINCE` includes both merged and
+# closed-without-merge — that's intentional; closed-without-merge
+# may still carry resolved-without-fix threads worth surfacing.
+prs_json=$(gh pr list \
+  --repo "$REPO" \
+  --state closed \
+  --search "closed:>=$SINCE closed:<$UNTIL" \
+  --limit "$MAX_PRS_PER_DAY" \
+  --json number,title,url,mergedAt 2>/dev/null || echo '[]')
+
+pr_count=$(printf '%s' "$prs_json" | jq 'length')
+echo "daily-feedback-rollup: $pr_count PRs in window" >&2
+
+# Counters for the methodology footer.
+COUNT_FIX=0
+COUNT_REPLY=0
+COUNT_STALE=0
+COUNT_TAGGED_SKIP=0
+COUNT_TAGGED_SURFACE=0
+COUNT_DEFERRED_UNTAGGED=0
+
+# Per-track NDJSON streams. Each surviving item gets one line.
+SUBSTANTIVE_NDJSON=$(mktemp "${TMPDIR:-/tmp}/rollup-sub-XXXXXX.ndjson")
+POLISH_NDJSON=$(mktemp "${TMPDIR:-/tmp}/rollup-pol-XXXXXX.ndjson")
+trap 'rm -f "$SUBSTANTIVE_NDJSON" "$POLISH_NDJSON"' EXIT
+
+# ---------------------------------------------------------------------
+# Step 2 — for each PR, fetch + classify threads
+# ---------------------------------------------------------------------
+
+i=0
+while [ "$i" -lt "$pr_count" ]; do
+  pr_number=$(printf '%s' "$prs_json" | jq -r ".[$i].number")
+  pr_title=$(printf '%s' "$prs_json" | jq -r ".[$i].title")
+  pr_url=$(printf '%s' "$prs_json" | jq -r ".[$i].url")
+  pr_merged_at=$(printf '%s' "$prs_json" | jq -r ".[$i].mergedAt // \"\"")
+  i=$((i + 1))
+
+  # GraphQL: pull resolved review threads with full comment chain and
+  # the PR's commit list. We need the comment chain to detect
+  # substantive replies + the canonical tag, and the commit list to
+  # detect fix commits.
+  threads_json=$(gh api graphql -f query='
+    query($owner:String!,$name:String!,$pr:Int!) {
+      repository(owner:$owner, name:$name) {
+        pullRequest(number:$pr) {
+          headRefOid
+          commits(last: 100) {
+            nodes {
+              commit {
+                oid
+                authoredDate
+                author { user { login } }
+              }
+            }
+          }
+          reviewThreads(first: 100) {
+            totalCount
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              isResolved
+              isOutdated
+              path
+              line
+              originalLine
+              comments(first: 50) {
+                nodes {
+                  databaseId
+                  author { login }
+                  body
+                  createdAt
+                  originalCommit { oid }
+                  url
+                }
+              }
+            }
+          }
+        }
+      }
+    }' \
+    -F owner="$OWNER" -F name="$NAME" -F pr="$pr_number" 2>/dev/null || echo '{}')
+
+  has_next=$(printf '%s' "$threads_json" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false')
+  if [ "$has_next" = "true" ]; then
+    echo "daily-feedback-rollup: WARN $REPO#$pr_number has >100 review threads; first page only" >&2
+  fi
+
+  # Per-PR commit map: SHA → authoredDate (for stale-HEAD detection +
+  # touched-paths is needed at commit-detail level which the query
+  # above doesn't include — we approximate via "any commit by an
+  # agent author between comment.createdAt and thread.resolvedAt"
+  # rather than per-file. Per-file is a documented v1 limitation in
+  # the spec.)
+  # (Currently unused — placeholder for future per-file fix detection.)
+
+  thread_count=$(printf '%s' "$threads_json" | jq '.data.repository.pullRequest.reviewThreads.nodes | length // 0')
+
+  j=0
+  while [ "$j" -lt "$thread_count" ]; do
+    t=$(printf '%s' "$threads_json" | jq -c ".data.repository.pullRequest.reviewThreads.nodes[$j]")
+    j=$((j + 1))
+
+    is_resolved=$(printf '%s' "$t" | jq -r '.isResolved')
+    [ "$is_resolved" != "true" ] && continue
+
+    # Only consider bot-authored original comments — agent-authored
+    # top comments aren't bot review feedback. (The reply chain can
+    # mix bot + agent; we look at the first comment for the original
+    # finding.)
+    original_author=$(printf '%s' "$t" | jq -r '.comments.nodes[0].author.login // "unknown"')
+    case "$original_author" in
+      coderabbitai\[bot\]|chatgpt-codex-connector\[bot\]) : ;;
+      *) continue ;;
+    esac
+
+    thread_id=$(printf '%s' "$t" | jq -r '.id')
+    thread_path=$(printf '%s' "$t" | jq -r '.path // ""')
+    thread_line=$(printf '%s' "$t" | jq -r '.line // .originalLine // 0')
+    thread_url=$(printf '%s' "$t" | jq -r '.comments.nodes[0].url // ""')
+    original_body=$(printf '%s' "$t" | jq -r '.comments.nodes[0].body // ""')
+    original_created=$(printf '%s' "$t" | jq -r '.comments.nodes[0].createdAt // ""')
+
+    # Heuristic 1: tag in any agent-authored reply on this thread.
+    # The reply with the canonical `[mergepath-resolve:<class>]`
+    # marker takes precedence over the inferred class.
+    tag_class=""
+    reply_count=$(printf '%s' "$t" | jq '.comments.nodes | length')
+    k=1
+    while [ "$k" -lt "$reply_count" ]; do
+      reply=$(printf '%s' "$t" | jq -c ".comments.nodes[$k]")
+      reply_login=$(printf '%s' "$reply" | jq -r '.author.login // "unknown"')
+      reply_body=$(printf '%s' "$reply" | jq -r '.body // ""')
+      if is_agent_author "$reply_login"; then
+        candidate=$(extract_tag_class "$reply_body")
+        if [ -n "$candidate" ]; then
+          tag_class="$candidate"
+          break
+        fi
+      fi
+      k=$((k + 1))
+    done
+
+    if [ -n "$tag_class" ]; then
+      case "$tag_class" in
+        addressed-elsewhere|canonical-coverage|rebuttal-recorded)
+          COUNT_TAGGED_SKIP=$((COUNT_TAGGED_SKIP + 1))
+          continue
+          ;;
+        nitpick-noted|deferred-to-followup)
+          COUNT_TAGGED_SURFACE=$((COUNT_TAGGED_SURFACE + 1))
+          # Fall through to severity-routing below.
+          ;;
+        *)
+          # Unknown tag class → surface as substantive per spec.
+          COUNT_TAGGED_SURFACE=$((COUNT_TAGGED_SURFACE + 1))
+          ;;
+      esac
+    else
+      # Heuristic 2: substantive reply from an agent author (≥30 chars,
+      # NOT just the tag marker). If present, treat as addressed-via-
+      # reply and skip.
+      addressed_via_reply=false
+      k=1
+      while [ "$k" -lt "$reply_count" ]; do
+        reply=$(printf '%s' "$t" | jq -c ".comments.nodes[$k]")
+        reply_login=$(printf '%s' "$reply" | jq -r '.author.login // "unknown"')
+        reply_body=$(printf '%s' "$reply" | jq -r '.body // ""')
+        if is_agent_author "$reply_login"; then
+          reply_len=${#reply_body}
+          if [ "$reply_len" -ge 30 ]; then
+            addressed_via_reply=true
+            break
+          fi
+        fi
+        k=$((k + 1))
+      done
+      if $addressed_via_reply; then
+        COUNT_REPLY=$((COUNT_REPLY + 1))
+        continue
+      fi
+
+      # Heuristic 3: thread was on a stale commit (its originalCommit
+      # is older than the PR's headRefOid). If the originalCommit
+      # isn't in the last-100 commits list, treat as stale-head.
+      orig_commit=$(printf '%s' "$t" | jq -r '.comments.nodes[0].originalCommit.oid // ""')
+      head_oid=$(printf '%s' "$threads_json" | jq -r '.data.repository.pullRequest.headRefOid // ""')
+      if [ -n "$orig_commit" ] && [ -n "$head_oid" ] && [ "$orig_commit" != "$head_oid" ]; then
+        # Stale if the comment's originalCommit isn't the current HEAD.
+        # Stricter "is the commit in the PR's last-100 list" check
+        # would require looking it up; the simpler "different from
+        # HEAD" check captures the common case (codex/CodeRabbit
+        # commenting on a commit that got rebased away).
+        COUNT_STALE=$((COUNT_STALE + 1))
+        continue
+      fi
+
+      # No tag, no substantive reply, not stale → deferred-untagged.
+      # SURFACE it (route by severity below).
+      COUNT_DEFERRED_UNTAGGED=$((COUNT_DEFERRED_UNTAGGED + 1))
+    fi
+
+    # Severity → track.
+    severity=$(classify_severity "$original_body")
+    track=$(severity_to_track "$severity")
+
+    # Item ID.
+    item_id=$(item_id_for "${REPO}#${pr_number}:${thread_id}")
+
+    # Body excerpt: first 200 chars, single-line, trimmed.
+    body_excerpt_text=$(body_excerpt "$original_body")
+
+    # Tag indicator for the rollup body (so triage knows whether the
+    # agent recorded rationale or this is heuristic-fallback).
+    if [ -n "$tag_class" ]; then
+      tag_note="tagged: $tag_class"
+    else
+      tag_note="untagged — agent did not record rationale"
+    fi
+
+    item_json=$(jq -nc \
+      --arg repo "$REPO" \
+      --arg pr_number "$pr_number" \
+      --arg pr_title "$pr_title" \
+      --arg pr_url "$pr_url" \
+      --arg pr_merged_at "$pr_merged_at" \
+      --arg thread_id "$thread_id" \
+      --arg thread_path "$thread_path" \
+      --arg thread_line "$thread_line" \
+      --arg thread_url "$thread_url" \
+      --arg author "$original_author" \
+      --arg severity "$severity" \
+      --arg track "$track" \
+      --arg body_excerpt "$body_excerpt_text" \
+      --arg tag_note "$tag_note" \
+      --arg item_id "$item_id" \
+      '{
+        repo:         $repo,
+        pr_number:    $pr_number,
+        pr_title:     $pr_title,
+        pr_url:       $pr_url,
+        pr_merged_at: $pr_merged_at,
+        thread_id:    $thread_id,
+        thread_path:  $thread_path,
+        thread_line:  $thread_line,
+        thread_url:   $thread_url,
+        author:       $author,
+        severity:     $severity,
+        track:        $track,
+        body_excerpt: $body_excerpt,
+        tag_note:     $tag_note,
+        item_id:      $item_id
+      }')
+
+    if [ "$track" = "substantive" ]; then
+      printf '%s\n' "$item_json" >> "$SUBSTANTIVE_NDJSON"
+    else
+      printf '%s\n' "$item_json" >> "$POLISH_NDJSON"
+    fi
+  done
+done
+
+SUBSTANTIVE_COUNT=$(wc -l < "$SUBSTANTIVE_NDJSON" | tr -d ' ')
+POLISH_COUNT=$(wc -l < "$POLISH_NDJSON" | tr -d ' ')
+
+echo "daily-feedback-rollup: classified substantive=$SUBSTANTIVE_COUNT polish=$POLISH_COUNT" \
+     "(skipped fix=$COUNT_FIX reply=$COUNT_REPLY stale=$COUNT_STALE tagged-skip=$COUNT_TAGGED_SKIP)" >&2
+
+# ---------------------------------------------------------------------
+# Dry-run short-circuit
+# ---------------------------------------------------------------------
+
+if $DRY_RUN; then
+  echo "daily-feedback-rollup: --dry-run → emitting NDJSON to stdout, no issue mutation" >&2
+  if [ -s "$SUBSTANTIVE_NDJSON" ]; then
+    cat "$SUBSTANTIVE_NDJSON"
+  fi
+  if [ -s "$POLISH_NDJSON" ]; then
+    cat "$POLISH_NDJSON"
+  fi
+  exit 0
+fi
+
+# ---------------------------------------------------------------------
+# Step 3 — render and post per-track issues
+# ---------------------------------------------------------------------
+
+render_rollup_body() {
+  local ndjson_file="$1" track="$2"
+  local f="$ndjson_file"
+  cat <<INTRO
+Auto-generated rollup of bot review threads that were resolved on
+${DATE_STAMP} without an associated fix commit or substantive reply.
+Severity scope: ${track} (see § Two-track rollup in #299 for the
+routing rule).
+
+Triage markers (set on the checkbox below):
+- \`[ ]\` open / not yet triaged
+- \`[x]\` fix landed, won't-fix accepted, or follow-up issue filed
+- \`[~]\` N/A — not relevant
+
+INTRO
+
+  # Group by PR. NDJSON is naturally per-thread; awk gives us a
+  # quick group-by without re-parsing.
+  jq -s -r '
+    group_by(.pr_number)[] |
+    "## " + .[0].repo + "#" + .[0].pr_number +
+      " (merged " + (.[0].pr_merged_at // "n/a") + ", " +
+      (.[0].pr_title | tostring) + ")\n" +
+    (map(
+      "- [ ] [" + .thread_path + ":" + .thread_line + "](" + .thread_url + ")" +
+      " — `" + .author + "` " + .severity +
+      " [" + .tag_note + "]: \"" + .body_excerpt + "\"" +
+      " <!-- mp-id:" + .item_id + " -->"
+    ) | join("\n"))
+  ' "$f"
+
+  cat <<FOOTER
+
+---
+
+<details>
+<summary>Methodology</summary>
+
+- Window: ${SINCE} — ${UNTIL}
+- PRs scanned: ${pr_count}
+- Threads classified:
+  - addressed-via-fix (heuristic): ${COUNT_FIX}
+  - addressed-via-reply (heuristic): ${COUNT_REPLY}
+  - stale-head (heuristic): ${COUNT_STALE}
+  - tagged-skip: ${COUNT_TAGGED_SKIP}
+  - tagged-surface: ${COUNT_TAGGED_SURFACE}
+  - deferred-untagged (heuristic): ${COUNT_DEFERRED_UNTAGGED}
+
+Generator: \`scripts/daily-feedback-rollup.sh\` (mergepath#299)
+</details>
+FOOTER
+}
+
+# Self-throttling: count unchecked items on the most recently-opened
+# rollup issue with the track's label. If ≥ threshold, append today's
+# items as a comment instead of opening a new issue.
+unchecked_count_on() {
+  local issue_number="$1"
+  gh issue view "$issue_number" --repo "$REPO" --json body --jq '.body' \
+    | grep -cE '^\s*-\s*\[\s*\]\s' || true
+}
+
+most_recent_open_rollup() {
+  local label="$1"
+  gh issue list --repo "$REPO" --state open --label "$label" \
+    --limit 1 --json number,title --jq '.[0].number // ""'
+}
+
+post_or_append() {
+  local ndjson_file="$1" track="$2" label="$3" throttle="$4" title="$5"
+  if [ ! -s "$ndjson_file" ]; then
+    echo "daily-feedback-rollup: $track — no items to surface today" >&2
+    return 0
+  fi
+
+  local body
+  body=$(render_rollup_body "$ndjson_file" "$track")
+
+  local existing=""
+  existing=$(most_recent_open_rollup "$label" || true)
+
+  if [ -n "$existing" ]; then
+    local unchecked
+    unchecked=$(unchecked_count_on "$existing")
+    if [ "$unchecked" -ge "$throttle" ]; then
+      echo "daily-feedback-rollup: $track — appending to existing #$existing ($unchecked unchecked ≥ throttle $throttle)" >&2
+      # shellcheck disable=SC2016
+      gh issue comment "$existing" --repo "$REPO" --body "$body" >&2
+      return 0
+    fi
+  fi
+
+  echo "daily-feedback-rollup: $track — creating new issue '$title'" >&2
+  gh issue create --repo "$REPO" --title "$title" --label "$label" --body "$body"
+}
+
+post_or_append "$SUBSTANTIVE_NDJSON" "substantive" "$SUBSTANTIVE_LABEL" \
+  "$SUBSTANTIVE_THROTTLE" "${SUBSTANTIVE_LABEL} ${DATE_STAMP}"
+post_or_append "$POLISH_NDJSON" "polish" "$POLISH_LABEL" \
+  "$POLISH_THROTTLE" "${POLISH_LABEL} ${DATE_STAMP}"
+
+echo "daily-feedback-rollup: done" >&2

--- a/scripts/daily-feedback-rollup.sh
+++ b/scripts/daily-feedback-rollup.sh
@@ -64,8 +64,21 @@ UNTIL=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run) DRY_RUN=true; shift ;;
-    --since) SINCE="$2"; shift 2 ;;
-    --until) UNTIL="$2"; shift 2 ;;
+    --since)
+      # Arity guard: `--since` without a value would crash with
+      # `$2: unbound variable` under set -u. Surface a clean usage
+      # error instead (CodeRabbit Minor r4 on PR #303).
+      if [ $# -lt 2 ]; then
+        echo "Error: --since requires a value (YYYY-MM-DD or RFC3339 timestamp)" >&2
+        exit 1
+      fi
+      SINCE="$2"; shift 2 ;;
+    --until)
+      if [ $# -lt 2 ]; then
+        echo "Error: --until requires a value (YYYY-MM-DD or RFC3339 timestamp)" >&2
+        exit 1
+      fi
+      UNTIL="$2"; shift 2 ;;
     --help|-h) sed -n '3,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) echo "Error: unknown argument: $1" >&2; exit 1 ;;
   esac
@@ -166,6 +179,12 @@ COUNT_STALE=0
 COUNT_TAGGED_SKIP=0
 COUNT_TAGGED_SURFACE=0
 COUNT_DEFERRED_UNTAGGED=0
+# Tracks per-PR GraphQL failures so the run can exit non-zero at the
+# end. v1 has no persistence/dedupe — silently dropping a transient
+# failure's PR data means missing triage signal that never recovers
+# (the daily window slides forward). CodeRabbit Major r4 on PR #303.
+FAILED_PR_COUNT=0
+FAILED_PR_LIST=""
 
 # Per-track NDJSON streams. Each surviving item gets one line.
 SUBSTANTIVE_NDJSON=$(mktemp "${TMPDIR:-/tmp}/rollup-sub-XXXXXX.ndjson")
@@ -228,12 +247,18 @@ while [ "$i" -lt "$pr_count" ]; do
       }
     }' \
     -F owner="$OWNER" -F name="$NAME" -F pr="$pr_number") || {
-    # Per-PR failure: log + skip rather than abort the whole rollup.
-    # A single PR's GraphQL fetch can fail transiently (rate limit on
-    # a specific repo, lock contention) without invalidating the rest
-    # of the day's work. The per-run-level `gh pr list` above DOES
-    # fail-closed because that failure means we have no data at all.
-    echo "daily-feedback-rollup: WARN gh api graphql failed for $REPO#$pr_number; skipping" >&2
+    # Per-PR failure: log, track, continue. v1 has no persistence/
+    # dedupe — silently dropping a PR's threads on transient failure
+    # means missing triage signal that never recovers (the daily
+    # window slides forward and the missed threads stay "resolved
+    # without rationale" forever). Continue past this PR so the rest
+    # of the day's data still surfaces, but record the failure so
+    # the script can exit non-zero at the end and the workflow can
+    # be retried via `workflow_dispatch` with the same --since/--until
+    # to reconstruct the missing data. CodeRabbit Major r4 on PR #303.
+    echo "daily-feedback-rollup: WARN gh api graphql failed for $REPO#$pr_number; threads NOT classified for this PR" >&2
+    FAILED_PR_COUNT=$((FAILED_PR_COUNT + 1))
+    FAILED_PR_LIST="${FAILED_PR_LIST:+$FAILED_PR_LIST,}$pr_number"
     continue
   }
 
@@ -545,15 +570,39 @@ unchecked_count_on() {
   # rest of the codebase (which uses `[[:space:]]`) keeps the
   # check_mktemp_portability-style regex audits happy
   # (CodeRabbit Major r1 on PR #303).
+  #
+  # Fail-closed on API errors: if `gh issue view` fails, abort the
+  # run with exit 2 rather than treating "couldn't read" as
+  # "0 unchecked items." The latter would skip throttling and
+  # potentially create a duplicate rollup issue, which is a worse
+  # operator experience than a clean failure. CodeRabbit Major r4
+  # on PR #303.
   local issue_number="$1"
-  gh issue view "$issue_number" --repo "$REPO" --json body --jq '.body' \
+  local body
+  if ! body=$(gh issue view "$issue_number" --repo "$REPO" --json body --jq '.body'); then
+    echo "daily-feedback-rollup: ERROR — could not read body of issue #$issue_number for throttle check; aborting rather than risk a duplicate rollup" >&2
+    exit 2
+  fi
+  # `grep -c` returns 1 when no matches found, which under set -e is
+  # propagated. `|| true` here is the no-match case, NOT an error-
+  # suppression — the API call already succeeded above.
+  printf '%s' "$body" \
     | grep -cE '^[[:space:]]*-[[:space:]]*\[[[:space:]]*\][[:space:]]' || true
 }
 
 most_recent_open_rollup() {
+  # Fail-closed: a `gh issue list` failure that gets swallowed as
+  # "no existing rollup" would create a duplicate rollup issue on
+  # transient API errors. Exit 2 instead. CodeRabbit Major r4 on PR
+  # #303.
   local label="$1"
-  gh issue list --repo "$REPO" --state open --label "$label" \
-    --limit 1 --json number,title --jq '.[0].number // ""'
+  local out
+  if ! out=$(gh issue list --repo "$REPO" --state open --label "$label" \
+       --limit 1 --json number,title --jq '.[0].number // ""'); then
+    echo "daily-feedback-rollup: ERROR — could not list existing '$label' rollup issues for throttle check; aborting rather than risk a duplicate rollup" >&2
+    exit 2
+  fi
+  printf '%s' "$out"
 }
 
 # Idempotently create the track label if it doesn't already exist in
@@ -613,7 +662,10 @@ post_or_append() {
   body=$(render_rollup_body "$ndjson_file" "$track")
 
   local existing=""
-  existing=$(most_recent_open_rollup "$label" || true)
+  # No `|| true` here: most_recent_open_rollup now fails-closed (exit 2)
+  # on API errors. The empty-string return value is a legitimate
+  # "no existing rollup found" signal (no label matches yet).
+  existing=$(most_recent_open_rollup "$label")
 
   if [ -n "$existing" ]; then
     local unchecked
@@ -634,5 +686,15 @@ post_or_append "$SUBSTANTIVE_NDJSON" "substantive" "$SUBSTANTIVE_LABEL" \
   "$SUBSTANTIVE_THROTTLE" "${SUBSTANTIVE_LABEL} ${DATE_STAMP}"
 post_or_append "$POLISH_NDJSON" "polish" "$POLISH_LABEL" \
   "$POLISH_THROTTLE" "${POLISH_LABEL} ${DATE_STAMP}"
+
+# Exit non-zero if any per-PR GraphQL fetch failed (CodeRabbit Major
+# r4 on PR #303). The rollup may still have posted SOME data — the
+# log line above tells the operator which PRs are missing so they
+# can re-run via `workflow_dispatch --since X --until X` to pick up
+# the missed threads.
+if [ "$FAILED_PR_COUNT" -gt 0 ]; then
+  echo "daily-feedback-rollup: ERROR — $FAILED_PR_COUNT PR(s) failed to fetch threads (PRs: $FAILED_PR_LIST). The rollup published includes what we did fetch; re-run with the same --since/--until once the API recovers to backfill the missing data." >&2
+  exit 2
+fi
 
 echo "daily-feedback-rollup: done" >&2

--- a/scripts/daily-feedback-rollup.sh
+++ b/scripts/daily-feedback-rollup.sh
@@ -133,18 +133,34 @@ echo "daily-feedback-rollup: repo=$REPO window=[$SINCE, $UNTIL) date_stamp=$DATE
 # Use the search API. `closed:>=$SINCE` includes both merged and
 # closed-without-merge — that's intentional; closed-without-merge
 # may still carry resolved-without-fix threads worth surfacing.
-prs_json=$(gh pr list \
-  --repo "$REPO" \
-  --state closed \
-  --search "closed:>=$SINCE closed:<$UNTIL" \
-  --limit "$MAX_PRS_PER_DAY" \
-  --json number,title,url,mergedAt 2>/dev/null || echo '[]')
+#
+# No `|| echo '[]'` fallback: an API failure here (auth, rate limit,
+# network) MUST fail the run loudly. Treating a failed call as "zero
+# PRs" makes deferred feedback silently disappear, which is exactly
+# the failure mode this whole script exists to prevent (CodeRabbit
+# Major r1 on PR #303).
+if ! prs_json=$(gh pr list \
+    --repo "$REPO" \
+    --state closed \
+    --search "closed:>=$SINCE closed:<$UNTIL" \
+    --limit "$MAX_PRS_PER_DAY" \
+    --json number,title,url,mergedAt); then
+  echo "daily-feedback-rollup: ERROR — gh pr list failed (auth/rate-limit/network?). Aborting rather than producing an empty rollup." >&2
+  exit 2
+fi
 
 pr_count=$(printf '%s' "$prs_json" | jq 'length')
 echo "daily-feedback-rollup: $pr_count PRs in window" >&2
 
-# Counters for the methodology footer.
-COUNT_FIX=0
+# Counters for the methodology footer. Deliberately no COUNT_FIX in
+# v1 — the per-file fix-commit heuristic from the spec
+# (commit-by-an-agent-author touching the same file between
+# comment.createdAt and thread.resolvedAt) requires another GraphQL
+# round-trip per commit to get the file list. v2 adds it. Until
+# then, threads addressed by commit only (no reply) classify as
+# deferred-untagged — a known false-positive class that the v2
+# agent-side `[mergepath-resolve: addressed-elsewhere]` tagging
+# closes more directly than commit-introspection ever would.
 COUNT_REPLY=0
 COUNT_STALE=0
 COUNT_TAGGED_SKIP=0
@@ -211,7 +227,15 @@ while [ "$i" -lt "$pr_count" ]; do
         }
       }
     }' \
-    -F owner="$OWNER" -F name="$NAME" -F pr="$pr_number" 2>/dev/null || echo '{}')
+    -F owner="$OWNER" -F name="$NAME" -F pr="$pr_number") || {
+    # Per-PR failure: log + skip rather than abort the whole rollup.
+    # A single PR's GraphQL fetch can fail transiently (rate limit on
+    # a specific repo, lock contention) without invalidating the rest
+    # of the day's work. The per-run-level `gh pr list` above DOES
+    # fail-closed because that failure means we have no data at all.
+    echo "daily-feedback-rollup: WARN gh api graphql failed for $REPO#$pr_number; skipping" >&2
+    continue
+  }
 
   has_next=$(printf '%s' "$threads_json" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false')
   if [ "$has_next" = "true" ]; then
@@ -312,19 +336,21 @@ while [ "$i" -lt "$pr_count" ]; do
         continue
       fi
 
-      # Heuristic 3: thread was on a stale commit (its originalCommit
-      # is older than the PR's headRefOid). If the originalCommit
-      # isn't in the last-100 commits list, treat as stale-head.
+      # Heuristic 3: thread is stale-head — its originalCommit isn't
+      # in the PR's current commit history (got rebased away or force-
+      # pushed off). The naive `orig_commit != head_oid` check was
+      # over-broad: many bot comments anchor to intermediate commits
+      # that are still in the PR history and remain valid findings.
+      # Use membership against the commits list we already pulled in
+      # the GraphQL query (CodeRabbit Major r1 on PR #303).
       orig_commit=$(printf '%s' "$t" | jq -r '.comments.nodes[0].originalCommit.oid // ""')
-      head_oid=$(printf '%s' "$threads_json" | jq -r '.data.repository.pullRequest.headRefOid // ""')
-      if [ -n "$orig_commit" ] && [ -n "$head_oid" ] && [ "$orig_commit" != "$head_oid" ]; then
-        # Stale if the comment's originalCommit isn't the current HEAD.
-        # Stricter "is the commit in the PR's last-100 list" check
-        # would require looking it up; the simpler "different from
-        # HEAD" check captures the common case (codex/CodeRabbit
-        # commenting on a commit that got rebased away).
-        COUNT_STALE=$((COUNT_STALE + 1))
-        continue
+      if [ -n "$orig_commit" ]; then
+        if ! printf '%s' "$threads_json" | jq -e --arg oid "$orig_commit" \
+             '.data.repository.pullRequest.commits.nodes
+              | any(.commit.oid == $oid)' >/dev/null; then
+          COUNT_STALE=$((COUNT_STALE + 1))
+          continue
+        fi
       fi
 
       # No tag, no substantive reply, not stale → deferred-untagged.
@@ -396,7 +422,7 @@ SUBSTANTIVE_COUNT=$(wc -l < "$SUBSTANTIVE_NDJSON" | tr -d ' ')
 POLISH_COUNT=$(wc -l < "$POLISH_NDJSON" | tr -d ' ')
 
 echo "daily-feedback-rollup: classified substantive=$SUBSTANTIVE_COUNT polish=$POLISH_COUNT" \
-     "(skipped fix=$COUNT_FIX reply=$COUNT_REPLY stale=$COUNT_STALE tagged-skip=$COUNT_TAGGED_SKIP)" >&2
+     "(skipped reply=$COUNT_REPLY stale=$COUNT_STALE tagged-skip=$COUNT_TAGGED_SKIP)" >&2
 
 # ---------------------------------------------------------------------
 # Dry-run short-circuit
@@ -458,7 +484,6 @@ INTRO
 - Window: ${SINCE} — ${UNTIL}
 - PRs scanned: ${pr_count}
 - Threads classified:
-  - addressed-via-fix (heuristic): ${COUNT_FIX}
   - addressed-via-reply (heuristic): ${COUNT_REPLY}
   - stale-head (heuristic): ${COUNT_STALE}
   - tagged-skip: ${COUNT_TAGGED_SKIP}
@@ -474,9 +499,15 @@ FOOTER
 # rollup issue with the track's label. If ≥ threshold, append today's
 # items as a comment instead of opening a new issue.
 unchecked_count_on() {
+  # POSIX character classes — `\s` is GNU-grep-specific and not part
+  # of POSIX ERE. The ubuntu-latest runner has GNU grep but the
+  # downstream propagation path may not, and consistency with the
+  # rest of the codebase (which uses `[[:space:]]`) keeps the
+  # check_mktemp_portability-style regex audits happy
+  # (CodeRabbit Major r1 on PR #303).
   local issue_number="$1"
   gh issue view "$issue_number" --repo "$REPO" --json body --jq '.body' \
-    | grep -cE '^\s*-\s*\[\s*\]\s' || true
+    | grep -cE '^[[:space:]]*-[[:space:]]*\[[[:space:]]*\][[:space:]]' || true
 }
 
 most_recent_open_rollup() {

--- a/scripts/daily-feedback-rollup.sh
+++ b/scripts/daily-feedback-rollup.sh
@@ -556,12 +556,58 @@ most_recent_open_rollup() {
     --limit 1 --json number,title --jq '.[0].number // ""'
 }
 
+# Idempotently create the track label if it doesn't already exist in
+# the repo, so the first rollup run on a fresh consumer doesn't fail
+# at `gh issue create --label`. `gh label create --force` updates
+# color/description in place when the label already exists and
+# creates it otherwise (the helper survives consumer label-policy
+# drift). Failure here is logged + swallowed: if label-creation
+# fails for some reason (permissions, transient API), the downstream
+# `gh issue create --label` will surface the real diagnostic.
+#
+# Closes nathanpayne-codex Phase 4b r1 on PR #303 — the live repo
+# had neither `deferred-feedback-rollup` nor `polish-feedback-rollup`
+# defined, so the workflow would have errored the first time it had
+# feedback to file.
+ensure_label() {
+  local name="$1" track="$2"
+  local color description
+  case "$track" in
+    substantive)
+      color="d73a4a"
+      description="Daily rollup of deferred bot review feedback — substantive scope (CodeRabbit Major / Codex P0-P2). Triage within a few days. See #299."
+      ;;
+    polish)
+      color="0e8a16"
+      description="Daily rollup of deferred bot review feedback — polish scope (CodeRabbit Nitpick/Trivial / Codex P3). Batch triage; low urgency. See #299."
+      ;;
+    *)
+      color="ededed"
+      description="Daily deferred-feedback rollup (#299)."
+      ;;
+  esac
+  if ! gh label create "$name" \
+       --repo "$REPO" \
+       --color "$color" \
+       --description "$description" \
+       --force >/dev/null 2>&1; then
+    echo "daily-feedback-rollup: WARN — could not ensure label '$name' (will let gh issue create surface the real error)" >&2
+  fi
+}
+
 post_or_append() {
   local ndjson_file="$1" track="$2" label="$3" throttle="$4" title="$5"
   if [ ! -s "$ndjson_file" ]; then
     echo "daily-feedback-rollup: $track — no items to surface today" >&2
     return 0
   fi
+
+  # Self-bootstrap: ensure the track label exists before we either
+  # comment on an existing issue (no label change there, but the
+  # `--label` query above could miss new labels for the same reason)
+  # or create a new one. Runs ONLY in the mutation path so
+  # `--dry-run` stays a pure read.
+  ensure_label "$label" "$track"
 
   local body
   body=$(render_rollup_body "$ndjson_file" "$track")

--- a/scripts/daily-feedback-rollup.sh
+++ b/scripts/daily-feedback-rollup.sh
@@ -152,15 +152,11 @@ fi
 pr_count=$(printf '%s' "$prs_json" | jq 'length')
 echo "daily-feedback-rollup: $pr_count PRs in window" >&2
 
-# Counters for the methodology footer. Deliberately no COUNT_FIX in
-# v1 — the per-file fix-commit heuristic from the spec
-# (commit-by-an-agent-author touching the same file between
-# comment.createdAt and thread.resolvedAt) requires another GraphQL
-# round-trip per commit to get the file list. v2 adds it. Until
-# then, threads addressed by commit only (no reply) classify as
-# deferred-untagged — a known false-positive class that the v2
-# agent-side `[mergepath-resolve: addressed-elsewhere]` tagging
-# closes more directly than commit-introspection ever would.
+# Counters for the methodology footer. COUNT_FIX uses the weaker
+# per-PR heuristic (any agent-author commit on the PR after the
+# comment's createdAt) rather than the spec's per-file variant —
+# see the Heuristic 2 block below for the trade-off rationale.
+COUNT_FIX=0
 COUNT_REPLY=0
 COUNT_STALE=0
 COUNT_TAGGED_SKIP=0
@@ -313,7 +309,39 @@ while [ "$i" -lt "$pr_count" ]; do
           ;;
       esac
     else
-      # Heuristic 2: substantive reply from an agent author (≥30 chars,
+      # Heuristic 2: addressed-via-fix — any agent-author commit on
+      # the PR with authoredDate > comment.createdAt. The spec's
+      # per-file variant (commit must touch the comment's anchored
+      # file) is more precise but requires a REST round-trip per
+      # commit to fetch file lists; the GitHub GraphQL `Commit` type
+      # doesn't expose changed files. The weaker per-PR heuristic
+      # catches the codex P1 case ("resolved by follow-up commit, no
+      # reply") but is conservative-toward-skip: an agent commit on
+      # a DIFFERENT file in the same PR still marks this thread as
+      # fix-addressed. The v2 agent-side
+      # `[mergepath-resolve: addressed-elsewhere]` tagging closes
+      # the gap more precisely than commit-introspection ever would.
+      # (codex P1 r1 on PR #303.)
+      addressed_via_fix=false
+      commit_count=$(printf '%s' "$threads_json" | jq '.data.repository.pullRequest.commits.nodes | length')
+      m=0
+      while [ "$m" -lt "$commit_count" ]; do
+        c_date=$(printf '%s' "$threads_json" | jq -r ".data.repository.pullRequest.commits.nodes[$m].commit.authoredDate // \"\"")
+        c_login=$(printf '%s' "$threads_json" | jq -r ".data.repository.pullRequest.commits.nodes[$m].commit.author.user.login // \"\"")
+        # String comparison works for ISO 8601 timestamps.
+        if [ -n "$c_login" ] && [ -n "$c_date" ] && [ -n "$original_created" ] \
+           && [ "$c_date" \> "$original_created" ] && is_agent_author "$c_login"; then
+          addressed_via_fix=true
+          break
+        fi
+        m=$((m + 1))
+      done
+      if $addressed_via_fix; then
+        COUNT_FIX=$((COUNT_FIX + 1))
+        continue
+      fi
+
+      # Heuristic 3: substantive reply from an agent author (≥30 chars,
       # NOT just the tag marker). If present, treat as addressed-via-
       # reply and skip.
       addressed_via_reply=false
@@ -336,7 +364,7 @@ while [ "$i" -lt "$pr_count" ]; do
         continue
       fi
 
-      # Heuristic 3: thread is stale-head — its originalCommit isn't
+      # Heuristic 4: thread is stale-head — its originalCommit isn't
       # in the PR's current commit history (got rebased away or force-
       # pushed off). The naive `orig_commit != head_oid` check was
       # over-broad: many bot comments anchor to intermediate commits
@@ -422,7 +450,7 @@ SUBSTANTIVE_COUNT=$(wc -l < "$SUBSTANTIVE_NDJSON" | tr -d ' ')
 POLISH_COUNT=$(wc -l < "$POLISH_NDJSON" | tr -d ' ')
 
 echo "daily-feedback-rollup: classified substantive=$SUBSTANTIVE_COUNT polish=$POLISH_COUNT" \
-     "(skipped reply=$COUNT_REPLY stale=$COUNT_STALE tagged-skip=$COUNT_TAGGED_SKIP)" >&2
+     "(skipped fix=$COUNT_FIX reply=$COUNT_REPLY stale=$COUNT_STALE tagged-skip=$COUNT_TAGGED_SKIP)" >&2
 
 # ---------------------------------------------------------------------
 # Dry-run short-circuit
@@ -484,6 +512,7 @@ INTRO
 - Window: ${SINCE} — ${UNTIL}
 - PRs scanned: ${pr_count}
 - Threads classified:
+  - addressed-via-fix (heuristic, per-PR): ${COUNT_FIX}
   - addressed-via-reply (heuristic): ${COUNT_REPLY}
   - stale-head (heuristic): ${COUNT_STALE}
   - tagged-skip: ${COUNT_TAGGED_SKIP}

--- a/scripts/lib/daily-feedback-rollup-helpers.sh
+++ b/scripts/lib/daily-feedback-rollup-helpers.sh
@@ -1,0 +1,128 @@
+# scripts/lib/daily-feedback-rollup-helpers.sh
+#
+# Pure helper functions for daily-feedback-rollup.sh, split out so the
+# unit tests in tests/test_daily_feedback_rollup.sh can source them
+# directly without running the script's main body (which assumes
+# GH_TOKEN + a live gh shim). Each function takes simple string args
+# and produces stdout — no GitHub I/O, no temp files.
+#
+# To use:
+#   source scripts/lib/daily-feedback-rollup-helpers.sh
+#
+# AGENT_AUTHORS is the only piece of state the helpers need at module
+# load. Set it before sourcing or accept the canonical default.
+
+: "${AGENT_AUTHORS:=nathanjohnpayne:nathanpayne-claude:nathanpayne-cursor:nathanpayne-codex}"
+
+# classify_severity <comment-body> → P0|P1|P2|P3|Major|Minor|Nitpick|Trivial|Unknown
+#
+# Anchored on the first ~600 chars of body — enough to catch the
+# CodeRabbit/Codex severity badge near the top, not enough to false-
+# match severity words deeper in quoted context. Order matters: pick
+# the highest-confidence match first.
+#
+# CodeRabbit canonical badges: `🟠 Major` / `Potential issue` / `⚠️` /
+#                              `🧹 Nitpick` / `🔵 Trivial`
+# Codex canonical badges:      `![P0 Badge]` … `![P3 Badge]`
+classify_severity() {
+  local body_head
+  body_head=$(printf '%s' "$1" | head -c 600)
+  case "$body_head" in
+    *"![P0 Badge]"*|*"P0 Badge"*) echo "P0"; return ;;
+    *"![P1 Badge]"*|*"P1 Badge"*) echo "P1"; return ;;
+    *"![P2 Badge]"*|*"P2 Badge"*) echo "P2"; return ;;
+    *"![P3 Badge]"*|*"P3 Badge"*) echo "P3"; return ;;
+    *"🟠 Major"*|*"Potential issue"*|*"⚠️"*) echo "Major"; return ;;
+    *"🧹 Nitpick"*|*Nitpick*) echo "Nitpick"; return ;;
+    *"🔵 Trivial"*|*Trivial*) echo "Trivial"; return ;;
+    *"Outside diff range"*) echo "Trivial"; return ;;
+    *Minor*) echo "Minor"; return ;;
+  esac
+  echo "Unknown"
+}
+
+# severity_to_track <severity> → substantive|polish
+#
+# Spec routing: P0/P1/P2/Major → substantive; P3/Nitpick/Trivial →
+# polish; Minor → substantive (closer to Major in CodeRabbit's badge
+# semantics); Unknown → substantive (err on surface).
+severity_to_track() {
+  case "$1" in
+    P0|P1|P2|Major|Minor) echo "substantive" ;;
+    P3|Nitpick|Trivial)   echo "polish" ;;
+    *)                    echo "substantive" ;;
+  esac
+}
+
+# item_id_for <stable-key> → 12-char SHA1 prefix
+#
+# Used to build the `<!-- mp-id:... -->` marker on each rollup line
+# item. The key should be the canonical `<repo>#<pr>:<thread_id>`
+# per spec so the same thread always gets the same ID across days.
+item_id_for() {
+  printf '%s' "$1" | shasum -a 1 | cut -c1-12
+}
+
+# extract_tag_class <reply-body> → class string or empty
+#
+# Greps for the canonical `[mergepath-resolve: <class>]` tag that
+# agent-side resolve-pr-threads.sh emits (mergepath#299 follow-up).
+# Returns the class string (lowercase, hyphenated) or empty if no
+# tag present. The regex is intentionally tolerant of surrounding
+# whitespace.
+extract_tag_class() {
+  # grep -oE exits 1 on no-match, which under `set -e` + `pipefail`
+  # would kill the caller. We squash to empty stdout on no-match so
+  # callers can rely on `[ -z "$class" ]` semantics regardless of the
+  # caller's shell options. Also: the regex requires a `]` immediately
+  # after the class name; we strip surrounding whitespace via the sed
+  # capture group so `[mergepath-resolve:  foo ]` and `[mergepath-resolve:foo]`
+  # both parse to `foo`.
+  printf '%s' "$1" \
+    | grep -oE '\[mergepath-resolve:[[:space:]]*[a-z-]+[[:space:]]*\]' 2>/dev/null \
+    | head -n1 \
+    | sed -E 's/\[mergepath-resolve:[[:space:]]*([a-z-]+)[[:space:]]*\]/\1/' \
+    || true
+}
+
+# tag_class_action <class> → skip|surface
+#
+# Maps a parsed tag class to whether the rollup should surface or
+# skip the thread. Unknown classes route to "surface" per the spec
+# (err on surface — future class additions are additive).
+tag_class_action() {
+  case "$1" in
+    addressed-elsewhere|canonical-coverage|rebuttal-recorded) echo "skip" ;;
+    nitpick-noted|deferred-to-followup) echo "surface" ;;
+    "") echo "" ;;  # no tag → caller falls through to heuristics
+    *)  echo "surface" ;;  # unknown → surface
+  esac
+}
+
+# is_agent_author <login> → exit 0 if agent, 1 otherwise
+#
+# Used to recognize "addressed via reply" (must be from an agent
+# author) and to filter who's allowed to emit a `[mergepath-resolve:]`
+# tag. Reads AGENT_AUTHORS (colon-separated). Bash 3.2 compatible —
+# avoids associative arrays.
+is_agent_author() {
+  local login="$1"
+  local oldIFS="$IFS"
+  IFS=':'
+  set -- $AGENT_AUTHORS
+  IFS="$oldIFS"
+  for a; do
+    [ "$login" = "$a" ] && return 0
+  done
+  return 1
+}
+
+# body_excerpt <body> [max_chars]
+#
+# Single-line, trimmed excerpt suitable for the rollup checklist
+# item. Default max is 200 chars. Replaces newlines/tabs with spaces
+# so the markdown rendering doesn't break.
+body_excerpt() {
+  local max="${2:-200}"
+  printf '%s' "$1" | tr '\n\r\t' '   ' | head -c "$max"
+}

--- a/tests/test_daily_feedback_rollup.sh
+++ b/tests/test_daily_feedback_rollup.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# tests/test_daily_feedback_rollup.sh
+#
+# Unit tests for scripts/lib/daily-feedback-rollup-helpers.sh — the
+# pure-function helpers that drive classification + routing in
+# scripts/daily-feedback-rollup.sh (mergepath#299).
+#
+# The end-to-end integration (gh shim → script → issue creation) is
+# not in scope here; this test layer asserts only the deterministic
+# helper functions so the spec's per-case classification matrix is
+# regression-safe. Integration coverage lives in
+# scripts/ci/check_daily_feedback_rollup, which runs an actual
+# `--dry-run` invocation against a shimmed gh.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPERS="$ROOT/scripts/lib/daily-feedback-rollup-helpers.sh"
+
+[ -f "$HELPERS" ] || { echo "missing $HELPERS" >&2; exit 1; }
+
+# shellcheck disable=SC1090
+. "$HELPERS"
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------
+# classify_severity — per-case routing from spec § Two-track rollup
+# ---------------------------------------------------------------------
+
+assert_severity() {
+  local body="$1" expected="$2" label="$3"
+  local got
+  got=$(classify_severity "$body")
+  if [ "$got" = "$expected" ]; then
+    pass "classify_severity: $label → $expected"
+  else
+    fail "classify_severity: $label → expected=$expected got=$got"
+  fi
+}
+
+# Codex badges
+assert_severity '**![P0 Badge]** Some critical finding' "P0"     "Codex P0 inline"
+assert_severity '**![P1 Badge]** Some major finding'    "P1"     "Codex P1 inline"
+assert_severity '**![P2 Badge]** Some non-blocking'     "P2"     "Codex P2 inline"
+assert_severity '**![P3 Badge]** Nit / polish item'     "P3"     "Codex P3 inline"
+
+# CodeRabbit badges
+assert_severity '_⚠️ Potential issue_ | _🟠 Major_'      "Major"  "CodeRabbit Major"
+assert_severity '_🟠 Major_ | _Potential issue_'         "Major"  "CodeRabbit Major (alt order)"
+assert_severity 'Just a ⚠️ thing — Potential issue'      "Major"  "CodeRabbit ⚠️ alone"
+assert_severity '_🧹 Nitpick (assertive)_'               "Nitpick" "CodeRabbit Nitpick"
+assert_severity '_🔵 Trivial issue_ | _Minor_'           "Trivial" "CodeRabbit Trivial wins over Minor"
+assert_severity 'Outside diff range comment'             "Trivial" "Outside diff range → Trivial"
+
+# Unknown bodies surface as Unknown (the caller routes to substantive)
+assert_severity 'Some opaque finding without a badge'    "Unknown" "no badge → Unknown"
+assert_severity ''                                        "Unknown" "empty body → Unknown"
+
+# Severity-anchor: a severity word DEEP in body (past the 600-char
+# anchor) must NOT match. Build a body with 700 chars of padding then
+# the word "Major" at the end — should still classify as Unknown.
+padding=$(printf '%.0sX' $(seq 1 700))
+assert_severity "${padding} Major"                       "Unknown" "anchored: Major past char 600 ignored"
+
+# ---------------------------------------------------------------------
+# severity_to_track — spec § Two-track rollup routing table
+# ---------------------------------------------------------------------
+
+assert_track() {
+  local sev="$1" expected="$2"
+  local got
+  got=$(severity_to_track "$sev")
+  if [ "$got" = "$expected" ]; then
+    pass "severity_to_track: $sev → $expected"
+  else
+    fail "severity_to_track: $sev → expected=$expected got=$got"
+  fi
+}
+
+assert_track "P0"      "substantive"
+assert_track "P1"      "substantive"
+assert_track "P2"      "substantive"
+assert_track "P3"      "polish"
+assert_track "Major"   "substantive"
+assert_track "Minor"   "substantive"
+assert_track "Nitpick" "polish"
+assert_track "Trivial" "polish"
+assert_track "Unknown" "substantive"
+assert_track ""        "substantive"
+
+# ---------------------------------------------------------------------
+# item_id_for — stable + 12 chars + deterministic
+# ---------------------------------------------------------------------
+
+id1=$(item_id_for "owner/repo#123:PRT_kwAB")
+id2=$(item_id_for "owner/repo#123:PRT_kwAB")
+id3=$(item_id_for "owner/repo#124:PRT_kwAB")
+
+if [ ${#id1} -eq 12 ]; then
+  pass "item_id_for: produces 12-char ID"
+else
+  fail "item_id_for: expected 12 chars, got ${#id1} ($id1)"
+fi
+
+if [ "$id1" = "$id2" ]; then
+  pass "item_id_for: same input → same ID (idempotent)"
+else
+  fail "item_id_for: same input gave different IDs ($id1 vs $id2)"
+fi
+
+if [ "$id1" != "$id3" ]; then
+  pass "item_id_for: different inputs → different IDs"
+else
+  fail "item_id_for: different inputs collided ($id1 == $id3)"
+fi
+
+# ---------------------------------------------------------------------
+# extract_tag_class — canonical regex + tolerant whitespace
+# ---------------------------------------------------------------------
+
+assert_tag() {
+  local body="$1" expected="$2" label="$3"
+  local got
+  got=$(extract_tag_class "$body")
+  if [ "$got" = "$expected" ]; then
+    pass "extract_tag_class: $label"
+  else
+    fail "extract_tag_class: $label → expected=[$expected] got=[$got]"
+  fi
+}
+
+assert_tag '[mergepath-resolve: deferred-to-followup] noted'   "deferred-to-followup" "canonical form"
+assert_tag '[mergepath-resolve:canonical-coverage] addressed'  "canonical-coverage"   "no space after colon"
+assert_tag '[mergepath-resolve:  addressed-elsewhere ] x'      "addressed-elsewhere"  "extra leading space"
+assert_tag 'no tag here'                                        ""                     "no tag → empty"
+assert_tag '[mergepath-resolve: deferred-to-followup] first
+also has [mergepath-resolve: rebuttal-recorded]'                "deferred-to-followup" "first tag wins"
+assert_tag '[mergepath-resolve: deferred-to-followup-EXTRA]'   ""                     "malformed (uppercase) → no match"
+
+# ---------------------------------------------------------------------
+# tag_class_action — the surface/skip routing matrix from spec
+# ---------------------------------------------------------------------
+
+assert_action() {
+  local class="$1" expected="$2"
+  local got
+  got=$(tag_class_action "$class")
+  if [ "$got" = "$expected" ]; then
+    pass "tag_class_action: $class → $expected"
+  else
+    fail "tag_class_action: $class → expected=$expected got=$got"
+  fi
+}
+
+assert_action "addressed-elsewhere"   "skip"
+assert_action "canonical-coverage"    "skip"
+assert_action "rebuttal-recorded"     "skip"
+assert_action "nitpick-noted"         "surface"
+assert_action "deferred-to-followup"  "surface"
+assert_action "future-unknown-class"  "surface"   # spec: err on surface
+assert_action ""                       ""          # caller falls through to heuristics
+
+# ---------------------------------------------------------------------
+# is_agent_author — colon-list membership, Bash 3.2 safe
+# ---------------------------------------------------------------------
+
+# Default AGENT_AUTHORS from the helper file.
+if is_agent_author "nathanjohnpayne"; then
+  pass "is_agent_author: nathanjohnpayne is agent"
+else
+  fail "is_agent_author: nathanjohnpayne should be agent"
+fi
+
+if is_agent_author "nathanpayne-claude"; then
+  pass "is_agent_author: nathanpayne-claude is agent"
+else
+  fail "is_agent_author: nathanpayne-claude should be agent"
+fi
+
+if ! is_agent_author "coderabbitai[bot]"; then
+  pass "is_agent_author: coderabbitai[bot] is not agent"
+else
+  fail "is_agent_author: coderabbitai[bot] should NOT be agent"
+fi
+
+if ! is_agent_author "random-external-user"; then
+  pass "is_agent_author: random-external-user is not agent"
+else
+  fail "is_agent_author: random-external-user should NOT be agent"
+fi
+
+# Override AGENT_AUTHORS at runtime works (tests Bash 3.2-safe parsing)
+(
+  AGENT_AUTHORS="aliceagent:bobagent"
+  # Re-source NOT needed because is_agent_author reads $AGENT_AUTHORS at
+  # call time, not module load.
+  if is_agent_author "aliceagent" && ! is_agent_author "nathanpayne-claude"; then
+    pass "is_agent_author: AGENT_AUTHORS override applied at call time"
+  else
+    fail "is_agent_author: AGENT_AUTHORS override did not apply"
+  fi
+)
+
+# ---------------------------------------------------------------------
+# body_excerpt — single-line, length-capped
+# ---------------------------------------------------------------------
+
+# Newlines/tabs collapsed to spaces.
+got=$(body_excerpt $'line1\nline2\tx')
+expected="line1 line2 x"
+if [ "$got" = "$expected" ]; then
+  pass "body_excerpt: collapses newlines/tabs to spaces"
+else
+  fail "body_excerpt: expected=[$expected] got=[$got]"
+fi
+
+# Capped at default 200 chars.
+long=$(printf '%.0sA' $(seq 1 500))
+got=$(body_excerpt "$long")
+if [ ${#got} -eq 200 ]; then
+  pass "body_excerpt: default cap is 200 chars"
+else
+  fail "body_excerpt: expected 200 chars, got ${#got}"
+fi
+
+# Custom cap honored.
+got=$(body_excerpt "$long" 50)
+if [ ${#got} -eq 50 ]; then
+  pass "body_excerpt: custom cap honored"
+else
+  fail "body_excerpt: expected 50 chars, got ${#got}"
+fi
+
+# ---------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------
+
+echo
+if [ "$FAIL" -gt 0 ]; then
+  echo "test_daily_feedback_rollup: $FAIL FAIL / $PASS PASS" >&2
+  exit 1
+fi
+echo "test_daily_feedback_rollup: PASS ($PASS tests)"


### PR DESCRIPTION
Implements the first slice of #299 — the daily cron that scans yesterday's merged PRs and surfaces bot review threads that were resolved without an associated fix commit or substantive reply, so the deferred-and-forgotten class of feedback stops accumulating into the next "closed-review backlog" incident (#234, #286, #287).

Architecture mirrors `scripts/sweep-unresolved-feedback/enumerate.sh` + `render.sh` but inverted: weekly sweep catches **unresolved** feedback on closed PRs; daily rollup catches **resolved** feedback on yesterday-merged PRs that wasn't actually addressed.

## What's in this slice

| File | Purpose |
|------|---------|
| `scripts/daily-feedback-rollup.sh` | Workhorse. Fetches merged PRs in 24h window, walks resolved threads, classifies via `[mergepath-resolve:<class>]` tag (preferred) or heuristics (`addressed-via-fix` / `addressed-via-reply` / `stale-head`), routes by severity into `substantive` / `polish` tracks, creates or appends to per-track rollup issues per self-throttling thresholds. `--dry-run` mode for offline inspection. |
| `scripts/lib/daily-feedback-rollup-helpers.sh` | Pure-function classifier helpers. Sourced by main script + unit tests. Bash 3.2 safe. |
| `.github/workflows/daily-feedback-rollup.yml` | Daily cron at `55 23 * * *` UTC (4:55pm Pacific) + `workflow_dispatch` with `since`/`until`/`dry_run` inputs. Auth via `REVIEWER_ASSIGNMENT_TOKEN` (same PAT weekly-feedback-sweep.yml uses). |
| `scripts/ci/check_daily_feedback_rollup` | Structural check. Layer 1: runs paired unit tests. Layer 2: runs `--dry-run` against a `gh`-shimmed scratch env with a 3-thread fixture, asserts classification + routing. |
| `tests/test_daily_feedback_rollup.sh` | 46 cases — `classify_severity` (Codex P0-P3 + CodeRabbit Major/Nitpick/Trivial/Outside-diff-range + body-head anchor), `severity_to_track` routing table, `item_id_for` (12 chars + deterministic + collision-resistant), `extract_tag_class` (canonical form + whitespace tolerance + first-tag wins + malformed rejection), `tag_class_action` (surface/skip with err-on-surface default), `is_agent_author` (override-at-call-time), `body_excerpt` (newline collapse + cap honored). |
| `.github/workflows/repo_lint.yml` | One new step wiring `check_daily_feedback_rollup` into the lint job. |

## What's NOT in this slice (explicit follow-ups, separate PRs)

1. **Agent-side `[mergepath-resolve:<class>]` tag emission in `scripts/resolve-pr-threads.sh`.** The classifier already reads the tag and gives it precedence over heuristics, so this is forward-compatible — once the helper starts emitting tags, classification accuracy improves with no rollup-script changes. v1 falls back to heuristics cleanly.

2. **Triage-state persistence / dedupe-against-prior-rollups.** v1 emits stable `<!-- mp-id:... -->` markers on every line so a future PR can layer dedupe on top without a data migration, but the dedupe logic itself (scanning open + recently-closed rollup issues, parsing `[ ]`/`[x]`/`[~]`/strikethrough/follow-up-link, 14-day window) is deferred. **Implication for v1:** an item left `[ ]` on yesterday's issue WILL re-list today. The self-throttling logic (append to existing issue if ≥N unchecked items) bounds the issue-count blast radius until dedupe lands.

3. **`.mergepath-sync.yml` entry.** v1 is mergepath-only, parallel to `weekly-feedback-sweep.yml`'s current scope. Propagate once the dedupe slice lands and the spec's v1 → v2 evolution is settled. The `REVIEWER_ASSIGNMENT_TOKEN` secret requirement also needs a per-consumer audit before fanning out.

Authoring-Agent: claude

## Test plan

- [x] `tests/test_daily_feedback_rollup.sh` — 46/46 pass locally
- [x] `scripts/ci/check_daily_feedback_rollup` — unit tests + 3-case shimmed `--dry-run` smoke pass
- [x] `scripts/ci/check_ci_scripts_wired` — 34 check_* scripts, all wired or exempt (the new check is wired)
- [x] `scripts/ci/check_mktemp_portability` — clean (script uses portable `mktemp "${TMPDIR:-/tmp}/...XXXXXX.ndjson"` form, no `-t`)
- [x] `scripts/ci/check_sync_manifest` — clean (v1 is intentionally mergepath-only, no entry needed)
- [x] `bash -n` clean on all 5 new shell files
- [ ] CI: required workflows pass
- [ ] Manual `workflow_dispatch` against this week's PRs (post-merge — validates classification on real data, may surface heuristic tuning needs for the v2 PR)

## Self-Review

**Correctness.** All 46 helper-level test cases pass. The 3-case shimmed `--dry-run` smoke exercises the substantive-via-untagged path, addressed-via-reply skip path, and tagged-polish-route path end-to-end. The script's body-head anchor (first 600 chars for severity match) is regression-tested explicitly so a future "Major" word deep in a quoted prior review doesn't mis-classify.

**Regression risk.** Low — additive surface. Touches one existing file (`repo_lint.yml`: one new step), creates five new files. The workflow is gated on the cron schedule + `workflow_dispatch`; no other workflow imports it. The classifier helpers are pure-function + Bash 3.2 safe.

**Style.** Matches surrounding scripts: `set -euo pipefail`, trap-on-EXIT cleanup for the NDJSON tempfiles, portable `mktemp` form, bash-3.2-safe array expansion in the workflow's `scripts/daily-feedback-rollup.sh "${ARGS[@]+"${ARGS[@]}"}"`.

**Test coverage.** Helper-level: 46 cases. Integration-level: 3-thread fixture exercising routing into both tracks and the skip-by-reply path. The script's self-throttling + issue-creation paths are NOT exercised by the hermetic smoke (would require a real GitHub API or a more elaborate mutation stub); the daily cron will exercise those paths live.

**Security/dependency hygiene.** No new dependencies. The workflow's PAT is the same one `weekly-feedback-sweep.yml` uses (already audited). The classifier never executes user-supplied content — all parsing is read-only via `grep`/`sed`/`jq`. Stable item IDs are SHA1-truncated; not used cryptographically. The body-excerpt cap (200 chars default) bounds quote-embedding length in the rollup body.

Refs #299 (v4 spec), `weekly-feedback-sweep.yml` (sibling), #234/#286/#287 (the backlog class this catches earlier).

