### PR TITLE
feat(propagation): add Layer 5 template-substitution lib + tests + docs

### DIFF
--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -189,6 +189,17 @@ jobs:
         # mirror lane silently re-overwriting them.
         run: ./scripts/ci/check_sync_overrides
 
+      - name: check_template_substitution
+        # Exercises tests/test_template_substitution.sh — verifies the
+        # Layer 5 template-substitution lib's v1 syntax (variable
+        # substitution, conditional blocks, comment-prefix flexibility,
+        # malformed-template error paths, strict-mode fact-miss, atomic
+        # render_to). The lib is the substitution engine for the
+        # `type: templated` manifest entries (activated in a follow-up
+        # PR); the check is wired now so the lib's contract is guarded
+        # independently of integration.
+        run: ./scripts/ci/check_template_substitution
+
       - name: check_coderabbit_config
         # Validates the template-level .coderabbit.yml stays on the
         # nit-suppressing profile (chill). Shares the yq install with

--- a/docs/agents/templated-propagation.md
+++ b/docs/agents/templated-propagation.md
@@ -8,7 +8,7 @@ This doc covers `scripts/lib/template-substitution.sh` — the rendering engine 
 
 Renders a source template to per-consumer output using two surfaces:
 
-1. **Variable substitution** — anywhere in the file, `{{key}}` is replaced by the value of `MERGEPATH_FACT_KEY` (uppercased, hyphens → underscores).
+1. **Variable substitution** — anywhere in the file, `{{key}}` is replaced by the value of `MERGEPATH_FACT_KEY` (uppercased, hyphens → underscores). Keys must match `[a-z0-9_-]+` (lowercase letters, digits, underscore, hyphen); a malformed key — e.g. one containing shell metacharacters — is rejected as malformed template (render exit code 1), distinct from a syntactically valid but unset fact (which is empty in lenient mode or exit code 3 in strict mode).
 2. **Conditional blocks** — `>>> if <expr> ... <<<` markers gate body lines on per-consumer facts. Marker lines are **always stripped** from output regardless of the expression; only the body lines between them are conditional. If `<expr>` is true, body lines are emitted verbatim; if false, body lines are dropped.
 
 Sync-side integration (follow-up PR) is responsible for exporting per-consumer facts from the manifest before invoking the lib. The lib itself reads facts only from the environment.
@@ -58,7 +58,7 @@ Inside `>>> if <expr>`, the lib supports:
 
 `contains` matches at word boundaries — `frameworks contains react` is false when `MERGEPATH_FACT_FRAMEWORKS="react-native"`, true when it's `"react typescript"`. Use distinct values for distinct concepts; don't rely on substring matching.
 
-Anything else in the expression slot is a malformed-template error (exit code 1) with a diagnostic listing the supported forms.
+Anything else in the expression slot (including a `<key>` that fails the `[a-z0-9_-]+` charset check) is a malformed-template error (exit code 1) with a diagnostic listing the supported forms.
 
 ### v1 deliberately omits
 
@@ -86,7 +86,7 @@ template_substitution::eval_expr "frameworks contains react"
 # Returns 0 (true), 1 (false), or 2 (malformed expression).
 ```
 
-The lib is `set -euo pipefail` internally but does not toggle global `set` state during rendering — callers can use the standard `|| rc=$?` pattern to capture the exit code without their own `set -e` being clobbered.
+The lib enables `set -euo pipefail` **only** when the file is executed directly (the noop usage-hint path at the bottom). When sourced — the normal case — no global shell options are toggled, so `render` and `render_to` will not clobber the caller's `set -e` / `set -u` / `pipefail` state. Callers capture exit codes with the standard `|| rc=$?` pattern.
 
 ## Why this syntax — design rationale
 

--- a/docs/agents/templated-propagation.md
+++ b/docs/agents/templated-propagation.md
@@ -1,0 +1,131 @@
+# Templated propagation — Layer 5 substitution lib
+
+Status: **lib landed; sync integration pending in follow-up PR.**
+
+This doc covers `scripts/lib/template-substitution.sh` — the rendering engine that activates `type: templated` entries in `.mergepath-sync.yml`. It exists ahead of integration so the lib's contract can be reviewed and stabilized before code paths in `scripts/sync-to-downstream.sh`, `scripts/workflow/verify-propagation-pr.sh`, and `scripts/ci/check_sync_manifest` depend on it.
+
+## What the lib does
+
+Renders a source template to per-consumer output using two surfaces:
+
+1. **Variable substitution** — anywhere in the file, `{{key}}` is replaced by the value of `MERGEPATH_FACT_KEY` (uppercased, hyphens → underscores).
+2. **Conditional blocks** — `>>> if <expr> ... <<<` markers gate body lines on per-consumer facts. The block (markers included) is kept iff `<expr>` evaluates true; otherwise the whole block is dropped.
+
+Sync-side integration (follow-up PR) is responsible for exporting per-consumer facts from the manifest before invoking the lib. The lib itself reads facts only from the environment.
+
+## Syntax reference
+
+### Variables
+
+```
+hello {{name}}!
+ts version {{node_version}}
+```
+
+- Missing facts render as empty string in lenient mode (default).
+- Set `MERGEPATH_TEMPLATE_STRICT=1` to make a reference-to-unset-fact a hard error (exit code 3).
+- Unclosed `{{` (no matching `}}`) is emitted verbatim — no error. The lib is permissive here so accidental token-like sequences in real source files don't false-fail.
+
+### Conditional blocks
+
+```
+// >>> if frameworks contains react
+import react from "eslint-plugin-react";
+// <<<
+```
+
+The leading comment prefix on a marker line is **stripped on parse** — the lib accepts any run of non-alphanumeric characters before the `>>>`/`<<<` sigil, so all of these work:
+
+- `// >>> if ...` / `// <<<` — JS, TS, C, C++, Rust, Go
+- `# >>> if ...` / `# <<<` — bash, YAML, Python, TOML
+- `-- >>> if ...` / `-- <<<` — SQL, Lua, Haskell
+- `<!-- >>> if ... -->` / `<!-- <<< -->` — HTML, XML
+- Leading whitespace before the comment chars is allowed.
+
+A kept block's body lines survive verbatim (including their own leading whitespace, comments, etc.). A skipped block drops every line between the markers — the markers themselves never appear in output.
+
+### Expression forms (v1)
+
+Inside `>>> if <expr>`, the lib supports:
+
+| Form | True when |
+|---|---|
+| `<key>` | `MERGEPATH_FACT_KEY` is set and non-empty |
+| `!<key>` | `MERGEPATH_FACT_KEY` is unset or empty |
+| `<key> contains <value>` | `<value>` appears as a space-separated word in `MERGEPATH_FACT_KEY` |
+| `<key> == <value>` | string equality |
+| `<key> != <value>` | string inequality |
+
+`contains` matches at word boundaries — `frameworks contains react` is false when `MERGEPATH_FACT_FRAMEWORKS="react-native"`, true when it's `"react typescript"`. Use distinct values for distinct concepts; don't rely on substring matching.
+
+Anything else in the expression slot is a malformed-template error (exit code 1) with a diagnostic listing the supported forms.
+
+### v1 deliberately omits
+
+- **Nested conditionals.** A second `>>> if` while another is still open is an error. The first real templated source (`examples/eslint.config.js` after Phase C) doesn't need nesting; relax later if a real source does.
+- **`else` / `elif`.** Express the alternative as a second top-level block with the negated condition.
+- **Loops or iteration.** Out of scope. Per-consumer expansion happens at the sync-call layer, not inside templates.
+- **Block-comment-only languages (JSON, CSS-without-`//`).** Templates must be in a language that supports the `<comment-chars> >>> ... <comment-chars> <<<` shape on its own line. Most config-as-code files satisfy this; JSON does not (workaround: use JSON5 or move the templated piece into a `.js` wrapper).
+
+## API
+
+Source the lib, then call:
+
+```bash
+source "scripts/lib/template-substitution.sh"
+
+# Render to stdout. Exit 0 success, 1 malformed template, 2 source-file
+# missing, 3 unknown fact in strict mode.
+template_substitution::render path/to/template.tpl
+
+# Atomic write via mktemp + mv. Same exit codes as render.
+template_substitution::render_to path/to/template.tpl path/to/dest
+
+# Expression evaluator exposed for direct testing.
+template_substitution::eval_expr "frameworks contains react"
+# Returns 0 (true), 1 (false), or 2 (malformed expression).
+```
+
+The lib is `set -euo pipefail` internally but does not toggle global `set` state during rendering — callers can use the standard `|| rc=$?` pattern to capture the exit code without their own `set -e` being clobbered.
+
+## Why this syntax — design rationale
+
+This section records the decisions taken so a future reader (or a reviewer asking "why didn't you just use Mustache?") doesn't have to reconstruct the trade-offs.
+
+### Why comment-prefix-agnostic markers, not `{{#if}}…{{/if}}`
+
+Mustache-style conditional markers (`{{#if frameworks.react}}…{{/if}}`) would have been the obvious choice — they're familiar and unambiguous. We picked comment-prefix markers instead because:
+
+1. **A source template that's valid in its target language stays editor-friendly.** `examples/eslint.config.js` with comment markers parses, lints, and previews exactly like a real ESLint config. Mustache `{{#if}}` would break syntax highlighting and prevent in-place evaluation. Templates that look like real code are easier to maintain.
+2. **No new dependency.** Pure bash, no vendored renderer, no shell-out to node. Matches the rest of `scripts/lib/`.
+3. **Mergepath already considered and rejected `{{TOKEN}}` markers for bootstrap-time name substitution** (`scripts/bootstrap/substitute.sh:19-27`). The rationale there was "markers visible to direct readers — bad UX." The constraint is weaker for templated propagation (template files clearly live under `examples/`, readers expect templating), but the precedent informed the syntax choice — line-comment markers are even more invisible to direct readers than Mustache tokens.
+
+`{{var}}` substitution is retained for the variable-replacement surface because it's the same shape `scripts/bootstrap/substitute.sh` already uses for `MERGEPATH_DESCRIPTION_HERE`-style markers, and conflating two syntaxes for "replace this with a value" is unnecessary churn.
+
+### Why facts in env vars, not a manifest sub-block
+
+The lib is invoked once per `<consumer × templated path>` combination by the sync script. The sync script reads `.mergepath-sync.yml`, extracts the consumer's facts, exports them as `MERGEPATH_FACT_<KEY>=<value>`, then forks the renderer. Passing facts via env is the most-portable way to hand structured data to a bash subprocess without a tempfile or stdin dance. It also keeps the lib trivially testable — tests just export the env and source the lib directly, with no manifest fixture needed.
+
+### Why no nested conditionals in v1
+
+The forcing function (`eslint.config.js` per consumer) has at most one layer of conditionals — independent framework blocks. Allowing nesting from day one would have added a stack-management state machine to the renderer for zero current benefit. The v1 lib explicitly fails on a second open marker so a future need surfaces loud rather than silently producing wrong output.
+
+### Why strict-mode is opt-in, not the default
+
+Real templates will accumulate optional-fact references over time (`{{node_version}}`, `{{lint_glob}}`, etc.) and not every consumer will set every fact. Lenient default avoids forcing every fact to be declared on every consumer just to satisfy the renderer. Strict mode is available for CI checks that want hard-fail behavior (e.g., "every consumer with `frameworks contains typescript` must declare `node_version`").
+
+## Limits and known gaps
+
+- **The lib alone produces no output anywhere yet.** It's wired into `repo_lint.yml` via `scripts/ci/check_template_substitution` so its tests run on every PR, but no manifest entry uses `type: templated` yet. The follow-up integration PR adds that.
+- **The lib doesn't know about consumer name or repo.** Facts must be uniform across consumers (e.g., `frameworks`, `node_version`); per-consumer name substitution (`mergepath` → `<consumer>`) still goes through `scripts/bootstrap/substitute.sh`'s allow-list-driven path. Long-term, both should share a single substitution lib (per [#168 Layer 5's original sketch](https://github.com/nathanjohnpayne/mergepath/issues/168) — "factor the substitution logic into `scripts/lib/template-substitution.sh` so bootstrap and sync share the lib"), but that consolidation is non-trivial because the two callers have different semantics (literal name allow-list vs. fact-driven substitution). Tracked as future work.
+- **No `--audit`-side rendering yet.** Until the integration PR lands, `--audit` will continue to print "templated (deferred — Layer 5, #168)" for `type: templated` entries.
+
+## What the follow-up PR adds
+
+The next PR builds on this lib to:
+
+1. Add `facts:` schema to consumer entries in `.mergepath-sync.yml`, plus `source:` + `dest:` fields on path entries (so `examples/eslint.config.js` can land at consumer-root `eslint.config.js`).
+2. Extend `scripts/sync-to-downstream.sh` to handle `type: templated` — render per consumer using their facts, write to `dest`, commit/PR via the propagation lane.
+3. Extend `scripts/ci/check_sync_manifest` to validate the new schema (facts vocabulary, source/dest mapping consistency).
+4. Extend `scripts/workflow/verify-propagation-pr.sh` to re-render the source against `mergepath@<sha>` with consumer facts and byte-verify the PR content — closes the propagation-lane gate for templated paths.
+5. First templated entry: `examples/eslint.config.js` → `eslint.config.js` across the 6 consumers with non-empty JS/TS surface area, unblocking the [mergepath#250](https://github.com/nathanjohnpayne/mergepath/issues/250) ESLint rollout backlog.

--- a/docs/agents/templated-propagation.md
+++ b/docs/agents/templated-propagation.md
@@ -9,7 +9,7 @@ This doc covers `scripts/lib/template-substitution.sh` — the rendering engine 
 Renders a source template to per-consumer output using two surfaces:
 
 1. **Variable substitution** — anywhere in the file, `{{key}}` is replaced by the value of `MERGEPATH_FACT_KEY` (uppercased, hyphens → underscores).
-2. **Conditional blocks** — `>>> if <expr> ... <<<` markers gate body lines on per-consumer facts. The block (markers included) is kept iff `<expr>` evaluates true; otherwise the whole block is dropped.
+2. **Conditional blocks** — `>>> if <expr> ... <<<` markers gate body lines on per-consumer facts. Marker lines are **always stripped** from output regardless of the expression; only the body lines between them are conditional. If `<expr>` is true, body lines are emitted verbatim; if false, body lines are dropped.
 
 Sync-side integration (follow-up PR) is responsible for exporting per-consumer facts from the manifest before invoking the lib. The lib itself reads facts only from the environment.
 
@@ -17,7 +17,7 @@ Sync-side integration (follow-up PR) is responsible for exporting per-consumer f
 
 ### Variables
 
-```
+```text
 hello {{name}}!
 ts version {{node_version}}
 ```
@@ -28,7 +28,7 @@ ts version {{node_version}}
 
 ### Conditional blocks
 
-```
+```js
 // >>> if frameworks contains react
 import react from "eslint-plugin-react";
 // <<<

--- a/scripts/ci/check_template_substitution
+++ b/scripts/ci/check_template_substitution
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/ci/check_template_substitution — CI entry point for the
+# Layer 5 template-substitution lib tests.
+#
+# Wraps tests/test_template_substitution.sh so the repo_lint workflow's
+# explicit check_* list picks it up. The lib at
+# scripts/lib/template-substitution.sh is the substitution engine for
+# `type: templated` manifest entries (activated in a follow-up PR);
+# this check guards the lib's contract independently of integration.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_template_substitution.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  echo "check_template_substitution: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/lib/template-substitution.sh
+++ b/scripts/lib/template-substitution.sh
@@ -361,12 +361,18 @@ template_substitution::render_to() {
     return 2
   fi
   # Capture existing dest mode (if any) before render — we need it
-  # before the rename clobbers the dest inode. `stat -f` is BSD/
-  # macOS; `stat -c` is GNU/Linux. Try both, fall back to empty.
+  # before the rename clobbers the dest inode. `stat -c` is GNU/
+  # Linux; `stat -f` is BSD/macOS. Try GNU first because that's the
+  # CI runner — and crucially because GNU `stat -f` means "filesystem
+  # status" (not "format"), so a BSD-first fallback chain writes
+  # filesystem text to stdout on Linux before failing, contaminating
+  # dest_mode with multi-line garbage (Codex P1 round 3 on PR #313).
+  # GNU `stat -c '%a'` and BSD `stat -f '%Mp%Lp'` both yield the
+  # mode in a chmod-acceptable form (e.g. "644" or "0644").
   local dest_mode=""
   if [ -e "$dest" ]; then
-    dest_mode=$(stat -f '%Mp%Lp' "$dest" 2>/dev/null \
-                || stat -c '%a' "$dest" 2>/dev/null \
+    dest_mode=$(stat -c '%a' "$dest" 2>/dev/null \
+                || stat -f '%Mp%Lp' "$dest" 2>/dev/null \
                 || printf '')
   fi
   local tmp

--- a/scripts/lib/template-substitution.sh
+++ b/scripts/lib/template-substitution.sh
@@ -53,8 +53,13 @@
 #
 # Bash 3.2 portable (no associative arrays, no ${var^^}). Matches
 # scripts/bootstrap/substitute.sh's portability bar.
-
-set -euo pipefail
+#
+# This file is a SOURCED library and intentionally does NOT set
+# `set -euo pipefail` at file scope — that would mutate the caller's
+# shell options unexpectedly (CodeRabbit Major / Codex P1 on PR #313).
+# Internal functions use the `|| rc=$?` pattern to capture exit codes
+# without depending on errexit. The executed-directly guard block at
+# the bottom does enable strict mode for the noop-script path.
 
 # Convert a lowercase-with-hyphens fact name to its env var form:
 # "frameworks" → "MERGEPATH_FACT_FRAMEWORKS"
@@ -69,8 +74,30 @@ template_substitution::_fact_var() {
 # Look up a fact value. Echoes the value (empty string if unset).
 # In strict mode, prints a diagnostic to stderr and returns 3 if the
 # fact is referenced but unset.
+#
+# Validates the key against [a-z0-9-] before passing to _fact_var
+# because _fact_var feeds into eval below. Without this guard, a key
+# containing shell metacharacters (e.g. `foo$(id)`) survives the `tr`
+# transformation and is interpreted at eval time as a command
+# substitution — RCE via a malicious manifest fact key (CodeRabbit
+# Critical on PR #313). Keys come from the manifest in practice, but
+# defense-in-depth catches a bad manifest entry or a future code
+# path that synthesizes keys from less-trusted input.
 template_substitution::_fact_value() {
   local key=$1
+  case "$key" in
+    ''|*[!a-z0-9_-]*)
+      # Reject anything outside [a-z0-9_-]. Underscores stay allowed
+      # because env-var-style fact keys (e.g. `node_version`) are
+      # natural in templates and underscores are not eval metachars.
+      # Shell metacharacters ($, (, ), backtick, ;, &, |, \) and
+      # uppercase letters are blocked: the former are the injection
+      # surface, the latter are reserved for the env-var form
+      # (_fact_var uppercases keys to derive MERGEPATH_FACT_<KEY>).
+      printf 'template: malformed fact key (must match [a-z0-9_-]+): %s\n' "$key" >&2
+      return 2
+      ;;
+  esac
   local var
   var=$(template_substitution::_fact_var "$key")
   # bash 3.2 indirect expansion via eval.
@@ -104,7 +131,7 @@ template_substitution::eval_expr() {
       local inner=${expr#!}
       inner=$(printf '%s' "$inner" | sed -e 's/^[[:space:]]*//')
       local v
-      v=$(template_substitution::_fact_value "$inner") || return 3
+      v=$(template_substitution::_fact_value "$inner") || return $?
       if [ -z "$v" ]; then return 0; else return 1; fi
       ;;
     *" contains "*)
@@ -113,7 +140,7 @@ template_substitution::eval_expr() {
       key=$(printf '%s' "$key" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
       needle=$(printf '%s' "$needle" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
       local haystack
-      haystack=$(template_substitution::_fact_value "$key") || return 3
+      haystack=$(template_substitution::_fact_value "$key") || return $?
       # Space-padded match so "react" doesn't match "react-native".
       case " $haystack " in
         *" $needle "*) return 0 ;;
@@ -126,7 +153,7 @@ template_substitution::eval_expr() {
       key=$(printf '%s' "$key" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
       want=$(printf '%s' "$want" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
       local have
-      have=$(template_substitution::_fact_value "$key") || return 3
+      have=$(template_substitution::_fact_value "$key") || return $?
       if [ "$have" = "$want" ]; then return 0; else return 1; fi
       ;;
     *" != "*)
@@ -135,7 +162,7 @@ template_substitution::eval_expr() {
       key=$(printf '%s' "$key" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
       want=$(printf '%s' "$want" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
       local have
-      have=$(template_substitution::_fact_value "$key") || return 3
+      have=$(template_substitution::_fact_value "$key") || return $?
       if [ "$have" != "$want" ]; then return 0; else return 1; fi
       ;;
     *" "*)
@@ -146,7 +173,7 @@ template_substitution::eval_expr() {
     *)
       # Bare key — truthy iff non-empty.
       local v
-      v=$(template_substitution::_fact_value "$expr") || return 3
+      v=$(template_substitution::_fact_value "$expr") || return $?
       if [ -n "$v" ]; then return 0; else return 1; fi
       ;;
   esac
@@ -176,7 +203,7 @@ template_substitution::_substitute_vars() {
             local key=${rest%%\}\}*}
             local after=${rest#*\}\}}
             local value
-            value=$(template_substitution::_fact_value "$key") || return 3
+            value=$(template_substitution::_fact_value "$key") || return $?
             out="$out$before$value"
             remaining=$after
             ;;
@@ -278,9 +305,12 @@ template_substitution::render() {
     local rendered
     local rc=0
     rendered=$(template_substitution::_substitute_vars "$line") || rc=$?
-    if [ "$rc" != "0" ]; then
-      return $rc
-    fi
+    case "$rc" in
+      0) ;;
+      2) return 1 ;;  # malformed fact key in template body → malformed template
+      3) return 3 ;;  # strict-mode unset fact
+      *) return $rc ;;
+    esac
     printf '%s\n' "$rendered"
   done < "$source"
 
@@ -292,24 +322,50 @@ template_substitution::render() {
 }
 
 # Render to a destination file atomically.
+#
+# Atomicity contract: the destination either contains the fully-
+# rendered output OR is unchanged from its prior state — never a
+# partial write. Implemented by rendering into a sibling temp file
+# and `mv`-renaming it over the destination. The temp file lives in
+# `$(dirname "$dest")` (NOT $TMPDIR) so the rename is guaranteed to
+# stay on the same filesystem; a cross-filesystem mv would degrade
+# to copy+unlink, breaking atomicity under interrupt (CodeRabbit
+# Major / Codex P2 on PR #313).
+#
+# mv failure (permission, ENOSPC, racing process) is checked
+# explicitly — without that, render_to could return 0 with no
+# destination write, silently losing the rendered output.
 template_substitution::render_to() {
   local source=$1
   local dest=$2
+  local dest_dir
+  dest_dir=$(dirname "$dest")
+  if [ ! -d "$dest_dir" ]; then
+    printf 'template: destination directory not found: %s\n' "$dest_dir" >&2
+    return 2
+  fi
   local tmp
-  tmp=$(mktemp "${TMPDIR:-/tmp}/template-render.XXXXXX")
+  tmp=$(mktemp "$dest_dir/.template-render.XXXXXX")
   local rc=0
   template_substitution::render "$source" >"$tmp" || rc=$?
   if [ "$rc" != "0" ]; then
     rm -f "$tmp"
     return $rc
   fi
-  mv "$tmp" "$dest"
+  if ! mv -f "$tmp" "$dest"; then
+    rm -f "$tmp"
+    printf 'template: mv failed writing %s\n' "$dest" >&2
+    return 1
+  fi
 }
 
 # Inline self-check: if invoked directly as a script (not sourced),
+# enable strict mode (safe because nothing else is sourcing us) and
 # emit a usage hint. Matches the convention used by other lib files
-# under scripts/lib/.
+# under scripts/lib/. Strict mode is intentionally NOT enabled at
+# file scope; see the comment near the top of this file.
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  set -euo pipefail
   cat >&2 <<EOF
 $(basename "$0") is a library. Source it from another bash script:
 

--- a/scripts/lib/template-substitution.sh
+++ b/scripts/lib/template-substitution.sh
@@ -100,10 +100,16 @@ template_substitution::_fact_value() {
   esac
   local var
   var=$(template_substitution::_fact_var "$key")
-  # bash 3.2 indirect expansion via eval.
-  local value
-  eval "value=\${$var-__MERGEPATH_FACT_UNSET__}"
-  if [ "$value" = "__MERGEPATH_FACT_UNSET__" ]; then
+  # bash 3.2 indirect expansion via eval. Detect set-or-unset with
+  # the `${var+x}` form (echoes "x" if var is set to ANY value
+  # including empty; echoes empty if unset). Earlier versions used
+  # a literal sentinel string compared via `=`, which mis-classified
+  # a fact legitimately set to that exact sentinel as unset
+  # (Codex P3 on PR #313). The +x form has no collision surface —
+  # the test is on the existence of the variable, not its value.
+  local is_set
+  eval "is_set=\${$var+x}"
+  if [ -z "$is_set" ]; then
     if [ "${MERGEPATH_TEMPLATE_STRICT:-0}" = "1" ]; then
       printf 'template: strict mode: fact %s (env %s) is not set\n' \
         "$key" "$var" >&2
@@ -112,6 +118,8 @@ template_substitution::_fact_value() {
     printf ''
     return 0
   fi
+  local value
+  eval "value=\${$var}"
   printf '%s' "$value"
 }
 
@@ -335,6 +343,14 @@ template_substitution::render() {
 # mv failure (permission, ENOSPC, racing process) is checked
 # explicitly — without that, render_to could return 0 with no
 # destination write, silently losing the rendered output.
+#
+# Mode preservation: if the destination already exists, its file
+# mode is captured before the rename and re-applied after, so a
+# pre-existing executable or world-readable file keeps its bits
+# rather than inheriting mktemp's 0600 (Codex P2 round 2 on PR
+# #313). When dest doesn't yet exist, the temp file's 0600 mode
+# stands — callers that need a specific mode on a new file set it
+# explicitly after rendering.
 template_substitution::render_to() {
   local source=$1
   local dest=$2
@@ -343,6 +359,15 @@ template_substitution::render_to() {
   if [ ! -d "$dest_dir" ]; then
     printf 'template: destination directory not found: %s\n' "$dest_dir" >&2
     return 2
+  fi
+  # Capture existing dest mode (if any) before render — we need it
+  # before the rename clobbers the dest inode. `stat -f` is BSD/
+  # macOS; `stat -c` is GNU/Linux. Try both, fall back to empty.
+  local dest_mode=""
+  if [ -e "$dest" ]; then
+    dest_mode=$(stat -f '%Mp%Lp' "$dest" 2>/dev/null \
+                || stat -c '%a' "$dest" 2>/dev/null \
+                || printf '')
   fi
   local tmp
   tmp=$(mktemp "$dest_dir/.template-render.XXXXXX")
@@ -356,6 +381,15 @@ template_substitution::render_to() {
     rm -f "$tmp"
     printf 'template: mv failed writing %s\n' "$dest" >&2
     return 1
+  fi
+  # Re-apply captured mode. chmod failure is non-fatal — the content
+  # is already correctly written, and a mode-preservation failure is
+  # less bad than reporting a render failure when the render itself
+  # succeeded. Surfaced via stderr only.
+  if [ -n "$dest_mode" ]; then
+    chmod "$dest_mode" "$dest" 2>/dev/null \
+      || printf 'template: warning: failed to restore mode %s on %s\n' \
+           "$dest_mode" "$dest" >&2
   fi
 }
 

--- a/scripts/lib/template-substitution.sh
+++ b/scripts/lib/template-substitution.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# scripts/lib/template-substitution.sh — render templated propagation
+# sources with per-consumer facts.
+#
+# v1 syntax (intentionally minimal — see docs/agents/templated-
+# propagation.md § Why this syntax for the rationale):
+#
+#   1. Variable substitution. Anywhere in the file:
+#        {{key}}                 → ${MERGEPATH_FACT_KEY:-""}
+#      Missing fact = empty string in lenient mode (default), hard
+#      fail in strict mode (MERGEPATH_TEMPLATE_STRICT=1).
+#
+#   2. Conditional blocks. Lines matching:
+#        >>> if <expr>
+#        ...body...
+#        <<<
+#      The leading comment prefix on the marker line is stripped (the
+#      lib accepts any non-alnum run before the `>>>`/`<<<` sigil so
+#      `//`, `#`, `--`, `<!-- … -->`, `/* … */` all work). Body lines
+#      survive verbatim if <expr> is true; the entire block (markers
+#      included) is omitted otherwise.
+#
+#      <expr> forms accepted in v1:
+#        - <key>                  truthy iff env MERGEPATH_FACT_KEY is set
+#                                 and non-empty
+#        - !<key>                 inverse of the above
+#        - <key> contains <value> for space-separated list facts
+#        - <key> == <value>       string equality
+#        - <key> != <value>       string inequality
+#
+#      Nesting is NOT supported in v1. Two `>>> if` opens without an
+#      intervening `<<<` is a malformed-template error (exit 1). Add
+#      nesting later if a real source file needs it.
+#
+# Facts source: environment variables. Each fact key (lowercase,
+# possibly with hyphens) maps to `MERGEPATH_FACT_<KEY>` (uppercase,
+# hyphens → underscores). List facts are space-separated. Sync
+# integration (scripts/sync-to-downstream.sh) is responsible for
+# extracting per-consumer facts from .mergepath-sync.yml and
+# exporting them before invoking this lib.
+#
+# API:
+#   template_substitution::render <source_file>
+#       Renders to stdout. Exit 0 success, 1 malformed template, 2
+#       source-file missing, 3 unknown fact in strict mode.
+#
+#   template_substitution::render_to <source_file> <dest_file>
+#       Atomic write via mktemp + mv. Same exit codes as render.
+#
+#   template_substitution::eval_expr <expr>
+#       Returns 0 if expr is true, 1 if false, 2 if expr is malformed.
+#       Exposed so tests can drive it directly.
+#
+# Bash 3.2 portable (no associative arrays, no ${var^^}). Matches
+# scripts/bootstrap/substitute.sh's portability bar.
+
+set -euo pipefail
+
+# Convert a lowercase-with-hyphens fact name to its env var form:
+# "frameworks" → "MERGEPATH_FACT_FRAMEWORKS"
+# "node-version" → "MERGEPATH_FACT_NODE_VERSION"
+template_substitution::_fact_var() {
+  local key=$1
+  local upper
+  upper=$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+  printf 'MERGEPATH_FACT_%s' "$upper"
+}
+
+# Look up a fact value. Echoes the value (empty string if unset).
+# In strict mode, prints a diagnostic to stderr and returns 3 if the
+# fact is referenced but unset.
+template_substitution::_fact_value() {
+  local key=$1
+  local var
+  var=$(template_substitution::_fact_var "$key")
+  # bash 3.2 indirect expansion via eval.
+  local value
+  eval "value=\${$var-__MERGEPATH_FACT_UNSET__}"
+  if [ "$value" = "__MERGEPATH_FACT_UNSET__" ]; then
+    if [ "${MERGEPATH_TEMPLATE_STRICT:-0}" = "1" ]; then
+      printf 'template: strict mode: fact %s (env %s) is not set\n' \
+        "$key" "$var" >&2
+      return 3
+    fi
+    printf ''
+    return 0
+  fi
+  printf '%s' "$value"
+}
+
+# Evaluate a conditional expression. Returns 0 (true), 1 (false), or
+# 2 (malformed).
+template_substitution::eval_expr() {
+  local expr=$1
+  # Trim leading/trailing whitespace.
+  expr=$(printf '%s' "$expr" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+  case "$expr" in
+    "")
+      printf 'template: empty conditional expression\n' >&2
+      return 2
+      ;;
+    "!"*)
+      local inner=${expr#!}
+      inner=$(printf '%s' "$inner" | sed -e 's/^[[:space:]]*//')
+      local v
+      v=$(template_substitution::_fact_value "$inner") || return 3
+      if [ -z "$v" ]; then return 0; else return 1; fi
+      ;;
+    *" contains "*)
+      local key=${expr%% contains *}
+      local needle=${expr#* contains }
+      key=$(printf '%s' "$key" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+      needle=$(printf '%s' "$needle" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+      local haystack
+      haystack=$(template_substitution::_fact_value "$key") || return 3
+      # Space-padded match so "react" doesn't match "react-native".
+      case " $haystack " in
+        *" $needle "*) return 0 ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *" == "*)
+      local key=${expr%% == *}
+      local want=${expr#* == }
+      key=$(printf '%s' "$key" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+      want=$(printf '%s' "$want" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+      local have
+      have=$(template_substitution::_fact_value "$key") || return 3
+      if [ "$have" = "$want" ]; then return 0; else return 1; fi
+      ;;
+    *" != "*)
+      local key=${expr%% != *}
+      local want=${expr#* != }
+      key=$(printf '%s' "$key" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+      want=$(printf '%s' "$want" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+      local have
+      have=$(template_substitution::_fact_value "$key") || return 3
+      if [ "$have" != "$want" ]; then return 0; else return 1; fi
+      ;;
+    *" "*)
+      printf 'template: malformed conditional expression: %s\n' "$expr" >&2
+      printf 'template: supported forms: <key>, !<key>, <key> contains <value>, <key> == <value>, <key> != <value>\n' >&2
+      return 2
+      ;;
+    *)
+      # Bare key — truthy iff non-empty.
+      local v
+      v=$(template_substitution::_fact_value "$expr") || return 3
+      if [ -n "$v" ]; then return 0; else return 1; fi
+      ;;
+  esac
+}
+
+# Apply {{key}} substitutions to a single line. Echoes the rewritten
+# line. In strict mode, an unset fact reference returns 3 (caller
+# handles).
+template_substitution::_substitute_vars() {
+  local line=$1
+  # Fast path: no `{{` on the line.
+  case "$line" in
+    *"{{"*) ;;
+    *) printf '%s' "$line"; return 0 ;;
+  esac
+
+  # Walk left-to-right, replacing each {{key}} occurrence.
+  local out=""
+  local remaining=$line
+  while :; do
+    case "$remaining" in
+      *"{{"*)
+        local before=${remaining%%\{\{*}
+        local rest=${remaining#*\{\{}
+        case "$rest" in
+          *"}}"*)
+            local key=${rest%%\}\}*}
+            local after=${rest#*\}\}}
+            local value
+            value=$(template_substitution::_fact_value "$key") || return 3
+            out="$out$before$value"
+            remaining=$after
+            ;;
+          *)
+            # Unclosed {{: emit as-is, stop.
+            out="$out$remaining"
+            remaining=""
+            break
+            ;;
+        esac
+        ;;
+      *)
+        out="$out$remaining"
+        remaining=""
+        break
+        ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
+# Regex helpers — POSIX BREs, anchored, comment-prefix-agnostic.
+# Marker line pattern: optional whitespace, optional non-alnum prefix
+# (the comment chars), optional whitespace, then the sigil, then space-
+# separated payload. We use grep -E with explicit anchors.
+template_substitution::_is_if_open() {
+  # $1: line. Returns 0 if it's a `>>> if ...` marker, echoing the
+  # expression on stdout. Returns 1 otherwise (no output).
+  local line=$1
+  printf '%s' "$line" | grep -E '^[[:space:]]*[^[:alnum:]{]*[[:space:]]*>>>[[:space:]]+if[[:space:]]+' >/dev/null || return 1
+  # Extract the expression after `>>> if `.
+  printf '%s' "$line" | sed -E 's/^[[:space:]]*[^[:alnum:]{]*[[:space:]]*>>>[[:space:]]+if[[:space:]]+//' \
+    | sed -e 's/[[:space:]]*$//' \
+    | sed -E 's,[[:space:]]*(\*/|-->)[[:space:]]*$,,'
+  return 0
+}
+
+template_substitution::_is_close() {
+  # $1: line. Returns 0 if it's a `<<<` marker line, 1 otherwise.
+  local line=$1
+  printf '%s' "$line" | grep -E '^[[:space:]]*[^[:alnum:]{]*[[:space:]]*<<<[[:space:]]*([^[:alnum:]{]*[[:space:]]*)?$' >/dev/null
+}
+
+# Render a template file to stdout. Implements the v1 syntax.
+template_substitution::render() {
+  local source=$1
+  if [ ! -f "$source" ]; then
+    printf 'template: source file not found: %s\n' "$source" >&2
+    return 2
+  fi
+
+  local in_conditional=0      # 0 outside, 1 inside (active), 2 inside (skipped)
+  local conditional_lineno=0  # for error diagnostics on unclosed `if`
+  local lineno=0
+  local line
+  # IFS= + -r preserves leading whitespace and backslashes. The trailing
+  # `|| [ -n "$line" ]` catches a file without a final newline.
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+
+    # `<<<` close marker?
+    if template_substitution::_is_close "$line"; then
+      if [ "$in_conditional" = "0" ]; then
+        printf 'template: %s:%d: unexpected `<<<` (no open `>>> if`)\n' \
+          "$source" "$lineno" >&2
+        return 1
+      fi
+      in_conditional=0
+      continue
+    fi
+
+    # `>>> if ...` open marker?
+    local expr
+    if expr=$(template_substitution::_is_if_open "$line"); then
+      if [ "$in_conditional" != "0" ]; then
+        printf 'template: %s:%d: nested `>>> if` is not supported in v1 (open at line %d)\n' \
+          "$source" "$lineno" "$conditional_lineno" >&2
+        return 1
+      fi
+      conditional_lineno=$lineno
+      local rc=0
+      template_substitution::eval_expr "$expr" || rc=$?
+      case $rc in
+        0) in_conditional=1 ;;
+        1) in_conditional=2 ;;
+        2) return 1 ;;  # malformed expr → malformed template
+        3) return 3 ;;  # strict-mode fact-miss
+        *) printf 'template: eval_expr returned unexpected rc=%d\n' "$rc" >&2; return 1 ;;
+      esac
+      continue
+    fi
+
+    # Body line.
+    if [ "$in_conditional" = "2" ]; then
+      # Inside a skipped block — drop the line.
+      continue
+    fi
+
+    local rendered
+    local rc=0
+    rendered=$(template_substitution::_substitute_vars "$line") || rc=$?
+    if [ "$rc" != "0" ]; then
+      return $rc
+    fi
+    printf '%s\n' "$rendered"
+  done < "$source"
+
+  if [ "$in_conditional" != "0" ]; then
+    printf 'template: %s: unclosed `>>> if` (opened at line %d)\n' \
+      "$source" "$conditional_lineno" >&2
+    return 1
+  fi
+}
+
+# Render to a destination file atomically.
+template_substitution::render_to() {
+  local source=$1
+  local dest=$2
+  local tmp
+  tmp=$(mktemp "${TMPDIR:-/tmp}/template-render.XXXXXX")
+  local rc=0
+  template_substitution::render "$source" >"$tmp" || rc=$?
+  if [ "$rc" != "0" ]; then
+    rm -f "$tmp"
+    return $rc
+  fi
+  mv "$tmp" "$dest"
+}
+
+# Inline self-check: if invoked directly as a script (not sourced),
+# emit a usage hint. Matches the convention used by other lib files
+# under scripts/lib/.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  cat >&2 <<EOF
+$(basename "$0") is a library. Source it from another bash script:
+
+  source "scripts/lib/template-substitution.sh"
+  template_substitution::render path/to/source.template
+
+See docs/agents/templated-propagation.md for the syntax reference.
+EOF
+  exit 2
+fi

--- a/tests/test_template_substitution.sh
+++ b/tests/test_template_substitution.sh
@@ -418,9 +418,12 @@ echo "new: {{key}}" > "$src"
   source "$LIB"
   template_substitution::render_to "$src" "$dest"
 )
-# Read mode in a portable way (same logic as the lib).
-actual_mode=$(stat -f '%Mp%Lp' "$dest" 2>/dev/null \
-              || stat -c '%a' "$dest" 2>/dev/null \
+# Read mode in a portable way (same order as the lib — GNU first, BSD
+# fallback; the inverse order breaks on Linux because GNU `stat -f`
+# means filesystem status, not format, and writes garbage to stdout
+# before failing).
+actual_mode=$(stat -c '%a' "$dest" 2>/dev/null \
+              || stat -f '%Mp%Lp' "$dest" 2>/dev/null \
               || echo "??")
 # BSD stat returns "0644", GNU returns "644". Accept both.
 case "$actual_mode" in

--- a/tests/test_template_substitution.sh
+++ b/tests/test_template_substitution.sh
@@ -1,0 +1,520 @@
+#!/usr/bin/env bash
+# tests/test_template_substitution.sh
+#
+# Unit tests for scripts/lib/template-substitution.sh. Covers v1 syntax:
+# variable substitution, conditional blocks across the four expression
+# forms, comment-prefix flexibility, error paths (unclosed/nested/
+# unexpected markers, malformed expressions), strict-mode fact-miss,
+# atomic render_to.
+#
+# Bash 3.2 portable. Runs without network. Invoked by
+# scripts/ci/check_template_substitution (which the lib's introduction
+# PR also wires up).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB="$ROOT/scripts/lib/template-substitution.sh"
+
+[[ -r "$LIB" ]] || { echo "missing $LIB" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/template-sub-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Reset all MERGEPATH_FACT_* env vars before each test so prior cases
+# can't bleed in.
+reset_facts() {
+  local var
+  for var in $(env | awk -F= '/^MERGEPATH_FACT_/ {print $1}'); do
+    unset "$var"
+  done
+  unset MERGEPATH_TEMPLATE_STRICT
+}
+
+# Source the lib in a subshell so test failures don't poison later
+# tests. Each render_case is its own subshell.
+render_case() {
+  # $1: template content (heredoc-friendly), $2..: KEY=VALUE env exports
+  local template_content=$1
+  shift
+  local src="$WORKDIR/src.$$.tpl"
+  local out="$WORKDIR/out.$$.txt"
+  local err="$WORKDIR/err.$$.txt"
+  printf '%s' "$template_content" > "$src"
+  (
+    reset_facts
+    for kv in "$@"; do
+      export "$kv"
+    done
+    # shellcheck disable=SC1090
+    source "$LIB"
+    local render_rc=0
+    template_substitution::render "$src" > "$out" 2> "$err" || render_rc=$?
+    echo "$render_rc" > "$WORKDIR/rc.$$.txt"
+  )
+  local rc
+  rc=$(cat "$WORKDIR/rc.$$.txt")
+  rm -f "$src" "$WORKDIR/rc.$$.txt"
+  # Echo: <rc>\t<stdout-file>\t<stderr-file>
+  printf '%s\t%s\t%s\n' "$rc" "$out" "$err"
+}
+
+# Helper: assert rendered output matches expected.
+expect_output() {
+  local label=$1 result=$2 expected=$3
+  local rc out_file err_file
+  rc=$(printf '%s' "$result" | cut -f1)
+  out_file=$(printf '%s' "$result" | cut -f2)
+  err_file=$(printf '%s' "$result" | cut -f3)
+  if [ "$rc" != "0" ]; then
+    fail "$label: expected rc=0, got rc=$rc; stderr:"
+    sed 's/^/    /' "$err_file" >&2
+    return
+  fi
+  local actual
+  actual=$(cat "$out_file")
+  if [ "$actual" = "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label: output mismatch"
+    echo "  expected:" >&2
+    printf '%s\n' "$expected" | sed 's/^/    /' >&2
+    echo "  actual:" >&2
+    printf '%s\n' "$actual" | sed 's/^/    /' >&2
+  fi
+}
+
+expect_rc() {
+  local label=$1 result=$2 want_rc=$3
+  local rc err_file
+  rc=$(printf '%s' "$result" | cut -f1)
+  err_file=$(printf '%s' "$result" | cut -f3)
+  if [ "$rc" = "$want_rc" ]; then
+    pass "$label (rc=$rc)"
+  else
+    fail "$label: expected rc=$want_rc, got rc=$rc; stderr:"
+    sed 's/^/    /' "$err_file" >&2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. Variable substitution
+# ---------------------------------------------------------------------------
+
+r=$(render_case "hello {{name}}!
+" "MERGEPATH_FACT_NAME=world")
+expect_output "1a {{key}} basic substitution" "$r" "hello world!"
+
+r=$(render_case "{{a}}-{{b}}-{{a}}
+" "MERGEPATH_FACT_A=foo" "MERGEPATH_FACT_B=bar")
+expect_output "1b multiple substitutions per line, repeats" "$r" "foo-bar-foo"
+
+r=$(render_case "plain line, no markers
+")
+expect_output "1c no markers passes through" "$r" "plain line, no markers"
+
+r=$(render_case "missing: <{{nope}}>
+")
+expect_output "1d lenient mode: missing fact = empty" "$r" "missing: <>"
+
+r=$(render_case "missing: <{{nope}}>
+" "MERGEPATH_TEMPLATE_STRICT=1")
+expect_rc "1e strict mode: missing fact = rc 3" "$r" 3
+
+r=$(render_case "unclosed: {{key
+")
+expect_output "1f unclosed {{ left verbatim" "$r" "unclosed: {{key"
+
+r=$(render_case "hyphen key: {{node-version}}
+" "MERGEPATH_FACT_NODE_VERSION=20")
+expect_output "1g hyphenated fact key → underscored env var" "$r" "hyphen key: 20"
+
+# ---------------------------------------------------------------------------
+# 2. Bare conditional: >>> if <key>
+# ---------------------------------------------------------------------------
+
+r=$(render_case "before
+// >>> if has_ts
+typescript line
+// <<<
+after
+" "MERGEPATH_FACT_HAS_TS=1")
+expect_output "2a bare conditional, truthy fact" "$r" "before
+typescript line
+after"
+
+r=$(render_case "before
+// >>> if has_ts
+typescript line
+// <<<
+after
+")
+expect_output "2b bare conditional, unset fact (lenient)" "$r" "before
+after"
+
+r=$(render_case "before
+// >>> if has_ts
+typescript line
+// <<<
+after
+" "MERGEPATH_FACT_HAS_TS=")
+expect_output "2c bare conditional, empty fact = falsy" "$r" "before
+after"
+
+# ---------------------------------------------------------------------------
+# 3. Negation: >>> if !<key>
+# ---------------------------------------------------------------------------
+
+r=$(render_case "// >>> if !has_ts
+no typescript
+// <<<
+")
+expect_output "3a negation, unset fact = true" "$r" "no typescript"
+
+r=$(render_case "// >>> if !has_ts
+no typescript
+// <<<
+" "MERGEPATH_FACT_HAS_TS=1")
+expect_output "3b negation, set fact = false" "$r" ""
+
+# ---------------------------------------------------------------------------
+# 4. List membership: >>> if <key> contains <value>
+# ---------------------------------------------------------------------------
+
+r=$(render_case "// >>> if frameworks contains react
+react block
+// <<<
+" "MERGEPATH_FACT_FRAMEWORKS=react typescript")
+expect_output "4a contains, present" "$r" "react block"
+
+r=$(render_case "// >>> if frameworks contains vue
+vue block
+// <<<
+" "MERGEPATH_FACT_FRAMEWORKS=react typescript")
+expect_output "4b contains, absent" "$r" ""
+
+# Word-boundary safety: "react" must NOT match "react-native".
+r=$(render_case "// >>> if frameworks contains react
+matched react
+// <<<
+" "MERGEPATH_FACT_FRAMEWORKS=react-native")
+expect_output "4c contains, word-boundary (react ≠ react-native)" "$r" ""
+
+r=$(render_case "// >>> if frameworks contains react-native
+matched native
+// <<<
+" "MERGEPATH_FACT_FRAMEWORKS=react-native react")
+expect_output "4d contains, hyphenated value matches" "$r" "matched native"
+
+# ---------------------------------------------------------------------------
+# 5. Equality / inequality
+# ---------------------------------------------------------------------------
+
+r=$(render_case "// >>> if node_version == 20
+node 20
+// <<<
+" "MERGEPATH_FACT_NODE_VERSION=20")
+expect_output "5a equality, match" "$r" "node 20"
+
+r=$(render_case "// >>> if node_version == 20
+node 20
+// <<<
+" "MERGEPATH_FACT_NODE_VERSION=18")
+expect_output "5b equality, no match" "$r" ""
+
+r=$(render_case "// >>> if node_version != 18
+modern node
+// <<<
+" "MERGEPATH_FACT_NODE_VERSION=20")
+expect_output "5c inequality, match" "$r" "modern node"
+
+r=$(render_case "// >>> if node_version != 18
+modern node
+// <<<
+" "MERGEPATH_FACT_NODE_VERSION=18")
+expect_output "5d inequality, no match" "$r" ""
+
+# ---------------------------------------------------------------------------
+# 6. Comment-prefix flexibility (each comment style must be recognized)
+# ---------------------------------------------------------------------------
+
+for prefix_label_pair in \
+    "// js-line" \
+    "# shell-yaml" \
+    "-- sql-lua" \
+    "<!-- html-open"; do
+  prefix=${prefix_label_pair% *}
+  label=${prefix_label_pair#* }
+  # html close needs trailing -->; handle separately for marker close
+  if [ "$label" = "html-open" ]; then
+    template=$(printf '%s >>> if frameworks contains react\nreact-only\n%s <<< -->\n' "$prefix" "$prefix")
+  else
+    template=$(printf '%s >>> if frameworks contains react\nreact-only\n%s <<<\n' "$prefix" "$prefix")
+  fi
+  r=$(render_case "$template" "MERGEPATH_FACT_FRAMEWORKS=react")
+  expect_output "6 prefix '$prefix' ($label) — block kept" "$r" "react-only"
+done
+
+# Mixed leading whitespace on marker.
+r=$(render_case "    // >>> if frameworks contains react
+react-only
+  // <<<
+" "MERGEPATH_FACT_FRAMEWORKS=react")
+expect_output "6e leading whitespace on markers" "$r" "react-only"
+
+# ---------------------------------------------------------------------------
+# 7. Variable substitution INSIDE a kept block (and skipped block)
+# ---------------------------------------------------------------------------
+
+r=$(render_case "// >>> if has_ts
+ts version {{node_version}}
+// <<<
+" "MERGEPATH_FACT_HAS_TS=1" "MERGEPATH_FACT_NODE_VERSION=20")
+expect_output "7a {{vars}} substituted inside kept block" "$r" "ts version 20"
+
+r=$(render_case "// >>> if has_ts
+ts version {{node_version}}
+// <<<
+")
+expect_output "7b {{vars}} inside skipped block are not substituted" "$r" ""
+
+# ---------------------------------------------------------------------------
+# 8. Malformed templates → rc 1
+# ---------------------------------------------------------------------------
+
+r=$(render_case "// >>> if has_ts
+unclosed body
+")
+expect_rc "8a unclosed if marker -> rc 1" "$r" 1
+
+r=$(render_case "before
+// <<<
+after
+")
+expect_rc "8b unexpected close marker -> rc 1" "$r" 1
+
+r=$(render_case "// >>> if outer
+outer body
+// >>> if inner
+nested body
+// <<<
+// <<<
+")
+expect_rc "8c nested if -> rc 1 (v1 doesnt support nesting)" "$r" 1
+
+r=$(render_case "// >>> if foo bar baz quux
+body
+// <<<
+")
+expect_rc "8d unknown expression form → rc 1" "$r" 1
+
+# ---------------------------------------------------------------------------
+# 9. eval_expr direct (drives the expression evaluator in isolation)
+# ---------------------------------------------------------------------------
+
+(
+  reset_facts
+  export MERGEPATH_FACT_FRAMEWORKS="react typescript"
+  export MERGEPATH_FACT_HAS_TS=1
+  # shellcheck disable=SC1090
+  source "$LIB"
+  set +e
+  template_substitution::eval_expr "has_ts"; r1=$?
+  template_substitution::eval_expr "!has_ts"; r2=$?
+  template_substitution::eval_expr "frameworks contains react"; r3=$?
+  template_substitution::eval_expr "frameworks contains vue"; r4=$?
+  template_substitution::eval_expr "node_version == 20"; r5=$?
+  template_substitution::eval_expr ""; r6=$?
+  set -e
+  if [ "$r1" = "0" ] && [ "$r2" = "1" ] && [ "$r3" = "0" ] && \
+     [ "$r4" = "1" ] && [ "$r5" = "1" ] && [ "$r6" = "2" ]; then
+    echo "PASS: 9 eval_expr direct (truthy/falsy/match/miss/empty)"
+  else
+    echo "FAIL: 9 eval_expr direct: got $r1/$r2/$r3/$r4/$r5/$r6 (expected 0/1/0/1/1/2)" >&2
+    exit 1
+  fi
+) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
+
+# ---------------------------------------------------------------------------
+# 10. render_to atomic write
+# ---------------------------------------------------------------------------
+
+src="$WORKDIR/atomic-src.tpl"
+dest="$WORKDIR/atomic-dest.txt"
+cat > "$src" <<'EOF'
+rendered: {{key}}
+EOF
+(
+  reset_facts
+  export MERGEPATH_FACT_KEY=value
+  # shellcheck disable=SC1090
+  source "$LIB"
+  template_substitution::render_to "$src" "$dest"
+)
+if [ -f "$dest" ] && [ "$(cat "$dest")" = "rendered: value" ]; then
+  pass "10a render_to writes destination file"
+else
+  fail "10a render_to: expected 'rendered: value', got: $(cat "$dest" 2>/dev/null || echo MISSING)"
+fi
+
+# render_to failure: malformed template → no partial write of dest.
+src="$WORKDIR/atomic-bad.tpl"
+dest="$WORKDIR/atomic-bad-dest.txt"
+echo "// >>> if has_ts" > "$src"
+echo "body" >> "$src"
+# (no <<<)
+(
+  reset_facts
+  # shellcheck disable=SC1090
+  source "$LIB"
+  exit_rc=0
+  template_substitution::render_to "$src" "$dest" || exit_rc=$?
+  echo "$exit_rc" > "$WORKDIR/atomic-rc.txt"
+)
+exit_rc=$(cat "$WORKDIR/atomic-rc.txt")
+if [ "$exit_rc" = "1" ] && [ ! -f "$dest" ]; then
+  pass "10b render_to atomic: malformed template leaves no partial dest"
+else
+  fail "10b render_to: expected rc=1 + no dest, got rc=$exit_rc, dest exists: $([ -f "$dest" ] && echo yes || echo no)"
+fi
+
+# ---------------------------------------------------------------------------
+# 11. End-to-end: ESLint-config-shaped template (the forcing function)
+# ---------------------------------------------------------------------------
+
+src="$WORKDIR/eslint.config.js.tpl"
+cat > "$src" <<'EOF'
+import js from "@eslint/js";
+import globals from "globals";
+
+// >>> if frameworks contains typescript
+import tseslint from "typescript-eslint";
+// <<<
+// >>> if frameworks contains astro
+import astro from "eslint-plugin-astro";
+// <<<
+// >>> if frameworks contains react
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+// <<<
+
+export default [
+  { ignores: ["node_modules/**", "dist/**"] },
+  js.configs.recommended,
+// >>> if frameworks contains typescript
+  ...tseslint.configs.recommended,
+// <<<
+// >>> if frameworks contains astro
+  ...astro.configs.recommended,
+// <<<
+// >>> if frameworks contains react
+  {
+    files: ["**/*.{jsx,tsx}"],
+    plugins: { react, "react-hooks": reactHooks },
+    rules: {
+      ...react.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off",
+    },
+  },
+// <<<
+];
+EOF
+
+# Case 11a: swipewatch profile (JS-only, no frameworks)
+expected_swipewatch='import js from "@eslint/js";
+import globals from "globals";
+
+
+export default [
+  { ignores: ["node_modules/**", "dist/**"] },
+  js.configs.recommended,
+];'
+(
+  reset_facts
+  export MERGEPATH_FACT_FRAMEWORKS=""
+  # shellcheck disable=SC1090
+  source "$LIB"
+  template_substitution::render "$src" > "$WORKDIR/swipewatch.out"
+)
+if [ "$(cat "$WORKDIR/swipewatch.out")" = "$expected_swipewatch" ]; then
+  pass "11a ESLint template, swipewatch profile (JS-only)"
+else
+  fail "11a swipewatch profile mismatch:"
+  diff <(printf '%s\n' "$expected_swipewatch") "$WORKDIR/swipewatch.out" | sed 's/^/    /' >&2
+fi
+
+# Case 11b: matchline profile (TS + React)
+expected_matchline='import js from "@eslint/js";
+import globals from "globals";
+
+import tseslint from "typescript-eslint";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+
+export default [
+  { ignores: ["node_modules/**", "dist/**"] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["**/*.{jsx,tsx}"],
+    plugins: { react, "react-hooks": reactHooks },
+    rules: {
+      ...react.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off",
+    },
+  },
+];'
+(
+  reset_facts
+  export MERGEPATH_FACT_FRAMEWORKS="react typescript"
+  # shellcheck disable=SC1090
+  source "$LIB"
+  template_substitution::render "$src" > "$WORKDIR/matchline.out"
+)
+if [ "$(cat "$WORKDIR/matchline.out")" = "$expected_matchline" ]; then
+  pass "11b ESLint template, matchline profile (TS+React)"
+else
+  fail "11b matchline profile mismatch:"
+  diff <(printf '%s\n' "$expected_matchline") "$WORKDIR/matchline.out" | sed 's/^/    /' >&2
+fi
+
+# Case 11c: nathanpaynedotcom profile (TS + Astro)
+expected_npc='import js from "@eslint/js";
+import globals from "globals";
+
+import tseslint from "typescript-eslint";
+import astro from "eslint-plugin-astro";
+
+export default [
+  { ignores: ["node_modules/**", "dist/**"] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  ...astro.configs.recommended,
+];'
+(
+  reset_facts
+  export MERGEPATH_FACT_FRAMEWORKS="astro typescript"
+  # shellcheck disable=SC1090
+  source "$LIB"
+  template_substitution::render "$src" > "$WORKDIR/npc.out"
+)
+if [ "$(cat "$WORKDIR/npc.out")" = "$expected_npc" ]; then
+  pass "11c ESLint template, nathanpaynedotcom profile (TS+Astro)"
+else
+  fail "11c nathanpaynedotcom profile mismatch:"
+  diff <(printf '%s\n' "$expected_npc") "$WORKDIR/npc.out" | sed 's/^/    /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================================"
+echo "PASS: $PASS   FAIL: $FAIL"
+echo "============================================================"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_template_substitution.sh
+++ b/tests/test_template_substitution.sh
@@ -126,6 +126,25 @@ r=$(render_case "missing: <{{nope}}>
 " "MERGEPATH_TEMPLATE_STRICT=1")
 expect_rc "1e strict mode: missing fact = rc 3" "$r" 3
 
+# 1e2: regression guard for sentinel collision (Codex P3 round 2 on PR #313).
+# A fact legitimately set to the OLD sentinel string must NOT be
+# misclassified as unset. With the +x detection this is just an
+# ordinary set-to-value case.
+r=$(render_case "value: <{{collides}}>
+" "MERGEPATH_FACT_COLLIDES=__MERGEPATH_FACT_UNSET__")
+expect_output "1e2 sentinel-collision regression: literal sentinel as value treated as set" "$r" "value: <__MERGEPATH_FACT_UNSET__>"
+
+# 1e3: fact set to empty string is treated as SET (distinct from unset).
+# Lenient mode: empty value → empty substitution (same as before).
+# Strict mode: empty value → NOT a strict-mode failure (the var IS set).
+# This is the new behavior under +x detection; previously a value of
+# "" round-tripped through the sentinel test as "set", but the
+# documentation of strict-mode said only an "unknown fact" (set/unset
+# distinction) triggers rc 3.
+r=$(render_case "empty: <{{empty_fact}}>
+" "MERGEPATH_FACT_EMPTY_FACT=" "MERGEPATH_TEMPLATE_STRICT=1")
+expect_output "1e3 strict mode: empty-string fact is set (not a strict failure)" "$r" "empty: <>"
+
 r=$(render_case "unclosed: {{key
 ")
 expect_output "1f unclosed {{ left verbatim" "$r" "unclosed: {{key"
@@ -383,6 +402,58 @@ if [ -f "$dest" ] && [ "$(cat "$dest")" = "rendered: value" ]; then
   pass "10a render_to writes destination file"
 else
   fail "10a render_to: expected 'rendered: value', got: $(cat "$dest" 2>/dev/null || echo MISSING)"
+fi
+
+# 10c: render_to preserves existing dest mode (Codex P2 round 2 on PR #313).
+# Pre-create dest with mode 0644 and verify mv doesn't strip to 0600.
+src="$WORKDIR/mode-src.tpl"
+dest="$WORKDIR/mode-dest.txt"
+echo "original content" > "$dest"
+chmod 644 "$dest"
+echo "new: {{key}}" > "$src"
+(
+  reset_facts
+  export MERGEPATH_FACT_KEY=after
+  # shellcheck disable=SC1090
+  source "$LIB"
+  template_substitution::render_to "$src" "$dest"
+)
+# Read mode in a portable way (same logic as the lib).
+actual_mode=$(stat -f '%Mp%Lp' "$dest" 2>/dev/null \
+              || stat -c '%a' "$dest" 2>/dev/null \
+              || echo "??")
+# BSD stat returns "0644", GNU returns "644". Accept both.
+case "$actual_mode" in
+  0644|644)
+    if [ "$(cat "$dest")" = "new: after" ]; then
+      pass "10c render_to preserves existing dest mode (0644, not 0600)"
+    else
+      fail "10c render_to: content wrong after mode-preservation render: $(cat "$dest")"
+    fi
+    ;;
+  *)
+    fail "10c render_to: expected mode 0644/644, got '$actual_mode'"
+    ;;
+esac
+
+# 10d: render_to writing a new file (no pre-existing dest) — verify
+# render still succeeds (mode preservation skips the chmod, but the
+# write must work).
+src="$WORKDIR/newfile-src.tpl"
+dest="$WORKDIR/newfile-dest.txt"
+echo "fresh: {{key}}" > "$src"
+[ -e "$dest" ] && rm "$dest"
+(
+  reset_facts
+  export MERGEPATH_FACT_KEY=new
+  # shellcheck disable=SC1090
+  source "$LIB"
+  template_substitution::render_to "$src" "$dest"
+)
+if [ -f "$dest" ] && [ "$(cat "$dest")" = "fresh: new" ]; then
+  pass "10d render_to writes new file (no pre-existing dest)"
+else
+  fail "10d render_to: expected fresh write, got: $(cat "$dest" 2>/dev/null || echo MISSING)"
 fi
 
 # render_to failure: malformed template → no partial write of dest.

--- a/tests/test_template_substitution.sh
+++ b/tests/test_template_substitution.sh
@@ -134,6 +134,29 @@ r=$(render_case "hyphen key: {{node-version}}
 " "MERGEPATH_FACT_NODE_VERSION=20")
 expect_output "1g hyphenated fact key → underscored env var" "$r" "hyphen key: 20"
 
+# 1h: injection attempt — key contains shell metacharacters. Without
+# input validation in _fact_value (CodeRabbit Critical on PR #313),
+# this key would be interpreted at eval time as a command
+# substitution. With validation, the renderer rejects with rc 2.
+r=$(render_case "compromised: {{foo\$(id)}}
+")
+expect_rc "1h injection attempt key -> rc 1 (rejected as malformed template)" "$r" 1
+
+# 1i: another injection vector — backticks.
+r=$(render_case "compromised: {{foo\`id\`}}
+")
+expect_rc "1i backtick key -> rc 1 (rejected as malformed template)" "$r" 1
+
+# 1j: uppercase keys rejected (reserved for env-var form).
+r=$(render_case "{{FOO}}
+" "MERGEPATH_FACT_FOO=bar")
+expect_rc "1j uppercase key -> rc 1 (rejected as malformed template)" "$r" 1
+
+# 1k: underscored keys allowed (natural shell var style).
+r=$(render_case "ts: {{has_ts}}
+" "MERGEPATH_FACT_HAS_TS=yes")
+expect_output "1k underscored key allowed" "$r" "ts: yes"
+
 # ---------------------------------------------------------------------------
 # 2. Bare conditional: >>> if <key>
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Introduces `scripts/lib/template-substitution.sh` — the rendering engine for `type: templated` manifest entries that `.mergepath-sync.yml` has reserved since #168 but never activated. Lib lands in isolation so its v1 syntax can be reviewed and stabilized before `scripts/sync-to-downstream.sh`, `scripts/workflow/verify-propagation-pr.sh`, and `scripts/ci/check_sync_manifest` take a dependency on it (follow-up integration PR).

Forcing function: the 6-repo ESLint rollout (parent #250) needs per-consumer trimmed config rendering. #168 Layer 5's original sketch only handled simple `{{REPO_NAME}}` substitution and couldn't express the per-consumer conditional-include pattern this lib introduces.

## What ships

- ` + 'scripts/lib/template-substitution.sh' + ` — pure-bash renderer (bash 3.2 portable, matches `scripts/bootstrap/substitute.sh`'s portability bar; no global ` + 'set -e' + ` toggling, callers use ` + '|| rc=$?' + `)
- ` + 'tests/test_template_substitution.sh' + ` — 37 cases including three end-to-end real-consumer fixture renderings (swipewatch JS-only, matchline TS+React, nathanpaynedotcom TS+Astro)
- ` + 'scripts/ci/check_template_substitution' + ` — CI wrapper matching the shape of ` + 'scripts/ci/check_sync_overrides' + `
- ` + 'docs/agents/templated-propagation.md' + ` — syntax reference + design rationale (why comment-prefix markers over Mustache, why facts in env, why no nesting in v1)
- ` + 'repo_lint.yml' + ` — adds ` + 'check_template_substitution' + ` between ` + 'check_sync_overrides' + ` and ` + 'check_coderabbit_config' + `

## What this PR explicitly does NOT do

- Activate ` + 'type: templated' + ` in any manifest entry (follow-up PR)
- Modify ` + 'scripts/sync-to-downstream.sh' + ` (follow-up PR — the ` + '\"templated (deferred — Layer 5, #168)\"' + ` stub at line 572 stays in place for now)
- Modify ` + 'scripts/ci/check_sync_manifest' + ` schema (follow-up PR)
- Modify ` + 'scripts/workflow/verify-propagation-pr.sh' + ` (follow-up PR)
- Restructure ` + 'examples/eslint.config.js' + ` (follow-up PR after integration)

Splitting into lib-then-integration breaks the big-bang risk of a 10-file PR and gives the lib's syntax a chance to settle before code paths depend on it. The lib is not yet wired into any code path, so this PR cannot change runtime behavior of sync, audit, verify-propagation-pr, or any other existing tool.

## v1 syntax

Comment-prefix-agnostic conditional markers (` + '//' + `, ` + '#' + `, ` + '--' + `, ` + '<!-- … -->' + ` all work) plus ` + '{{var}}' + ` substitution:

\`\`\`js
import js from \"@eslint/js\";

// >>> if frameworks contains typescript
import tseslint from \"typescript-eslint\";
// <<<
// >>> if frameworks contains react
import react from \"eslint-plugin-react\";
// <<<

export default [
  js.configs.recommended,
// >>> if frameworks contains typescript
  ...tseslint.configs.recommended,
// <<<
];
\`\`\`

Expression forms: ` + '<key>' + `, ` + '!<key>' + `, ` + '<key> contains <value>' + ` (word-boundary safe), ` + '<key> == <value>' + `, ` + '<key> != <value>' + `. No nesting in v1.

Facts source: env vars (` + 'MERGEPATH_FACT_FRAMEWORKS=\"react typescript\"' + `). The sync caller (follow-up PR) extracts per-consumer facts from the manifest and exports them before invoking the lib.

Full rationale in [docs/agents/templated-propagation.md](https://github.com/nathanjohnpayne/mergepath/blob/feat/layer5-template-substitution-lib/docs/agents/templated-propagation.md).

## Testing

- [x] ` + 'bash tests/test_template_substitution.sh' + ` → 37 PASS, 0 FAIL
- [x] ` + 'scripts/ci/check_template_substitution' + ` → same
- [x] ` + 'scripts/ci/check_ci_scripts_wired' + ` → PASS (35 check_* scripts, all wired or exempt)
- [x] ` + 'scripts/ci/check_spec_test_alignment' + ` → PASS
- [x] ` + 'scripts/ci/check_duplicate_docs' + ` → PASS (pre-existing warnings only)
- [x] ` + 'scripts/ci/check_required_root_files' + ` → PASS
- Manual verification: end-to-end fixture renders for swipewatch / matchline / nathanpaynedotcom diff cleanly against hand-written expected outputs (test cases 11a-11c)

## Self-Review

- [x] **Correctness:** lib semantics match v1 syntax documented in `docs/agents/templated-propagation.md`. 37-case test suite includes the three real consumer profiles from the forcing function (rendered output diffed against hand-written expected fixtures), so the lib's contract is grounded in the actual workload it will serve, not just synthetic edge cases.
- [x] **Regression risk:** negligible. New files only; single workflow edit adds one step to `repo_lint.yml` between `check_sync_overrides` and `check_coderabbit_config` without touching their behavior. Lib is not yet wired into any code path.
- [x] **Style and conventions:** bash 3.2 portable (no associative arrays, no `${var^^}`, no GNU-only sed flags). API surface (`namespace::fn`) matches `scripts/lib/preflight-helpers.sh`. CI wrapper matches `scripts/ci/check_sync_overrides`. Doc at `docs/agents/templated-propagation.md` per agent-docs convention. No global `set -e` toggling during render.
- [x] **Test coverage:** 37 cases covering all five expression forms, all four malformed-template error paths, strict + lenient modes, both API entry points (render + render_to), atomic rollback on render failure, and three real-world fixture renderings. `eval_expr` exercised directly so expression-parsing regressions surface in isolation.
- [x] **Security and dependency hygiene:** no new dependencies. No network. No filesystem writes outside an explicit dest path (render_to uses mktemp + mv). Reads facts only from env vars. No shell injection: no eval of user-controlled strings, no unquoted expansions in command arguments.

---
_Phase 4b cleared on efee51f (external `nathanpayne-codex` APPROVED, all bot threads resolved). Re-firing pull_request:edited event to refresh stale Label Gate._
