### PR TITLE
feat(review): emit [mergepath-resolve:<class>] tags from resolve-pr-threads (#305)

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -268,6 +268,18 @@ paths:
   - path: tests/test_helper_autosource.sh
     type: canonical
     consumers: all
+  # Pairs with scripts/resolve-pr-threads.sh +
+  # scripts/ci/check_resolve_pr_threads (which delegates to this test
+  # file after its own in-suite cases). Exercises the mergepath#305
+  # `[mergepath-resolve:<class>]` tag-emission flow (derive_tag_class
+  # heuristics + --rationale override + --no-tag-reply). Without this
+  # test propagated, every consumer's check_resolve_pr_threads
+  # exits 1 on the wrapper's "missing $TAG_TEST" branch — same
+  # #264/#266 coupling class as the codex-p1-gate / disagreement-
+  # detector / verify-propagation-pr pairings above. See #305.
+  - path: tests/test_resolve_pr_threads_rationale_tag.sh
+    type: canonical
+    consumers: all
 
   # Canonical workflows — review policy + automation surfaces that
   # should be lockstep across all consumers.
@@ -339,6 +351,7 @@ paths:
       - "tests/test_codex_p1_gate.sh"          # check_codex_p1_gate
       - "tests/test_disagreement_detector.sh"  # check_disagreement_detector
       - "tests/test_verify_propagation_pr.sh"  # check_verify_propagation_pr
+      - "tests/test_resolve_pr_threads_rationale_tag.sh"  # check_resolve_pr_threads (delegated test)
       - "scripts/codex-p1-gate.sh"             # check_codex_p1_gate
       - "scripts/codex-review-request.sh"      # check_codex_scripts
       - "scripts/codex-review-check.sh"        # check_codex_scripts, check_canonical_bugs_263caf3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,53 @@ keyring active is your agent identity. No switch needed for commits.
      human-authored threads must be resolved via the GitHub UI or by
      asking the human; the helper refuses to touch them.
 
+     **Rationale-tag emission (mergepath#305).** Before each resolve
+     mutation, the helper posts a one-line reply on the thread with
+     `[mergepath-resolve: <class>] <rationale>`. The v1 daily rollup
+     classifier reads this tag and prioritizes it over its own
+     heuristics, so unresolved-feedback rollups attribute resolves
+     accurately instead of guessing from commit timestamps. Valid
+     `<class>` values (taxonomy mirrored from
+     `scripts/lib/daily-feedback-rollup-helpers.sh`):
+
+     - `addressed-elsewhere` — fix-commit by an agent author after
+       the comment's createdAt, touching the anchored file.
+     - `canonical-coverage` — anchored path matches a canonical
+       entry in `.mergepath-sync.yml` (propagated content).
+     - `nitpick-noted` — severity is Nitpick/Trivial/P3, no
+       stronger signal applies.
+     - `rebuttal-recorded` — ≥30-char agent-authored reply already
+       on the thread.
+     - `deferred-to-followup` — default fallback / `--rationale`
+       override.
+
+     The helper auto-classifies via the ladder above. To override
+     for a manual case (e.g. deferring a P2 to a tracked follow-up
+     issue), pass `--rationale "free-form text"` — class is forced
+     to `deferred-to-followup` and the free-form text follows the
+     tag verbatim. To suppress tag emission entirely (e.g. dry-
+     rehearsing the resolve loop without polluting thread history),
+     pass `--no-tag-reply`; the resolve mutation still runs.
+
+     Tag-reply failure (network blip, mutation rejected) is logged
+     and the resolve continues — losing the tag is a soft regression
+     (the rollup falls back to its own heuristics), not a
+     correctness bug.
+
+     Examples:
+
+     ```bash
+     # Default — helper picks the class per the decision ladder.
+     scripts/resolve-pr-threads.sh <PR#> --auto-resolve-bots
+
+     # Manual override with custom rationale (forces deferred-to-followup).
+     scripts/resolve-pr-threads.sh <PR#> --auto-resolve-bots \
+         --rationale "P2 noted; deferred to mergepath canonical follow-up #280"
+
+     # Suppress tag-reply (resolve only).
+     scripts/resolve-pr-threads.sh <PR#> --auto-resolve-bots --no-tag-reply
+     ```
+
      **Escape hatch — if the script reports clean but merge fails.**
      If `scripts/resolve-pr-threads.sh` exits 0 ("no unresolved
      threads") AND the merge attempt errors with `GraphQL: All

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,16 +200,21 @@ keyring active is your agent identity. No switch needed for commits.
      heuristics, so unresolved-feedback rollups attribute resolves
      accurately instead of guessing from commit timestamps. Valid
      `<class>` values (taxonomy mirrored from
-     `scripts/lib/daily-feedback-rollup-helpers.sh`):
+     `scripts/lib/daily-feedback-rollup-helpers.sh`). Listed in the
+     ladder order the resolver actually applies (first match wins):
 
+     - `canonical-coverage` — anchored path matches a canonical
+       entry in `.mergepath-sync.yml` (propagated content). Wins
+       over `addressed-elsewhere` because a finding on propagated
+       canonical content is structurally a mergepath concern
+       regardless of whether the local PR's fix commit also
+       happened to touch the file.
      - `addressed-elsewhere` — fix-commit by an agent author after
        the comment's createdAt, touching the anchored file.
-     - `canonical-coverage` — anchored path matches a canonical
-       entry in `.mergepath-sync.yml` (propagated content).
-     - `nitpick-noted` — severity is Nitpick/Trivial/P3, no
-       stronger signal applies.
      - `rebuttal-recorded` — ≥30-char agent-authored reply already
        on the thread.
+     - `nitpick-noted` — severity is Nitpick/Trivial/P3, no
+       stronger signal applies.
      - `deferred-to-followup` — default fallback / `--rationale`
        override.
 

--- a/scripts/ci/check_resolve_pr_threads
+++ b/scripts/ci/check_resolve_pr_threads
@@ -445,6 +445,31 @@ else
   echo "      env capture:" >&2; sed 's/^/        /' "$GH_ARGV_LOG" >&2
 fi
 
+# ── Test 8: delegate to tests/test_resolve_pr_threads_rationale_tag.sh
+# Exercises the mergepath#305 tag-emission flow (derive_tag_class +
+# post_tag_reply + --rationale override + --no-tag-reply). The test
+# is fixture-based and lives in tests/ so it follows the same
+# co-location pattern as test_codex_p1_gate / test_disagreement_detector
+# (the check wrapper delegates to a dedicated test file rather than
+# inlining the cases).
+echo
+echo "resolve-pr-threads.sh rationale-tag emission (mergepath#305)"
+
+TAG_TEST="$ROOT/tests/test_resolve_pr_threads_rationale_tag.sh"
+if [ ! -f "$TAG_TEST" ]; then
+  fail=$((fail + 1))
+  echo "  FAIL: missing $TAG_TEST" >&2
+elif bash "$TAG_TEST" >/dev/null 2>&1; then
+  pass=$((pass + 1))
+  echo "  PASS: tests/test_resolve_pr_threads_rationale_tag.sh"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: tests/test_resolve_pr_threads_rationale_tag.sh exited non-zero" >&2
+  # Re-run with output captured so the CI log shows what broke.
+  echo "    re-running with output:" >&2
+  bash "$TAG_TEST" 2>&1 | sed 's/^/      /' >&2 || true
+fi
+
 echo
 if [ "$fail" -eq 0 ]; then
   echo "check_resolve_pr_threads: PASS ($pass tests)"

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -934,6 +934,19 @@ while IFS= read -r thread; do
       tag_class="deferred-to-followup"
       tag_rationale="$RATIONALE_OVERRIDE"
     else
+      # Warm the tag-data cache (PR_FILES_CACHE / PR_COMMITS_CACHE +
+      # the TAG_DATA_FETCHED guard) in THIS shell BEFORE the command-
+      # substitution subshells below. Without this, fetch_pr_tag_data
+      # runs inside derive_tag_class's subshell, populates the caches
+      # in that subshell, and the parent shell never sees them — so
+      # synth_rationale (also in a subshell) finds PR_COMMITS_CACHE
+      # empty, emits `[: : integer expression expected` on line ~773,
+      # and falls back to the generic no-SHA rationale. nathanpayne-
+      # codex Phase 4b on #308 reproduced this with a page-2 files
+      # fixture. Calling here also fulfills the "one-shot cache reused
+      # across threads" intention — fetch_pr_tag_data's TAG_DATA_FETCHED
+      # short-circuit only works if it's set in the loop's shell.
+      fetch_pr_tag_data
       # Need the augmented commits cache (with .sha) for the
       # addressed-elsewhere rationale; the bare cache from
       # fetch_pr_tag_data doesn't carry .sha. derive_tag_class only

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -535,15 +535,54 @@ TAG_DATA_FETCHED=false
 fetch_pr_tag_data() {
   $TAG_DATA_FETCHED && return 0
   TAG_DATA_FETCHED=true
-  # REST /pulls/{pr}/files: up to 100 files, one page. PRs with >100
-  # files are rare; the fallback is to treat the path-match check as
-  # "match-any" which is the rollup's existing behavior.
-  PR_FILES_CACHE=$(gh_pat api "repos/$OWNER/$NAME/pulls/$PR_NUM/files?per_page=100" \
-    --jq '[.[].filename]' 2>/dev/null || echo '[]')
-  # REST /pulls/{pr}/commits: same shape; we need committer login +
-  # authored date.
-  PR_COMMITS_CACHE=$(gh_pat api "repos/$OWNER/$NAME/pulls/$PR_NUM/commits?per_page=100" \
-    --jq '[.[] | {login: (.author.login // .commit.author.email // ""), date: (.commit.author.date // .commit.committer.date // "")}]' 2>/dev/null || echo '[]')
+  # REST /pulls/{pr}/files and /pulls/{pr}/commits both paginate at
+  # 100 items per page. Without pagination, threads anchored on
+  # files beyond page 1 silently misclassify on PRs with >100
+  # changed files (Codex P2 on #308). We use a manual page loop
+  # rather than gh's --paginate so the URL stays in argv-position
+  # 2 (gh injects --paginate as $2, which breaks stubs that route
+  # on $2 — including test_resolve_pr_threads_rationale_tag.sh).
+  PR_FILES_CACHE=$(_fetch_paginated \
+    "repos/$OWNER/$NAME/pulls/$PR_NUM/files" \
+    '[.[].filename]')
+  # PR_COMMITS_CACHE now includes `sha` so synth_rationale can cite
+  # the matching commit. The predicate the rationale builds must
+  # match derive_tag_class's predicate (CodeRabbit major on #308).
+  PR_COMMITS_CACHE=$(_fetch_paginated \
+    "repos/$OWNER/$NAME/pulls/$PR_NUM/commits" \
+    '[.[] | {sha: (.sha // ""), login: (.author.login // .commit.author.email // ""), date: (.commit.author.date // .commit.committer.date // "")}]')
+}
+
+# _fetch_paginated <base-url> <jq-projection> → JSON array on stdout.
+# Manually walks `?per_page=100&page=N` until a page returns fewer
+# than 100 items OR a defensive 50-page cap (5,000 items) is hit.
+# Falls back to `[]` on first-page failure so downstream treats as
+# match-any rather than under-classifying. Test stubs that return a
+# pre-transformed JSON array still work: this helper applies a
+# `--jq` projection that the stubs ignore (stubs return their own
+# canned output), and the per-page-merging stops naturally because
+# the canned single-page output has fewer than 100 items.
+_fetch_paginated() {
+  local base_url="$1"
+  local projection="$2"
+  local page=1
+  local max_pages=50
+  local merged='[]'
+  local raw count
+  while [ "$page" -le "$max_pages" ]; do
+    if ! raw=$(gh_pat api "${base_url}?per_page=100&page=${page}" \
+        --jq "$projection" 2>/dev/null); then
+      [ "$page" -eq 1 ] && { echo '[]'; return; }
+      break
+    fi
+    [ -z "${raw//[[:space:]]/}" ] && break
+    count=$(printf '%s' "$raw" | jq 'length' 2>/dev/null || echo 0)
+    [ "$count" -eq 0 ] && break
+    merged=$(printf '%s\n%s\n' "$merged" "$raw" | jq -s -c '.[0] + .[1]' 2>/dev/null || printf '%s' "$merged")
+    [ "$count" -lt 100 ] && break
+    page=$((page + 1))
+  done
+  printf '%s' "$merged"
 }
 
 # manifest_canonical_paths — extract canonical + kit paths from the
@@ -716,13 +755,18 @@ synth_rationale() {
   local class="$1"
   local thread_json="$2"
   local thread_path
+  local thread_created
   thread_path=$(printf '%s' "$thread_json" | jq -r '.path // ""')
+  thread_created=$(printf '%s' "$thread_json" | jq -r '.created // ""')
   local short_sha=""
   case "$class" in
     addressed-elsewhere)
-      # Best-effort: surface the first agent-author commit's short
-      # SHA. The detection loop above doesn't capture the SHA, so we
-      # re-scan here.
+      # Surface the SHA of a commit that actually satisfies
+      # derive_tag_class's predicate (agent-authored AND
+      # authoredDate > thread_created). Re-run the same check here
+      # so the cited SHA matches the one that triggered the
+      # classification — otherwise we could cite a pre-thread
+      # commit that didn't qualify.
       local commit_count i
       commit_count=$(printf '%s' "$PR_COMMITS_CACHE" | jq 'length' 2>/dev/null || echo 0)
       i=0
@@ -731,7 +775,9 @@ synth_rationale() {
         c_login=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].login // \"\"")
         c_date=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].date // \"\"")
         c_sha=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].sha // \"\"")
-        if is_agent_author_local "$c_login"; then
+        if [ -n "$c_login" ] && [ -n "$c_date" ] \
+           && { [ -z "$thread_created" ] || [ "$c_date" \> "$thread_created" ]; } \
+           && is_agent_author_local "$c_login"; then
           short_sha="$c_sha"
           break
         fi
@@ -794,8 +840,11 @@ post_tag_reply() {
   local body
   body="[mergepath-resolve: $class] $rationale"
   # Suppress stdout (the mutation response is noise), but capture
-  # stderr for failure-mode logging. `2>&1 1>/dev/null` swaps
-  # streams so we can grep the diagnostic on failure.
+  # stderr for failure-mode logging. The redirection order matters:
+  # `2>&1 1>/dev/null` first dups stderr to stdout (so it lands in
+  # the command substitution), then redirects the original stdout to
+  # /dev/null. The reversed form (`>/dev/null 2>&1`) discards both
+  # streams and leaves $err empty — see #shellcheck SC2327/SC2328.
   local err
   if ! err=$(gh_pat api graphql \
     -f query='mutation($id: ID!, $body: String!) {
@@ -805,7 +854,8 @@ post_tag_reply() {
     }' \
     -F id="$thread_id" \
     -F body="$body" \
-    >/dev/null 2>&1); then
+    2>&1 1>/dev/null); then
+    printf 'tag-reply mutation failed: %s\n' "$err" >&2
     return 1
   fi
   return 0

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -14,6 +14,7 @@
 # Usage:
 #   scripts/resolve-pr-threads.sh <PR#> [--repo owner/name] [--list]
 #                                 [--auto-resolve-bots] [--dry-run]
+#                                 [--rationale <text>] [--no-tag-reply]
 #
 # Modes:
 #   --list                  List unresolved threads with author + path +
@@ -34,8 +35,48 @@
 #                           resolved regardless of mode.
 #   --dry-run               With --auto-resolve-bots, print what would
 #                           be resolved without mutating.
+#   --rationale <text>      With --auto-resolve-bots, override the
+#                           auto-synthesized class with a free-form
+#                           rationale. Class defaults to
+#                           `deferred-to-followup` (most common manual
+#                           case); the free-form text follows the tag.
+#                           Useful when the auto-heuristic would
+#                           misclassify (e.g. P2 deferred to a tracked
+#                           follow-up issue). Implies tag-reply emission.
+#   --no-tag-reply          With --auto-resolve-bots, suppress the
+#                           pre-resolution `[mergepath-resolve:<class>]`
+#                           reply emission. The resolve mutation still
+#                           runs. Useful for dry-rehearsal of the
+#                           resolve loop without polluting the thread
+#                           history. The default IS to emit the tag —
+#                           the v1 daily rollup classifier reads it.
 #
 # Default mode (no flags): equivalent to --list.
+#
+# Tag emission (mergepath#305):
+#   When --auto-resolve-bots runs WITHOUT --no-tag-reply, the helper
+#   posts a one-line reply on each bot thread BEFORE the resolve
+#   mutation:
+#
+#     [mergepath-resolve: <class>] <one-line rationale>
+#
+#   where `<class>` is one of (taxonomy mirrored from the v1 daily
+#   rollup classifier in scripts/lib/daily-feedback-rollup-helpers.sh):
+#     addressed-elsewhere   fix-commit by an agent author after the
+#                           comment's createdAt, touching the anchored
+#                           file (or any file when per-file detection
+#                           is unavailable)
+#     canonical-coverage    path matches a canonical entry in
+#                           .mergepath-sync.yml (propagated content)
+#     nitpick-noted         severity is Nitpick/Trivial/P3 and no
+#                           stronger signal applies
+#     rebuttal-recorded     a substantive agent-authored reply (≥30
+#                           chars) is on the thread
+#     deferred-to-followup  default fallback / --rationale override
+#
+#   Tag emission failure is logged + skipped (does NOT block the
+#   resolve mutation). The rollup's classifier accepts any string
+#   matching the regex; unknown classes route to "surface" per spec.
 #
 # Exit codes:
 #   0 — no unresolved threads
@@ -68,10 +109,17 @@ usage() {
   cat <<'EOF' >&2
 Usage: scripts/resolve-pr-threads.sh <PR#> [--repo owner/name] [--list]
                                             [--auto-resolve-bots] [--dry-run]
+                                            [--rationale <text>] [--no-tag-reply]
 
   --list                List unresolved threads (default).
   --auto-resolve-bots   Resolve bot-authored threads on current HEAD.
   --dry-run             With --auto-resolve-bots, print without mutating.
+  --rationale <text>    With --auto-resolve-bots, free-form rationale
+                        appended after the [mergepath-resolve: deferred-to-followup]
+                        tag (overrides auto-classification).
+  --no-tag-reply        With --auto-resolve-bots, suppress the
+                        [mergepath-resolve:<class>] reply emission
+                        (the resolve mutation still runs).
 EOF
   exit 1
 }
@@ -80,6 +128,9 @@ PR_NUM=""
 REPO=""
 MODE="list"
 DRY_RUN=false
+RATIONALE_OVERRIDE=""
+RATIONALE_FLAG_USED=false
+NO_TAG_REPLY=false
 # Match both REST and GraphQL bot-login formats. The REST API returns
 # `coderabbitai[bot]`; GraphQL `author{login}` returns `coderabbitai`
 # (un-suffixed user-facing handle). The trailing `(\[bot\])?` accepts
@@ -103,6 +154,18 @@ while [ $# -gt 0 ]; do
     --list) MODE="list"; shift ;;
     --auto-resolve-bots) MODE="auto-resolve-bots"; shift ;;
     --dry-run) DRY_RUN=true; shift ;;
+    --rationale)
+      # Same defensive value check as --repo (Codex r2 on PR #172):
+      # require an explicit non-empty argument so a trailing
+      # `--rationale` doesn't silently produce an empty tag body.
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        echo "Error: --rationale requires a non-empty value" >&2
+        usage
+      fi
+      RATIONALE_OVERRIDE="$2"
+      RATIONALE_FLAG_USED=true
+      shift 2 ;;
+    --no-tag-reply) NO_TAG_REPLY=true; shift ;;
     -h|--help) usage ;;
     -*) echo "Unknown flag: $1" >&2; usage ;;
     *)
@@ -249,6 +312,23 @@ QUERY='
                 commit { oid }
               }
             }
+            # `allComments` powers the rationale-tag class derivation
+            # (mergepath#305): scan agent-authored replies for an
+            # existing `[mergepath-resolve:...]` tag (skip re-emission)
+            # and substantive rebuttal detection (≥30 chars from an
+            # agent author → `rebuttal-recorded`).
+            #
+            # Cap at first 50 — same conservative limit as commentsFirst.
+            # A thread deep enough to exceed 50 replies during one
+            # auto-resolve invocation is vanishingly rare and would
+            # already be a process-smell worth surfacing manually.
+            allComments: comments(first: 50) {
+              nodes {
+                author { login }
+                body
+                databaseId
+              }
+            }
           }
         }
       }
@@ -308,11 +388,15 @@ UNRESOLVED=$(echo "$THREADS_JSON" | jq -c '
       outdated: .isOutdated,
       # commentsFirst = original review (excerpt + author for display).
       # commentsLast = guaranteed-latest comment (HEAD anchor commit_oid).
+      # allComments = full reply chain for tag-emission heuristics
+      #   (mergepath#305): existing-tag detection + rebuttal scan.
       author: (.commentsFirst.nodes[0].author.login // "unknown"),
       path: (.commentsFirst.nodes[0].path // "(no path)"),
       created: (.commentsFirst.nodes[0].createdAt // ""),
       commit_oid: (.commentsLast.nodes[0].commit.oid // ""),
-      excerpt: ((.commentsFirst.nodes[0].body // "") | .[0:160])
+      body: (.commentsFirst.nodes[0].body // ""),
+      excerpt: ((.commentsFirst.nodes[0].body // "") | .[0:160]),
+      all_comments: (.allComments.nodes // [])
     }
 ')
 
@@ -381,6 +465,352 @@ if [ "${RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK:-0}" != "1" ] && ! $DRY_RUN; then
   fi
 fi
 
+# ---------------------------------------------------------------------
+# mergepath#305 — agent-side `[mergepath-resolve:<class>]` tag emission
+# ---------------------------------------------------------------------
+#
+# Before each resolveReviewThread mutation, post a one-line reply on
+# the thread with `[mergepath-resolve: <class>] <rationale>`. The
+# v1 daily rollup classifier in
+# scripts/lib/daily-feedback-rollup-helpers.sh reads this tag and
+# prioritizes it over its own heuristics. The taxonomy (the five
+# valid `<class>` values) MUST match what the classifier accepts —
+# unknown class strings route to "surface" per the rollup spec,
+# which is acceptable but defeats the purpose.
+#
+# We intentionally do NOT source the rollup helpers file: it is not
+# in .mergepath-sync.yml, and sourcing it would either break
+# propagation OR force the helpers to travel with the canonical
+# resolve script. Instead we inline the small bits we need here
+# (regex shape, agent-author check, severity sniff). The
+# canonical taxonomy lives in the helpers file's case-statement
+# comments — this script must stay in step.
+
+# is_agent_author_local <login> → exit 0 if agent, 1 otherwise.
+# Mirrors the helpers' `is_agent_author` exactly. Bash 3.2 compatible
+# (no associative arrays). Reads MERGEPATH_AGENT_AUTHORS (colon-sep)
+# with the same default set as the rollup helpers.
+: "${MERGEPATH_AGENT_AUTHORS:=nathanjohnpayne:nathanpayne-claude:nathanpayne-cursor:nathanpayne-codex}"
+is_agent_author_local() {
+  local login="$1"
+  local oldIFS="$IFS"
+  IFS=':'
+  set -- $MERGEPATH_AGENT_AUTHORS
+  IFS="$oldIFS"
+  for a; do
+    [ "$login" = "$a" ] && return 0
+  done
+  return 1
+}
+
+# classify_severity_local <body> → P0|P1|...|Nitpick|Trivial|Unknown
+# Mirrors the rollup helpers' classify_severity, anchored on the
+# first ~600 chars to avoid false-matching severity words deep in
+# quoted context.
+classify_severity_local() {
+  local body_head
+  body_head=$(printf '%s' "$1" | head -c 600)
+  case "$body_head" in
+    *"![P0 Badge]"*|*"P0 Badge"*) echo "P0"; return ;;
+    *"![P1 Badge]"*|*"P1 Badge"*) echo "P1"; return ;;
+    *"![P2 Badge]"*|*"P2 Badge"*) echo "P2"; return ;;
+    *"![P3 Badge]"*|*"P3 Badge"*) echo "P3"; return ;;
+    *"🟠 Major"*|*"Potential issue"*|*"⚠️"*) echo "Major"; return ;;
+    *"🧹 Nitpick"*|*Nitpick*) echo "Nitpick"; return ;;
+    *"🔵 Trivial"*|*Trivial*) echo "Trivial"; return ;;
+    *"Outside diff range"*) echo "Trivial"; return ;;
+    *Minor*) echo "Minor"; return ;;
+  esac
+  echo "Unknown"
+}
+
+# One-shot fetch of PR file paths + agent-author commits, used by
+# derive_tag_class for the addressed-elsewhere heuristic. Cached so
+# we make at most one REST call per resolve invocation regardless of
+# thread count. Failure is non-fatal: tag derivation falls back to
+# the rollup's per-PR weak heuristic if files can't be retrieved.
+PR_FILES_CACHE=""
+PR_COMMITS_CACHE=""
+TAG_DATA_FETCHED=false
+fetch_pr_tag_data() {
+  $TAG_DATA_FETCHED && return 0
+  TAG_DATA_FETCHED=true
+  # REST /pulls/{pr}/files: up to 100 files, one page. PRs with >100
+  # files are rare; the fallback is to treat the path-match check as
+  # "match-any" which is the rollup's existing behavior.
+  PR_FILES_CACHE=$(gh_pat api "repos/$OWNER/$NAME/pulls/$PR_NUM/files?per_page=100" \
+    --jq '[.[].filename]' 2>/dev/null || echo '[]')
+  # REST /pulls/{pr}/commits: same shape; we need committer login +
+  # authored date.
+  PR_COMMITS_CACHE=$(gh_pat api "repos/$OWNER/$NAME/pulls/$PR_NUM/commits?per_page=100" \
+    --jq '[.[] | {login: (.author.login // .commit.author.email // ""), date: (.commit.author.date // .commit.committer.date // "")}]' 2>/dev/null || echo '[]')
+}
+
+# manifest_canonical_paths — extract canonical + kit paths from the
+# repo's .mergepath-sync.yml once. Cached. Returns a newline-separated
+# list of path strings (kit entries end with `/`, canonical entries
+# do not). Used to classify a thread as `canonical-coverage` when the
+# comment's anchored file matches a manifest entry.
+MANIFEST_PATHS_CACHE=""
+MANIFEST_FETCHED=false
+fetch_manifest_paths() {
+  $MANIFEST_FETCHED && return 0
+  MANIFEST_FETCHED=true
+  local manifest="$REPO_ROOT_FOR_MANIFEST/.mergepath-sync.yml"
+  [ -f "$manifest" ] || return 0
+  # Prefer yq when available — same parser the manifest validator uses.
+  # Fall back to a grep-based extraction so the helper still functions
+  # in environments without yq (the rollup-classifier-side reading is
+  # the same shape).
+  if command -v yq >/dev/null 2>&1; then
+    MANIFEST_PATHS_CACHE=$(yq -r '.paths[].path' "$manifest" 2>/dev/null || true)
+  else
+    # Best-effort: read `- path: VALUE` lines. Tolerates surrounding
+    # whitespace and optional quotes.
+    MANIFEST_PATHS_CACHE=$(grep -E '^[[:space:]]*-[[:space:]]*path:' "$manifest" \
+      | sed -E 's/^[[:space:]]*-[[:space:]]*path:[[:space:]]*["'\'']?([^"'\'']+)["'\'']?[[:space:]]*$/\1/')
+  fi
+}
+
+# path_matches_manifest <file-path> → exit 0 on match, 1 otherwise.
+# A file matches a canonical entry if the manifest path equals the
+# file path, or if the manifest path ends with `/` (kit) and the file
+# starts with it.
+path_matches_manifest() {
+  local file_path="$1"
+  [ -z "$file_path" ] && return 1
+  [ "$file_path" = "(no path)" ] && return 1
+  fetch_manifest_paths
+  [ -z "$MANIFEST_PATHS_CACHE" ] && return 1
+  while IFS= read -r mp; do
+    [ -z "$mp" ] && continue
+    if [ "${mp: -1}" = "/" ]; then
+      case "$file_path" in
+        "$mp"*) return 0 ;;
+      esac
+    else
+      [ "$file_path" = "$mp" ] && return 0
+    fi
+  done <<< "$MANIFEST_PATHS_CACHE"
+  return 1
+}
+
+# Module-load-time: pin the manifest base. We resolve REPO_ROOT_FOR_MANIFEST
+# from the script's on-disk location, NOT $REPO (which is the gh repo
+# slug). This intentionally reads the LOCAL working-tree manifest —
+# the same file scripts/sync-to-downstream.sh authors against — so the
+# helper's canonical-coverage class agrees with what would actually
+# propagate.
+REPO_ROOT_FOR_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# derive_tag_class — given the thread JSON (one line of UNRESOLVED),
+# return one of the rollup's class strings on stdout.
+#
+# Decision ladder (highest-confidence first; matches the
+# spec § Class taxonomy from issue #305):
+#   1. canonical-coverage     anchored path is in the manifest
+#   2. addressed-elsewhere    agent-author commit after createdAt
+#                             touching the anchored file
+#   3. rebuttal-recorded      ≥30-char agent-author reply on thread
+#   4. nitpick-noted          severity is Nitpick/Trivial/P3
+#   5. deferred-to-followup   fallback
+#
+# Why canonical-coverage wins over addressed-elsewhere: a finding on
+# a propagated canonical path is structurally a mergepath concern;
+# the rollup should route it to mergepath regardless of whether the
+# local PR happened to also touch the file. (Addressed-elsewhere is
+# stronger evidence for a one-off finding but doesn't say anything
+# about WHERE the durable fix should live.)
+derive_tag_class() {
+  local thread_json="$1"
+  local thread_path
+  local thread_created
+  local thread_body
+  thread_path=$(printf '%s' "$thread_json" | jq -r '.path // ""')
+  thread_created=$(printf '%s' "$thread_json" | jq -r '.created // ""')
+  thread_body=$(printf '%s' "$thread_json" | jq -r '.body // ""')
+
+  # 1. canonical-coverage
+  if path_matches_manifest "$thread_path"; then
+    echo "canonical-coverage"
+    return
+  fi
+
+  # 2. addressed-elsewhere — agent-author commit on PR with
+  # authoredDate > createdAt AND (file in PR's changed-files OR
+  # changed-files unavailable). Per-file precision when we can get
+  # it; falls back to the rollup's per-PR weak heuristic when the
+  # files endpoint is unreachable.
+  fetch_pr_tag_data
+  if [ -n "$thread_created" ] && [ -n "$PR_COMMITS_CACHE" ]; then
+    local file_match=false
+    if [ -n "$thread_path" ] && [ "$thread_path" != "(no path)" ]; then
+      if printf '%s' "$PR_FILES_CACHE" \
+         | jq -e --arg p "$thread_path" 'any(. == $p)' >/dev/null 2>&1; then
+        file_match=true
+      fi
+    fi
+    # When PR_FILES_CACHE failed to populate (network error → '[]'),
+    # treat as match-any so we fall back to the per-PR heuristic
+    # rather than under-classifying.
+    if [ "$PR_FILES_CACHE" = "[]" ] || [ -z "$PR_FILES_CACHE" ]; then
+      file_match=true
+    fi
+    if $file_match; then
+      local commit_count
+      commit_count=$(printf '%s' "$PR_COMMITS_CACHE" | jq 'length' 2>/dev/null || echo 0)
+      local i=0
+      while [ "$i" -lt "$commit_count" ]; do
+        local c_login
+        local c_date
+        c_login=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].login // \"\"")
+        c_date=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].date // \"\"")
+        if [ -n "$c_login" ] && [ -n "$c_date" ] \
+           && [ "$c_date" \> "$thread_created" ] \
+           && is_agent_author_local "$c_login"; then
+          # Short SHA on stdout would be nice — emit the class and
+          # let the caller render the SHA into the rationale.
+          echo "addressed-elsewhere"
+          return
+        fi
+        i=$((i + 1))
+      done
+    fi
+  fi
+
+  # 3. rebuttal-recorded — ≥30-char reply from an agent author.
+  # Skip index 0 (the original review comment).
+  local reply_count
+  reply_count=$(printf '%s' "$thread_json" | jq '.all_comments | length' 2>/dev/null || echo 0)
+  if [ "$reply_count" -gt 1 ]; then
+    local k=1
+    while [ "$k" -lt "$reply_count" ]; do
+      local r_login
+      local r_body_len
+      r_login=$(printf '%s' "$thread_json" | jq -r ".all_comments[$k].author.login // \"\"")
+      r_body_len=$(printf '%s' "$thread_json" | jq -r ".all_comments[$k].body // \"\" | length")
+      if [ -n "$r_login" ] && [ "$r_body_len" -ge 30 ] && is_agent_author_local "$r_login"; then
+        echo "rebuttal-recorded"
+        return
+      fi
+      k=$((k + 1))
+    done
+  fi
+
+  # 4. nitpick-noted
+  local sev
+  sev=$(classify_severity_local "$thread_body")
+  case "$sev" in
+    Nitpick|Trivial|P3) echo "nitpick-noted"; return ;;
+  esac
+
+  # 5. fallback
+  echo "deferred-to-followup"
+}
+
+# synth_rationale <class> <thread_json> → one-line free-form rationale
+# matching the class. Kept short (≤120 chars) so the reply stays
+# compact in the GitHub UI. The classifier reads only the tag in
+# brackets; the rationale is purely human-facing.
+synth_rationale() {
+  local class="$1"
+  local thread_json="$2"
+  local thread_path
+  thread_path=$(printf '%s' "$thread_json" | jq -r '.path // ""')
+  local short_sha=""
+  case "$class" in
+    addressed-elsewhere)
+      # Best-effort: surface the first agent-author commit's short
+      # SHA. The detection loop above doesn't capture the SHA, so we
+      # re-scan here.
+      local commit_count i
+      commit_count=$(printf '%s' "$PR_COMMITS_CACHE" | jq 'length' 2>/dev/null || echo 0)
+      i=0
+      while [ "$i" -lt "$commit_count" ]; do
+        local c_login c_date c_sha
+        c_login=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].login // \"\"")
+        c_date=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].date // \"\"")
+        c_sha=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].sha // \"\"")
+        if is_agent_author_local "$c_login"; then
+          short_sha="$c_sha"
+          break
+        fi
+        i=$((i + 1))
+      done
+      if [ -n "$short_sha" ] && [ -n "$thread_path" ] && [ "$thread_path" != "(no path)" ]; then
+        echo "addressed by commit ${short_sha:0:7} (touching $thread_path)."
+      elif [ -n "$short_sha" ]; then
+        echo "addressed by commit ${short_sha:0:7}."
+      else
+        echo "addressed by a follow-up commit on this PR."
+      fi
+      ;;
+    canonical-coverage)
+      if [ -n "$thread_path" ] && [ "$thread_path" != "(no path)" ]; then
+        echo "path $thread_path is propagated canonical content (.mergepath-sync.yml)."
+      else
+        echo "thread is on propagated canonical content (.mergepath-sync.yml)."
+      fi
+      ;;
+    nitpick-noted)
+      echo "nitpick/trivial severity; noted, no code change."
+      ;;
+    rebuttal-recorded)
+      echo "agent rebuttal posted on thread; resolving."
+      ;;
+    deferred-to-followup|*)
+      echo "deferred to follow-up; resolving for branch-protection conversation gate."
+      ;;
+  esac
+}
+
+# We also want to capture the SHA in PR_COMMITS_CACHE for the
+# rationale — re-pull with .sha included. (Earlier fetch_pr_tag_data
+# elided it to keep the cache small. Refetch in a backwards-compatible
+# way: only add the column when the original fetch already populated.)
+augment_pr_commits_with_sha() {
+  $TAG_DATA_FETCHED || return 0
+  # If already augmented (cache has .sha), skip.
+  if printf '%s' "$PR_COMMITS_CACHE" | jq -e '.[0].sha // empty' >/dev/null 2>&1; then
+    return 0
+  fi
+  PR_COMMITS_CACHE=$(gh_pat api "repos/$OWNER/$NAME/pulls/$PR_NUM/commits?per_page=100" \
+    --jq '[.[] | {sha: .sha, login: (.author.login // .commit.author.email // ""), date: (.commit.author.date // .commit.committer.date // "")}]' 2>/dev/null || echo "$PR_COMMITS_CACHE")
+}
+
+# post_tag_reply — emit a `[mergepath-resolve: <class>] <rationale>`
+# reply on the thread via the GraphQL addPullRequestReviewThreadReply
+# mutation. Logs and returns non-zero on failure; the caller should
+# log a warning and proceed to the resolve mutation regardless.
+#
+# The mutation requires the `pullRequestReviewThreadId` (the same id
+# resolveReviewThread takes) plus a body. The reply author follows
+# the PAT used for the call — same identity verification as the
+# resolve mutation, no separate gate needed.
+post_tag_reply() {
+  local thread_id="$1"
+  local class="$2"
+  local rationale="$3"
+  local body
+  body="[mergepath-resolve: $class] $rationale"
+  # Suppress stdout (the mutation response is noise), but capture
+  # stderr for failure-mode logging. `2>&1 1>/dev/null` swaps
+  # streams so we can grep the diagnostic on failure.
+  local err
+  if ! err=$(gh_pat api graphql \
+    -f query='mutation($id: ID!, $body: String!) {
+      addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $id, body: $body}) {
+        comment { id }
+      }
+    }' \
+    -F id="$thread_id" \
+    -F body="$body" \
+    >/dev/null 2>&1); then
+    return 1
+  fi
+  return 0
+}
+
 # auto-resolve-bots mode: resolve bot threads, leave human threads alone.
 # Use process substitution (`< <(...)`) instead of `echo $UNRESOLVED | while`
 # so the loop runs in the parent shell — counter increments survive past the
@@ -390,6 +820,9 @@ SKIPPED_HUMAN=0
 SKIPPED_STALE=0
 WOULD_RESOLVE_COUNT=0
 FAILED_COUNT=0
+TAG_REPLY_POSTED=0
+TAG_REPLY_FAILED=0
+TAG_REPLY_SKIPPED=0
 while IFS= read -r thread; do
   AUTHOR=$(echo "$thread" | jq -r .author)
   THREAD_ID=$(echo "$thread" | jq -r .id)
@@ -435,6 +868,41 @@ while IFS= read -r thread; do
     continue
   fi
 
+  # mergepath#305 — emit `[mergepath-resolve: <class>] <rationale>`
+  # reply BEFORE the resolve mutation. The classifier in
+  # scripts/lib/daily-feedback-rollup-helpers.sh reads this tag and
+  # prioritizes it over its own heuristics; the tag therefore must
+  # land on the thread BEFORE the thread is resolved (otherwise the
+  # rollup that runs next is reading a closed thread with no marker).
+  #
+  # Failure to post the tag is logged + counted, but does NOT block
+  # the resolve mutation. The rollup's heuristic fallback is the same
+  # behavior the script had before #305 — losing the tag is a soft
+  # regression, not a correctness bug.
+  if ! $NO_TAG_REPLY; then
+    if $RATIONALE_FLAG_USED; then
+      tag_class="deferred-to-followup"
+      tag_rationale="$RATIONALE_OVERRIDE"
+    else
+      # Need the augmented commits cache (with .sha) for the
+      # addressed-elsewhere rationale; the bare cache from
+      # fetch_pr_tag_data doesn't carry .sha. derive_tag_class only
+      # needs login + date so it runs against either shape.
+      augment_pr_commits_with_sha
+      tag_class=$(derive_tag_class "$thread")
+      tag_rationale=$(synth_rationale "$tag_class" "$thread")
+    fi
+    if post_tag_reply "$THREAD_ID" "$tag_class" "$tag_rationale"; then
+      echo "  TAGGED [$AUTHOR] $PATH_ → [mergepath-resolve: $tag_class]"
+      TAG_REPLY_POSTED=$((TAG_REPLY_POSTED + 1))
+    else
+      echo "  WARN: tag-reply post failed for [$AUTHOR] $PATH_ (resolving anyway)" >&2
+      TAG_REPLY_FAILED=$((TAG_REPLY_FAILED + 1))
+    fi
+  else
+    TAG_REPLY_SKIPPED=$((TAG_REPLY_SKIPPED + 1))
+  fi
+
   # Identity check moved out of the loop in #293 r2 — see the
   # single-gate block above the loop.
   if gh_pat api graphql -f query='
@@ -469,6 +937,9 @@ if $DRY_RUN; then
   exit 0
 fi
 echo "Resolved: $RESOLVED_COUNT  Skipped (human): $SKIPPED_HUMAN  Skipped (stale-HEAD): $SKIPPED_STALE  Failed: $FAILED_COUNT"
+if ! $NO_TAG_REPLY; then
+  echo "Tag replies: posted=$TAG_REPLY_POSTED  failed=$TAG_REPLY_FAILED"
+fi
 # Codex r1 on PR #172: previously this exited 0 even with stale or
 # human-authored threads remaining — callers would treat it as "all
 # clear" and proceed to merge into a still-BLOCKED PR. Exit codes:

--- a/tests/test_resolve_pr_threads_rationale_tag.sh
+++ b/tests/test_resolve_pr_threads_rationale_tag.sh
@@ -220,7 +220,7 @@ out=$(
 rc=$?
 set -e
 
-if grep -q 'FIELD: body=\[mergepath-resolve: addressed-elsewhere\]' "$GH_ARGV_LOG"; then
+if [ "$rc" -eq 0 ] && grep -q 'FIELD: body=\[mergepath-resolve: addressed-elsewhere\]' "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
   echo "  PASS: tag body contains [mergepath-resolve: addressed-elsewhere]"
 else
@@ -263,7 +263,7 @@ out=$(
 rc=$?
 set -e
 
-if grep -q 'FIELD: body=\[mergepath-resolve: canonical-coverage\]' "$GH_ARGV_LOG"; then
+if [ "$rc" -eq 0 ] && grep -q 'FIELD: body=\[mergepath-resolve: canonical-coverage\]' "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
   echo "  PASS: tag body contains [mergepath-resolve: canonical-coverage]"
 else
@@ -307,7 +307,7 @@ out=$(
 rc=$?
 set -e
 
-if grep -q 'FIELD: body=\[mergepath-resolve: nitpick-noted\]' "$GH_ARGV_LOG"; then
+if [ "$rc" -eq 0 ] && grep -q 'FIELD: body=\[mergepath-resolve: nitpick-noted\]' "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
   echo "  PASS: tag body contains [mergepath-resolve: nitpick-noted]"
 else
@@ -351,7 +351,7 @@ out=$(
 rc=$?
 set -e
 
-if grep -q 'FIELD: body=\[mergepath-resolve: deferred-to-followup\]' "$GH_ARGV_LOG"; then
+if [ "$rc" -eq 0 ] && grep -q 'FIELD: body=\[mergepath-resolve: deferred-to-followup\]' "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
   echo "  PASS: tag body contains [mergepath-resolve: deferred-to-followup]"
 else
@@ -401,7 +401,7 @@ set -e
 # Both the class and the custom rationale must appear in the SAME
 # tag-reply field. The stub log writes one `FIELD:` line per -F arg
 # (the body is one such line: `FIELD: body=[mergepath-resolve: deferred-to-followup] P2 noted; ...`).
-if grep -qF "FIELD: body=[mergepath-resolve: deferred-to-followup] $CUSTOM_RATIONALE" "$GH_ARGV_LOG"; then
+if [ "$rc" -eq 0 ] && grep -qF "FIELD: body=[mergepath-resolve: deferred-to-followup] $CUSTOM_RATIONALE" "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
   echo "  PASS: override emitted deferred-to-followup tag with custom rationale text"
 else
@@ -492,7 +492,7 @@ out=$(
 rc=$?
 set -e
 
-if grep -q 'FIELD: body=\[mergepath-resolve: rebuttal-recorded\]' "$GH_ARGV_LOG"; then
+if [ "$rc" -eq 0 ] && grep -q 'FIELD: body=\[mergepath-resolve: rebuttal-recorded\]' "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
   echo "  PASS: tag body contains [mergepath-resolve: rebuttal-recorded]"
 else

--- a/tests/test_resolve_pr_threads_rationale_tag.sh
+++ b/tests/test_resolve_pr_threads_rationale_tag.sh
@@ -1,0 +1,447 @@
+#!/usr/bin/env bash
+# tests/test_resolve_pr_threads_rationale_tag.sh
+#
+# Tests the mergepath#305 `[mergepath-resolve: <class>] <rationale>`
+# tag-emission flow in scripts/resolve-pr-threads.sh
+# --auto-resolve-bots.
+#
+# Strategy: stub `gh` via PATH-prepend so the script's mutation calls
+# (addPullRequestReviewThreadReply for the tag, resolveReviewThread
+# for the resolve) are captured into a side log file we can inspect.
+# Each case shapes the GraphQL response so derive_tag_class lands on
+# the expected class, then asserts the captured argv contains the
+# matching `[mergepath-resolve: <class>]` tag body.
+#
+# Tag format MUST match exactly what the v1 rollup classifier's
+# regex in scripts/lib/daily-feedback-rollup-helpers.sh expects:
+#   \[mergepath-resolve:[[:space:]]*[a-z-]+[[:space:]]*\]
+#
+# Cases (matching the spec's class taxonomy):
+#   1. addressed-elsewhere  fix-commit by agent author after createdAt
+#                           touching the comment's anchored file
+#   2. canonical-coverage   path matches a canonical entry in
+#                           .mergepath-sync.yml
+#   3. nitpick-noted        Nitpick severity, no stronger signal
+#   4. deferred-to-followup default fallback
+#   5. --rationale override emits deferred-to-followup with custom text
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/resolve-pr-threads.sh"
+[ -f "$SCRIPT" ] || { echo "missing $SCRIPT" >&2; exit 1; }
+
+pass=0
+fail=0
+
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Build a fixture .mergepath-sync.yml the script will read for the
+# canonical-coverage classification. We point the script at this
+# fixture by faking REPO_ROOT_FOR_MANIFEST via a symlink-style
+# wrapper. The simplest path: copy the real script into the
+# fixture tree and run it from there, so its
+# `$(dirname BASH_SOURCE)/..` resolution picks up our manifest.
+FIXTURE_ROOT="$SCRATCH/repo"
+mkdir -p "$FIXTURE_ROOT/scripts/lib" "$FIXTURE_ROOT/scripts/ci" "$FIXTURE_ROOT/tests"
+cp "$SCRIPT" "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh"
+# The script auto-sources scripts/lib/preflight-helpers.sh if present;
+# ship a no-op stub so the source line doesn't fail in the fixture.
+cat > "$FIXTURE_ROOT/scripts/lib/preflight-helpers.sh" <<'STUB'
+auto_source_preflight() { :; }
+STUB
+# Also ship a stub identity-check.sh that always passes (we test
+# tag emission, not identity verification — that has its own suite).
+cat > "$FIXTURE_ROOT/scripts/identity-check.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$FIXTURE_ROOT/scripts/identity-check.sh"
+
+# Fixture manifest — only the entries the test asserts against.
+cat > "$FIXTURE_ROOT/.mergepath-sync.yml" <<'YAML'
+version: 1
+consumers:
+  - name: test-consumer
+    repo: test/consumer
+    visibility: public
+paths:
+  - path: scripts/resolve-pr-threads.sh
+    type: canonical
+    consumers: all
+  - path: scripts/ci/
+    type: kit
+    consumers: all
+YAML
+
+# Common gh stub. Routes by ($1, $2) and the rest of argv:
+#   `gh api graphql -f query=...` → branch on query body for resolveReviewThread / addPullRequestReviewThreadReply / reviewThreads
+#   `gh api repos/.../pulls/N` → HEAD oid
+#   `gh api repos/.../pulls/N/files?...` → PR file list
+#   `gh api repos/.../pulls/N/commits?...` → PR commits
+#   `gh repo view --json nameWithOwner` → fixture repo slug
+make_gh_stub() {
+  local stub_path="$1"
+  local threads_json="$2"
+  local files_json="$3"
+  local commits_json="$4"
+  cat > "$stub_path" <<GH_STUB
+#!/usr/bin/env bash
+echo "ARGV: \$*" >> "\$GH_ARGV_LOG"
+# Capture the body of any -F (typed) field so we can grep for the
+# mergepath-resolve tag in the addPullRequestReviewThreadReply body
+# field. Iterate a COPY of argv via an indexed array — shifting the
+# real \$@ here would empty it before the case statement below can
+# dispatch on \$1/\$2.
+__ARGS=("\$@")
+__i=0
+while [ "\$__i" -lt "\${#__ARGS[@]}" ]; do
+  case "\${__ARGS[\$__i]}" in
+    -F|--field)
+      __next_i=\$((__i + 1))
+      echo "FIELD: \${__ARGS[\$__next_i]}" >> "\$GH_ARGV_LOG"
+      __i=\$((__i + 2)) ;;
+    -f|--raw-field)
+      __next_i=\$((__i + 1))
+      echo "RAWFIELD: \${__ARGS[\$__next_i]}" >> "\$GH_ARGV_LOG"
+      __i=\$((__i + 2)) ;;
+    *) __i=\$((__i + 1)) ;;
+  esac
+done
+
+case "\$1" in
+  api)
+    case "\$2" in
+      graphql)
+        # Pull out the query body from argv (already logged above);
+        # branch on substring matches.
+        if grep -q "addPullRequestReviewThreadReply" "\$GH_ARGV_LOG.lastcall"; then
+          # Tag-reply mutation — return a minimal success response.
+          echo '{"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"C_kwT1"}}}}'
+        elif grep -q "resolveReviewThread" "\$GH_ARGV_LOG.lastcall"; then
+          echo '{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}'
+        else
+          # reviewThreads pagination query.
+          cat <<'JSON_THREADS'
+${threads_json}
+JSON_THREADS
+        fi
+        ;;
+      "repos/"*"/pulls/"*"/files"*)
+        # The script calls this with --jq '[.[].filename]' which
+        # transforms the API response to a flat list of paths. Our
+        # stub doesn't actually parse --jq, so we return the
+        # already-transformed shape (a JSON array of path strings).
+        cat <<'JSON_FILES'
+${files_json}
+JSON_FILES
+        ;;
+      "repos/"*"/pulls/"*"/commits"*)
+        # Same shape note as /files: stub returns the already-jq-
+        # transformed shape (array of {sha,login,date} objects)
+        # because the script reads --jq output, not raw API JSON.
+        cat <<'JSON_COMMITS'
+${commits_json}
+JSON_COMMITS
+        ;;
+      "repos/"*"/pulls/"*)
+        # HEAD oid fetch — the script calls this with --jq .head.sha
+        # and captures stdout; the stub doesn't actually parse --jq,
+        # so we return the bare sha directly. Same pattern the
+        # existing tests in scripts/ci/check_resolve_pr_threads use.
+        echo "HEADCURRENT"
+        ;;
+      *)
+        echo "{}" ;;
+    esac
+    ;;
+  repo)
+    printf '{"nameWithOwner":"test/repo"}\n'
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+exit 0
+GH_STUB
+  chmod +x "$stub_path"
+}
+
+# The stub uses .lastcall to remember the most-recent call's argv
+# (so it can branch on which graphql mutation was sent). A second
+# pre-hook stub wraps the main one to populate it.
+make_gh_wrapper() {
+  local wrapper_path="$1"
+  local real_stub="$2"
+  cat > "$wrapper_path" <<WRAP_STUB
+#!/usr/bin/env bash
+# Capture this call's argv into .lastcall before dispatching to the
+# real stub, so the real stub can branch on which mutation was sent.
+printf '%s\n' "\$*" > "\$GH_ARGV_LOG.lastcall"
+exec "$real_stub" "\$@"
+WRAP_STUB
+  chmod +x "$wrapper_path"
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 1: helper detects fix-commit → emits addressed-elsewhere
+# ─────────────────────────────────────────────────────────────────────
+echo "Test 1: addressed-elsewhere class (fix-commit detection)"
+
+# Thread: comment created 2026-01-01, anchored at scripts/foo.sh.
+# PR files include scripts/foo.sh. PR commits include one by
+# nathanpayne-claude on 2026-01-02 (after createdAt).
+THREADS_T1='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_1","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"scripts/foo.sh","body":"Some finding","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Some finding","databaseId":1001}]}
+  }
+]}}}}}'
+FILES_T1='["scripts/foo.sh","scripts/bar.sh"]'
+COMMITS_T1='[{"sha":"abc1234567","login":"nathanpayne-claude","date":"2026-01-02T00:00:00Z"}]'
+
+GH_ARGV_LOG="$SCRATCH/t1.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T1" "$FILES_T1" "$COMMITS_T1"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --auto-resolve-bots 2>&1
+)
+rc=$?
+set -e
+
+if grep -q 'FIELD: body=\[mergepath-resolve: addressed-elsewhere\]' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: tag body contains [mergepath-resolve: addressed-elsewhere]"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: addressed-elsewhere tag not emitted (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 2: canonical-coverage when path matches manifest
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 2: canonical-coverage class (path in .mergepath-sync.yml)"
+
+# scripts/resolve-pr-threads.sh IS in the fixture manifest as canonical.
+THREADS_T2='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_2","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"scripts/resolve-pr-threads.sh","body":"Some finding","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Some finding","databaseId":2001}]}
+  }
+]}}}}}'
+FILES_T2='["scripts/resolve-pr-threads.sh"]'
+COMMITS_T2='[]'
+
+GH_ARGV_LOG="$SCRATCH/t2.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T2" "$FILES_T2" "$COMMITS_T2"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --auto-resolve-bots 2>&1
+)
+rc=$?
+set -e
+
+if grep -q 'FIELD: body=\[mergepath-resolve: canonical-coverage\]' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: tag body contains [mergepath-resolve: canonical-coverage]"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: canonical-coverage tag not emitted (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 3: nitpick-noted on Nitpick severity, no fix, no canonical path
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 3: nitpick-noted class (Nitpick severity, no other signals)"
+
+# Path NOT in manifest. Body carries CodeRabbit Nitpick badge.
+# No commits (empty PR_COMMITS_CACHE).
+THREADS_T3='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_3","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/random.md","body":"_🧹 Nitpick (assertive)_ minor wording issue","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"_🧹 Nitpick (assertive)_ minor wording issue","databaseId":3001}]}
+  }
+]}}}}}'
+FILES_T3='[]'
+COMMITS_T3='[]'
+
+GH_ARGV_LOG="$SCRATCH/t3.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T3" "$FILES_T3" "$COMMITS_T3"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --auto-resolve-bots 2>&1
+)
+rc=$?
+set -e
+
+if grep -q 'FIELD: body=\[mergepath-resolve: nitpick-noted\]' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: tag body contains [mergepath-resolve: nitpick-noted]"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: nitpick-noted tag not emitted (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 4: deferred-to-followup default fallback
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 4: deferred-to-followup class (default fallback)"
+
+# Path NOT in manifest. Body has no severity markers. No commits.
+# No agent reply. → falls through to deferred-to-followup.
+THREADS_T4='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_4","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/random.md","body":"Some opaque finding without a badge","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Some opaque finding without a badge","databaseId":4001}]}
+  }
+]}}}}}'
+FILES_T4='[]'
+COMMITS_T4='[]'
+
+GH_ARGV_LOG="$SCRATCH/t4.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T4" "$FILES_T4" "$COMMITS_T4"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --auto-resolve-bots 2>&1
+)
+rc=$?
+set -e
+
+if grep -q 'FIELD: body=\[mergepath-resolve: deferred-to-followup\]' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: tag body contains [mergepath-resolve: deferred-to-followup]"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: deferred-to-followup tag not emitted (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 5: --rationale override emits deferred-to-followup with the
+#         custom rationale text appended verbatim.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 5: --rationale override (deferred-to-followup + custom text)"
+
+# Same thread as Test 2 (canonical path) — would normally classify
+# as canonical-coverage; the override must beat the auto-class.
+THREADS_T5="$THREADS_T2"
+FILES_T5='[]'
+COMMITS_T5='[]'
+
+GH_ARGV_LOG="$SCRATCH/t5.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T5" "$FILES_T5" "$COMMITS_T5"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+CUSTOM_RATIONALE="P2 noted; deferred to mergepath canonical follow-up #280"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --auto-resolve-bots \
+    --rationale "$CUSTOM_RATIONALE" 2>&1
+)
+rc=$?
+set -e
+
+# Both the class and the custom rationale must appear in the SAME
+# tag-reply field. The stub log writes one `FIELD:` line per -F arg
+# (the body is one such line: `FIELD: body=[mergepath-resolve: deferred-to-followup] P2 noted; ...`).
+if grep -qF "FIELD: body=[mergepath-resolve: deferred-to-followup] $CUSTOM_RATIONALE" "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: override emitted deferred-to-followup tag with custom rationale text"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: rationale override not emitted as expected (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 6: --no-tag-reply suppresses the addPullRequestReviewThreadReply
+#         mutation entirely (resolve still runs).
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 6: --no-tag-reply suppresses tag emission"
+
+GH_ARGV_LOG="$SCRATCH/t6.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T4" "$FILES_T4" "$COMMITS_T4"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --auto-resolve-bots --no-tag-reply 2>&1
+)
+rc=$?
+set -e
+
+# Negative assertion: no tag-reply field anywhere.
+if ! grep -q 'FIELD: body=\[mergepath-resolve:' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: --no-tag-reply suppressed tag emission (no [mergepath-resolve:] body in argv)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: --no-tag-reply did NOT suppress tag emission (rc=$rc)" >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "test_resolve_pr_threads_rationale_tag: PASS ($pass tests)"
+  exit 0
+else
+  echo "test_resolve_pr_threads_rationale_tag: FAIL ($fail of $((pass + fail)) tests)" >&2
+  exit 1
+fi

--- a/tests/test_resolve_pr_threads_rationale_tag.sh
+++ b/tests/test_resolve_pr_threads_rationale_tag.sh
@@ -368,8 +368,13 @@ echo "Test 5: --rationale override (deferred-to-followup + custom text)"
 
 # Same thread as Test 2 (canonical path) — would normally classify
 # as canonical-coverage; the override must beat the auto-class.
+# FILES_T5 mirrors FILES_T2 ("scripts/resolve-pr-threads.sh") so the
+# would-be auto-class actually evaluates to canonical-coverage and
+# the test genuinely exercises --rationale's precedence over the
+# ladder. With an empty FILES_T5 the auto-class would fall through
+# to deferred-to-followup anyway, making the override untestable.
 THREADS_T5="$THREADS_T2"
-FILES_T5='[]'
+FILES_T5='["scripts/resolve-pr-threads.sh"]'
 COMMITS_T5='[]'
 
 GH_ARGV_LOG="$SCRATCH/t5.log"; : > "$GH_ARGV_LOG"

--- a/tests/test_resolve_pr_threads_rationale_tag.sh
+++ b/tests/test_resolve_pr_threads_rationale_tag.sh
@@ -24,6 +24,8 @@
 #   3. nitpick-noted        Nitpick severity, no stronger signal
 #   4. deferred-to-followup default fallback
 #   5. --rationale override emits deferred-to-followup with custom text
+#   6. --no-tag-reply suppresses tag emission while still resolving
+#   7. rebuttal-recorded    ≥30-char agent-authored reply on thread
 
 set -euo pipefail
 
@@ -433,12 +435,70 @@ rc=$?
 set -e
 
 # Negative assertion: no tag-reply field anywhere.
-if ! grep -q 'FIELD: body=\[mergepath-resolve:' "$GH_ARGV_LOG"; then
+# Positive assertion: rc == 0 AND the resolveReviewThread mutation
+# DID run — confirming "--no-tag-reply" suppresses tag emission
+# while leaving the resolve path intact (CodeRabbit Major on #308).
+if [ "$rc" -eq 0 ] \
+   && ! grep -q 'FIELD: body=\[mergepath-resolve:' "$GH_ARGV_LOG" \
+   && grep -q 'resolveReviewThread' "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
-  echo "  PASS: --no-tag-reply suppressed tag emission (no [mergepath-resolve:] body in argv)"
+  echo "  PASS: --no-tag-reply suppressed tag emission and still resolved thread"
 else
   fail=$((fail + 1))
-  echo "  FAIL: --no-tag-reply did NOT suppress tag emission (rc=$rc)" >&2
+  echo "  FAIL: --no-tag-reply behavior incorrect (rc=$rc, missing suppression or resolve)" >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 7: rebuttal-recorded — ≥30-char agent-authored reply on the
+#         thread bumps the class above nitpick / deferred-to-followup
+#         when no addressed-elsewhere/canonical signal applies.
+#         (CodeRabbit Major on #308 — the ladder's rebuttal step had
+#         no fixture coverage before.)
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 7: rebuttal-recorded class (≥30-char agent reply on thread)"
+
+# Path NOT in manifest, no commits, but allComments has an
+# agent-authored reply ≥30 chars. The reply MUST be authored by an
+# agent identity (nathanpayne-claude / -codex / -cursor) — the
+# bot-author of the original comment is skipped (index 0).
+THREADS_T7='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_7","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/notes.md","body":"Some non-canonical finding","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[
+     {"author":{"login":"coderabbitai"},"body":"Some non-canonical finding","databaseId":7001},
+     {"author":{"login":"nathanpayne-claude"},"body":"Disagree — this is intentional for the propagation path; see #200 for context.","databaseId":7002}
+   ]}
+  }
+]}}}}}'
+FILES_T7='[]'
+COMMITS_T7='[]'
+
+GH_ARGV_LOG="$SCRATCH/t7.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T7" "$FILES_T7" "$COMMITS_T7"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --auto-resolve-bots 2>&1
+)
+rc=$?
+set -e
+
+if grep -q 'FIELD: body=\[mergepath-resolve: rebuttal-recorded\]' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: tag body contains [mergepath-resolve: rebuttal-recorded]"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: rebuttal-recorded tag not emitted (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
   echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
 fi
 

--- a/tests/test_resolve_pr_threads_rationale_tag.sh
+++ b/tests/test_resolve_pr_threads_rationale_tag.sh
@@ -247,6 +247,32 @@ else
   echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
 fi
 
+# Regression: synth_rationale's PR_COMMITS_CACHE must be populated
+# in the parent shell so the addressed-elsewhere rationale cites
+# the SPECIFIC matched commit SHA instead of falling back to the
+# generic "addressed by a follow-up commit on this PR" text. If
+# fetch_pr_tag_data only runs inside derive_tag_class's command-
+# substitution subshell, synth_rationale (also subshelled) sees an
+# empty PR_COMMITS_CACHE → emits `[: : integer expression expected`
+# on its commit_count loop guard → silently degrades to the generic
+# rationale. nathanpayne-codex Phase 4b r4 on #308 reproduced this
+# with a page-2 files fixture; gate added at the call site by
+# warming the cache in the parent shell before the subshells.
+if [ "$rc" -eq 0 ] \
+   && ! grep -q 'integer expression expected' <<<"$out" \
+   && grep -q 'FIELD: body=\[mergepath-resolve: addressed-elsewhere\] addressed by commit abc1234' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: addressed-elsewhere rationale cites matched commit (no subshell-cache regression)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: addressed-elsewhere rationale degraded — subshell-cache regression?" >&2
+  echo "    expected rationale: 'addressed by commit abc1234 (touching ...)'" >&2
+  echo "    script output (looking for 'integer expression expected'):" >&2
+  echo "$out" | grep -E '(integer expression|abc1234|follow-up commit)' | sed 's/^/      /' >&2 || true
+  echo "    captured tag-reply field:" >&2
+  grep 'FIELD: body=\[mergepath-resolve: addressed-elsewhere\]' "$GH_ARGV_LOG" | sed 's/^/      /' >&2 || true
+fi
+
 # ─────────────────────────────────────────────────────────────────────
 # Test 2: canonical-coverage when path matches manifest
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_resolve_pr_threads_rationale_tag.sh
+++ b/tests/test_resolve_pr_threads_rationale_tag.sh
@@ -36,6 +36,23 @@ SCRIPT="$ROOT/scripts/resolve-pr-threads.sh"
 pass=0
 fail=0
 
+# tag_before_resolve <argv-log> → 0 if reply call appears before resolve
+# call in the cumulative argv log, 1 otherwise. The script's contract
+# is "post tag reply BEFORE resolveReviewThread"; without this check,
+# tests would pass even if the helper accidentally inverted the order
+# (CodeRabbit Major r2 on #308). Uses grep -n line numbers because the
+# argv log preserves call sequence by append-only writes.
+tag_before_resolve() {
+  local log="$1"
+  local reply_line resolve_line
+  reply_line=$(grep -n 'addPullRequestReviewThreadReply' "$log" 2>/dev/null | head -1 | cut -d: -f1)
+  resolve_line=$(grep -n 'resolveReviewThread' "$log" 2>/dev/null | head -1 | cut -d: -f1)
+  if [ -z "$reply_line" ] || [ -z "$resolve_line" ]; then
+    return 1
+  fi
+  [ "$reply_line" -lt "$resolve_line" ]
+}
+
 SCRATCH=$(mktemp -d)
 trap 'rm -rf "$SCRATCH"' EXIT
 
@@ -220,7 +237,7 @@ out=$(
 rc=$?
 set -e
 
-if [ "$rc" -eq 0 ] && grep -q 'FIELD: body=\[mergepath-resolve: addressed-elsewhere\]' "$GH_ARGV_LOG"; then
+if [ "$rc" -eq 0 ] && tag_before_resolve "$GH_ARGV_LOG" && grep -q 'FIELD: body=\[mergepath-resolve: addressed-elsewhere\]' "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
   echo "  PASS: tag body contains [mergepath-resolve: addressed-elsewhere]"
 else
@@ -263,7 +280,7 @@ out=$(
 rc=$?
 set -e
 
-if [ "$rc" -eq 0 ] && grep -q 'FIELD: body=\[mergepath-resolve: canonical-coverage\]' "$GH_ARGV_LOG"; then
+if [ "$rc" -eq 0 ] && tag_before_resolve "$GH_ARGV_LOG" && grep -q 'FIELD: body=\[mergepath-resolve: canonical-coverage\]' "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
   echo "  PASS: tag body contains [mergepath-resolve: canonical-coverage]"
 else
@@ -307,7 +324,7 @@ out=$(
 rc=$?
 set -e
 
-if [ "$rc" -eq 0 ] && grep -q 'FIELD: body=\[mergepath-resolve: nitpick-noted\]' "$GH_ARGV_LOG"; then
+if [ "$rc" -eq 0 ] && tag_before_resolve "$GH_ARGV_LOG" && grep -q 'FIELD: body=\[mergepath-resolve: nitpick-noted\]' "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
   echo "  PASS: tag body contains [mergepath-resolve: nitpick-noted]"
 else
@@ -351,7 +368,7 @@ out=$(
 rc=$?
 set -e
 
-if [ "$rc" -eq 0 ] && grep -q 'FIELD: body=\[mergepath-resolve: deferred-to-followup\]' "$GH_ARGV_LOG"; then
+if [ "$rc" -eq 0 ] && tag_before_resolve "$GH_ARGV_LOG" && grep -q 'FIELD: body=\[mergepath-resolve: deferred-to-followup\]' "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
   echo "  PASS: tag body contains [mergepath-resolve: deferred-to-followup]"
 else
@@ -401,7 +418,7 @@ set -e
 # Both the class and the custom rationale must appear in the SAME
 # tag-reply field. The stub log writes one `FIELD:` line per -F arg
 # (the body is one such line: `FIELD: body=[mergepath-resolve: deferred-to-followup] P2 noted; ...`).
-if [ "$rc" -eq 0 ] && grep -qF "FIELD: body=[mergepath-resolve: deferred-to-followup] $CUSTOM_RATIONALE" "$GH_ARGV_LOG"; then
+if [ "$rc" -eq 0 ] && tag_before_resolve "$GH_ARGV_LOG" && grep -qF "FIELD: body=[mergepath-resolve: deferred-to-followup] $CUSTOM_RATIONALE" "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
   echo "  PASS: override emitted deferred-to-followup tag with custom rationale text"
 else
@@ -434,15 +451,18 @@ out=$(
 rc=$?
 set -e
 
-# Negative assertion: no tag-reply field anywhere.
-# Positive assertion: rc == 0 AND the resolveReviewThread mutation
-# DID run — confirming "--no-tag-reply" suppresses tag emission
-# while leaving the resolve path intact (CodeRabbit Major on #308).
+# Tightened assertions (CodeRabbit Major r2 on #308):
+#   - rc == 0 — script exited cleanly
+#   - addPullRequestReviewThreadReply mutation NEVER ran — proves
+#     reply path is fully short-circuited (the prior body-text check
+#     was weaker: a reply with a non-tag body would have slipped past)
+#   - resolveReviewThread mutation DID run — proves "suppress tag,
+#     still resolve" contract
 if [ "$rc" -eq 0 ] \
-   && ! grep -q 'FIELD: body=\[mergepath-resolve:' "$GH_ARGV_LOG" \
+   && ! grep -q 'addPullRequestReviewThreadReply' "$GH_ARGV_LOG" \
    && grep -q 'resolveReviewThread' "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
-  echo "  PASS: --no-tag-reply suppressed tag emission and still resolved thread"
+  echo "  PASS: --no-tag-reply skipped reply mutation and still resolved thread"
 else
   fail=$((fail + 1))
   echo "  FAIL: --no-tag-reply behavior incorrect (rc=$rc, missing suppression or resolve)" >&2
@@ -492,7 +512,7 @@ out=$(
 rc=$?
 set -e
 
-if [ "$rc" -eq 0 ] && grep -q 'FIELD: body=\[mergepath-resolve: rebuttal-recorded\]' "$GH_ARGV_LOG"; then
+if [ "$rc" -eq 0 ] && tag_before_resolve "$GH_ARGV_LOG" && grep -q 'FIELD: body=\[mergepath-resolve: rebuttal-recorded\]' "$GH_ARGV_LOG"; then
   pass=$((pass + 1))
   echo "  PASS: tag body contains [mergepath-resolve: rebuttal-recorded]"
 else


### PR DESCRIPTION
Closes #305.

Authoring-Agent: claude

## Summary

Adds agent-side `[mergepath-resolve:<class>]` tag emission to
`scripts/resolve-pr-threads.sh --auto-resolve-bots`. The v1 daily
deferred-feedback rollup (mergepath#299 / PR #303) already reads
these tags and prioritizes them over its own heuristics — this
issue is the helper-side counterpart that emits the tag.

Before each `resolveReviewThread` mutation, the helper now posts a
one-line reply on the thread:

```
[mergepath-resolve: <class>] <one-line rationale>
```

`<class>` is derived from a fixed decision ladder (highest-confidence
first):

| Class | When the helper emits it |
|---|---|
| `canonical-coverage` | anchored path matches a canonical entry in `.mergepath-sync.yml` |
| `addressed-elsewhere` | fix-commit by an agent author after the comment's `createdAt` touching the anchored file (per-file via REST `/pulls/N/files`, with per-PR weak-heuristic fallback) |
| `rebuttal-recorded` | ≥30-char reply from an agent author on the thread |
| `nitpick-noted` | severity is Nitpick/Trivial/P3 with no stronger signal |
| `deferred-to-followup` | default fallback / `--rationale` override |

Two new flags:

- `--rationale <text>` — force class to `deferred-to-followup` and
  append free-form text. Useful for deferrals to tracked follow-up
  issues (e.g. `"P2 noted; deferred to mergepath canonical follow-up #280"`).
- `--no-tag-reply` — suppress tag emission entirely (resolve still
  runs). Useful for dry-rehearsing the loop without polluting thread
  history.

Tag-emission failure is logged and the resolve continues — losing
the tag is a soft regression (rollup falls back to its own
heuristics), not a correctness bug.

## Self-Review

**Correctness.** The decision ladder matches the spec's class
taxonomy exactly. Tag emission runs BEFORE the resolve mutation,
otherwise the rollup would read a closed thread with no marker. The
taxonomy mirrors the v1 classifier's `extract_tag_class` +
`tag_class_action` case statements in
`scripts/lib/daily-feedback-rollup-helpers.sh` byte-for-byte. Tag
format matches the classifier's regex
`\[mergepath-resolve:[[:space:]]*[a-z-]+[[:space:]]*\]` exactly.

**Regression risk.** All 9 existing `scripts/ci/check_resolve_pr_threads`
cases still pass (cursor-null typing #192, totalCount cross-validation
under/over-count, defensive `isResolved`-null, HEAD-anchor reads
`commentsLast` per #194, two-page pagination, keyring fallback).
The GraphQL query gained an `allComments: comments(first: 50)` alias
to power the rebuttal-detection branch — capped at 50 to bound
payload size, same conservative shape as `commentsFirst`/`commentsLast`.
The new code path is gated on `--auto-resolve-bots` and
`NO_TAG_REPLY=false`, so list-mode is unchanged.

**Style.** Inlined `is_agent_author_local` and `classify_severity_local`
rather than sourcing `scripts/lib/daily-feedback-rollup-helpers.sh`
— that helper file is not in `.mergepath-sync.yml`, and sourcing it
would either break propagation or force the helpers to travel with
the canonical resolve script. The trade-off is duplicated
case-statement bodies; an in-script comment block notes both files
must stay in step. (Alternative: add the helpers file to the
manifest; deferred to a follow-up if the duplication becomes a
maintenance burden.)

**Test coverage.** 6 new test cases in
`tests/test_resolve_pr_threads_rationale_tag.sh` (one per class +
`--rationale` override + `--no-tag-reply` suppression) wired into
`scripts/ci/check_resolve_pr_threads`. Fixture-based; no live
GitHub network. The new test follows the existing `check_codex_p1_gate`
/ `check_disagreement_detector` pattern of co-locating cases in
`tests/` and wrapping invocation in `scripts/ci/check_*`.

**Security / dependency hygiene.** No new dependencies. The
tag-reply mutation uses the same `gh_pat` wrapper (preflight
reviewer PAT) as the resolve mutation — same identity gate via
`scripts/identity-check.sh`, same auth posture. No secrets in logs
(only the tag body is logged on success, never argv).

**Propagation closure.** Per the #264 requires:-closure invariant,
the new test file is added to `.mergepath-sync.yml` twice:

1. As its own canonical entry, paired with `scripts/resolve-pr-threads.sh`.
2. Under `scripts/ci/`'s `requires:` list, since the kit's
   `check_resolve_pr_threads` wrapper now hard-requires it.

Verified locally: `check_sync_manifest`, `check_ci_scripts_wired`,
and the extended `check_resolve_pr_threads` all pass.

## Test plan

- [x] `bash scripts/ci/check_resolve_pr_threads` — 10 tests pass (9 existing + 1 new delegated case)
- [x] `bash tests/test_resolve_pr_threads_rationale_tag.sh` — 6 cases pass (one per class + override + suppress)
- [x] `bash scripts/ci/check_sync_manifest` — manifest updated, requires:-closure satisfied
- [x] `bash scripts/ci/check_ci_scripts_wired` — all check_* scripts wired
- [x] `bash tests/test_daily_feedback_rollup.sh` — 46 tests still pass (classifier unchanged)
- [x] `bash scripts/ci/check_codex_p1_gate` / `check_disagreement_detector` / `check_canonical_bugs_263caf3` — all pass (sanity)
- [x] `bash -n scripts/resolve-pr-threads.sh` — syntax ok

