### PR TITLE
fix: sanitize fake-key placeholder in op-firebase-deploy integration fixture (#306 fan-out unblock)

### DIFF
--- a/scripts/ci/check_op_firebase_deploy_integration
+++ b/scripts/ci/check_op_firebase_deploy_integration
@@ -119,7 +119,7 @@ write_fake_sa_key() {
   "type": "service_account",
   "project_id": "fake-project",
   "private_key_id": "fake-key-id",
-  "private_key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
   "client_email": "$sa_email",
   "client_id": "0",
   "auth_uri": "https://accounts.google.com/o/oauth2/auth",


### PR DESCRIPTION
One-character fix: sanitize the fake-key placeholder in `scripts/ci/check_op_firebase_deploy_integration`'s JSON fixture so consumer-side secret-scanners don't trip on the `-----BEGIN PRIVATE KEY-----` marker.

## Repro

Surfaced on the #306 fan-out wave (7 consumer PRs opened against the daily-rollup workflow chain):

- **nathanjohnpayne/device-source-of-truth#87** — `Frontend (Smoke + Coercion)` job's secret-detector step:
  ```
  Potential public secrets found in tracked files:
  - scripts/ci/check_op_firebase_deploy_integration:122 (Private key block) -----BEGIN PRIVATE KEY-----
  ```
- **nathanjohnpayne/friends-and-family-billing#272** — same finding from its `test:secrets` step

5 of 7 fan-out targets don't run a secret-scanner with this regex and passed clean. The 2 that do legitimately blocked.

## Fix

Replace the literal `"-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n"` placeholder with `"REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY"`. The resolver's `source_cred_is_usable` short-circuits on `type == "service_account"` and never reads `private_key` — the placeholder string is purely a JSON-shape filler.

## Validation

All 5 integration cases still pass locally:

```
PASS: case0_explicit_gac_override
PASS: case1_project_sa_key_present
PASS: case2_preflight_adc_present
PASS: case3_shared_op_adc_present
PASS: case4_local_adc_present
check_op_firebase_deploy_integration: PASS (5 cases)
```

## Post-merge plan

Re-run `scripts/sync-to-downstream.sh --sync-all --recreate-existing --repos device-source-of-truth,friends-and-family-billing` to force-update the two affected PR branches with the fix. The other 5 fan-out PRs are unaffected (no secret-scanner) but can be updated via the same flag for cleanliness if you prefer.

Authoring-Agent: claude

## Test plan

- [x] Local `MERGEPATH_RUN_INTEGRATION=1 bash scripts/ci/check_op_firebase_deploy_integration` — 5/5 PASS
- [x] `grep -rn "BEGIN PRIVATE KEY" scripts/ tests/` — no other matches anywhere in propagated content
- [ ] CI: required workflows pass
- [ ] Post-merge re-sync to the 2 affected consumers; verify their secret-scanner steps clear

## Self-Review

**Correctness.** Resolver short-circuits on `type == "service_account"` (lines 233-265 of `scripts/firebase/op-firebase-deploy`); `private_key` field contents are never parsed. Placeholder string can be anything; "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY" is explicit enough that future agents/scanners see it's not a key.

**Regression risk.** Negligible. Single-field placeholder change in a test fixture; no production code path touched.

**Style.** Inline-fixture pattern unchanged; only the string contents differ.

**Test coverage.** Same 5 integration cases pass.

**Security/dependency hygiene.** Removes a false-positive secret marker from tracked files. No real key was ever in the file; the change is purely about scanner regex hygiene.

Refs: #306 (the propagation wave that surfaced this).
