### PR TITLE
feat(propagation): activate Phase C — ESLint templated entry + per-consumer facts.frameworks

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -96,27 +96,45 @@ consumers:
   - name: matchline
     repo: nathanjohnpayne/matchline
     visibility: private
+    facts:
+      frameworks: [react, typescript]
   - name: nathanpaynedotcom
     repo: nathanjohnpayne/nathanpaynedotcom
     visibility: private
+    facts:
+      frameworks: [astro, typescript]
+  # overridebroadway has zero lintable JS/TS surface area today; it's
+  # excluded from the ESLint templated entry's consumers list rather
+  # than carrying empty facts. No facts block needed.
   - name: overridebroadway
     repo: nathanjohnpayne/overridebroadway
     visibility: private
+  # Same exclusion rationale as overridebroadway above.
   - name: device-source-of-truth
     repo: nathanjohnpayne/device-source-of-truth
     visibility: public
   - name: friends-and-family-billing
     repo: nathanjohnpayne/friends-and-family-billing
     visibility: public
+    facts:
+      frameworks: [react]
   - name: device-platform-reporting
     repo: nathanjohnpayne/device-platform-reporting
     visibility: public
+    facts:
+      frameworks: [react]
+  # swipewatch has minimal Node + vitest code, no frameworks. The
+  # empty `frameworks: []` list opts it into the JS baseline only.
   - name: swipewatch
     repo: nathanjohnpayne/swipewatch
     visibility: public
+    facts:
+      frameworks: []
   - name: tadlockpsychiatry
     repo: nathanjohnpayne/tadlockpsychiatry
     visibility: private
+    facts:
+      frameworks: [react, typescript]
 
 # Path types:
 #   canonical  — byte-for-byte mirror. Any difference is drift.
@@ -482,6 +500,41 @@ paths:
   - path: scripts/workflow/
     type: kit
     consumers: all
+
+  # Templated entries — rendered per consumer via scripts/lib/
+  # template-substitution.sh using the consumer's facts.* from the
+  # consumers: block above. See § Path types above for the full
+  # contract, and docs/agents/templated-propagation.md for syntax.
+
+  # ESLint flat-config per the Mergepath ESLint standard floor
+  # (mergepath#250). Source is the conditional-block template at
+  # examples/eslint.config.js; dest lands at the consumer repo's
+  # root as eslint.config.js. The render keeps the JS baseline
+  # always-on and stacks framework blocks (typescript / astro /
+  # react) per the consumer's declared `facts.frameworks`.
+  #
+  # Consumers excluded: device-source-of-truth and overridebroadway
+  # have zero lintable JS/TS surface area; the ESLint policy floor
+  # doesn't apply to them (rules/repo_rules.md § ESLint policy).
+  #
+  # Per-consumer rendered shapes:
+  #   matchline          → JS + TS + React + react-hooks
+  #   nathanpaynedotcom  → JS + TS + Astro
+  #   friends-and-family-billing → JS + React + react-hooks
+  #   device-platform-reporting  → JS + React + react-hooks
+  #   tadlockpsychiatry  → JS + TS + React + react-hooks
+  #   swipewatch         → JS baseline only (frameworks: [])
+  - path: examples/eslint.config.js
+    source: examples/eslint.config.js
+    dest: eslint.config.js
+    type: templated
+    consumers:
+      - matchline
+      - nathanpaynedotcom
+      - friends-and-family-billing
+      - device-platform-reporting
+      - tadlockpsychiatry
+      - swipewatch
 
 # Per-consumer exclusions. Use sparingly — drift exceptions become
 # audit noise over time. Each entry must list a `reason:` so future

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -507,23 +507,29 @@ paths:
   # contract, and docs/agents/templated-propagation.md for syntax.
 
   # ESLint flat-config per the Mergepath ESLint standard floor
-  # (mergepath#250). Source is the conditional-block template at
-  # examples/eslint.config.js; dest lands at the consumer repo's
-  # root as eslint.config.js. The render keeps the JS baseline
-  # always-on and stacks framework blocks (typescript / astro /
-  # react) per the consumer's declared `facts.frameworks`.
+  # (mergepath#250). Two manifest entries because ESLint
+  # `eslint.config.js` resolution honors `package.json "type"`:
+  # ESM consumers need ESM syntax (import/export default), CJS
+  # consumers need CJS syntax (require/module.exports). Mixing
+  # would fail to load (Codex P1 on PR #318). The template-author
+  # maintains both source files in parallel; the body inside the
+  # export is byte-identical, only the import/export syntax differs.
   #
-  # Consumers excluded: device-source-of-truth and overridebroadway
-  # have zero lintable JS/TS surface area; the ESLint policy floor
-  # doesn't apply to them (rules/repo_rules.md § ESLint policy).
+  # Consumers excluded from both entries: device-source-of-truth
+  # and overridebroadway have zero lintable JS/TS surface area;
+  # the ESLint policy floor doesn't apply (rules/repo_rules.md §
+  # ESLint policy).
   #
-  # Per-consumer rendered shapes:
-  #   matchline          → JS + TS + React + react-hooks
-  #   nathanpaynedotcom  → JS + TS + Astro
-  #   friends-and-family-billing → JS + React + react-hooks
-  #   device-platform-reporting  → JS + React + react-hooks
-  #   tadlockpsychiatry  → JS + TS + React + react-hooks
-  #   swipewatch         → JS baseline only (frameworks: [])
+  # Per-consumer rendered shapes (driven by facts.frameworks; module
+  # syntax driven by which entry the consumer is in below):
+  #   matchline (ESM)                  → JS + TS + React + react-hooks
+  #   nathanpaynedotcom (ESM)          → JS + TS + Astro
+  #   tadlockpsychiatry (ESM)          → JS + TS + React + react-hooks
+  #   friends-and-family-billing (CJS) → JS + React + react-hooks
+  #   device-platform-reporting (CJS)  → JS + React + react-hooks
+  #   swipewatch (CJS)                 → JS baseline only
+
+  # ESM variant — consumers with `"type": "module"` in package.json
   - path: examples/eslint.config.js
     source: examples/eslint.config.js
     dest: eslint.config.js
@@ -531,9 +537,18 @@ paths:
     consumers:
       - matchline
       - nathanpaynedotcom
+      - tadlockpsychiatry
+
+  # CJS variant — consumers without `"type": "module"` (default
+  # CJS resolution). Same body as the ESM variant; only the
+  # imports and module.exports differ.
+  - path: examples/eslint.config.cjs.js
+    source: examples/eslint.config.cjs.js
+    dest: eslint.config.js
+    type: templated
+    consumers:
       - friends-and-family-billing
       - device-platform-reporting
-      - tadlockpsychiatry
       - swipewatch
 
 # Per-consumer exclusions. Use sparingly — drift exceptions become

--- a/examples/eslint.config.cjs.js
+++ b/examples/eslint.config.cjs.js
@@ -1,0 +1,149 @@
+// eslint.config.js (CommonJS variant)
+//
+// Auto-generated from nathanjohnpayne/mergepath's templated source
+// at examples/eslint.config.cjs.js (per the Mergepath ESLint
+// standard, mergepath#250). Edit upstream, not this rendered copy
+// — local edits will be overwritten on the next propagation run.
+//
+// This is the CommonJS variant. It's rendered for consumers whose
+// package.json does NOT declare `"type": "module"` (default CJS
+// resolution). ESM consumers get the sibling examples/
+// eslint.config.js (ESM variant) instead — see .mergepath-sync.yml
+// for the consumers: partitioning.
+//
+// >>> if _template_only_notes
+// Template-author notes (this block is stripped from every
+// rendered consumer copy because no consumer sets
+// `facts._template_only_notes`):
+//
+// Rendered per consumer by scripts/lib/template-substitution.sh
+// (#313) using the consumer's `facts.frameworks` from
+// `.mergepath-sync.yml`. The CJS variant exists because ESM-syntax
+// `eslint.config.js` in a CJS package fails to load (Codex P1 on
+// PR #318 by chatgpt-codex-connector caught this gap). Module-
+// format partitioning lives in the manifest's consumers: lists
+// rather than a per-consumer fact, so the template-author only
+// edits one variant at a time and the rendered output is
+// trivially CommonJS for every entry in this template's consumers
+// list.
+//
+// Per-consumer facts.frameworks vocabulary (closed set, same as
+// ESM variant):
+//   typescript  → enables typescript-eslint baseline + TS parsing
+//   astro       → enables eslint-plugin-astro
+//   react       → enables eslint-plugin-react + react-hooks
+//
+// A consumer with no frameworks (e.g., swipewatch — pure Node +
+// vitest) gets the JS baseline only. Multiple frameworks stack in
+// declaration order. Keep this template's body byte-identical (modulo
+// import/export syntax) to the ESM variant — divergence between the
+// two would render differently for nominally-equivalent CJS vs ESM
+// consumers, which is a misfeature.
+// <<<
+
+const js = require("@eslint/js");
+const globals = require("globals");
+
+// >>> if frameworks contains typescript
+const tseslint = require("typescript-eslint");
+// <<<
+// >>> if frameworks contains astro
+const astro = require("eslint-plugin-astro");
+// <<<
+// >>> if frameworks contains react
+const react = require("eslint-plugin-react");
+const reactHooks = require("eslint-plugin-react-hooks");
+// <<<
+
+module.exports = [
+  // Ignore generated / vendored output. Customize per-consumer via
+  // a follow-up commit on the propagation PR if a repo needs extras
+  // (e.g., functions/lib for cloud-functions repos).
+  {
+    ignores: [
+      "node_modules/**",
+      "dist/**",
+      "build/**",
+      "coverage/**",
+      ".astro/**",
+      ".next/**",
+      ".vercel/**",
+    ],
+  },
+
+  // Baseline JS recommended — required by the Mergepath policy floor.
+  js.configs.recommended,
+
+  // Apply browser + node globals to all JS sources by default. Narrow
+  // these per-file-pattern in a follow-up commit if the repo has a
+  // clean split (e.g., scripts/* node-only, src/* browser-only).
+  //
+  // `*.cjs` files are split out so ESLint parses them as CommonJS
+  // (`sourceType: "commonjs"`) rather than ES modules — otherwise
+  // top-level `require`/`module.exports` and CommonJS scope rules
+  // produce false-positive parse errors. The defaults ESLint applies
+  // by extension are: `module` for `.js`/`.mjs`, `commonjs` for
+  // `.cjs`; we make that explicit here so the policy is
+  // self-documenting.
+  {
+    files: ["**/*.{js,mjs,jsx}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+  },
+  {
+    files: ["**/*.cjs"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "commonjs",
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+
+// >>> if frameworks contains typescript
+  // TypeScript recommended ruleset — applied to .ts / .tsx via the
+  // typescript-eslint plugin's flat-config preset. Includes the
+  // parser, the recommended rule set, and the file-glob targeting.
+  ...tseslint.configs.recommended,
+// <<<
+
+// >>> if frameworks contains astro
+  // Astro recommended ruleset — applied to .astro files. The plugin
+  // exposes its flat-config-compatible preset under .configs.recommended.
+  ...astro.configs.recommended,
+// <<<
+
+// >>> if frameworks contains react
+  // React + React Hooks recommended rulesets — applied to .jsx / .tsx.
+  // Detect the React version automatically from package.json. The
+  // React 17+ JSX transform makes `react/react-in-jsx-scope` obsolete;
+  // turn it off explicitly so the rule doesn't flag every component.
+  {
+    files: ["**/*.{jsx,tsx}"],
+    plugins: {
+      react,
+      "react-hooks": reactHooks,
+    },
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    rules: {
+      ...react.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off",
+    },
+    settings: {
+      react: { version: "detect" },
+    },
+  },
+// <<<
+];

--- a/examples/eslint.config.cjs.js
+++ b/examples/eslint.config.cjs.js
@@ -115,9 +115,14 @@ module.exports = [
 // <<<
 
 // >>> if frameworks contains astro
-  // Astro recommended ruleset — applied to .astro files. The plugin
-  // exposes its flat-config-compatible preset under .configs.recommended.
-  ...astro.configs.recommended,
+  // Astro flat-config recommended ruleset — applied to .astro files.
+  // The plugin exposes its flat-config preset under the bracketed
+  // `configs['flat/recommended']` key (NOT the legacy
+  // `configs.recommended` which is the eslintrc-shape config). Same
+  // key for ESM and CJS — the plugin's export shape is module-
+  // system-agnostic. Codex P2 round 2 on PR #318 caught this gap
+  // for the CJS variant; ESM variant fixed in parallel for symmetry.
+  ...astro.configs['flat/recommended'],
 // <<<
 
 // >>> if frameworks contains react

--- a/examples/eslint.config.js
+++ b/examples/eslint.config.js
@@ -100,9 +100,13 @@ export default [
 // <<<
 
 // >>> if frameworks contains astro
-  // Astro recommended ruleset — applied to .astro files. The plugin
-  // exposes its flat-config-compatible preset under .configs.recommended.
-  ...astro.configs.recommended,
+  // Astro flat-config recommended ruleset — applied to .astro files.
+  // The plugin exposes its flat-config preset under the bracketed
+  // `configs['flat/recommended']` key (NOT the legacy
+  // `configs.recommended` which is the eslintrc-shape config).
+  // Same key for ESM and CJS — the plugin's export shape is
+  // module-system-agnostic.
+  ...astro.configs['flat/recommended'],
 // <<<
 
 // >>> if frameworks contains react

--- a/examples/eslint.config.js
+++ b/examples/eslint.config.js
@@ -1,56 +1,49 @@
-// examples/eslint.config.js
+// eslint.config.js
 //
-// Sample ESLint flat-config that consumer repos can copy to satisfy
-// the Mergepath ESLint policy (rules/repo_rules.md § ESLint policy).
+// Auto-generated from nathanjohnpayne/mergepath's templated source
+// at examples/eslint.config.js (per the Mergepath ESLint standard,
+// mergepath#250). Edit upstream, not this rendered copy — local
+// edits will be overwritten on the next propagation run.
 //
-// This file is NOT loaded by ESLint at the Mergepath repo itself —
-// Mergepath has no package.json and is exempt from the policy. The
-// file lives under examples/ so it can be copied verbatim, then
-// customized per consumer.
+// >>> if _template_only_notes
+// Template-author notes (this block is stripped from every
+// rendered consumer copy because no consumer sets
+// `facts._template_only_notes`):
 //
-// Layout:
+// Rendered per consumer by scripts/lib/template-substitution.sh
+// (#313) using the consumer's `facts.frameworks` from
+// `.mergepath-sync.yml`, then propagated to the consumer repo's
+// root as `eslint.config.js` via the templated path-type in
+// scripts/sync-to-downstream.sh (Phase B2, #316).
 //
-//   - Baseline JS recommended ruleset (eslint/js) — required by the
-//     Mergepath policy floor.
-//   - Three optional, framework-specific blocks (TypeScript, Astro,
-//     React). DELETE the ones that don't apply to your repo and
-//     install the packages listed in their leading comment.
+// Per-consumer facts.frameworks vocabulary (closed set):
+//   typescript  → enables typescript-eslint baseline + TS parsing
+//   astro       → enables eslint-plugin-astro
+//   react       → enables eslint-plugin-react + react-hooks
 //
-// Install (minimum):
-//
-//   npm install --save-dev eslint @eslint/js globals
-//
-// Then, per framework you keep below, add the matching packages
-// (the comment above each block lists them).
-//
-// Run:
-//
-//   npx eslint .
-//
-// Format note: this file is intentionally a `.js` (NOT `.mjs`) flat
-// config. The `eslint.config.js` filename is the only spelling the
-// Mergepath CI check accepts; if you have a strong reason to use
-// `.mjs`/`.cjs`/`.ts`, file an exception in `.sync-overrides.yml`
-// with a `reason:` per docs/agents/code-modification-rules.md.
+// A consumer with no frameworks (e.g., swipewatch — pure Node +
+// vitest) gets the JS baseline only. Multiple frameworks stack in
+// declaration order.
+// <<<
 
 import js from "@eslint/js";
 import globals from "globals";
 
-// --- Optional: TypeScript ---------------------------------------------------
-// npm install --save-dev typescript typescript-eslint
-// import tseslint from "typescript-eslint";
-
-// --- Optional: Astro --------------------------------------------------------
-// npm install --save-dev eslint-plugin-astro
-// import astro from "eslint-plugin-astro";
-
-// --- Optional: React + React Hooks ------------------------------------------
-// npm install --save-dev eslint-plugin-react eslint-plugin-react-hooks
-// import react from "eslint-plugin-react";
-// import reactHooks from "eslint-plugin-react-hooks";
+// >>> if frameworks contains typescript
+import tseslint from "typescript-eslint";
+// <<<
+// >>> if frameworks contains astro
+import astro from "eslint-plugin-astro";
+// <<<
+// >>> if frameworks contains react
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+// <<<
 
 export default [
-  // Ignore generated / vendored output. Customize per repo.
+  // Ignore generated / vendored output. Customize per-consumer via
+  // a follow-up commit on the propagation PR if a repo needs extras
+  // (e.g., functions/lib for cloud-functions repos).
   {
     ignores: [
       "node_modules/**",
@@ -63,18 +56,20 @@ export default [
     ],
   },
 
-  // Baseline JS recommended — required by the policy.
+  // Baseline JS recommended — required by the Mergepath policy floor.
   js.configs.recommended,
 
   // Apply browser + node globals to all JS sources by default. Narrow
-  // these per-file-pattern if your repo has a clean split.
+  // these per-file-pattern in a follow-up commit if the repo has a
+  // clean split (e.g., scripts/* node-only, src/* browser-only).
   //
   // `*.cjs` files are split out so ESLint parses them as CommonJS
   // (`sourceType: "commonjs"`) rather than ES modules — otherwise
   // top-level `require`/`module.exports` and CommonJS scope rules
   // produce false-positive parse errors. The defaults ESLint applies
   // by extension are: `module` for `.js`/`.mjs`, `commonjs` for
-  // `.cjs`; we make that explicit here so the policy is self-documenting.
+  // `.cjs`; we make that explicit here so the policy is
+  // self-documenting.
   {
     files: ["**/*.{js,mjs,jsx}"],
     languageOptions: {
@@ -97,41 +92,43 @@ export default [
     },
   },
 
-  // ----- TypeScript ---------------------------------------------------------
-  // Uncomment the `import tseslint` line above and the spread below.
-  // typescript-eslint exposes a flat-compatible `configs.recommended`
-  // array; spread it into the top-level config.
-  //
-  // ...tseslint.configs.recommended,
+// >>> if frameworks contains typescript
+  // TypeScript recommended ruleset — applied to .ts / .tsx via the
+  // typescript-eslint plugin's flat-config preset. Includes the
+  // parser, the recommended rule set, and the file-glob targeting.
+  ...tseslint.configs.recommended,
+// <<<
 
-  // ----- Astro --------------------------------------------------------------
-  // Uncomment the `import astro` line above and the spread below.
-  // eslint-plugin-astro v1+ exports a flat-compatible `configs` map.
-  //
-  // ...astro.configs.recommended,
+// >>> if frameworks contains astro
+  // Astro recommended ruleset — applied to .astro files. The plugin
+  // exposes its flat-config-compatible preset under .configs.recommended.
+  ...astro.configs.recommended,
+// <<<
 
-  // ----- React + React Hooks ------------------------------------------------
-  // Uncomment the React imports above and the block below.
-  //
-  // {
-  //   files: ["**/*.{jsx,tsx}"],
-  //   plugins: {
-  //     react,
-  //     "react-hooks": reactHooks,
-  //   },
-  //   languageOptions: {
-  //     parserOptions: {
-  //       ecmaFeatures: { jsx: true },
-  //     },
-  //   },
-  //   rules: {
-  //     ...react.configs.recommended.rules,
-  //     ...reactHooks.configs.recommended.rules,
-  //     // React 17+ JSX transform: not needed.
-  //     "react/react-in-jsx-scope": "off",
-  //   },
-  //   settings: {
-  //     react: { version: "detect" },
-  //   },
-  // },
+// >>> if frameworks contains react
+  // React + React Hooks recommended rulesets — applied to .jsx / .tsx.
+  // Detect the React version automatically from package.json. The
+  // React 17+ JSX transform makes `react/react-in-jsx-scope` obsolete;
+  // turn it off explicitly so the rule doesn't flag every component.
+  {
+    files: ["**/*.{jsx,tsx}"],
+    plugins: {
+      react,
+      "react-hooks": reactHooks,
+    },
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    rules: {
+      ...react.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off",
+    },
+    settings: {
+      react: { version: "detect" },
+    },
+  },
+// <<<
 ];


### PR DESCRIPTION
**Filed by:** `nathanpayne-claude` (per the #317 attribution convention).

## Summary

First real templated entry, end-to-end exercise of the Layer 5 machinery shipped in #313 (lib) and #316 (sync integration). Two-file diff: `examples/eslint.config.js` restructured into a conditional-block template, and `.mergepath-sync.yml` gets `facts.frameworks` on 6 consumers plus the templated manifest entry. Unblocks Phase D — the consumer-side ESLint rollout PRs against parent #250 (6 issues: device-platform-reporting#75, friends-and-family-billing#264, matchline#222, nathanpaynedotcom#357, swipewatch#46, tadlockpsychiatry#49).

## Per-consumer rendered shapes

| Consumer | `facts.frameworks` | Rendered shape |
|---|---|---|
| matchline | `[react, typescript]` | JS + TS + React + react-hooks |
| nathanpaynedotcom | `[astro, typescript]` | JS + TS + Astro |
| friends-and-family-billing | `[react]` | JS + React + react-hooks |
| device-platform-reporting | `[react]` | JS + React + react-hooks |
| tadlockpsychiatry | `[react, typescript]` | JS + TS + React + react-hooks |
| swipewatch | `[]` | JS baseline only |

`overridebroadway` and `device-source-of-truth` are excluded from the templated entry's `consumers:` list (zero lintable JS/TS surface area; no `facts` block needed).

## Template structure (`examples/eslint.config.js`)

Three conditional surfaces:

1. **Imports** — `// >>> if frameworks contains <X>` blocks around the optional `import tseslint`, `import astro`, `import react / reactHooks` lines. Each block is stripped if the consumer doesn't declare that framework.
2. **Flat-config spreads** — same conditional structure around `...tseslint.configs.recommended`, `...astro.configs.recommended`, and the React `files+plugins+rules` object.
3. **Template-author notes** — wrapped in `>>> if _template_only_notes ... <<<`, a never-true conditional (no consumer sets that fact) that strips the meta-commentary from every rendered output while keeping it visible to template editors. Lightweight idiom worth flagging — could be more explicit (e.g. `if always_false`) but `_template_only_notes` is self-documenting.

The pre-existing `scripts/ci/check_eslint_config_present` and `check_eslint_config_policy` tests still pass against the template source (10/10) — the `>>> if` markers live inside `//` line comments, so `node --check` accepts the file as valid JS and the grep for `@eslint/js` + `js.configs.recommended` still finds them at the top level.

## Focus areas for review

1. **`_template_only_notes` never-true idiom.** Lightweight, but if you want a more first-class "this block is template-author-only" mechanism in the lib itself, this is the place to flag it before more templated entries adopt the pattern.
2. **`swipewatch` with `facts.frameworks: []`.** The empty list renders the JS baseline only — exercises the "consumer with no frameworks" path through the lib (`contains` against an empty haystack always false). Worth confirming this is the desired UX vs. omitting `facts` entirely (which would silently default to empty too, but loses the explicit intent).
3. **Exclusion via `consumers:` list rather than `facts: {frameworks: []}`.** For `overridebroadway` and `device-source-of-truth`, I picked exclusion-from-consumers-list. Alternative: include them with empty frameworks. Trade-off: exclusion is more explicit ("this consumer doesn't get this file at all"); inclusion-with-empty is more uniform ("all consumers get the same entry; some render to JS-baseline").
4. **No Phase D rollout in this PR.** Source-of-truth template + manifest entry land here; Phase D opens the per-consumer PRs separately via `--sync-all --repos <name>`. Canary first (swipewatch), then fanout. Worth confirming this split-vs.-monolith approach.

## Testing

- [x] `scripts/ci/check_sync_manifest` (live) → PASS (8 consumers, 41 path entries; +1 templated)
- [x] `bash tests/test_check_sync_manifest.sh` → 22 PASS, 0 FAIL
- [x] `bash tests/test_eslint_policy_check.sh` → 10 PASS, 0 FAIL (template source still satisfies the policy floor as raw JS)
- [x] `scripts/ci/check_ci_scripts_wired`, `check_spec_test_alignment`, `check_template_substitution`, `check_eslint_config_present`, `check_eslint_config_policy` → all PASS
- [x] Smoke-rendered the template via the lib for three real consumer profiles (swipewatch JS-only, matchline TS+React, nathanpaynedotcom TS+Astro) — outputs match expected framework subsets
- [x] `scripts/sync-to-downstream.sh --sync-all --dry-run --repos swipewatch` → templated entry shows up in the planned manifest paths with "(templated, rendered per consumer facts: examples/eslint.config.js)" annotation

## Self-Review

- [x] **Correctness.** Template renders correctly for all 6 consumer profiles per smoke tests. Conditional-block idiom matches the v1 syntax spec in `docs/agents/templated-propagation.md`. Manifest entry uses explicit `source:` and `dest:` (per the Phase B2 schema). `facts.frameworks` values are within the closed vocabulary documented in the template header.
- [x] **Regression risk.** Two-file diff. No `scripts/sync-to-downstream.sh` or `scripts/lib/template-substitution.sh` change. The existing eslint policy check tests continue to pass against the new template source. No existing canonical/kit propagation paths affected (templated lives alongside, not inside, the canonical/kit dispatch).
- [x] **Style and conventions.** Manifest entry placement (after the `kit` block, before `exclusions`) matches the schema doc's groupings. Per-consumer `facts` indentation matches the surrounding consumer entries. Template uses the same comment-marker syntax (`//` line comments) that the lib's contract supports for JS sources.
- [x] **Test coverage.** End-to-end smoke tests for 3 consumer profiles cover the matrix of "no frameworks / single framework / multiple frameworks". Manifest validator regression suite covers the schema (facts shape, dest no-escape, source-existence). No new test cases needed for this PR specifically — the template rendering is exercised by the existing 22 cases via the lib's contract, and the manifest entry is validated by `check_sync_manifest`.
- [x] **Security and dependency hygiene.** No new dependencies beyond what the manual ESLint adoption would have required (`eslint`, `@eslint/js`, `globals`, plus per-framework packages). Template renders are bounded by the closed `frameworks` vocabulary — a typo in `facts.frameworks` produces an unknown-but-harmless value (the `contains` test against it returns false). No shell injection: the template source is read by `git show` (immutable mergepath content) and rendered by the lib whose key-charset validator from #313 covers the eval boundary.

Authoring-Agent: claude

_(refresh #2 — re-firing pull_request:edited to clear stale Label Gate per [#315](https://github.com/nathanjohnpayne/mergepath/issues/315))_
