### PR TITLE
fix(propagation): closure for new test files + check_sync_manifest path-empty fail-closed (Phase D CHANGES_REQUESTED hotfix)

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -378,6 +378,25 @@ paths:
   - path: tests/test_daily_feedback_rollup.sh
     type: canonical
     consumers: all
+  # Pairs with scripts/lib/template-substitution.sh (#313) +
+  # scripts/ci/check_template_substitution. The check wrapper hard-
+  # fails on the missing test file; without this propagated, every
+  # consumer's check_template_substitution exits 1 on the wrapper's
+  # `missing $TEST_SCRIPT` branch. Same #264 coupling class as the
+  # other paired-test entries above. Surfaced as nathanpayne-codex
+  # Phase 4b CHANGES_REQUESTED on all five Phase D consumer PRs.
+  - path: tests/test_template_substitution.sh
+    type: canonical
+    consumers: all
+  # Pairs with scripts/sync-to-downstream.sh's export_consumer_facts +
+  # scripts/ci/check_export_consumer_facts. Same coupling class as
+  # above — the check wrapper hard-fails on missing test file. Filed
+  # in mergepath#319 alongside the export_consumer_facts hotfix but
+  # the test file itself wasn't added to the manifest at the time.
+  # nathanpayne-codex Phase 4b CHANGES_REQUESTED caught the gap.
+  - path: tests/test_export_consumer_facts.sh
+    type: canonical
+    consumers: all
 
   # Canonical workflows — review policy + automation surfaces that
   # should be lockstep across all consumers.
@@ -473,6 +492,8 @@ paths:
       - "tests/test_disagreement_detector.sh"  # check_disagreement_detector
       - "tests/test_verify_propagation_pr.sh"  # check_verify_propagation_pr
       - "tests/test_resolve_pr_threads_rationale_tag.sh"  # check_resolve_pr_threads (delegated test)
+      - "tests/test_template_substitution.sh"  # check_template_substitution
+      - "tests/test_export_consumer_facts.sh"  # check_export_consumer_facts
       - "scripts/codex-p1-gate.sh"             # check_codex_p1_gate
       - "scripts/codex-review-request.sh"      # check_codex_scripts
       - "scripts/codex-review-check.sh"        # check_codex_scripts, check_canonical_bugs_263caf3

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -210,7 +210,8 @@ if ! path_rows=$(yq -r '
   | ((.path // "") + "|" + (.type // "") + "|"
      + (.consumers | (select(tag == "!!str") // (join(","))) | tostring)
      + "|" + (.dest // "") + "|" + (.source // "")
-     + "|" + (has("dest") | tostring) + "|" + (has("source") | tostring))
+     + "|" + (has("dest") | tostring) + "|" + (has("source") | tostring)
+     + "|" + (has("path") | tostring))
 ' "$MANIFEST" 2>&1); then
   echo "FAIL: could not extract .paths from the manifest (yq error):"
   printf '%s\n' "$path_rows"
@@ -226,8 +227,25 @@ fi
 # names so the choice is unambiguous. Codex Phase 4b
 # CHANGES_REQUESTED on PR #316 by nathanpayne-codex surfaced the
 # empty-dest gap that made this field-stability issue visible.
-while IFS='|' read -r path type consumers dest source has_dest has_source; do
-  [ -z "$path" ] && continue
+while IFS='|' read -r path type consumers dest source has_dest has_source has_path; do
+  # An entry without a `path` field (or with `path: ""`) is a
+  # malformed manifest entry. Previously coerced to empty + silently
+  # `continue`d, letting malformed entries hide in the manifest with
+  # only an empty-line side effect. CodeRabbit Major + Codex Phase 4b
+  # CHANGES_REQUESTED on Phase D consumer PRs both flagged the
+  # silent-skip — fail-closed instead. has_path distinguishes
+  # "absent" from "explicit empty" (parallel to the dest/source
+  # has_* probes added in #316).
+  if [ "$has_path" != "true" ]; then
+    echo "FAIL: a .paths[] entry has no 'path' field (omitted entirely; manifest entries must declare 'path')"
+    FAILED=1
+    continue
+  fi
+  if [ -z "$path" ]; then
+    echo "FAIL: a .paths[] entry has explicit path: \"\" (empty); path must be non-empty"
+    FAILED=1
+    continue
+  fi
 
   # 4a-ter: empty-string `dest:` or `source:` is a misconfiguration —
   # the yq `(.dest // "")` extraction collapses "absent" and

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -227,6 +227,15 @@ fi
 # names so the choice is unambiguous. Codex Phase 4b
 # CHANGES_REQUESTED on PR #316 by nathanpayne-codex surfaced the
 # empty-dest gap that made this field-stability issue visible.
+#
+# Why the outer `[ -n "$path_rows" ]` guard: an empty `.paths: []`
+# (yq emits no lines) combined with `<<< "$path_rows"` (here-string
+# always appends a newline) yields one blank `read` iteration, which
+# the new `has_path != "true"` fail-closed check below would treat
+# as a malformed entry. Same guard pattern as the consumer_rows
+# loop above. Codex Phase 4b P2 on PR #320 by nathanpayne-codex
+# caught this regression from PR #320's own fail-closed addition.
+if [ -n "$path_rows" ]; then
 while IFS='|' read -r path type consumers dest source has_dest has_source has_path; do
   # An entry without a `path` field (or with `path: ""`) is a
   # malformed manifest entry. Previously coerced to empty + silently
@@ -401,6 +410,7 @@ while IFS='|' read -r path type consumers dest source has_dest has_source has_pa
     done
   fi
 done <<< "$path_rows"
+fi  # end: if [ -n "$path_rows" ]
 
 # 7. requires: closure invariant (#264).
 #

--- a/tests/test_check_sync_manifest.sh
+++ b/tests/test_check_sync_manifest.sh
@@ -542,6 +542,39 @@ else
   fail "Case 18 unexpected (rc=$rc): $out"
 fi
 
+# Case 18c: .paths[] entry missing `path` field rejected (fail-closed,
+# was silent-skip). CodeRabbit Major + Codex Phase 4b CHANGES_REQUESTED
+# on Phase D consumer PRs both flagged the same gap.
+MANIFEST_NO_PATH="$MIN_HEADER
+  - type: canonical
+    consumers: all
+"
+PATHS_NO_PATH="scripts/foo.sh"
+set +e
+out=$(run_with_fixture "$MANIFEST_NO_PATH" "$PATHS_NO_PATH"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "has no 'path' field"; then
+  pass "Case 18c: .paths[] entry without path field rejected (fail-closed)"
+else
+  fail "Case 18c unexpected (rc=$rc): $out"
+fi
+
+# Case 18d: .paths[] entry with explicit empty path: "" rejected.
+MANIFEST_EMPTY_PATH="$MIN_HEADER
+  - path: \"\"
+    type: canonical
+    consumers: all
+"
+PATHS_EMPTY_PATH="scripts/foo.sh"
+set +e
+out=$(run_with_fixture "$MANIFEST_EMPTY_PATH" "$PATHS_EMPTY_PATH"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q 'explicit path: ""'; then
+  pass "Case 18d: .paths[] entry with explicit empty path rejected"
+else
+  fail "Case 18d unexpected (rc=$rc): $out"
+fi
+
 # Case 18b: explicit source: "" rejected (parallel to dest).
 MANIFEST_SRC_EMPTY="$MIN_HEADER
   - path: examples/foo.js

--- a/tests/test_check_sync_manifest.sh
+++ b/tests/test_check_sync_manifest.sh
@@ -542,6 +542,28 @@ else
   fail "Case 18 unexpected (rc=$rc): $out"
 fi
 
+# Case 18bis: .paths: [] (empty sequence) passes — yq emits no
+# rows, the outer guard skips the loop, and validation completes
+# without firing the new fail-closed has_path check on the
+# bash-here-string-injected blank iteration. Codex Phase 4b P2 on
+# PR #320 by nathanpayne-codex caught the regression from the
+# original PR #320 patch where the guard was missing.
+MANIFEST_EMPTY_PATHS='version: 1
+consumers:
+  - name: example
+    repo: example-org/example
+    visibility: public
+paths: []
+'
+set +e
+out=$(run_with_fixture "$MANIFEST_EMPTY_PATHS" ""); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_sync_manifest: PASS"; then
+  pass "Case 18bis: empty .paths: [] passes (no false-positive from has_path check)"
+else
+  fail "Case 18bis unexpected (rc=$rc): $out"
+fi
+
 # Case 18c: .paths[] entry missing `path` field rejected (fail-closed,
 # was silent-skip). CodeRabbit Major + Codex Phase 4b CHANGES_REQUESTED
 # on Phase D consumer PRs both flagged the same gap.


### PR DESCRIPTION
**Filed by:** `nathanpayne-claude`.

## Summary

Hotfix for two issues `nathanpayne-codex` flagged via Phase 4b CHANGES_REQUESTED on all 5 Phase D consumer PRs (dpr#83, matchline#234, nathanpaynedotcom#373, ffb#274, tadlockpsychiatry#58). Same root-cause class as #264 — propagation closure invariant gap — plus a fail-closed correctness fix to the manifest validator itself.

## Gap 1 — Two test files missing from manifest closure

Phase B1 (#313) added `scripts/ci/check_template_substitution` → `tests/test_template_substitution.sh`.
Phase D hotfix (#319) added `scripts/ci/check_export_consumer_facts` → `tests/test_export_consumer_facts.sh`.

Both check_*'s went into the `scripts/ci/` kit propagation. Neither paired test was added to the manifest as a canonical entry. Consumers got the wrappers without the tests; at runtime both wrappers exit 1 with "missing $TEST_SCRIPT".

The `.mergepath-sync.yml` `requires:` invariant on the `scripts/ci/` kit exists to catch exactly this shape (see #264 for the original closure-gap incident), but the requires: list is authored content — it didn't include either new test.

**Fix:** add both tests as canonical entries AND add both paths to the `scripts/ci/` kit's `requires:` list (closes the invariant gap for the next contributor).

## Gap 2 — check_sync_manifest silent-skipped malformed entries

`(.path // "")` coerced missing path to empty; `[ -z "$path" ] && continue` silently skipped. A malformed entry (omitted `path:` or explicit `path: ""`) slipped past validation.

Both CodeRabbit Major and Codex Phase 4b independently flagged this on dpr#83's propagated copy.

**Fix:** extend the yq extraction with `has("path") | tostring` as a positional flag (parallel to `has_dest`/`has_source` from #316), then fail-closed:
- `has_path == false` → FAIL "no 'path' field"  
- `has_path == true && path == ""` → FAIL "explicit empty"

Two regression cases (18c, 18d) pin both shapes.

## Verification

- `bash tests/test_check_sync_manifest.sh` → 24 PASS, 0 FAIL (was 22)
- `scripts/ci/check_sync_manifest` (live) → PASS (8 consumers, 44 entries; was 42)
- Manual fixture repro: omitted-path manifest fails with clear diagnostic; empty-path manifest same
- `scripts/ci/check_ci_scripts_wired` → PASS

## Self-Review

- [x] **Correctness.** Both fixes verified against fixture manifests + the live manifest. The closure invariant on the `scripts/ci/` kit is now structurally complete for the two affected check_*'s.
- [x] **Regression risk.** Manifest schema unchanged; the new yq `has("path")` extraction adds a positional field that the loop reads via the same `IFS='|' read -r ... has_path` pattern used for the existing has_dest/has_source flags. No existing call sites need updating.
- [x] **Style + conventions.** Adds 2 canonical entries + 2 lines to the existing `requires:` list. yq idiom matches the #316 has_*-flag pattern. Path-empty fix mirrors the structure of the existing dest-empty / source-empty checks.
- [x] **Test coverage.** Cases 18c + 18d guard both omitted-path and explicit-empty-path shapes. Manifest itself smoke-tests the requires: closure invariant via `check_sync_manifest`'s existing pass.
- [x] **Security + dependency hygiene.** No new deps. Manifest entries reference local repo paths.

## Phase D follow-up after this lands

All 5 Phase D consumer PRs need to re-sync against this hotfix's mergepath HEAD to pick up the missing test files. Options:
1. Close existing PRs + `--sync-all --repos <all-five> --recreate-existing` (clean)
2. Push the 2 missing test files to each existing branch manually (less churn)

Will pick option 1 after merge since it also folds in the hotfix's check_sync_manifest improvement that consumers should see.

Authoring-Agent: claude

_(refresh #2 — re-firing pull_request:edited per [#315](https://github.com/nathanjohnpayne/mergepath/issues/315) workaround)_
