### PR TITLE
feat(propagation): activate Layer 5 templated path-type (manifest + audit + sync materialize)

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -134,9 +134,20 @@ consumers:
 #                the rendering. Audit re-renders per consumer and
 #                byte-diffs against the on-disk destination. Sync
 #                materializes the rendered output into the destination
-#                path. The propagation-PR verification (#264 lane)
-#                re-renders against mergepath@<sha> with the consumer's
-#                facts and byte-verifies the PR content.
+#                path.
+#
+#                v1 NOTE: the propagation-PR review lane (#264) does
+#                NOT YET re-render-and-verify templated entries. The
+#                lane's parse_manifest_paths.sh emits only source
+#                paths, so a PR touching a templated `dest` reads as
+#                "off propagation surface" and the lane gate denies
+#                exemption — templated propagation PRs route to
+#                normal Phase 4 review. A follow-up PR will extend
+#                verify-propagation-pr.sh to re-render against
+#                mergepath@<sha> with the consumer's facts and
+#                byte-verify the PR content. See docs/agents/
+#                templated-propagation.md § Propagation-lane
+#                verification — v1 limitation.
 #
 #                Templated entries require explicit `source:` and
 #                `dest:` fields (the source path in Mergepath does

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -126,10 +126,54 @@ consumers:
 #                are ignored. This matches scripts/ci/, where each
 #                consumer adds repo-specific check_* scripts alongside
 #                the canonical ones.
-#   templated  — RESERVED for Layer 5 (#168). Not yet supported by
-#                --audit; scripts/sync-to-downstream.sh refuses to
-#                process templated entries until the substitution
-#                lib lands.
+#   templated  — rendered per consumer via scripts/lib/template-
+#                substitution.sh (#313). The Mergepath source is a
+#                template with `>>> if <expr> ... <<<` conditional
+#                blocks and `{{key}}` variable substitutions; the
+#                consumer's facts (see consumer.facts below) drive
+#                the rendering. Audit re-renders per consumer and
+#                byte-diffs against the on-disk destination. Sync
+#                materializes the rendered output into the destination
+#                path. The propagation-PR verification (#264 lane)
+#                re-renders against mergepath@<sha> with the consumer's
+#                facts and byte-verifies the PR content.
+#
+#                Templated entries require explicit `source:` and
+#                `dest:` fields (the source path in Mergepath does
+#                NOT equal the destination path in the consumer —
+#                this is the whole point of templated propagation,
+#                e.g., examples/eslint.config.js → eslint.config.js).
+#                For canonical and kit, source = dest = path; the
+#                source/dest fields are optional and default to path
+#                when omitted.
+#
+# Per-entry source/dest fields:
+#   source:     path within Mergepath where the source template lives
+#               (defaults to `path` when omitted)
+#   dest:       path within each consumer where the rendered output
+#               (or canonical/kit content) lands (defaults to `path`)
+#
+# Per-consumer facts (templated propagation only):
+#   Each consumer entry MAY carry a `facts:` block — a mapping of
+#   fact keys (matching [a-z0-9_-]+) to values. Facts are exported
+#   as MERGEPATH_FACT_<KEY> env vars before invoking the template
+#   substitution lib, where uppercase + hyphen-to-underscore is
+#   applied per the lib's contract. List-valued facts (yaml `[a, b]`)
+#   are serialized as space-separated for the lib's `contains`
+#   expression form.
+#
+#   Example:
+#     consumers:
+#       - name: matchline
+#         repo: nathanjohnpayne/matchline
+#         visibility: private
+#         facts:
+#           frameworks: [react, typescript]
+#           node_version: "20"
+#
+#   Canonical/kit consumers don't require facts; the block is
+#   optional and only consulted for templated entries the consumer
+#   opts into.
 #
 # `consumers: all` means every entry in the consumers list above.
 # Per-consumer exclusions live under the `exclusions:` block at the

--- a/docs/agents/templated-propagation.md
+++ b/docs/agents/templated-propagation.md
@@ -11,7 +11,7 @@ Renders a source template to per-consumer output using two surfaces:
 1. **Variable substitution** — anywhere in the file, `{{key}}` is replaced by the value of `MERGEPATH_FACT_KEY` (uppercased, hyphens → underscores). Keys must match `[a-z0-9_-]+` (lowercase letters, digits, underscore, hyphen); a malformed key — e.g. one containing shell metacharacters — is rejected as malformed template (render exit code 1), distinct from a syntactically valid but unset fact (which is empty in lenient mode or exit code 3 in strict mode).
 2. **Conditional blocks** — `>>> if <expr> ... <<<` markers gate body lines on per-consumer facts. Marker lines are **always stripped** from output regardless of the expression; only the body lines between them are conditional. If `<expr>` is true, body lines are emitted verbatim; if false, body lines are dropped.
 
-Sync-side integration (follow-up PR) is responsible for exporting per-consumer facts from the manifest before invoking the lib. The lib itself reads facts only from the environment.
+Sync-side integration (landed; see § Sync integration below) is responsible for exporting per-consumer facts from the manifest before invoking the lib. The lib itself reads facts only from the environment.
 
 ## Syntax reference
 
@@ -116,9 +116,9 @@ Real templates will accumulate optional-fact references over time (`{{node_versi
 
 ## Limits and known gaps
 
-- **The lib alone produces no output anywhere yet.** It's wired into `repo_lint.yml` via `scripts/ci/check_template_substitution` so its tests run on every PR, but no manifest entry uses `type: templated` yet. The follow-up integration PR adds that.
+- **No live templated entry in the manifest yet.** The lib + sync integration are wired (audit, materialize for per-commit + sync-all), but `.mergepath-sync.yml` has zero entries of `type: templated` today. Phase C adds the first one (`examples/eslint.config.js` → `eslint.config.js`) to unblock the [mergepath#250](https://github.com/nathanjohnpayne/mergepath/issues/250) ESLint rollout.
 - **The lib doesn't know about consumer name or repo.** Facts must be uniform across consumers (e.g., `frameworks`, `node_version`); per-consumer name substitution (`mergepath` → `<consumer>`) still goes through `scripts/bootstrap/substitute.sh`'s allow-list-driven path. Long-term, both should share a single substitution lib (per [#168 Layer 5's original sketch](https://github.com/nathanjohnpayne/mergepath/issues/168) — "factor the substitution logic into `scripts/lib/template-substitution.sh` so bootstrap and sync share the lib"), but that consolidation is non-trivial because the two callers have different semantics (literal name allow-list vs. fact-driven substitution). Tracked as future work.
-- **No `--audit`-side rendering yet.** Until the integration PR lands, `--audit` will continue to print "templated (deferred — Layer 5, #168)" for `type: templated` entries.
+- **Propagation-lane verification not yet implemented for templated.** See § Propagation-lane verification — v1 limitation below. Templated propagation PRs route to normal Phase 4 review until `verify-propagation-pr.sh` learns to re-render + byte-verify.
 
 ## Sync integration — what's wired up
 

--- a/docs/agents/templated-propagation.md
+++ b/docs/agents/templated-propagation.md
@@ -1,8 +1,8 @@
 # Templated propagation — Layer 5 substitution lib
 
-Status: **lib landed; sync integration pending in follow-up PR.**
+Status: **lib + sync/audit integration landed.** Propagation-lane verification of templated PRs is deferred to a follow-up (templated PRs go through normal Phase 4 review in v1).
 
-This doc covers `scripts/lib/template-substitution.sh` — the rendering engine that activates `type: templated` entries in `.mergepath-sync.yml`. It exists ahead of integration so the lib's contract can be reviewed and stabilized before code paths in `scripts/sync-to-downstream.sh`, `scripts/workflow/verify-propagation-pr.sh`, and `scripts/ci/check_sync_manifest` depend on it.
+This doc covers `scripts/lib/template-substitution.sh` — the rendering engine that activates `type: templated` entries in `.mergepath-sync.yml` — plus the sync integration that wires it into `scripts/sync-to-downstream.sh` for both audit and materialize.
 
 ## What the lib does
 
@@ -120,12 +120,52 @@ Real templates will accumulate optional-fact references over time (`{{node_versi
 - **The lib doesn't know about consumer name or repo.** Facts must be uniform across consumers (e.g., `frameworks`, `node_version`); per-consumer name substitution (`mergepath` → `<consumer>`) still goes through `scripts/bootstrap/substitute.sh`'s allow-list-driven path. Long-term, both should share a single substitution lib (per [#168 Layer 5's original sketch](https://github.com/nathanjohnpayne/mergepath/issues/168) — "factor the substitution logic into `scripts/lib/template-substitution.sh` so bootstrap and sync share the lib"), but that consolidation is non-trivial because the two callers have different semantics (literal name allow-list vs. fact-driven substitution). Tracked as future work.
 - **No `--audit`-side rendering yet.** Until the integration PR lands, `--audit` will continue to print "templated (deferred — Layer 5, #168)" for `type: templated` entries.
 
-## What the follow-up PR adds
+## Sync integration — what's wired up
 
-The next PR builds on this lib to:
+The follow-up integration PR landed:
 
-1. Add `facts:` schema to consumer entries in `.mergepath-sync.yml`, plus `source:` + `dest:` fields on path entries (so `examples/eslint.config.js` can land at consumer-root `eslint.config.js`).
-2. Extend `scripts/sync-to-downstream.sh` to handle `type: templated` — render per consumer using their facts, write to `dest`, commit/PR via the propagation lane.
-3. Extend `scripts/ci/check_sync_manifest` to validate the new schema (facts vocabulary, source/dest mapping consistency).
-4. Extend `scripts/workflow/verify-propagation-pr.sh` to re-render the source against `mergepath@<sha>` with consumer facts and byte-verify the PR content — closes the propagation-lane gate for templated paths.
-5. First templated entry: `examples/eslint.config.js` → `eslint.config.js` across the 6 consumers with non-empty JS/TS surface area, unblocking the [mergepath#250](https://github.com/nathanjohnpayne/mergepath/issues/250) ESLint rollout backlog.
+1. **Manifest schema** — `.mergepath-sync.yml` supports `facts:` blocks on consumers (mapping of `[a-z0-9_-]+` keys to scalar/list values) and `source:` + `dest:` fields on path entries (both default to `.path` when omitted; templated entries typically declare both because source ≠ dest is the point).
+
+2. **`scripts/ci/check_sync_manifest`** — validates the new schema. Templated entries without an explicit `dest:` produce a WARN (the source-dest decoupling is the whole point). Facts values that are nested mappings are rejected (the lib expects scalar/list); facts keys outside `[a-z0-9_-]+` are rejected (lib contract).
+
+3. **`scripts/sync-to-downstream.sh --audit`** — `compare_templated()` renders the source with the consumer's facts and byte-diffs against the consumer's on-disk dest. Reports `ok` / `drift:<lines>` / `missing` in the same tag scheme as canonical/kit.
+
+4. **`scripts/sync-to-downstream.sh <commit-sha>`** (per-commit slice) — `materialize_templated_targets()` renders each opted-in templated entry that changed at the commit and writes to the consumer's dest. Honors `.sync-overrides.yml` on the dest path. The commit body lists the templated paths with a "(templated, rendered from <source>)" annotation.
+
+5. **`scripts/sync-to-downstream.sh --sync-all`** (steady-state) — same materialize behavior for every templated entry the consumer opts into, regardless of changed-at-commit. Dry-run plan output shows templated targets explicitly.
+
+### Manifest example
+
+```yaml
+consumers:
+  - name: matchline
+    repo: nathanjohnpayne/matchline
+    visibility: private
+    facts:
+      frameworks: [react, typescript]
+      node_version: "20"
+
+paths:
+  - path: examples/eslint.config.js
+    type: templated
+    source: examples/eslint.config.js
+    dest: eslint.config.js
+    consumers: [matchline, swipewatch, ...]
+```
+
+A render for matchline exports `MERGEPATH_FACT_FRAMEWORKS="react typescript"` and `MERGEPATH_FACT_NODE_VERSION=20`, then runs the lib against `examples/eslint.config.js`. The output lands at `eslint.config.js` in the consumer's PR branch.
+
+## Propagation-lane verification — v1 limitation
+
+The `propagation_prs` review-lane exemption in `.github/review-policy.yml` (#264) currently does NOT cover templated entries: `scripts/workflow/verify-propagation-pr.sh` and its `parse_manifest_paths.sh` helper emit only mergepath-side `.path` values, so a PR touching a templated `dest` (which doesn't equal `.path`) reads as "off propagation surface" and the lane gate denies exemption — the PR routes to normal Phase 4 review.
+
+This is the **intentional v1 behavior**: templated rendering is new infrastructure, and an external review per templated propagation PR is appropriate while we build confidence. A follow-up PR will extend `verify-propagation-pr.sh` to re-render the source against `mergepath@<sha>` with the consumer's facts and byte-verify the PR content, at which point templated PRs become lane-eligible.
+
+Until then, expect templated propagation PRs to carry `needs-external-review`; they're not stuck — Phase 4a (Codex) or 4b (CLI handoff) will clear the gate normally.
+
+## What's queued next
+
+1. **Phase C** — restructure `examples/eslint.config.js` into a conditional-block template, add `facts.frameworks` to all 8 consumer entries, add the manifest entry for `eslint.config.js`.
+2. **Phase D** — canary propagation to swipewatch (smallest JS surface), then fanout to the remaining 5 consumers. Each consumer's PR carries the rendered config + a devDeps install + findings triage per its consumer-side issue.
+3. **Phase E** — close the 6 consumer issues and the [mergepath#250](https://github.com/nathanjohnpayne/mergepath/issues/250) parent tracker; file a retrospective on Layer 5 cost vs. payoff for future "should we templated-ize X?" judgment calls.
+4. **Lane-eligibility for templated** — extend `verify-propagation-pr.sh` to re-render-and-verify templated entries. Order vs. Phase D is flexible; v1 doesn't block on it.

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -286,7 +286,17 @@ while IFS=$'\t' read -r path type consumers dest source; do
   # different path.
   if [ -n "$source" ] && [ "$source" != "$path" ]; then
     src_target="$REPO_ROOT/$source"
-    if [ ! -e "$src_target" ]; then
+    # Templated sources must be regular files (a directory can't be a
+    # template). Canonical/kit also accept the explicit source
+    # override for future flexibility; use `-f` (regular file) for
+    # templated and `-e` (any FS entry, since kit could point at a
+    # directory) for the others. CodeRabbit Major on PR #316.
+    if [ "$type" = "templated" ]; then
+      if [ ! -f "$src_target" ]; then
+        echo "FAIL: path '$path' source '$source' must be a regular file for templated entries"
+        FAILED=1
+      fi
+    elif [ ! -e "$src_target" ]; then
       echo "FAIL: path '$path' source '$source' does not exist on disk"
       FAILED=1
     fi

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -118,6 +118,48 @@ if [ -n "$consumer_rows" ]; then
   done <<< "$consumer_rows"
 fi
 
+# 3.5: per-consumer `facts:` block validation (optional; required
+# for templated propagation per docs/agents/templated-propagation.md).
+# Each fact key must match the lib's accepted charset [a-z0-9_-]+
+# (anything else is rejected at render time as malformed). List-valued
+# facts (yaml `[a, b]`) are allowed; scalar values are too. Mappings
+# of mappings are not — the lib expects flat scalar/list values, and
+# rejecting nested mappings here catches the misconfiguration at
+# manifest validation rather than at the first render attempt.
+if ! facts_rows=$(yq -r '
+  .consumers[]
+  | select(.facts != null)
+  | .name as $cn
+  | .facts | to_entries[]
+  | $cn + "\t" + .key + "\t" + (.value | tag)
+' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract consumer facts from the manifest (yq error):"
+  printf '%s\n' "$facts_rows"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
+if [ -n "$facts_rows" ]; then
+  while IFS=$'\t' read -r fact_consumer fact_key fact_tag; do
+    [ -z "$fact_consumer" ] && continue
+    # Key charset — same as the lib's `_fact_value` validator.
+    case "$fact_key" in
+      ''|*[!a-z0-9_-]*)
+        echo "FAIL: consumer '$fact_consumer' facts: key '$fact_key' must match [a-z0-9_-]+ (per scripts/lib/template-substitution.sh contract)"
+        FAILED=1
+        ;;
+    esac
+    # Value type — scalar (any !!str/!!int/!!float/!!bool) or sequence.
+    # A nested mapping (!!map) is the misconfiguration this guards.
+    case "$fact_tag" in
+      '!!str'|'!!int'|'!!float'|'!!bool'|'!!seq'|'!!null') ;;
+      *)
+        echo "FAIL: consumer '$fact_consumer' fact '$fact_key' has unsupported value type '$fact_tag' (must be scalar or list)"
+        FAILED=1
+        ;;
+    esac
+  done <<< "$facts_rows"
+fi
+
 # Build a set of valid consumer names for cross-check
 valid_consumers=$(yq -r '.consumers[].name' "$MANIFEST" | tr '\n' ',')
 
@@ -137,14 +179,15 @@ fi
 if ! path_rows=$(yq -r '
   .paths[]
   | ((.path // "") + "\t" + (.type // "") + "\t"
-     + (.consumers | (select(tag == "!!str") // (join(","))) | tostring))
+     + (.consumers | (select(tag == "!!str") // (join(","))) | tostring)
+     + "\t" + (.dest // "") + "\t" + (.source // ""))
 ' "$MANIFEST" 2>&1); then
   echo "FAIL: could not extract .paths from the manifest (yq error):"
   printf '%s\n' "$path_rows"
   echo "check_sync_manifest: FAIL"
   exit 1
 fi
-while IFS=$'\t' read -r path type consumers; do
+while IFS=$'\t' read -r path type consumers dest source; do
   [ -z "$path" ] && continue
 
   # 4a: reject repo-escaping paths. An absolute path or one
@@ -173,6 +216,45 @@ while IFS=$'\t' read -r path type consumers; do
       ;;
   esac
 
+  # 4a-bis: same safety checks on `dest:` (optional) and `source:`
+  # (optional) — both must be repo-relative, no absolute paths, no
+  # `..` segments. dest lives in the CONSUMER repo (so the existence
+  # check below doesn't apply), but the safety rule protects every
+  # consumer from a write-outside-root via a bad manifest entry.
+  # source lives in mergepath but defaults to `.path` when omitted;
+  # only validate when explicitly set.
+  for field_pair in "dest:$dest" "source:$source"; do
+    field_name="${field_pair%%:*}"
+    field_val="${field_pair#*:}"
+    [ -z "$field_val" ] && continue
+    case "$field_val" in
+      /*)
+        echo "FAIL: path '$path' has $field_name '$field_val' that is absolute — must be repo-relative"
+        FAILED=1
+        continue 2
+        ;;
+    esac
+    case "/$field_val/" in
+      */../*)
+        echo "FAIL: path '$path' has $field_name '$field_val' containing a '..' segment — must not escape the repo root"
+        FAILED=1
+        continue 2
+        ;;
+    esac
+  done
+
+  # 4b: templated entries SHOULD declare `dest:` explicitly (their
+  # whole point is source-dest decoupling — `examples/eslint.config.js`
+  # in mergepath renders to `eslint.config.js` at the consumer). A
+  # templated entry that omits `dest:` would land the rendered output
+  # at the same path the source lives at, which is almost never what
+  # you want. Warn-not-fail: there might be a future use case for
+  # path-preserving templated rendering (e.g., per-consumer customization
+  # of a same-name file), so don't block, but make the omission noisy.
+  if [ "$type" = "templated" ] && [ -z "$dest" ]; then
+    echo "WARN: templated path '$path' omits 'dest:' — rendered output will land at the same path as the source. If that's intentional, explicitly set 'dest: $path' to silence this warning."
+  fi
+
   # 4: path exists on disk
   case "$type" in
     kit)
@@ -194,6 +276,21 @@ while IFS=$'\t' read -r path type consumers; do
       FAILED=1
       ;;
   esac
+
+  # 4c: existence-check source override. If `source:` is set
+  # (currently only meaningful for templated entries with source ≠
+  # path, but accepted for canonical/kit too for future flexibility),
+  # verify the source-of-truth file exists in mergepath. The default
+  # source = path case was already covered by the existence check
+  # above; this only fires when source is explicitly set to a
+  # different path.
+  if [ -n "$source" ] && [ "$source" != "$path" ]; then
+    src_target="$REPO_ROOT/$source"
+    if [ ! -e "$src_target" ]; then
+      echo "FAIL: path '$path' source '$source' does not exist on disk"
+      FAILED=1
+    fi
+  fi
 
   # 6: consumers field
   if [ "$consumers" = "all" ]; then

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -126,6 +126,35 @@ fi
 # of mappings are not — the lib expects flat scalar/list values, and
 # rejecting nested mappings here catches the misconfiguration at
 # manifest validation rather than at the first render attempt.
+
+# 3.5a: assert `.facts` ITSELF is a mapping when present. Without
+# this, a sequence-typed facts block (e.g. `facts: [react, typescript]`)
+# silently passes — `to_entries` on a sequence yields numeric
+# indices that pass the [a-z0-9_-]+ key charset check (digits are
+# valid), so the per-entry validation below false-passes. Codex
+# Phase 4b CHANGES_REQUESTED on PR #316 by nathanpayne-codex caught
+# this gap. Fail-closed at the structural-shape layer before the
+# per-entry iteration.
+if ! facts_shape_rows=$(yq -r '
+  .consumers[]
+  | select(.facts != null)
+  | .name + "\t" + (.facts | tag)
+' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract consumer facts-block tags (yq error):"
+  printf '%s\n' "$facts_shape_rows"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
+if [ -n "$facts_shape_rows" ]; then
+  while IFS=$'\t' read -r facts_consumer facts_yaml_tag; do
+    [ -z "$facts_consumer" ] && continue
+    if [ "$facts_yaml_tag" != "!!map" ]; then
+      echo "FAIL: consumer '$facts_consumer' facts: must be a YAML mapping (got tag '$facts_yaml_tag')"
+      FAILED=1
+    fi
+  done <<< "$facts_shape_rows"
+fi
+
 if ! facts_rows=$(yq -r '
   .consumers[]
   | select(.facts != null)
@@ -178,17 +207,45 @@ if [ "$paths_tag" != "!!seq" ]; then
 fi
 if ! path_rows=$(yq -r '
   .paths[]
-  | ((.path // "") + "\t" + (.type // "") + "\t"
+  | ((.path // "") + "|" + (.type // "") + "|"
      + (.consumers | (select(tag == "!!str") // (join(","))) | tostring)
-     + "\t" + (.dest // "") + "\t" + (.source // ""))
+     + "|" + (.dest // "") + "|" + (.source // "")
+     + "|" + (has("dest") | tostring) + "|" + (has("source") | tostring))
 ' "$MANIFEST" 2>&1); then
   echo "FAIL: could not extract .paths from the manifest (yq error):"
   printf '%s\n' "$path_rows"
   echo "check_sync_manifest: FAIL"
   exit 1
 fi
-while IFS=$'\t' read -r path type consumers dest source; do
+# Why IFS='|' and not '\t': bash `read` with IFS=$'\t' collapses
+# runs of whitespace (including tabs), so an empty-valued field
+# between two tabs gets eaten and downstream fields shift left
+# (turning an explicit `dest: ""` into the next field's value).
+# `|` is non-whitespace, so empty fields are preserved positionally.
+# Pipes don't appear in repo-relative paths, type names, or consumer
+# names so the choice is unambiguous. Codex Phase 4b
+# CHANGES_REQUESTED on PR #316 by nathanpayne-codex surfaced the
+# empty-dest gap that made this field-stability issue visible.
+while IFS='|' read -r path type consumers dest source has_dest has_source; do
   [ -z "$path" ] && continue
+
+  # 4a-ter: empty-string `dest:` or `source:` is a misconfiguration —
+  # the yq `(.dest // "")` extraction collapses "absent" and
+  # "explicitly empty" to the same empty string, so we use the
+  # parallel `has("dest")` / `has("source")` probes to distinguish.
+  # An explicit `dest: ""` would pass through to materialize and
+  # blow up there (Codex P1 / Phase 4b CHANGES_REQUESTED on PR
+  # #316 by nathanpayne-codex). Reject at validation.
+  if [ "$has_dest" = "true" ] && [ -z "$dest" ]; then
+    echo "FAIL: path '$path' has explicit dest: \"\" — dest must be non-empty when set"
+    FAILED=1
+    continue
+  fi
+  if [ "$has_source" = "true" ] && [ -z "$source" ]; then
+    echo "FAIL: path '$path' has explicit source: \"\" — source must be non-empty when set"
+    FAILED=1
+    continue
+  fi
 
   # 4a: reject repo-escaping paths. An absolute path or one
   # containing a `..` segment would make the on-disk existence check

--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -390,6 +390,107 @@ compare_canonical() {
   REPLY="drift:$lines"
 }
 
+# Compare a single templated entry: render mergepath@HEAD's source
+# template using the consumer's facts (via scripts/lib/template-
+# substitution.sh) and byte-compare against the consumer's on-disk
+# destination. Outputs the same status tag scheme as compare_canonical:
+#   "ok" / "drift:<lines>" / "missing"
+#
+# Args: mp_path (manifest identifier), source_path (where the source
+# template lives in mergepath — defaults to mp_path upstream when
+# omitted), dest_path (where the rendered output lives in the
+# consumer), consumer_name (for facts lookup), consumer_root.
+#
+# Why a function-scoped subshell for the render: export_consumer_facts
+# mutates MERGEPATH_FACT_* env vars; running the render inside a
+# subshell scopes those exports so a subsequent consumer iteration
+# doesn't see stale facts from this one. The subshell's stdout is
+# captured to the tmp file via the `(...) > "$tmp"` redirection.
+compare_templated() {
+  local mp_path=$1
+  local source_path=$2
+  local dest_path=$3
+  local consumer_name=$4
+  local consumer_root=$5
+
+  local mp_source="$MERGEPATH_ROOT/$source_path"
+  local consumer_dest="$consumer_root/$dest_path"
+
+  if [ ! -e "$mp_source" ]; then
+    err "compare_templated: source $source_path not found in mergepath"
+    REPLY="drift:0"
+    return 0
+  fi
+  if [ ! -e "$consumer_dest" ]; then
+    REPLY="missing"
+    return 0
+  fi
+
+  local manifest="$MERGEPATH_ROOT/$MANIFEST_PATH"
+  local tmp_rendered
+  tmp_rendered=$(mktemp "${TMPDIR:-/tmp}/compare-templated.XXXXXX") || {
+    err "compare_templated: mktemp failed"
+    REPLY="drift:0"
+    return 0
+  }
+  local render_rc=0
+  (
+    export_consumer_facts "$consumer_name" "$manifest"
+    # shellcheck disable=SC1091
+    source "$MERGEPATH_ROOT/scripts/lib/template-substitution.sh"
+    template_substitution::render "$mp_source"
+  ) > "$tmp_rendered" 2>/dev/null || render_rc=$?
+  if [ "$render_rc" != "0" ]; then
+    rm -f "$tmp_rendered"
+    err "compare_templated: render failed (rc=$render_rc) for $source_path with $consumer_name's facts"
+    REPLY="drift:0"
+    return 0
+  fi
+
+  if cmp -s "$tmp_rendered" "$consumer_dest"; then
+    REPLY="ok"
+  else
+    local lines
+    lines=$( { diff "$tmp_rendered" "$consumer_dest" || true; } | wc -l | tr -d ' ')
+    REPLY="drift:$lines"
+  fi
+  rm -f "$tmp_rendered"
+}
+
+# Export a consumer's facts:* from the manifest as MERGEPATH_FACT_*
+# env vars in the current (sub)shell. Unsets any prior
+# MERGEPATH_FACT_* exports first so successive callers don't see
+# stale facts from a different consumer. List-valued facts (yaml
+# `[a, b]`) are serialized as space-separated, matching the lib's
+# `<key> contains <value>` expectations.
+#
+# Uses the `env(VAR)` mikefarah/yq form for consumer-name injection
+# (the `--arg` jq-compat flag works too but env-var is the
+# documented mikefarah idiom).
+export_consumer_facts() {
+  local consumer_name=$1
+  local manifest=$2
+
+  # Clean slate — prior consumer's facts must not leak in.
+  local var
+  for var in $(env | awk -F= '/^MERGEPATH_FACT_/ {print $1}'); do
+    unset "$var"
+  done
+
+  while IFS=$'\t' read -r key value; do
+    [ -z "$key" ] && continue
+    local upper
+    upper=$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+    export "MERGEPATH_FACT_$upper=$value"
+  done < <(MERGEPATH_CONSUMER_NAME="$consumer_name" yq -r '
+    env(MERGEPATH_CONSUMER_NAME) as $cn
+    | .consumers[] | select(.name == $cn) | .facts // {} | to_entries[]
+    | .key + "\t" + (
+        .value | if (tag == "!!seq") then join(" ") else tostring end
+      )
+  ' "$manifest")
+}
+
 # Compare a kit directory: every file under Mergepath's path must
 # exist (byte-identical) in the consumer; consumer-only files are
 # allowed and ignored. Outputs a status tag in $REPLY:
@@ -538,14 +639,20 @@ run_audit() {
     # we get the same effect via `select(tag == "!!str") // <fallback>`,
     # which yields the original scalar when consumers is a string and
     # the join'd list otherwise.
+    # Extended yq tuple: include source + dest so templated entries can
+    # be audited with source-template / dest-rendered remapping. For
+    # canonical/kit, source and dest default to .path; the audit code
+    # below ignores those fields for those types.
     local paths
     paths=$(yq -r '
       .paths[]
       | (.path + "\t" + .type + "\t"
-         + (.consumers | (select(tag == "!!str") // (join(","))) | tostring))
+         + (.consumers | (select(tag == "!!str") // (join(","))) | tostring)
+         + "\t" + (.source // .path)
+         + "\t" + (.dest // .path))
     ' "$manifest")
 
-    while IFS=$'\t' read -r mp_path mp_type mp_consumers; do
+    while IFS=$'\t' read -r mp_path mp_type mp_consumers mp_source mp_dest; do
       [ -z "$mp_path" ] && continue
       if ! in_path_filter "$mp_path"; then
         continue
@@ -570,10 +677,13 @@ run_audit() {
           [ "$REPLY" != "ok" ] && AUDIT_DRIFT_FOUND=1
           ;;
         templated)
-          # Layer 5 territory. Skip with a clear marker so the human
-          # sees these entries are intentionally deferred, not silently
-          # in-sync.
-          printf "  %s %-50s %s\n" "·" "$mp_path" "templated (deferred — Layer 5, #168)"
+          # Layer 5 activated (#313 lib + this PR). Render the source
+          # template with the consumer's facts and byte-diff against
+          # the on-disk destination.
+          compare_templated "$mp_path" "$mp_source" "$mp_dest" \
+                            "$consumer_name" "$consumer_root"
+          emit_status_line "$mp_dest" "$REPLY"
+          [ "$REPLY" != "ok" ] && AUDIT_DRIFT_FOUND=1
           ;;
         *)
           err "unknown path type '$mp_type' for $mp_path"

--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -457,6 +457,104 @@ compare_templated() {
   rm -f "$tmp_rendered"
 }
 
+# Materialize templated targets into a consumer workspace. For each
+# path in $templated_list (comma-joined manifest .path values),
+# fetch source/dest from the manifest, read the source from
+# mergepath@$sha, render via the substitution lib with the
+# consumer's facts, and write to the consumer's dest (atomically
+# via template_substitution::render_to). Honors the consumer's
+# .sync-overrides.yml skip_paths on the DEST path — the consumer
+# cares about the path landing in their tree, not the mergepath-
+# side source path.
+#
+# Args:
+#   $1 consumer_name        — for fact lookup + log lines
+#   $2 sha                  — mergepath commit to read source from
+#   $3 workspace            — consumer workspace root (writes land
+#                             at $workspace/repo/<dest>)
+#   $4 templated_list       — comma-joined manifest .path values
+#                             (caller-supplied, typically from
+#                             sync_consumer_skipped_targets in the
+#                             per-commit path or
+#                             sync_all_consumer_templated_targets in
+#                             the sync-all path)
+#   $5 consumer_overrides   — absolute path to the consumer's
+#                             .sync-overrides.yml (or empty string
+#                             if the consumer has no overrides file)
+#
+# Returns 0 on success (no targets is a clean no-op), non-zero if
+# any render failed. Materializes files into the workspace;
+# committing/pushing is the caller's concern.
+materialize_templated_targets() {
+  local consumer_name=$1
+  local sha=$2
+  local workspace=$3
+  local templated_list=$4
+  local consumer_overrides=$5
+
+  [ -z "$templated_list" ] && return 0
+
+  local manifest="$MERGEPATH_ROOT/$MANIFEST_PATH"
+  local short_sha=${sha:0:7}
+  local tpl_path tpl_source tpl_dest tpl_meta tpl_tmp tpl_consumer_target
+  local _tpl_paths
+  IFS=',' read -ra _tpl_paths <<< "$templated_list"
+  for tpl_path in "${_tpl_paths[@]}"; do
+    [ -z "$tpl_path" ] && continue
+
+    # Per-entry source + dest from the manifest. Default to .path when
+    # omitted (canonical/kit's symmetric model); templated entries
+    # typically declare both explicitly.
+    tpl_meta=$(MERGEPATH_TPL_PATH="$tpl_path" yq -r '
+      env(MERGEPATH_TPL_PATH) as $p
+      | .paths[] | select(.path == $p) | (.source // .path) + "\t" + (.dest // .path)
+    ' "$manifest")
+    tpl_source=$(echo "$tpl_meta" | cut -f1)
+    tpl_dest=$(echo "$tpl_meta" | cut -f2)
+    if [ -z "$tpl_source" ] || [ -z "$tpl_dest" ]; then
+      err "$consumer_name: could not resolve source/dest for templated entry '$tpl_path' (yq returned empty)"
+      return 1
+    fi
+
+    # Consumer-side override filter — applied to DEST because that's
+    # what lands in the consumer tree.
+    if [ -n "$consumer_overrides" ] && override_should_skip_path "$consumer_overrides" "$tpl_dest"; then
+      printf "  · %s skip %s (templated, per .sync-overrides.yml: %s)\n" \
+        "$consumer_name" "$tpl_dest" "$OVERRIDE_SKIP_REASON"
+      continue
+    fi
+
+    # Read source from mergepath@$sha into a tmp file, then render
+    # via the lib in a subshell so the MERGEPATH_FACT_* exports
+    # don't leak to other materializations in the same consumer
+    # (multiple templated entries) or the next consumer iteration.
+    tpl_tmp=$(mktemp "${TMPDIR:-/tmp}/mergepath-template-src.XXXXXX") || {
+      err "$consumer_name: mktemp failed for templated source"
+      return 1
+    }
+    if ! git -C "$MERGEPATH_ROOT" show "$sha:$tpl_source" >"$tpl_tmp" 2>/dev/null; then
+      rm -f "$tpl_tmp"
+      err "$consumer_name: could not read templated source $tpl_source from mergepath@$short_sha"
+      return 1
+    fi
+
+    tpl_consumer_target="$workspace/repo/$tpl_dest"
+    mkdir -p "$(dirname "$tpl_consumer_target")"
+    if ! (
+      export_consumer_facts "$consumer_name" "$manifest"
+      # shellcheck disable=SC1091
+      source "$MERGEPATH_ROOT/scripts/lib/template-substitution.sh"
+      template_substitution::render_to "$tpl_tmp" "$tpl_consumer_target"
+    ); then
+      rm -f "$tpl_tmp"
+      err "$consumer_name: render failed for templated $tpl_source → $tpl_dest"
+      return 1
+    fi
+    rm -f "$tpl_tmp"
+    printf "  ✎ %s rendered %s → %s\n" "$consumer_name" "$tpl_source" "$tpl_dest"
+  done
+}
+
 # Export a consumer's facts:* from the manifest as MERGEPATH_FACT_*
 # env vars in the current (sub)shell. Unsets any prior
 # MERGEPATH_FACT_* exports first so successive callers don't see
@@ -827,8 +925,17 @@ sync_all_consumer_templated_targets() {
   done
 }
 
-# Count manifest paths skipped (kit + templated) so the summary can name
-# them. Echoes "kit_count\ttemplated_count\tkit_paths\ttemplated_paths".
+# Enumerate manifest paths the per-commit sync needs to know about
+# beyond the canonical slice: kit paths that changed at the commit
+# (still deferred to slice 2, included in the commit-body
+# deferred-note) AND templated paths that changed (now materialized
+# in slice 5 / #313+follow-up — the function name predates the
+# templated activation, kept for back-compat).
+#
+# Echoes "kit_count\ttemplated_count\tkit_paths\ttemplated_paths".
+# Caller splits the templated CSV and passes it through to
+# materialize_templated_targets via sync_open_pr's 8th positional
+# arg; the kit CSV is still display-only in the deferred-note.
 sync_consumer_skipped_targets() {
   local consumer_name=$1
   local changed_files=$2
@@ -1156,9 +1263,15 @@ sync_open_pr() {
   done <<< "$targets"
   targets="$filtered_targets"
 
-  if [ -z "$targets" ]; then
+  # Early-exit gate. Pre-templated-activation this checked $targets
+  # only (canonical-after-override-filter); now also gate on
+  # $templated_list so a commit that touches ONLY a templated source
+  # (no canonical changes) still materializes. Templated override
+  # filtering happens inside materialize_templated_targets — its
+  # skip path counters are separate from canonical's.
+  if [ -z "$targets" ] && [ -z "$templated_list" ]; then
     if [ "$override_skip_count" -gt 0 ]; then
-      printf "  ⊘ %s — all canonical targets skipped per .sync-overrides.yml (%d entries)\n" \
+      printf "  ⊘ %s — all canonical targets skipped per .sync-overrides.yml (%d entries); no templated targets either\n" \
         "$consumer_name" "$override_skip_count"
       SYNC_SKIPPED=$((SYNC_SKIPPED + 1))
       SYNC_PR_OPENED=$((SYNC_PR_OPENED - 1))  # pre-decrement to offset the caller's post-success increment
@@ -1218,6 +1331,17 @@ sync_open_pr() {
     esac
   done <<< "$targets"
 
+  # Templated materialize — render mergepath@$sha's source templates
+  # with the consumer's facts (per scripts/lib/template-substitution.sh,
+  # #313) and write to consumer dest paths. The helper handles
+  # source/dest resolution from the manifest, per-entry override
+  # filtering on dest, and atomic render_to. Failures abort the
+  # whole consumer (same all-or-nothing semantics as canonical).
+  if ! materialize_templated_targets "$consumer_name" "$sha" "$workspace" \
+                                      "$templated_list" "$consumer_overrides"; then
+    return 1
+  fi
+
   # Sanity: did the copy actually change anything? If the consumer was
   # already in sync (someone hand-propagated it before us, or a prior
   # sync ran but the PR was never opened), don't push an empty commit.
@@ -1246,13 +1370,29 @@ sync_open_pr() {
   git -C "$workspace/repo" add -A
   local target_lines
   target_lines=$(while IFS= read -r p; do [ -z "$p" ] && continue; echo "  - $p"; done <<< "$targets")
+  # Append templated dest paths to the commit-body file list. Use the
+  # `.dest` value (where the file lands in the consumer), not `.path`
+  # (the manifest identifier in mergepath), so a reader sees the same
+  # paths that show up in `git status`.
+  if [ -n "$templated_list" ]; then
+    local _tpls _tpl _tpl_dest
+    IFS=',' read -ra _tpls <<< "$templated_list"
+    for _tpl in "${_tpls[@]}"; do
+      [ -z "$_tpl" ] && continue
+      _tpl_dest=$(MERGEPATH_TPL_PATH="$_tpl" yq -r '
+        env(MERGEPATH_TPL_PATH) as $p
+        | .paths[] | select(.path == $p) | (.dest // .path)
+      ' "$MERGEPATH_ROOT/$MANIFEST_PATH")
+      target_lines+=$'\n'"  - ${_tpl_dest} (templated, rendered from ${_tpl})"
+    done
+  fi
   local deferred_note=""
-  if [ -n "$kit_list" ] || [ -n "$templated_list" ]; then
+  if [ -n "$kit_list" ]; then
     deferred_note="
 Deferred this propagation (sync-to-downstream.sh ${SCRIPT_VERSION}
-only handles canonical paths; kit + templated land in slices 2 and 5):
-  kit:       ${kit_list:-none}
-  templated: ${templated_list:-none}
+handles canonical + templated paths in this slice; kit lands in
+slice 2):
+  kit: ${kit_list:-none}
 "
   fi
   if ! git -C "$workspace/repo" commit -q -m "$(cat <<EOF
@@ -1528,9 +1668,12 @@ sync_all_open_pr() {
   done <<< "$kit_targets"
   kit_targets="$filtered_kit"
 
-  if [ -z "$canonical_targets" ] && [ -z "$kit_targets" ]; then
+  # Early-exit gate. Pre-templated-activation this checked canonical
+  # and kit only; now also gate on $templated_list so a consumer
+  # whose only opt-ins are templated entries still materializes.
+  if [ -z "$canonical_targets" ] && [ -z "$kit_targets" ] && [ -z "$templated_list" ]; then
     if [ "$override_skip_count" -gt 0 ]; then
-      printf "  ⊘ %s — all canonical+kit targets skipped per .sync-overrides.yml (%d entries)\n" \
+      printf "  ⊘ %s — all canonical+kit targets skipped per .sync-overrides.yml (%d entries); no templated targets either\n" \
         "$consumer_name" "$override_skip_count"
       SYNC_SKIPPED=$((SYNC_SKIPPED + 1))
       SYNC_PR_OPENED=$((SYNC_PR_OPENED - 1))  # offset caller's eager increment
@@ -1616,6 +1759,17 @@ sync_all_open_pr() {
     done <<< "$kit_files"
   done <<< "$kit_targets"
 
+  # Templated materialize — render mergepath@$sha's source templates
+  # with each consumer's facts (per scripts/lib/template-substitution.sh,
+  # #313) and write to consumer dest paths. The helper handles
+  # source/dest resolution from the manifest, per-entry override
+  # filtering on dest, and atomic render_to. Failures abort the
+  # whole consumer (same all-or-nothing semantics as canonical/kit).
+  if ! materialize_templated_targets "$consumer_name" "$sha" "$workspace" \
+                                      "$templated_list" "$consumer_overrides"; then
+    return 1
+  fi
+
   # Sanity: did the copy actually change anything? A consumer already
   # at HEAD state (hand-propagated, or a prior --sync-all PR merged)
   # should not get an empty commit / PR.
@@ -1641,11 +1795,25 @@ sync_all_open_pr() {
   git -C "$workspace/repo" add -A
 
   # Build the path lists for the commit / PR body.
-  local canonical_lines kit_lines
+  local canonical_lines kit_lines templated_lines
   canonical_lines=$(while IFS= read -r p; do [ -z "$p" ] && continue; echo "  - $p"; done <<< "$canonical_targets")
   kit_lines=$(while IFS= read -r p; do [ -z "$p" ] && continue; echo "  - $p (kit, allow-extras)"; done <<< "$kit_targets")
+  templated_lines=""
+  if [ -n "$templated_list" ]; then
+    local _tpls_a _tpl_a _tpl_a_dest
+    IFS=',' read -ra _tpls_a <<< "$templated_list"
+    for _tpl_a in "${_tpls_a[@]}"; do
+      [ -z "$_tpl_a" ] && continue
+      _tpl_a_dest=$(MERGEPATH_TPL_PATH="$_tpl_a" yq -r '
+        env(MERGEPATH_TPL_PATH) as $p
+        | .paths[] | select(.path == $p) | (.dest // .path)
+      ' "$MERGEPATH_ROOT/$MANIFEST_PATH")
+      templated_lines+="  - ${_tpl_a_dest} (templated, rendered from ${_tpl_a})"$'\n'
+    done
+  fi
   [ -z "$canonical_lines" ] && canonical_lines="  (none)"
   [ -z "$kit_lines" ] && kit_lines="  (none)"
+  [ -z "$templated_lines" ] && templated_lines="  (none)"
 
   local override_note=""
   if [ -n "$override_skipped_list" ]; then
@@ -1655,23 +1823,18 @@ divergences left untouched):
   ${override_skipped_list}
 "
   fi
-  local templated_note=""
-  if [ -n "$templated_list" ]; then
-    templated_note="
-Deferred (templated paths land in Layer 5, #168):
-  ${templated_list}
-"
-  fi
 
   if ! git -C "$workspace/repo" commit -q -m "$(cat <<EOF
-bulk sync to mergepath@${short_sha} — verbatim canonical/kit mirror per .mergepath-sync.yml
+bulk sync to mergepath@${short_sha} — verbatim canonical/kit mirror + per-consumer templated render per .mergepath-sync.yml
 
 Source: https://github.com/nathanjohnpayne/mergepath/commit/${sha}
 Canonical paths synced:
 ${canonical_lines}
 Kit paths synced:
 ${kit_lines}
-${override_note}${templated_note}
+Templated paths rendered (per-consumer facts applied):
+${templated_lines}
+${override_note}
 Authoring-Agent: claude
 
 ## Self-Review
@@ -1753,7 +1916,10 @@ ${canonical_lines}
 
 ## Kit paths synced
 ${kit_lines}
-${override_note}${templated_note}
+
+## Templated paths rendered (per-consumer facts applied)
+${templated_lines}
+${override_note}
 Authoring-Agent: claude
 
 ## Self-Review
@@ -1794,8 +1960,8 @@ sync_all_one_consumer() {
   local templated_list
   templated_list=$(echo "$templated_targets" | grep -v '^$' | paste -sd, - 2>/dev/null || true)
 
-  if [ -z "$canonical_targets" ] && [ -z "$kit_targets" ]; then
-    printf "  · %s (no canonical/kit manifest paths opted in)\n" "$consumer_name"
+  if [ -z "$canonical_targets" ] && [ -z "$kit_targets" ] && [ -z "$templated_targets" ]; then
+    printf "  · %s (no canonical/kit/templated manifest paths opted in)\n" "$consumer_name"
     SYNC_SKIPPED=$((SYNC_SKIPPED + 1))
     return 0
   fi
@@ -1923,7 +2089,7 @@ sync_all_one_consumer() {
       printf '%s' "$plan_skipped"
     fi
     if [ -n "$templated_list" ]; then
-      printf "      (deferred — templated, Layer 5: %s)\n" "$templated_list"
+      printf "      (templated, rendered per consumer facts: %s)\n" "$templated_list"
     fi
     SYNC_PR_OPENED=$((SYNC_PR_OPENED + 1))
     return 0

--- a/tests/test_check_sync_manifest.sh
+++ b/tests/test_check_sync_manifest.sh
@@ -314,6 +314,186 @@ fi
 # recurses through the new "run regression suite" call at the bottom
 # of check_sync_manifest. Trust the CI invocation to do the smoke.
 
+# --- Templated + source/dest + facts validation (PR following #313) --
+
+# Case 9: templated with explicit source ≠ path + dest passes.
+MANIFEST_TPL_OK="$MIN_HEADER
+  - path: examples/eslint.config.js
+    type: templated
+    source: examples/eslint.config.js
+    dest: eslint.config.js
+    consumers: all
+"
+PATHS_TPL_OK="examples/eslint.config.js"
+set +e
+out=$(run_with_fixture "$MANIFEST_TPL_OK" "$PATHS_TPL_OK"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_sync_manifest: PASS"; then
+  pass "Case 9: templated with source/dest passes"
+else
+  fail "Case 9 unexpected (rc=$rc): $out"
+fi
+
+# Case 10: templated without dest emits WARN but passes.
+MANIFEST_TPL_NODEST="$MIN_HEADER
+  - path: examples/eslint.config.js
+    type: templated
+    consumers: all
+"
+PATHS_TPL_NODEST="examples/eslint.config.js"
+set +e
+out=$(run_with_fixture "$MANIFEST_TPL_NODEST" "$PATHS_TPL_NODEST"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "WARN: templated path" && echo "$out" | grep -q "check_sync_manifest: PASS"; then
+  pass "Case 10: templated without dest warns but passes"
+else
+  fail "Case 10 unexpected (rc=$rc): $out"
+fi
+
+# Case 11: absolute `dest:` is rejected.
+MANIFEST_DEST_ABS="$MIN_HEADER
+  - path: examples/x.js
+    type: templated
+    dest: /etc/passwd
+    consumers: all
+"
+PATHS_DEST_ABS="examples/x.js"
+set +e
+out=$(run_with_fixture "$MANIFEST_DEST_ABS" "$PATHS_DEST_ABS"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "dest '/etc/passwd' that is absolute"; then
+  pass "Case 11: absolute dest rejected"
+else
+  fail "Case 11 unexpected (rc=$rc): $out"
+fi
+
+# Case 12: dest with '..' segment is rejected.
+MANIFEST_DEST_DOTDOT="$MIN_HEADER
+  - path: examples/x.js
+    type: templated
+    dest: ../escape.js
+    consumers: all
+"
+PATHS_DEST_DOTDOT="examples/x.js"
+set +e
+out=$(run_with_fixture "$MANIFEST_DEST_DOTDOT" "$PATHS_DEST_DOTDOT"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "containing a '..' segment"; then
+  pass "Case 12: dest with '..' rejected"
+else
+  fail "Case 12 unexpected (rc=$rc): $out"
+fi
+
+# Case 13: source ≠ path triggers source existence check, fails on missing.
+MANIFEST_SRC_MISSING="$MIN_HEADER
+  - path: eslint.config.js
+    type: templated
+    source: examples/missing.js
+    dest: eslint.config.js
+    consumers: all
+"
+# Materialize path (existence requirement) but NOT source.
+PATHS_SRC_MISSING="eslint.config.js"
+set +e
+out=$(run_with_fixture "$MANIFEST_SRC_MISSING" "$PATHS_SRC_MISSING"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "source 'examples/missing.js' does not exist"; then
+  pass "Case 13: source ≠ path with missing source rejected"
+else
+  fail "Case 13 unexpected (rc=$rc): $out"
+fi
+
+# Case 14: valid consumer facts (scalar + list) pass.
+MANIFEST_FACTS_OK='version: 1
+consumers:
+  - name: example
+    repo: example-org/example
+    visibility: public
+    facts:
+      frameworks: [react, typescript]
+      node_version: "20"
+      has_ts: yes
+paths:
+  - path: scripts/foo.sh
+    type: canonical
+    consumers: all
+'
+PATHS_FACTS_OK="scripts/foo.sh"
+set +e
+out=$(run_with_fixture "$MANIFEST_FACTS_OK" "$PATHS_FACTS_OK"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_sync_manifest: PASS"; then
+  pass "Case 14: valid consumer facts (scalar + list) pass"
+else
+  fail "Case 14 unexpected (rc=$rc): $out"
+fi
+
+# Case 15: facts key with uppercase rejected.
+MANIFEST_FACTS_KEY_BAD='version: 1
+consumers:
+  - name: example
+    repo: example-org/example
+    visibility: public
+    facts:
+      Frameworks: [react]
+paths:
+  - path: scripts/foo.sh
+    type: canonical
+    consumers: all
+'
+set +e
+out=$(run_with_fixture "$MANIFEST_FACTS_KEY_BAD" "scripts/foo.sh"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "facts: key 'Frameworks' must match"; then
+  pass "Case 15: facts key with uppercase rejected"
+else
+  fail "Case 15 unexpected (rc=$rc): $out"
+fi
+
+# Case 16: facts value as nested mapping rejected.
+MANIFEST_FACTS_NESTED='version: 1
+consumers:
+  - name: example
+    repo: example-org/example
+    visibility: public
+    facts:
+      framework_config:
+        react: true
+        ts: true
+paths:
+  - path: scripts/foo.sh
+    type: canonical
+    consumers: all
+'
+set +e
+out=$(run_with_fixture "$MANIFEST_FACTS_NESTED" "scripts/foo.sh"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "unsupported value type '!!map'"; then
+  pass "Case 16: facts value as nested mapping rejected"
+else
+  fail "Case 16 unexpected (rc=$rc): $out"
+fi
+
+# Case 17: consumer without facts: block still validates (facts is optional).
+MANIFEST_NO_FACTS='version: 1
+consumers:
+  - name: example
+    repo: example-org/example
+    visibility: public
+paths:
+  - path: scripts/foo.sh
+    type: canonical
+    consumers: all
+'
+set +e
+out=$(run_with_fixture "$MANIFEST_NO_FACTS" "scripts/foo.sh"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_sync_manifest: PASS"; then
+  pass "Case 17: consumer without facts: passes (facts is optional)"
+else
+  fail "Case 17 unexpected (rc=$rc): $out"
+fi
+
 echo
 TOTAL=$((PASS + FAIL))
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_check_sync_manifest.sh
+++ b/tests/test_check_sync_manifest.sh
@@ -495,6 +495,70 @@ else
   fail "Case 16 unexpected (rc=$rc): $out"
 fi
 
+# Case 17b: facts as a sequence rejected (must be a mapping).
+# Codex Phase 4b CHANGES_REQUESTED on PR #316 by nathanpayne-codex
+# caught this gap — `to_entries` on a sequence yields numeric-index
+# keys that pass the [a-z0-9_-]+ charset check, so per-entry
+# validation false-passed.
+MANIFEST_FACTS_SEQ='version: 1
+consumers:
+  - name: example
+    repo: example-org/example
+    visibility: public
+    facts: [react, typescript]
+paths:
+  - path: scripts/foo.sh
+    type: canonical
+    consumers: all
+'
+set +e
+out=$(run_with_fixture "$MANIFEST_FACTS_SEQ" "scripts/foo.sh"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "facts: must be a YAML mapping (got tag '!!seq')"; then
+  pass "Case 17b: facts as sequence rejected"
+else
+  fail "Case 17b unexpected (rc=$rc): $out"
+fi
+
+# Case 18: explicit dest: "" on templated entry rejected. Same Codex
+# Phase 4b finding — empty-string dest would pass through to
+# materialize_templated_targets which then aborts with a less-clear
+# error. Reject at validation. (Also exercises the IFS='|' field-
+# stability fix, since with IFS=$'\t' the empty dest field would
+# collapse and the validator would never see it as "" specifically.)
+MANIFEST_DEST_EMPTY="$MIN_HEADER
+  - path: examples/foo.js
+    type: templated
+    dest: \"\"
+    consumers: all
+"
+PATHS_DEST_EMPTY="examples/foo.js"
+set +e
+out=$(run_with_fixture "$MANIFEST_DEST_EMPTY" "$PATHS_DEST_EMPTY"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q 'explicit dest: "" — dest must be non-empty when set'; then
+  pass "Case 18: explicit empty dest: \"\" rejected"
+else
+  fail "Case 18 unexpected (rc=$rc): $out"
+fi
+
+# Case 18b: explicit source: "" rejected (parallel to dest).
+MANIFEST_SRC_EMPTY="$MIN_HEADER
+  - path: examples/foo.js
+    type: templated
+    source: \"\"
+    dest: eslint.config.js
+    consumers: all
+"
+set +e
+out=$(run_with_fixture "$MANIFEST_SRC_EMPTY" "examples/foo.js"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q 'explicit source: "" — source must be non-empty when set'; then
+  pass "Case 18b: explicit empty source: \"\" rejected"
+else
+  fail "Case 18b unexpected (rc=$rc): $out"
+fi
+
 # Case 17: consumer without facts: block still validates (facts is optional).
 MANIFEST_NO_FACTS='version: 1
 consumers:

--- a/tests/test_check_sync_manifest.sh
+++ b/tests/test_check_sync_manifest.sh
@@ -397,10 +397,31 @@ PATHS_SRC_MISSING="eslint.config.js"
 set +e
 out=$(run_with_fixture "$MANIFEST_SRC_MISSING" "$PATHS_SRC_MISSING"); rc=$?
 set -e
-if [ "$rc" = "1" ] && echo "$out" | grep -q "source 'examples/missing.js' does not exist"; then
-  pass "Case 13: source ≠ path with missing source rejected"
+if [ "$rc" = "1" ] && echo "$out" | grep -q "source 'examples/missing.js' must be a regular file for templated entries"; then
+  pass "Case 13: source ≠ path with missing source rejected (templated: requires regular file)"
 else
   fail "Case 13 unexpected (rc=$rc): $out"
+fi
+
+# Case 13b: templated source pointing at a DIRECTORY is rejected (a
+# directory can't be a template). CodeRabbit Major on PR #316 caught
+# this gap — the previous `-e` check would have accepted a directory.
+MANIFEST_SRC_ISDIR="$MIN_HEADER
+  - path: eslint.config.js
+    type: templated
+    source: examples/somedir
+    dest: eslint.config.js
+    consumers: all
+"
+PATHS_SRC_ISDIR="eslint.config.js
+examples/somedir/"
+set +e
+out=$(run_with_fixture "$MANIFEST_SRC_ISDIR" "$PATHS_SRC_ISDIR"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "must be a regular file for templated entries"; then
+  pass "Case 13b: templated source pointing at a directory rejected"
+else
+  fail "Case 13b unexpected (rc=$rc): $out"
 fi
 
 # Case 14: valid consumer facts (scalar + list) pass.


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Activates the `templated` path-type that PR #313 reserved. Adds the manifest schema (`source:`/`dest:` per-entry, `facts:` per-consumer), validator coverage, audit re-render via the lib (#313), and sync materialize in both per-commit and `--sync-all` paths. Unblocks Phase C (ESLint conditional-block template + manifest entry) which unblocks Phase D (6-consumer ESLint rollout, parent #250).

Three commits, each self-contained:
- `16bbef7` — schema + check_sync_manifest validation + compare_templated + audit dispatch + 9 new validator tests
- `43942aa` — sync materialize in `sync_open_pr` (per-commit) + `sync_all_open_pr` (steady-state), with `materialize_templated_targets()` helper shared between them
- `cc78ade` — docs update

## What's wired up

- **Manifest** (`.mergepath-sync.yml` schema docs only — no actual templated entry yet; Phase C adds one): real spec for `templated` type, `source:`/`dest:` (both default to `.path`), per-consumer `facts:` mapping with charset rules.
- **Validator** (`scripts/ci/check_sync_manifest`): WARN on templated without explicit `dest:`, FAIL on absolute or `..`-containing `dest:`/`source:`, FAIL on missing `source:` file, FAIL on facts keys outside `[a-z0-9_-]+` or facts values as nested mappings.
- **Audit** (`scripts/sync-to-downstream.sh --audit`): `compare_templated()` renders source with consumer facts, byte-diffs against dest, reports `ok`/`drift:<lines>`/`missing` in the existing tag scheme. Replaces the "templated (deferred — Layer 5, #168)" stub.
- **Sync (per-commit)** (`scripts/sync-to-downstream.sh <commit-sha>`): `materialize_templated_targets()` renders + writes for opted-in templated entries that changed at the commit. Honors `.sync-overrides.yml` on dest. Commit body lists templated paths with "(templated, rendered from <source>)" annotation.
- **Sync (--sync-all)**: same materialize behavior for every templated entry the consumer opts into. Dry-run plan + commit body + PR body all updated.

## What's deliberately NOT in this PR

- **`verify-propagation-pr.sh` extension for templated re-render verification.** Templated PRs route to normal Phase 4 review in v1 — the existing lane-gate check sees the templated `dest` as "off propagation surface" (since `parse_manifest_paths.sh` only emits source paths) and correctly denies lane exemption. Documented in `docs/agents/templated-propagation.md` § "Propagation-lane verification — v1 limitation".
- **End-to-end materialize test against a real templated entry.** Deferred to Phase C where the ESLint template will exercise the materialize loop in CI. For this PR, validation rests on: bash `-n` syntax, existing test_check_sync_manifest passing on the new schema, and structural parallelism with the proven canonical/kit materialize loops.

## Subtle gotcha fixed mid-PR

Bash apostrophe-vs-heredoc inside an outer-quoted command substitution: my initial commit-body draft said "Templated paths rendered (with this consumer's facts):" — the apostrophe in "consumer's" tripped bash's quote tracker in the `"\$(cat <<EOF ... EOF)"` form and produced a spurious parse error 100+ lines later. Rephrased to "Templated paths rendered (per-consumer facts applied):". Worth flagging because the failure mode (error at an apparently-unrelated line) is hard to diagnose cold.

## Focus areas for review

1. **Eval boundary in `materialize_templated_targets`.** Renders happen in a subshell so MERGEPATH_FACT_* exports don't leak; the lib (#313) has the key-charset validator at the eval site; combined this should be tight, but worth a second look.
2. **Override semantics for templated.** I apply `.sync-overrides.yml` on the DEST path (consumer cares about what lands in their tree). Alternative would be filtering on `.path` (mergepath identifier). Picked dest; flag if you'd pick otherwise.
3. **Templated entries unreachable in current CI.** Live manifest has zero templated entries, so the materialize path is structurally verified but not exercised end-to-end. Worth deciding whether to land a throwaway templated entry in this PR for CI coverage, or trust Phase C's ESLint entry to backfill the coverage.
4. **`sync_consumer_skipped_targets` naming drift.** Function name predates templated activation; templated is no longer "skipped." Kept name for back-compat (call sites are stable), updated docstring. Push back if you'd rather rename + ripple.
5. **Apostrophe-vs-heredoc gotcha.** See above — if you have a stronger fix (e.g., switch to `<<'EOF'` to make the heredoc literal, sidestepping the issue entirely), that'd be more durable than my prose-rewrite workaround.

## Testing

- [x] `bash tests/test_check_sync_manifest.sh` → 18 PASS, 0 FAIL (was 9; added 9 new for the new schema)
- [x] `scripts/ci/check_sync_manifest` against live manifest → PASS (8 consumer(s), 40 path entry/entries)
- [x] `scripts/ci/check_ci_scripts_wired` → PASS
- [x] `scripts/ci/check_spec_test_alignment` → PASS
- [x] `bash -n scripts/sync-to-downstream.sh` → syntax OK
- Manual review of materialize_templated_targets logic against the parallel canonical/kit patterns

## Self-Review

- [x] **Correctness.** Audit + sync materialize structurally mirror canonical/kit. Override filter on dest. Subshell scoping prevents fact leakage. Atomicity via `render_to`. Manifest validator catches misconfigurations at validation rather than render time.
- [x] **Regression risk.** Sync code is well-trodden (#231 destructive-step ordering, #200 overrides, #264 propagation lane). Changes are additive within the existing structure — the new templated branch sits alongside canonical/kit, doesn't refactor either. Templated unreachable in live CI today since no manifest entry uses it; the dispatch path is exercised by bash `-n` + parallel exercise of the audit dispatch in the first commit.
- [x] **Style and conventions.** Matches existing function-naming (`compare_*`, `sync_*_targets`, `materialize_*`). YAML reading via yq throughout. Logging via existing `printf "  %s %s\n"` patterns. Bash 3.2 portable (no associative arrays, no `${var^^}`).
- [x] **Test coverage.** 18 cases (9 new) in test_check_sync_manifest cover the schema validator. End-to-end materialize coverage deferred to Phase C; called out explicitly in the PR body.
- [x] **Security and dependency hygiene.** No new external dependencies. The lib's key-charset validator from #313 covers the eval boundary. Override filter prevents writes to consumer-flagged divergence paths. `dest:` validation prevents write-outside-root via a bad manifest entry.

---
_Phase 4b cleared on 955c59f (external `nathanpayne-codex` APPROVED, all bot threads resolved). Re-firing `pull_request:edited` event to refresh stale Label Gate per [#315](https://github.com/nathanjohnpayne/mergepath/issues/315) — the recurring auto-clear-driven Label Gate bug._
