### PR TITLE
feat(rollup): dedupe daily rollup against prior-rollup triage state (#304)

### DIFF
--- a/scripts/ci/check_daily_feedback_rollup
+++ b/scripts/ci/check_daily_feedback_rollup
@@ -212,6 +212,41 @@ cat >"$FIXTURES/threads.json" <<'JSON'
 }
 JSON
 
+# ----- Fake prior rollup body (#304 dedupe pass) -----
+#
+# Thread A's stable mp-id is the SHA1[1:12] of "owner/repo#999:PRT_thread_a"
+# — we hardcode it here so the dedupe assertion is reproducible. If
+# item_id_for ever changes its hashing strategy, this fixture must be
+# refreshed in lockstep (and the unit tests would catch that first).
+THREAD_A_MPID="aa2b2e31d8f9"
+# Thread C is referenced as a follow-up issue `#888` on a different
+# rollup line to exercise the `#N` triage signal end-to-end.
+THREAD_C_MPID="1d9cdc0a026f"
+
+cat >"$FIXTURES/prior-substantive-rollups.json" <<JSON
+[
+  {
+    "number": 7001,
+    "state": "OPEN",
+    "body": "## owner/repo#900 (merged 2026-05-14, fix: prior PR)\n- [x] [scripts/old.sh:1](https://github.com/owner/repo/pull/900#discussion_r99) — \`chatgpt-codex-connector[bot]\` P1 [untagged]: \"fix landed in commit\" <!-- mp-id:${THREAD_A_MPID} -->\n- [ ] [scripts/another.sh:5](https://github.com/owner/repo/pull/900#discussion_r100) — \`coderabbitai[bot]\` Major [untagged]: \"still open elsewhere\" <!-- mp-id:9999deadbeef -->"
+  }
+]
+JSON
+
+cat >"$FIXTURES/prior-polish-rollups.json" <<JSON
+[
+  {
+    "number": 7002,
+    "state": "OPEN",
+    "body": "## owner/repo#901 (merged 2026-05-13, fix: polish prior)\n- [ ] [scripts/x.sh:1](https://github.com/owner/repo/pull/901#discussion_r200) — \`coderabbitai[bot]\` Nitpick [untagged]: \"polish, filed #888\" <!-- mp-id:${THREAD_C_MPID} -->"
+  }
+]
+JSON
+
+cat >"$FIXTURES/prior-empty.json" <<'JSON'
+[]
+JSON
+
 # ----- gh shim — dispatches on argv -----
 cat >"$BIN/gh" <<STUB
 #!/usr/bin/env bash
@@ -232,6 +267,41 @@ case "\$1" in
     # gh api graphql -f query='...' -F owner=... -F name=... -F pr=999
     # (we don't introspect the query — just return the fixture)
     cat "$FIXTURES/threads.json"
+    exit 0
+    ;;
+  issue)
+    # gh issue list --repo ... --label <label> --state all|open --search ... --limit ... --json number,state,body
+    # The dedupe pass (mergepath#304) calls this twice per track:
+    # once with --state all + closed:>= search, once with --state open.
+    # Dispatch on the --label value so substantive vs polish prior
+    # rollups can be different (and so an unrelated label returns []).
+    label=""
+    state=""
+    for ((i=1; i<=\$#; i++)); do
+      arg="\${!i}"
+      if [ "\$arg" = "--label" ]; then
+        next_i=\$((i + 1))
+        label="\${!next_i}"
+      elif [ "\$arg" = "--state" ]; then
+        next_i=\$((i + 1))
+        state="\${!next_i}"
+      fi
+    done
+    case "\$label" in
+      deferred-feedback-rollup)
+        # Substantive label: return prior rollup ONLY on the --state all
+        # call (which the dedupe pass uses for closed-in-window). The
+        # second --state open call returns the same OPEN rollup so the
+        # dedupe pass picks it up regardless of which branch hits.
+        cat "$FIXTURES/prior-substantive-rollups.json"
+        ;;
+      polish-feedback-rollup)
+        cat "$FIXTURES/prior-polish-rollups.json"
+        ;;
+      *)
+        cat "$FIXTURES/prior-empty.json"
+        ;;
+    esac
     exit 0
     ;;
   *)
@@ -283,37 +353,36 @@ if [ "$RC" -ne 0 ]; then
 fi
 
 # Assertions on the NDJSON output.
+#
+# Pre-#304 baseline was 2 NDJSON lines (Thread A substantive + Thread C
+# polish; B reply-skipped, D stale-skipped, E fix-skipped). With the
+# #304 dedupe pass active and prior rollups in the gh shim containing
+# Thread A's mp-id as `[x]` and Thread C's mp-id on a line with `#888`,
+# BOTH should now be dedupe-skipped — so the expected line count is 0.
 LINES=$(wc -l < "$OUT_FILE" | tr -d ' ')
-if [ "$LINES" -ne 2 ]; then
-  echo "FAIL: expected 2 NDJSON lines (A substantive + C polish; B reply-skipped, D stale-skipped, E fix-skipped), got $LINES" >&2
+if [ "$LINES" -ne 0 ]; then
+  echo "FAIL: expected 0 NDJSON lines after #304 dedupe pass (A + C both triaged on prior rollups), got $LINES" >&2
   cat "$OUT_FILE" >&2
   echo "  stderr:" >&2
   sed 's/^/    /' "$ERR_FILE" >&2
   exit 1
 fi
 
-# Thread A — substantive (P1, untagged)
-if ! grep -q '"thread_id":"PRT_thread_a"' "$OUT_FILE"; then
-  echo "FAIL: thread A (P1 untagged) missing from output" >&2
+# Thread A must be FILTERED — its mp-id appeared `[x]` on the prior
+# substantive rollup fixture (gh-shim returns prior-substantive-rollups.json).
+if grep -q '"thread_id":"PRT_thread_a"' "$OUT_FILE"; then
+  echo "FAIL: thread A should be dedupe-filtered (prior [x] in substantive rollup)" >&2
   cat "$OUT_FILE" >&2
   exit 1
 fi
-if ! grep '"thread_id":"PRT_thread_a"' "$OUT_FILE" | grep -q '"track":"substantive"'; then
-  echo "FAIL: thread A should route to substantive (P1)" >&2
-  exit 1
-fi
-if ! grep '"thread_id":"PRT_thread_a"' "$OUT_FILE" | grep -q '"severity":"P1"'; then
-  echo "FAIL: thread A should classify as P1" >&2
-  exit 1
-fi
 
-# Thread B — must be FILTERED (substantive reply from agent)
+# Thread B — still FILTERED (substantive reply from agent, classifier-level skip)
 if grep -q '"thread_id":"PRT_thread_b"' "$OUT_FILE"; then
   echo "FAIL: thread B (addressed-via-reply) should be filtered out" >&2
   exit 1
 fi
 
-# Thread D — must be FILTERED (stale-head: originalCommit not in
+# Thread D — still FILTERED (stale-head: originalCommit not in
 # commits.nodes). Locks in the regression fix: the prior naive
 # `orig_commit != head_oid` check would have incorrectly classified
 # Thread A (whose originalCommit matches headRefOid) as in-history
@@ -324,39 +393,41 @@ if grep -q '"thread_id":"PRT_thread_d"' "$OUT_FILE"; then
   exit 1
 fi
 
-# Thread E — must be FILTERED (addressed-via-fix: agent-author
+# Thread E — still FILTERED (addressed-via-fix: agent-author
 # commits at 07:00 + 07:30 are both AFTER the comment's createdAt of
-# 05:00). Validates the per-PR fix-commit heuristic that closes the
-# codex P1 r1 finding on this PR. The other threads' createdAts
-# (08:00+) are AFTER both commits, so the fix-gate doesn't fire for
-# them — keeping the substantive/polish routing assertions intact.
+# 05:00).
 if grep -q '"thread_id":"PRT_thread_e"' "$OUT_FILE"; then
   echo "FAIL: thread E (addressed-via-fix: agent commit after comment) should be filtered out" >&2
   exit 1
 fi
 
-# Thread C — polish (P3, tagged nitpick-noted)
-if ! grep -q '"thread_id":"PRT_thread_c"' "$OUT_FILE"; then
-  echo "FAIL: thread C (tagged nitpick-noted P3) missing from output" >&2
-  cat "$OUT_FILE" >&2
-  exit 1
-fi
-if ! grep '"thread_id":"PRT_thread_c"' "$OUT_FILE" | grep -q '"track":"polish"'; then
-  echo "FAIL: thread C should route to polish (P3)" >&2
-  exit 1
-fi
-if ! grep '"thread_id":"PRT_thread_c"' "$OUT_FILE" | grep -q '"tag_note":"tagged: nitpick-noted"'; then
-  echo "FAIL: thread C should carry the canonical tag note" >&2
-  grep '"thread_id":"PRT_thread_c"' "$OUT_FILE" >&2
-  exit 1
-fi
-
-# Stable item IDs must be present + 12 chars
-if ! grep -oE '"item_id":"[a-f0-9]{12}"' "$OUT_FILE" | head -1 >/dev/null; then
-  echo "FAIL: item_id markers missing or wrong shape" >&2
+# Thread C must be FILTERED — its mp-id appeared on a line with `#888`
+# follow-up reference on the prior polish rollup fixture (the `#N`
+# follow-up triage signal added in #304).
+if grep -q '"thread_id":"PRT_thread_c"' "$OUT_FILE"; then
+  echo "FAIL: thread C should be dedupe-filtered (prior #N follow-up ref in polish rollup)" >&2
   cat "$OUT_FILE" >&2
   exit 1
 fi
 
-echo "check_daily_feedback_rollup: PASS (unit tests + 5-case --dry-run smoke)"
+# Methodology counter (stderr): confirm the dedupe pass actually fired.
+# We want to see `dedup=2` in the per-track summary stderr line. This
+# is the load-bearing observable proving #304 is wired end-to-end.
+if ! grep -q 'dedup=2' "$ERR_FILE"; then
+  echo "FAIL: expected stderr summary to report dedup=2 (Threads A + C filtered by prior-rollup signals)" >&2
+  echo "  stderr:" >&2
+  sed 's/^/    /' "$ERR_FILE" >&2
+  exit 1
+fi
+
+# Confirm the prior-triaged set was assembled. Verifies both labels
+# were scanned (substantive + polish), so a regression that scans only
+# one would surface here.
+if ! grep -qE 'dedupe: [0-9]+ prior-triaged mp-id' "$ERR_FILE"; then
+  echo "FAIL: expected stderr to log the prior-triaged mp-id count" >&2
+  sed 's/^/    /' "$ERR_FILE" >&2
+  exit 1
+fi
+
+echo "check_daily_feedback_rollup: PASS (unit tests + 5-case --dry-run smoke + #304 dedupe)"
 exit 0

--- a/scripts/daily-feedback-rollup.sh
+++ b/scripts/daily-feedback-rollup.sh
@@ -638,13 +638,28 @@ filter_ndjson_against_triaged() {
   # filter each NDJSON line. We use a single jq invocation per stream
   # rather than a per-line shell loop (10x faster on real-world
   # rollups with >50 items).
-  jq -R -s '
+  if ! jq -R -s '
     split("\n") | map(select(length > 0)) | reduce .[] as $id ({}; . + {($id): true})
-  ' < "$TRIAGED_IDS_FILE" > "$tmp.set"
+  ' < "$TRIAGED_IDS_FILE" > "$tmp.set"; then
+    echo "daily-feedback-rollup: ERROR — failed to build dedupe set from $TRIAGED_IDS_FILE" >&2
+    rm -f "$tmp.set" "$tmp"
+    exit 2
+  fi
 
-  jq -c --slurpfile triagedSet "$tmp.set" '
+  # No `|| true` here: jq failure (parse error, runtime fault, bad
+  # NDJSON line) would silently truncate the stream and the dedupe
+  # filter would over-skip — contradicting the script's silent-data-
+  # loss-prevention contract (CodeRabbit Major r1 on PR #307). Fail-
+  # closed instead: exit 2 with a clean diagnostic, leaving the temp
+  # files trapped for cleanup by the EXIT trap. The operator's retry
+  # path is identical to the per-PR-fetch failure case above.
+  if ! jq -c --slurpfile triagedSet "$tmp.set" '
     select(.item_id as $id | ($triagedSet[0][$id] // false) | not)
-  ' < "$stream" > "$tmp.out" || true
+  ' < "$stream" > "$tmp.out"; then
+    echo "daily-feedback-rollup: ERROR — dedupe filter failed while processing $stream (jq runtime error?)" >&2
+    rm -f "$tmp.set" "$tmp.out" "$tmp"
+    exit 2
+  fi
 
   mv "$tmp.out" "$stream"
   rm -f "$tmp.set" "$tmp"

--- a/scripts/daily-feedback-rollup.sh
+++ b/scripts/daily-feedback-rollup.sh
@@ -7,17 +7,20 @@
 # per track (substantive / polish), so the deferred-and-forgotten
 # class of feedback gets surfaced while the context is still hot.
 #
-# Implements the first slice of mergepath#299. The follow-ups
-# explicitly NOT in this slice:
+# Implements the first slice of mergepath#299 + the v2 dedupe pass
+# from mergepath#304. The remaining follow-up explicitly NOT in this
+# script:
 #
 #   - Agent-side `[mergepath-resolve:<class>]` tag emission in
 #     `scripts/resolve-pr-threads.sh`. This script reads the tag if
 #     present (forward-compatibility) and falls back to heuristics
 #     when it isn't.
-#   - Full triage-state persistence / dedupe-against-prior-rollups
-#     (the `<!-- mp-id:... -->` marker + 14-day window). v1 emits
-#     the stable IDs so a future PR can layer dedupe on top without
-#     a data migration; the dedupe logic itself is deferred.
+#
+# Dedupe pass (#304): before emitting today's per-track NDJSON, the
+# script fetches the set of already-triaged `mp-id`s from prior
+# rollups (open + recently-closed in the 14-day window) and filters
+# them out. Triage signals: `[x]`, `[~]`, strikethrough, `#N` ref on
+# the line, or a closed host issue (implies all its items triaged).
 #
 # Architecture mirrors `scripts/sweep-unresolved-feedback/enumerate.sh`
 # + `render.sh` but inverted: enumerate looks for UNresolved feedback
@@ -116,6 +119,14 @@ SUBSTANTIVE_THROTTLE="${ROLLUP_SUBSTANTIVE_THROTTLE:-5}"
 POLISH_THROTTLE="${ROLLUP_POLISH_THROTTLE:-20}"
 MAX_PRS_PER_DAY="${ROLLUP_MAX_PRS_PER_DAY:-100}"
 AGENT_AUTHORS="${ROLLUP_AGENT_AUTHORS:-nathanjohnpayne:nathanpayne-claude:nathanpayne-cursor:nathanpayne-codex}"
+# Dedupe window (in days): prior rollups closed more than N days ago
+# are presumed stale and their items re-list per #304 spec. Open
+# rollups always contribute regardless of age.
+DEDUPE_WINDOW_DAYS="${ROLLUP_DEDUPE_WINDOW_DAYS:-14}"
+# Cap on prior rollups to scan per label (safety net against runaway
+# label scopes). The 14-day window already bounds expected volume;
+# this is belt-and-suspenders.
+MAX_PRIOR_ROLLUPS_PER_LABEL="${ROLLUP_MAX_PRIOR_ROLLUPS_PER_LABEL:-50}"
 
 # Compute the window. Default: yesterday 00:00:00Z → today 00:00:00Z UTC.
 # BSD date (macOS) and GNU date have divergent flag syntax — try GNU first.
@@ -179,6 +190,15 @@ COUNT_STALE=0
 COUNT_TAGGED_SKIP=0
 COUNT_TAGGED_SURFACE=0
 COUNT_DEFERRED_UNTAGGED=0
+# Dedupe pass (#304): items skipped because their mp-id appears
+# triaged on a prior rollup issue (open in the 14-day window OR
+# closed in that window). Surfaces in the methodology footer.
+COUNT_DEDUP_SKIPPED=0
+# Tracks per-prior-rollup fetch failures so the script can warn but
+# continue: dedupe is best-effort — if we can't read a prior rollup,
+# the worst case is re-listing an already-triaged item, which is the
+# pre-#304 behaviour. Loud warn + continue beats fail-closed here.
+DEDUP_FETCH_FAILURES=0
 # Tracks per-PR GraphQL failures so the run can exit non-zero at the
 # end. v1 has no persistence/dedupe — silently dropping a transient
 # failure's PR data means missing triage signal that never recovers
@@ -482,11 +502,166 @@ while [ "$i" -lt "$pr_count" ]; do
   done
 done
 
+PRE_DEDUP_SUBSTANTIVE=$(wc -l < "$SUBSTANTIVE_NDJSON" | tr -d ' ')
+PRE_DEDUP_POLISH=$(wc -l < "$POLISH_NDJSON" | tr -d ' ')
+
+# ---------------------------------------------------------------------
+# Step 2.5 — dedupe against prior rollups (mergepath#304)
+# ---------------------------------------------------------------------
+#
+# Fetch open + recently-closed rollup issues (both tracks) within the
+# 14-day window, parse the `<!-- mp-id:... -->` markers off each
+# triaged line, and filter today's NDJSON streams to drop any mp-id
+# already in the triaged set.
+#
+# Triage signals (per parse_triaged_ids_from_body in the helpers):
+#   - `[x]` / `[X]`            → fix landed / won't-fix / followup-filed
+#   - `[~]` / `[-]`            → N/A / not-relevant
+#   - Strikethrough `~~...~~`  → preserves item visibility, excludes from re-list
+#   - `#N` ref on same line    → follow-up issue filed
+# Plus the implicit signal:
+#   - Closed host issue        → ALL its items are triaged
+#
+# Cross-track scan: a substantive item triaged on a prior polish-track
+# rollup also counts (and vice versa). Track-routing can flip across
+# days as severity classification changes; the mp-id is the canonical
+# identity, not the track. (Closes a foot-gun the spec didn't call
+# out explicitly but is the natural read.)
+
+TRIAGED_IDS_FILE=$(mktemp "${TMPDIR:-/tmp}/rollup-triaged-XXXXXX.ids")
+# Extend the EXIT trap to clean this up too.
+trap 'rm -f "$SUBSTANTIVE_NDJSON" "$POLISH_NDJSON" "$TRIAGED_IDS_FILE"' EXIT
+
+# Compute the dedupe-window cutoff. We pass it to `gh issue list` as
+# `closed:>=YYYY-MM-DD` so the search server-side filters out stale
+# closed rollups; open rollups aren't filtered (an open rollup is
+# triage-active regardless of age — the cap is just protection
+# against runaway label scopes).
+if date -u -d "@0" '+%Y-%m-%d' >/dev/null 2>&1; then
+  DEDUP_CUTOFF=$(date -u -d "${DEDUPE_WINDOW_DAYS} days ago" '+%Y-%m-%d')
+else
+  DEDUP_CUTOFF=$(date -u -v-"${DEDUPE_WINDOW_DAYS}"d '+%Y-%m-%d')
+fi
+
+# Fetch prior rollup issues for one label and append their triaged
+# mp-ids to TRIAGED_IDS_FILE. Best-effort: on transient API failure,
+# warn-and-continue rather than fail-closed — dedupe is an
+# optimisation, not a correctness invariant. (The post-create
+# atomicity gate above protects the all-or-nothing post path; the
+# dedupe pass is read-only and additive.)
+collect_triaged_ids_for_label() {
+  local label="$1"
+  local list_json
+  # Search query: every issue with this label that's either open OR
+  # closed within the dedupe window. The `is:issue` qualifier is
+  # implicit for `gh issue list`. The label scope is the rollup
+  # label; the `--search` filters by date.
+  if ! list_json=$(gh issue list \
+       --repo "$REPO" \
+       --label "$label" \
+       --state all \
+       --search "is:issue label:$label closed:>=$DEDUP_CUTOFF" \
+       --limit "$MAX_PRIOR_ROLLUPS_PER_LABEL" \
+       --json number,state,body 2>/dev/null); then
+    echo "daily-feedback-rollup: WARN dedupe: could not list prior '$label' rollups (best-effort, continuing)" >&2
+    DEDUP_FETCH_FAILURES=$((DEDUP_FETCH_FAILURES + 1))
+    return 0
+  fi
+  # Also fold in OPEN rollups (no date filter — open = live triage
+  # surface regardless of age). The earlier `gh issue list` with the
+  # `closed:>=` search excludes open issues (the search clause
+  # `closed:` doesn't match open ones), so we do a second pass.
+  local open_json
+  if ! open_json=$(gh issue list \
+       --repo "$REPO" \
+       --label "$label" \
+       --state open \
+       --limit "$MAX_PRIOR_ROLLUPS_PER_LABEL" \
+       --json number,state,body 2>/dev/null); then
+    echo "daily-feedback-rollup: WARN dedupe: could not list open '$label' rollups (best-effort, continuing)" >&2
+    DEDUP_FETCH_FAILURES=$((DEDUP_FETCH_FAILURES + 1))
+    open_json='[]'
+  fi
+  # Merge the two arrays, de-dupe on issue number (an open issue
+  # showing up only in `open_json`, a closed-in-window issue only in
+  # `list_json` — no overlap in normal cases, but unique just in
+  # case the search query semantics drift).
+  local merged
+  merged=$(jq -s '
+    (.[0] // []) + (.[1] // [])
+    | unique_by(.number)
+  ' <(printf '%s' "$list_json") <(printf '%s' "$open_json"))
+
+  local n
+  n=$(printf '%s' "$merged" | jq 'length')
+  local x=0
+  while [ "$x" -lt "$n" ]; do
+    local issue_state issue_body
+    issue_state=$(printf '%s' "$merged" | jq -r ".[$x].state")
+    issue_body=$(printf '%s' "$merged" | jq -r ".[$x].body // \"\"")
+    if [ "$issue_state" = "CLOSED" ] || [ "$issue_state" = "closed" ]; then
+      # Closed host → ALL mp-ids on this rollup are implicitly triaged.
+      parse_all_ids_from_body "$issue_body" >> "$TRIAGED_IDS_FILE"
+    else
+      # Open host → only lines with an explicit triage signal count.
+      parse_triaged_ids_from_body "$issue_body" >> "$TRIAGED_IDS_FILE"
+    fi
+    x=$((x + 1))
+  done
+}
+
+# Scan BOTH track labels. mp-ids are track-agnostic so cross-track
+# triage signals must apply.
+collect_triaged_ids_for_label "$SUBSTANTIVE_LABEL"
+collect_triaged_ids_for_label "$POLISH_LABEL"
+
+# De-dupe the triaged set (a single mp-id can appear on multiple
+# prior rollups via the throttling-append path).
+if [ -s "$TRIAGED_IDS_FILE" ]; then
+  sort -u "$TRIAGED_IDS_FILE" -o "$TRIAGED_IDS_FILE"
+fi
+TRIAGED_ID_COUNT=$(wc -l < "$TRIAGED_IDS_FILE" | tr -d ' ')
+echo "daily-feedback-rollup: dedupe: ${TRIAGED_ID_COUNT} prior-triaged mp-id(s) in 14-day window (window from ${DEDUP_CUTOFF})" >&2
+
+# Filter both NDJSON streams against TRIAGED_IDS_FILE. Track skipped
+# count per stream and update COUNT_DEDUP_SKIPPED.
+filter_ndjson_against_triaged() {
+  local stream="$1"
+  if [ ! -s "$stream" ] || [ ! -s "$TRIAGED_IDS_FILE" ]; then
+    return 0
+  fi
+  local tmp
+  tmp=$(mktemp "${TMPDIR:-/tmp}/rollup-filter-XXXXXX.ndjson")
+  local pre post
+  pre=$(wc -l < "$stream" | tr -d ' ')
+  # jq -R reads raw text. Slurp the triaged IDs into a set, then
+  # filter each NDJSON line. We use a single jq invocation per stream
+  # rather than a per-line shell loop (10x faster on real-world
+  # rollups with >50 items).
+  jq -R -s '
+    split("\n") | map(select(length > 0)) | reduce .[] as $id ({}; . + {($id): true})
+  ' < "$TRIAGED_IDS_FILE" > "$tmp.set"
+
+  jq -c --slurpfile triagedSet "$tmp.set" '
+    select(.item_id as $id | ($triagedSet[0][$id] // false) | not)
+  ' < "$stream" > "$tmp.out" || true
+
+  mv "$tmp.out" "$stream"
+  rm -f "$tmp.set" "$tmp"
+  post=$(wc -l < "$stream" | tr -d ' ')
+  local skipped=$((pre - post))
+  COUNT_DEDUP_SKIPPED=$((COUNT_DEDUP_SKIPPED + skipped))
+}
+
+filter_ndjson_against_triaged "$SUBSTANTIVE_NDJSON"
+filter_ndjson_against_triaged "$POLISH_NDJSON"
+
 SUBSTANTIVE_COUNT=$(wc -l < "$SUBSTANTIVE_NDJSON" | tr -d ' ')
 POLISH_COUNT=$(wc -l < "$POLISH_NDJSON" | tr -d ' ')
 
 echo "daily-feedback-rollup: classified substantive=$SUBSTANTIVE_COUNT polish=$POLISH_COUNT" \
-     "(skipped fix=$COUNT_FIX reply=$COUNT_REPLY stale=$COUNT_STALE tagged-skip=$COUNT_TAGGED_SKIP)" >&2
+     "(skipped fix=$COUNT_FIX reply=$COUNT_REPLY stale=$COUNT_STALE tagged-skip=$COUNT_TAGGED_SKIP dedup=$COUNT_DEDUP_SKIPPED)" \
+     "(pre-dedupe substantive=$PRE_DEDUP_SUBSTANTIVE polish=$PRE_DEDUP_POLISH)" >&2
 
 # ---------------------------------------------------------------------
 # Dry-run short-circuit
@@ -583,8 +758,9 @@ INTRO
   - tagged-skip: ${COUNT_TAGGED_SKIP}
   - tagged-surface: ${COUNT_TAGGED_SURFACE}
   - deferred-untagged (heuristic): ${COUNT_DEFERRED_UNTAGGED}
+- Dedupe pass (#304): ${COUNT_DEDUP_SKIPPED} item(s) previously triaged on prior rollups in the ${DEDUPE_WINDOW_DAYS}-day window (since ${DEDUP_CUTOFF})
 
-Generator: \`scripts/daily-feedback-rollup.sh\` (mergepath#299)
+Generator: \`scripts/daily-feedback-rollup.sh\` (mergepath#299 v1 + #304 dedupe)
 </details>
 FOOTER
 }

--- a/scripts/lib/daily-feedback-rollup-helpers.sh
+++ b/scripts/lib/daily-feedback-rollup-helpers.sh
@@ -126,3 +126,104 @@ body_excerpt() {
   local max="${2:-200}"
   printf '%s' "$1" | tr '\n\r\t' '   ' | head -c "$max"
 }
+
+# parse_triaged_ids_from_body <rollup-body> → newline-separated mp-ids
+#
+# Scans a prior rollup issue body line-by-line and emits, on stdout,
+# the `mp-id` of every line item considered "already triaged" — i.e.
+# excluded from future rollups (issue #304 dedupe pass).
+#
+# Triage signals recognised on a single rollup line:
+#   - Checkbox `[x]` or `[X]`              → fix landed / won't-fix / followup-filed
+#   - Checkbox `[~]` or `[-]`              → N/A / not-relevant
+#   - Strikethrough wrapping the bullet    → `~~- [ ] ... ~~`
+#   - A `#N` issue reference on the line   → follow-up filed
+#
+# Caller is responsible for the **closed host issue** signal: if the
+# rollup issue itself is closed, the caller should treat every mp-id
+# from its body as triaged (regardless of per-line state). We don't
+# do it here because this helper has no view of issue state — it gets
+# only the body text. The caller can use this helper's output for the
+# "closed-host implies all triaged" branch by re-running it with a
+# fall-through: parse_all_ids_from_body for closed hosts (skip the
+# per-line signal check). For simplicity, this helper exposes a
+# second mode via `parse_all_ids_from_body`.
+#
+# Per-item follow-up-link granularity trade-off: a reply ON a specific
+# checklist line is not addressable in plain Markdown — replies live
+# in the issue-comment stream, not on a specific bullet. The spec
+# permits the simpler interpretation: "any `#N` reference on the
+# line itself counts as a follow-up signal for THAT line." Reply-
+# comments on the host issue that mention `#N` without anchoring to
+# a specific mp-id are intentionally NOT consumed here; the
+# follow-up-filed user signal is to drop the `#N` into the bullet
+# text itself, which the agent or human triaging the rollup can do
+# in one edit. This keeps the helper a pure body-string parser with
+# no API I/O.
+#
+# Bash 3.2 + POSIX awk compatible. Output is mp-id per line, no
+# duplicates (dedupe within the helper so the caller's set-membership
+# check is O(1) per candidate).
+parse_triaged_ids_from_body() {
+  # awk processes the body line-by-line, extracts the mp-id from
+  # `<!-- mp-id:XXXXXXXXXXXX -->`, and prints it only if the same line
+  # carries a triage signal. We use awk (not bash + grep loop) so a
+  # 200-line rollup body parses in a single subprocess. POSIX-portable
+  # awk patterns only (no gawk-specific regex shortcuts).
+  printf '%s\n' "$1" | awk '
+    {
+      line = $0
+      # 1) extract the mp-id, if any
+      if (match(line, /<!-- *mp-id:[a-f0-9]+ *-->/)) {
+        marker = substr(line, RSTART, RLENGTH)
+        # strip prefix/suffix and any surrounding whitespace
+        sub(/^<!-- *mp-id:/, "", marker)
+        sub(/ *-->$/, "", marker)
+        id = marker
+      } else {
+        next
+      }
+
+      triaged = 0
+
+      # 2) checkbox [x] / [X]  → fix-landed / won-fix / followup-filed
+      if (line ~ /\[[ \t]*[xX][ \t]*\]/) triaged = 1
+      # 3) checkbox [~] / [-]  → N/A
+      else if (line ~ /\[[ \t]*[~\-][ \t]*\]/) triaged = 1
+      # 4) strikethrough wrapping a bullet  → ~~- [ ] ... ~~
+      else if (line ~ /~~.*\[[ \t]*\][ \t]*.*~~/) triaged = 1
+      # 5) follow-up issue ref on the same line  → #N
+      #    The hash must be preceded by a word boundary (start of
+      #    line, whitespace, or common punctuation like `(`, `[`,
+      #    `,`, `;`). POSIX awk does NOT support `\b`, so we make
+      #    the leading-boundary explicit. The digit-only requirement
+      #    on `[0-9]+` already excludes URL anchors like
+      #    `pull/999#discussion_r1` (which have a letter after `#`),
+      #    so no trailing boundary is needed.
+      else if (line ~ /(^|[ \t(\[,;])#[0-9]+/) triaged = 1
+
+      if (triaged) {
+        print id
+      }
+    }
+  ' | awk '!seen[$0]++'
+}
+
+# parse_all_ids_from_body <rollup-body> → newline-separated mp-ids
+#
+# Like parse_triaged_ids_from_body but does NOT check triage signals
+# — emits every mp-id present in the body. Used by the caller for the
+# "closed host issue → all items triaged" branch (issue #304 spec's
+# implicit won't-fix rule for closed rollup hosts).
+parse_all_ids_from_body() {
+  printf '%s\n' "$1" | awk '
+    {
+      if (match($0, /<!-- *mp-id:[a-f0-9]+ *-->/)) {
+        marker = substr($0, RSTART, RLENGTH)
+        sub(/^<!-- *mp-id:/, "", marker)
+        sub(/ *-->$/, "", marker)
+        print marker
+      }
+    }
+  ' | awk '!seen[$0]++'
+}

--- a/tests/test_daily_feedback_rollup.sh
+++ b/tests/test_daily_feedback_rollup.sh
@@ -236,6 +236,121 @@ else
 fi
 
 # ---------------------------------------------------------------------
+# parse_triaged_ids_from_body — mergepath#304 dedupe signal matrix
+# ---------------------------------------------------------------------
+#
+# Each test asserts the helper extracts exactly the expected set of
+# triaged mp-ids from a sample rollup body. Order doesn't matter
+# (helper de-dupes via awk), so we sort-compare.
+
+assert_triaged_ids() {
+  local body="$1" expected_sorted="$2" label="$3"
+  local got
+  got=$(parse_triaged_ids_from_body "$body" | sort | tr '\n' ' ' | sed 's/ $//')
+  local expected
+  expected=$(printf '%s' "$expected_sorted" | tr '\n' ' ' | sed 's/ $//')
+  if [ "$got" = "$expected" ]; then
+    pass "parse_triaged_ids_from_body: $label"
+  else
+    fail "parse_triaged_ids_from_body: $label → expected=[$expected] got=[$got]"
+  fi
+}
+
+# 1) Plain `[x]` checkbox triages
+body1='- [x] fix landed for this item <!-- mp-id:aaaa11112222 -->
+- [ ] still open <!-- mp-id:bbbb11112222 -->'
+assert_triaged_ids "$body1" "aaaa11112222" "[x] checkbox marks triaged; [ ] does not"
+
+# 2) Capital `[X]` also counts
+body2='- [X] handled by upstream <!-- mp-id:cccc11112222 -->'
+assert_triaged_ids "$body2" "cccc11112222" "[X] uppercase checkbox marks triaged"
+
+# 3) `[~]` marks N/A
+body3='- [~] not relevant to this codepath <!-- mp-id:dddd11112222 -->
+- [ ] still open <!-- mp-id:eeee11112222 -->'
+assert_triaged_ids "$body3" "dddd11112222" "[~] checkbox marks triaged"
+
+# 4) `[-]` also marks N/A (alias)
+body4='- [-] obsolete <!-- mp-id:ffff11112222 -->'
+assert_triaged_ids "$body4" "ffff11112222" "[-] checkbox marks triaged"
+
+# 5) Strikethrough wraps a `[ ]` bullet
+body5='~~- [ ] superseded item ~~ <!-- mp-id:1111aaaabbbb -->
+- [ ] not striked <!-- mp-id:2222aaaabbbb -->'
+assert_triaged_ids "$body5" "1111aaaabbbb" "~~strikethrough~~ marks triaged even with empty [ ]"
+
+# 6) `#N` follow-up reference on same line as the item
+body6='- [ ] punted to #456 for later <!-- mp-id:3333aaaabbbb -->
+- [ ] no link here <!-- mp-id:4444aaaabbbb -->'
+assert_triaged_ids "$body6" "3333aaaabbbb" "follow-up #N reference marks triaged"
+
+# 7) `#N` follow-up at end of line (different spacing/punctuation)
+body7='- [ ] addressed in (#789) <!-- mp-id:5555aaaabbbb -->'
+assert_triaged_ids "$body7" "5555aaaabbbb" "follow-up #N inside parens marks triaged"
+
+# 8) URL anchor like `pull/999#discussion_r1` must NOT count as `#N`
+body8='- [ ] [scripts/x.sh:10](https://github.com/owner/repo/pull/999#discussion_r1) — `coderabbitai[bot]` Nitpick: "polish" <!-- mp-id:6666aaaabbbb -->'
+assert_triaged_ids "$body8" "" "URL anchor #discussion_rN does NOT mark triaged"
+
+# 9) Empty + lines-without-marker emit nothing
+body9='Just some intro text.
+- [x] no mp-id marker on this line
+- [ ] open item, no marker either
+## ## ## heading'
+assert_triaged_ids "$body9" "" "lines without mp-id marker produce nothing"
+
+# 10) Multiple triaged signals on one line — single ID emitted (dedupe)
+body10='- [x] also has #123 <!-- mp-id:7777aaaabbbb -->'
+assert_triaged_ids "$body10" "7777aaaabbbb" "multiple signals on one line → single mp-id"
+
+# 11) Same mp-id appearing on two lines (both triaged) → de-duped output
+body11='- [x] first <!-- mp-id:8888aaaabbbb -->
+- [x] dup <!-- mp-id:8888aaaabbbb -->'
+assert_triaged_ids "$body11" "8888aaaabbbb" "duplicate mp-ids → de-duped output"
+
+# 12) Realistic rollup-body fragment with mixed states
+body12='## owner/repo#42 (merged 2026-05-14T12:00Z, fix: foo)
+- [x] [scripts/a.sh:10](https://github.com/owner/repo/pull/42#discussion_r1) — `coderabbitai[bot]` Major: "issue A" <!-- mp-id:aaaa00000001 -->
+- [ ] [scripts/b.sh:20](https://github.com/owner/repo/pull/42#discussion_r2) — `coderabbitai[bot]` Nitpick: "issue B" <!-- mp-id:aaaa00000002 -->
+- [~] [scripts/c.sh:30](https://github.com/owner/repo/pull/42#discussion_r3) — `chatgpt-codex-connector[bot]` P2: "issue C" <!-- mp-id:aaaa00000003 -->
+~~- [ ] [scripts/d.sh:40](https://github.com/owner/repo/pull/42#discussion_r4) — `coderabbitai[bot]` Minor: "issue D" ~~ <!-- mp-id:aaaa00000004 -->
+- [ ] [scripts/e.sh:50](https://github.com/owner/repo/pull/42#discussion_r5) — `coderabbitai[bot]` Major: "issue E, filed #999" <!-- mp-id:aaaa00000005 -->'
+# Expected triaged: 1 ([x]), 3 ([~]), 4 (~~~), 5 (#999) — NOT 2 (open, no signal)
+assert_triaged_ids "$body12" "aaaa00000001 aaaa00000003 aaaa00000004 aaaa00000005" "realistic mixed-state rollup fragment"
+
+# ---------------------------------------------------------------------
+# parse_all_ids_from_body — closed-host fallback
+# ---------------------------------------------------------------------
+
+assert_all_ids() {
+  local body="$1" expected_sorted="$2" label="$3"
+  local got
+  got=$(parse_all_ids_from_body "$body" | sort | tr '\n' ' ' | sed 's/ $//')
+  local expected
+  expected=$(printf '%s' "$expected_sorted" | tr '\n' ' ' | sed 's/ $//')
+  if [ "$got" = "$expected" ]; then
+    pass "parse_all_ids_from_body: $label"
+  else
+    fail "parse_all_ids_from_body: $label → expected=[$expected] got=[$got]"
+  fi
+}
+
+# 13) parse_all_ids ignores triage state — emits every mp-id
+body_all1='- [ ] open <!-- mp-id:cccccc111111 -->
+- [x] done <!-- mp-id:cccccc222222 -->
+- [~] na  <!-- mp-id:cccccc333333 -->'
+assert_all_ids "$body_all1" "cccccc111111 cccccc222222 cccccc333333" \
+  "closed-host: every mp-id surfaces regardless of state"
+
+# 14) parse_all_ids dedupes
+body_all2='- [ ] one <!-- mp-id:ddd444aaaaaa -->
+- [x] same id <!-- mp-id:ddd444aaaaaa -->'
+assert_all_ids "$body_all2" "ddd444aaaaaa" "closed-host: duplicate mp-ids de-duped"
+
+# 15) parse_all_ids on a body with no markers → empty
+assert_all_ids "no markers here at all" "" "closed-host: no markers → empty"
+
+# ---------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #304.

Authoring-Agent: claude

## Summary

Adds the v2 dedupe pass to the daily-feedback rollup workflow shipped in #303. v1 emitted stable `<!-- mp-id:... -->` markers on every line item but did NOT consult prior rollups, so an item left `[ ]` yesterday re-listed today. This PR layers the dedupe-against-prior-rollups logic on top of the v1 generator without any data migration.

### What changed

- **New pure helpers** in `scripts/lib/daily-feedback-rollup-helpers.sh`:
  - `parse_triaged_ids_from_body <body>` → newline-separated mp-ids. Recognises `[x]`/`[X]`/`[~]`/`[-]` checkboxes, `~~...~~` strikethrough wrapping a bullet, and `#N` follow-up issue references on the same line.
  - `parse_all_ids_from_body <body>` → every mp-id regardless of triage state. Used for the implicit "closed host issue → all items triaged" branch.
- **Dedupe pass** in `scripts/daily-feedback-rollup.sh`, between the per-PR classification loop and the dry-run gate:
  - Fetches open + closed-in-14-day-window rollup issues for BOTH `deferred-feedback-rollup` and `polish-feedback-rollup` labels (cross-track scan — mp-ids are track-agnostic).
  - Builds a `TRIAGED_IDS_FILE` set; closed hosts contribute all their mp-ids, open hosts only contribute mp-ids on lines that carry a triage signal.
  - Filters both NDJSON streams (`SUBSTANTIVE_NDJSON` / `POLISH_NDJSON`) via a single `jq --slurpfile` pass per stream (avoids a per-line shell loop).
  - Increments `COUNT_DEDUP_SKIPPED` and surfaces it both in the stderr summary line and in the methodology footer of the rendered rollup body.
- **15 new unit tests** covering each triage-signal type, dedupe of duplicate mp-ids within a body, the URL-anchor false-positive guard (`pull/999#discussion_r1` must NOT count as `#N`), and a realistic mixed-state rollup-body fixture.
- **Integration smoke extended** in `scripts/ci/check_daily_feedback_rollup`: the `gh` shim now returns fake prior rollups carrying Thread A's mp-id as `[x]` (substantive) and Thread C's mp-id alongside a `#888` reference (polish). Post-dedupe NDJSON line count drops from 2 → 0 with `dedup=2` in the stderr summary, locking the end-to-end wiring.

### Behaviour summary

| Signal on prior rollup line | Re-listed today? |
|---|---|
| `- [ ]` (open) | yes (this is the v1 behaviour the PR preserves) |
| `- [x]` / `- [X]` | **no** (triaged) |
| `- [~]` / `- [-]` | **no** (N/A) |
| `~~- [ ] ... ~~` | **no** (visibility-preserved, excluded) |
| Same line carries `#789` | **no** (follow-up filed) |
| Host issue is closed | **no** (all items implicit won't-fix) |
| Host issue is open + older than 14 days | yes (stale host → re-list) |

### Design trade-offs (documented inline)

- **Per-item follow-up granularity.** The spec mentions reply-comment threads with `#N` references as a possible triage signal. We deliberately do NOT consume issue-comment replies — instead we require the user to drop the `#N` into the bullet text itself. This keeps the helper a pure body-string parser with no API I/O. The simpler interpretation is explicitly permitted by the #304 spec.
- **Cross-track scan.** mp-ids are deterministic on `<repo>#<pr>:<thread_id>` — they don't encode track. A thread that flipped from `Major` (substantive) to `Nitpick` (polish) due to a classifier update should still dedupe across tracks. We scan both labels accordingly.
- **Best-effort on dedupe-fetch failure.** Dedupe is an optimisation, not a correctness invariant. If `gh issue list` fails for one label, we warn and continue rather than fail-closed — the worst-case post-failure outcome is re-listing an already-triaged item (which is the pre-#304 baseline behaviour). This is opposite of the v1 post-create atomicity gate (which DOES fail-closed because partial post is worse than no post).

## Self-Review

### Correctness
- The triage-signal regex correctly handles the URL-anchor false-positive case (`pull/999#discussion_r1` contains `#discussion` not `#N`, and the digit-only `#[0-9]+` requirement excludes it). Unit test #8 locks this.
- `parse_all_ids_from_body` for closed hosts means every item on a closed rollup is dedupe-skipped going forward — this matches the spec's implicit-won't-fix semantics.
- mp-id de-duplication happens inside the helpers (via `awk '!seen[$0]++'`) AND again in the main script (via `sort -u`), so a single mp-id appearing on the v1 throttling-append path (which can write the same item to one issue twice) doesn't double-count.
- The 14-day window is enforced server-side via `closed:>=$DEDUP_CUTOFF` in the search query, plus a `MAX_PRIOR_ROLLUPS_PER_LABEL` (default 50) safety cap.

### Regression risk
- Pre-existing classifier behaviour is untouched: every test that was green before (46 unit + 5-case integration smoke) is still green. The new dedupe step is purely additive — it runs AFTER classification and only REMOVES items, never alters or adds them.
- The dry-run path now also exercises the dedupe pass (which calls `gh issue list`). The shim was extended to handle that; production `--dry-run` against a real repo will issue read-only `gh issue list` calls, which is consistent with the read-only-in-dry-run contract.
- I considered gating dedupe on `--dry-run` (i.e. don't fetch prior rollups in dry-run mode) but rejected that — operators inspecting `--dry-run` output expect it to match what a real run would post.

### Style
- Bash 3.2 compatible (no associative arrays, no `mapfile`, no `\b` regex). The earlier draft used `\b` in awk which isn't POSIX-portable; the final regex uses an explicit `(^|[ \t(\[,;])` boundary.
- POSIX character classes for grep/awk regex consistency (`[[:space:]]` not `\s`) — matches the codebase convention enforced by `check_mktemp_portability`-style audits.
- Functions documented with header comments explaining the trade-off, signal matrix, and Bash 3.2 portability notes.

### Test coverage
- 15 new unit tests covering every triage-signal type from the #304 spec, plus the URL-anchor negative case, the dedupe-within-helper guarantee, and a realistic mixed-state rollup fragment.
- Integration smoke extended with a fake prior-rollup fixture that exercises BOTH the substantive `[x]` path AND the polish `#N` follow-up path. Asserts the dedup counter surfaces in the stderr summary.

### Security
- No new credentials, no new write paths, no new shell-injection surfaces. The `gh issue list` calls are read-only and use the same `GH_TOKEN` as the existing PR-list call. The jq invocations use `--arg`/`--slurpfile` so no shell variables are interpolated into jq programs.
- No new dependencies (still `gh`, `jq`, `shasum`).

## Test plan

- [x] `bash tests/test_daily_feedback_rollup.sh` → 61 PASS (was 46; +15 dedupe cases)
- [x] `bash scripts/ci/check_daily_feedback_rollup` → PASS (unit + integration smoke + dedupe)
- [x] `bash scripts/ci/check_ci_scripts_wired` → PASS
- [x] `bash scripts/ci/check_mktemp_portability` → PASS
- [x] `bash scripts/ci/check_sync_manifest` → PASS
- [x] `bash -n` syntax check on both shell files
- [ ] Live `workflow_dispatch` of `daily-feedback-rollup.yml` against this repo's prior rollup issues (post-merge; documented in #304 AC)
