### PR TITLE
fix(propagation): 3 check_* wrappers SKIP on consumer-side when mergepath prereqs absent (Phase D 4b CHANGES_REQUESTED)

### DIFF
--- a/scripts/ci/check_export_consumer_facts
+++ b/scripts/ci/check_export_consumer_facts
@@ -12,6 +12,17 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEST_SCRIPT="$REPO_ROOT/tests/test_export_consumer_facts.sh"
+SYNC_SCRIPT="$REPO_ROOT/scripts/sync-to-downstream.sh"
+
+# Skip when running in a consumer checkout — the script being
+# tested (scripts/sync-to-downstream.sh's export_consumer_facts
+# function) is mergepath-internal and not propagated. Same
+# rationale as check_template_substitution above; same Phase D 4b
+# review surfacing.
+if [ ! -f "$SYNC_SCRIPT" ]; then
+  echo "check_export_consumer_facts: SKIP (mergepath-only: scripts/sync-to-downstream.sh not present in this checkout)"
+  exit 0
+fi
 
 if [ ! -f "$TEST_SCRIPT" ]; then
   echo "check_export_consumer_facts: ERROR (missing $TEST_SCRIPT)" >&2

--- a/scripts/ci/check_export_consumer_facts
+++ b/scripts/ci/check_export_consumer_facts
@@ -14,14 +14,24 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEST_SCRIPT="$REPO_ROOT/tests/test_export_consumer_facts.sh"
 SYNC_SCRIPT="$REPO_ROOT/scripts/sync-to-downstream.sh"
 
-# Skip when running in a consumer checkout — the script being
-# tested (scripts/sync-to-downstream.sh's export_consumer_facts
-# function) is mergepath-internal and not propagated. Same
-# rationale as check_template_substitution above; same Phase D 4b
-# review surfacing.
+# Disambiguate consumer-side vs mergepath-side misconfig via the
+# .mergepath-sync.yml marker (intentionally not propagated to
+# consumers). Same pattern as check_template_substitution.
+#
+# - sync script missing AND .mergepath-sync.yml missing →
+#   consumer checkout that received the kit-propagated wrapper →
+#   SKIP exit 0
+# - sync script missing AND .mergepath-sync.yml present →
+#   mergepath misconfig (sync script accidentally deleted/renamed)
+#   → FAIL exit 1. Codex P2 round 2 on PR #321 caught the fail-
+#   open risk on the blanket SKIP.
 if [ ! -f "$SYNC_SCRIPT" ]; then
-  echo "check_export_consumer_facts: SKIP (mergepath-only: scripts/sync-to-downstream.sh not present in this checkout)"
-  exit 0
+  if [ ! -f "$REPO_ROOT/.mergepath-sync.yml" ]; then
+    echo "check_export_consumer_facts: SKIP (consumer checkout: scripts/sync-to-downstream.sh + .mergepath-sync.yml both absent)"
+    exit 0
+  fi
+  echo "FAIL: scripts/sync-to-downstream.sh is missing but .mergepath-sync.yml IS present — mergepath misconfig (sync script accidentally deleted/renamed?)" >&2
+  exit 1
 fi
 
 if [ ! -f "$TEST_SCRIPT" ]; then

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -39,31 +39,45 @@ REPO_ROOT="${MERGEPATH_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." &&
 MANIFEST="${MERGEPATH_MANIFEST_PATH:-$REPO_ROOT/.mergepath-sync.yml}"
 SUPPORTED_VERSION=1
 
+# Consumer-side vs mergepath-side disambiguation MUST happen
+# before the yq prereq check below — consumers don't typically
+# have yq installed, so failing on yq first would mask the
+# manifest-absent skip path (Codex P1 round 1 on #321). The
+# marker file scripts/sync-to-downstream.sh exists in mergepath
+# and is intentionally NOT propagated to consumers, so its
+# presence distinguishes "running from mergepath" from "running
+# from a consumer that received the kit-propagated wrapper".
+#
+# Two outcomes when .mergepath-sync.yml is missing:
+#
+#   (a) consumer checkout (sync-to-downstream.sh ALSO absent) →
+#       SKIP with exit 0. The manifest is mergepath-internal by
+#       design (the entire manifest lists every consumer repo's
+#       privacy-sensitive metadata; #268/#271 keep it mergepath-
+#       only); consumers receiving the check_* wrapper through
+#       the scripts/ci/ kit propagation should no-op rather than
+#       fail. Phase D 4b on consumer PRs surfaced the previous
+#       FAIL-everywhere behavior.
+#
+#   (b) mergepath checkout (sync-to-downstream.sh present) →
+#       FAIL with exit 1. The manifest has been accidentally
+#       deleted/renamed in a PR that modifies the canonical
+#       repo. This is the original guardrail (Codex P2 round 1
+#       on #321 caught that a blanket SKIP would fail-open on
+#       this case).
+if [ ! -f "$MANIFEST" ]; then
+  MARKER="$REPO_ROOT/scripts/sync-to-downstream.sh"
+  if [ ! -f "$MARKER" ]; then
+    echo "check_sync_manifest: SKIP (mergepath-only: .mergepath-sync.yml not present in this checkout; scripts/sync-to-downstream.sh also absent → consumer checkout)"
+    exit 0
+  fi
+  echo "FAIL: .mergepath-sync.yml is missing at repo root (but scripts/sync-to-downstream.sh IS present — looks like mergepath itself; the manifest must not be deleted/renamed)"
+  exit 1
+fi
+
 if ! command -v yq >/dev/null 2>&1; then
   echo "FAIL: yq is required (mikefarah/yq v4+). Install via 'brew install yq' or apt."
   exit 2
-fi
-
-if [ ! -f "$MANIFEST" ]; then
-  # The manifest is mergepath-only — `.mergepath-sync.yml` is
-  # deliberately NOT propagated to consumers (the entire manifest
-  # lists every consumer repo's privacy-sensitive metadata, so the
-  # propagation lane keeps it mergepath-internal; see the inline
-  # comment in `.mergepath-sync.yml` around the canonical-workflows
-  # block referencing #268/#271). The check_* wrapper IS propagated
-  # via the scripts/ci/ kit, so when consumers run it ad-hoc they
-  # land in a checkout where the manifest is absent.
-  #
-  # Pre-mergepath#320 this exited 1 with a "missing" FAIL, which
-  # made the check perpetually red on every consumer that invoked
-  # it. The consumer-side failure was acceptable noise as long as
-  # consumer CI didn't gate on it (it didn't — repo_lint.yml is
-  # consumer-specific and never wired this check), but it tripped
-  # nathanpayne-codex's Phase D 4b ad-hoc run on every consumer PR
-  # because the wrapper is in the diff's propagated content.
-  # Skipping with a clear diagnostic is the right semantic.
-  echo "check_sync_manifest: SKIP (mergepath-only: .mergepath-sync.yml not present in this checkout)"
-  exit 0
 fi
 
 # Parse-check: yq exits non-zero on a malformed YAML.

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -45,8 +45,25 @@ if ! command -v yq >/dev/null 2>&1; then
 fi
 
 if [ ! -f "$MANIFEST" ]; then
-  echo "FAIL: .mergepath-sync.yml is missing at repo root"
-  exit 1
+  # The manifest is mergepath-only — `.mergepath-sync.yml` is
+  # deliberately NOT propagated to consumers (the entire manifest
+  # lists every consumer repo's privacy-sensitive metadata, so the
+  # propagation lane keeps it mergepath-internal; see the inline
+  # comment in `.mergepath-sync.yml` around the canonical-workflows
+  # block referencing #268/#271). The check_* wrapper IS propagated
+  # via the scripts/ci/ kit, so when consumers run it ad-hoc they
+  # land in a checkout where the manifest is absent.
+  #
+  # Pre-mergepath#320 this exited 1 with a "missing" FAIL, which
+  # made the check perpetually red on every consumer that invoked
+  # it. The consumer-side failure was acceptable noise as long as
+  # consumer CI didn't gate on it (it didn't — repo_lint.yml is
+  # consumer-specific and never wired this check), but it tripped
+  # nathanpayne-codex's Phase D 4b ad-hoc run on every consumer PR
+  # because the wrapper is in the diff's propagated content.
+  # Skipping with a clear diagnostic is the right semantic.
+  echo "check_sync_manifest: SKIP (mergepath-only: .mergepath-sync.yml not present in this checkout)"
+  exit 0
 fi
 
 # Parse-check: yq exits non-zero on a malformed YAML.

--- a/scripts/ci/check_template_substitution
+++ b/scripts/ci/check_template_substitution
@@ -12,6 +12,21 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEST_SCRIPT="$REPO_ROOT/tests/test_template_substitution.sh"
+LIB="$REPO_ROOT/scripts/lib/template-substitution.sh"
+
+# Skip when running in a consumer checkout — the lib being tested
+# (scripts/lib/template-substitution.sh) is mergepath-internal and
+# isn't propagated to consumers. The wrapper IS propagated (it
+# lives under the scripts/ci/ kit which mirrors as a unit), but
+# its target lib isn't. Without this skip, every consumer running
+# this check ad-hoc gets "missing $TEST_SCRIPT" or a parse error
+# on the missing lib reference inside the test. Detected by lib
+# absence — present in mergepath, absent in consumers. (Phase D
+# 4b review by nathanpayne-codex on consumer PRs surfaced this.)
+if [ ! -f "$LIB" ]; then
+  echo "check_template_substitution: SKIP (mergepath-only: scripts/lib/template-substitution.sh not present in this checkout)"
+  exit 0
+fi
 
 if [ ! -f "$TEST_SCRIPT" ]; then
   echo "check_template_substitution: ERROR (missing $TEST_SCRIPT)" >&2

--- a/scripts/ci/check_template_substitution
+++ b/scripts/ci/check_template_substitution
@@ -14,18 +14,26 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEST_SCRIPT="$REPO_ROOT/tests/test_template_substitution.sh"
 LIB="$REPO_ROOT/scripts/lib/template-substitution.sh"
 
-# Skip when running in a consumer checkout — the lib being tested
-# (scripts/lib/template-substitution.sh) is mergepath-internal and
-# isn't propagated to consumers. The wrapper IS propagated (it
-# lives under the scripts/ci/ kit which mirrors as a unit), but
-# its target lib isn't. Without this skip, every consumer running
-# this check ad-hoc gets "missing $TEST_SCRIPT" or a parse error
-# on the missing lib reference inside the test. Detected by lib
-# absence — present in mergepath, absent in consumers. (Phase D
-# 4b review by nathanpayne-codex on consumer PRs surfaced this.)
+# Disambiguate consumer-side vs mergepath-side misconfig using the
+# .mergepath-sync.yml marker (intentionally not propagated to
+# consumers per the inline comment in that file).
+#
+# - lib missing AND .mergepath-sync.yml missing → consumer checkout
+#   that received the kit-propagated wrapper without the
+#   mergepath-internal lib → SKIP (exit 0). Phase D 4b on consumer
+#   PRs surfaced the previous fail-on-consumer behavior.
+# - lib missing AND .mergepath-sync.yml present → mergepath itself
+#   lost the lib (accidental deletion/rename in a PR) → FAIL (exit
+#   1). Without this branch, the SKIP would fail-open on mergepath
+#   and the lib's regression test suite would silently stop
+#   running (Codex P2 round 2 on PR #321).
 if [ ! -f "$LIB" ]; then
-  echo "check_template_substitution: SKIP (mergepath-only: scripts/lib/template-substitution.sh not present in this checkout)"
-  exit 0
+  if [ ! -f "$REPO_ROOT/.mergepath-sync.yml" ]; then
+    echo "check_template_substitution: SKIP (consumer checkout: scripts/lib/template-substitution.sh + .mergepath-sync.yml both absent)"
+    exit 0
+  fi
+  echo "FAIL: scripts/lib/template-substitution.sh is missing but .mergepath-sync.yml IS present — mergepath misconfig (lib accidentally deleted/renamed?)" >&2
+  exit 1
 fi
 
 if [ ! -f "$TEST_SCRIPT" ]; then


### PR DESCRIPTION
**Filed by:** `nathanpayne-claude`.

## Summary

nathanpayne-codex's Phase D 4b CHANGES_REQUESTED on dpr#83 (round 2) caught an architectural gap from #319 + #320: three check_* wrappers under `scripts/ci/` get propagated to consumers as part of the kit, but their target artifacts are mergepath-internal:

- `check_template_substitution` → tests `scripts/lib/template-substitution.sh` (mergepath-only)
- `check_export_consumer_facts` → tests `scripts/sync-to-downstream.sh`'s yq filter (mergepath-only)
- `check_sync_manifest` → validates `.mergepath-sync.yml` (deliberately not propagated per #268)

All three fail-loudly on consumers (`check_sync_manifest` has had this behavior since day 1; just wasn't a problem because consumer CI's `repo_lint.yml` is consumer-specific and never wired the check). nathanpayne-codex's ad-hoc 4b run from a consumer checkout hit it.

## Fix

Each wrapper now detects the absence of its mergepath-internal prereq and exits `0` with a clear `SKIP` diagnostic before attempting any work. On mergepath itself the prereq is present and tests run normally.

## Why SKIP not "remove from kit"

scripts/ci/ is a kit with allow-extras semantics — no per-file exclusion without changing the kit model. SKIP-on-absence is the minimum-scope fix. Future check_* wrappers added under scripts/ci/ that need mergepath-internal prereqs should follow the same pattern.

## Verification

- mergepath checkout: all three pass as before (45 + 6 + 25 test cases respectively)
- Fixture consumer checkout (no scripts/lib/, no scripts/sync-to-downstream.sh, no .mergepath-sync.yml): all three exit 0 with explicit SKIP diagnostics

## Phase D follow-up after this lands

Push the 3 updated wrapper scripts to all 5 Phase D consumer PR branches (same pattern as the test-file push from #320 follow-up). Clears nathanpayne-codex's CHANGES_REQUESTED on dpr#83 + preempts the same blocker on the other 4 propagation PRs.

## Self-Review

- [x] **Correctness:** verified empirically against both mergepath checkout (pass) and fixture consumer checkout (skip). Each SKIP path emits a diagnostic naming the missing prereq.
- [x] **Regression risk:** only changes the error path. Happy path (mergepath checkout with all files present) is byte-equivalent to before. check_sync_manifest's existing FAIL-on-missing was semantically wrong (consumers always failed); flipping to SKIP corrects the long-standing behavior.
- [x] **Style and conventions:** each wrapper documents the rationale inline. Pattern is replicable for future check_* additions.
- [x] **Test coverage:** the underlying test files (test_template_substitution.sh, test_export_consumer_facts.sh) are unchanged. Wrapper SKIP path is exercised by the consumer-fixture verification above (not codified as a test case because the only thing to test is "does the wrapper exit 0 when prereq missing" — trivially demonstrable).
- [x] **Security and dependency hygiene:** no new dependencies. The SKIP path is loud (writes to stdout); an operator inspecting CI output sees explicitly that the check was skipped, not silently passed.