### PR TITLE
fix(workflows): auto-clear flakiness — retry + PAT-driven removal + tighter sweep (#324)

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -396,6 +396,11 @@ auto_clear_labels:
   # Periodic sweep catches the 👍-after-last-push case: Codex reacts
   # on the PR issue with no synchronize / pull_request_review /
   # workflow_run event to fire the event-driven path. Defaults to
-  # true; set false if the every-15-minute cron is too noisy for a
+  # true; set false if the every-5-minute cron is too noisy for a
   # given repo's PR volume.
   scheduled_sweep_enabled: true
+  # Documentary only — the actual cron lives in
+  # .github/workflows/auto-clear-blocking-labels.yml. Tightened from
+  # 15→5 minutes in mergepath#324 to close the 👍-after-last-push
+  # gap (observed on 3 of 6 mergepath#250 Phase D consumer PRs).
+  scheduled_sweep_interval_minutes: 5

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -38,11 +38,21 @@ on:
   # Periodic sweep — catches the 👍-after-last-push case (codex
   # reacts on the PR issue but no synchronize / review / workflow_run
   # event fires, so the event-driven path stays inert). Runs every
-  # 15 minutes against any open PR carrying needs-external-review.
+  # 5 minutes against any open PR carrying needs-external-review.
   # Idempotent (no-op when label absent or gate not yet met). Sub-C
   # of #191. See scheduled-sweep job below for the cadence knob.
+  #
+  # Tightened from 15→5 min in mergepath#324 to close the
+  # 👍-after-last-push gap observed across the mergepath#250 Phase D
+  # propagation fanout (3 of 6 consumer PRs needed manual
+  # request-label-removal.sh because no event-driven trigger
+  # fired and the prior 15-min sweep stranded them for up to 15 min
+  # after Codex cleared). 3× the API quota cost, but a meaningfully
+  # shorter blocker window. The PAT-driven label removal added in
+  # #324 also helps — but the sweep is still the only backstop for
+  # the no-event path.
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/5 * * * *'
 
 permissions:
   pull-requests: write
@@ -57,6 +67,14 @@ permissions:
   # nathanjohnpayne/matchline#233 (#306 propagation canary); see
   # #310 for the full repro + permission scope rationale.
   actions: read
+  # `checks: write` is required so the "Surface infra failure as
+  # check-run" step (#324) can POST a failed check-run to the PR's
+  # checks tab when this workflow hits an infrastructure error
+  # (failed label read, failed label removal, codex-review-check.sh
+  # rc=3, contract-drift rc). Without a visible check-run, flake
+  # recurrences are invisible unless someone happens to look at the
+  # workflow run log.
+  checks: write
 
 jobs:
   evaluate-and-clear:
@@ -140,11 +158,27 @@ jobs:
       - name: Re-evaluate gate per PR + remove label on pass
         if: steps.pr.outputs.numbers != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT-driven label removal (#315/#324). GITHUB_TOKEN-driven
+          # events do NOT trigger downstream workflows (recursion
+          # prevention) — pr-review-policy.yml's Label Gate would
+          # stay stuck on the pre-clear failure state until the next
+          # push or label toggle. A PAT-driven event triggers
+          # downstream workflows normally, so Label Gate re-fires and
+          # mergeStateStatus flips to CLEAN within seconds rather
+          # than stalling until something else fires the policy
+          # workflow. Closes mergepath#315. Token is the same
+          # REVIEWER_ASSIGNMENT_TOKEN used by
+          # .github/workflows/daily-feedback-rollup.yml.
+          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           PR_NUMBERS: ${{ steps.pr.outputs.numbers }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Source the gh-retry helper (#324). with_gh_retry wraps gh
+          # calls in 3×30s retry on transient failures (HTTP 5xx,
+          # rate-limit, "Resource not accessible by integration") so a
+          # flaky read or write doesn't silently leave the label stuck.
+          source scripts/lib/gh-retry-helpers.sh
           # codex-review-check.sh exits:
           #   0 = gate passes
           #   1 = gate fails (one or more of CI/reviewer/codex not met)
@@ -164,7 +198,7 @@ jobs:
 
             # Skip if label not present (no-op, common case on
             # synchronize/workflow_run for under-threshold PRs).
-            if ! HAS_LABEL=$(gh pr view "$PR" --repo "$REPO" --json labels \
+            if ! HAS_LABEL=$(with_gh_retry gh pr view "$PR" --repo "$REPO" --json labels \
               --jq '[.labels[].name] | contains(["needs-external-review"])'); then
               # Infra error — NOT a warning-only skip. This workflow
               # exists to clear a merge-blocking label; if it can't even
@@ -191,7 +225,7 @@ jobs:
             case "$rc" in
               0)
                 echo "Gate passes — removing needs-external-review label."
-                if ! gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
+                if ! with_gh_retry gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
                   # The gate passed but the removal API call failed —
                   # the label is still stuck. That is an infra error,
                   # not a warning: the job must not report success
@@ -206,7 +240,7 @@ jobs:
                 # delimiter must be column-0 unless using `<<-` with
                 # tabs; YAML run blocks make that brittle).
                 comment_body='**Automated label removal.** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD (CI green + reviewer-identity APPROVED + Codex cleared). Removed `needs-external-review` so Label Gate passes and the PR can merge. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#195) for the trigger doctrine.'
-                gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
+                with_gh_retry gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
                   || echo "::warning::Failed to post attribution comment for PR #$PR"
                 ;;
               1)
@@ -229,7 +263,32 @@ jobs:
             esac
             echo "::endgroup::"
           done <<<"$PR_NUMBERS"
+          # Surface the infra-error sentinel to the next step (#324)
+          # so the check-run can be posted without re-deriving state.
+          echo "HAD_INFRA_ERROR=$had_infra_error" >> "$GITHUB_ENV"
           exit "$had_infra_error"
+
+      - name: Surface infra failure as check-run
+        # Run even when the prior step failed — `if: always()` + the
+        # HAD_INFRA_ERROR sentinel so we only post a failed check-run
+        # when the prior step actually hit an infra error (not when
+        # everything was clean or only gate-evaluation said "not yet
+        # met").
+        if: always() && env.HAD_INFRA_ERROR == '1'
+        env:
+          # check-run POST works with GITHUB_TOKEN + `checks: write`
+          # (added above). No PAT needed for this annotation surface.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${{ github.repository }}/check-runs" \
+            -X POST \
+            -f name='auto-clear-blocking-labels' \
+            -f head_sha='${{ github.sha }}' \
+            -f status='completed' \
+            -f conclusion='failure' \
+            -F 'output[title]=Auto-clear hit an infrastructure error' \
+            -F 'output[summary]=See workflow run logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
   scheduled-sweep:
     name: Periodic sweep for stale needs-external-review labels
@@ -254,10 +313,14 @@ jobs:
       - name: Find PRs carrying needs-external-review
         id: find
         env:
+          # Read-only list query. GITHUB_TOKEN is sufficient here —
+          # the PAT-switch in the next step is what triggers downstream
+          # workflows when the label is actually removed.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          source scripts/lib/gh-retry-helpers.sh
           # Read the per-repo cadence/enable knob from review-policy.yml.
           # Defaults: enabled=true. Operators can opt out by setting
           #   auto_clear_labels:
@@ -301,7 +364,7 @@ jobs:
           # gh failure (auth, rate limit, network) silently became
           # "0 PRs found" and the sweep no-op'd instead of failing
           # loudly.
-          if ! prs_raw=$(gh pr list --repo "$REPO" --state open \
+          if ! prs_raw=$(with_gh_retry gh pr list --repo "$REPO" --state open \
             --label needs-external-review --limit 500 \
             --json number --jq '.[].number'); then
             echo "::error::Failed to list open PRs with needs-external-review on $REPO"
@@ -325,11 +388,20 @@ jobs:
       - name: Re-evaluate gate per PR
         if: steps.find.outputs.prs != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT-driven label removal (#315/#324). See
+          # evaluate-and-clear job above for the rationale; same
+          # secret, same recursion-prevention bypass. Without the
+          # PAT, the scheduled sweep would remove the label but
+          # downstream workflows (pr-review-policy.yml Label Gate)
+          # would not re-fire — so mergeStateStatus would stay
+          # BLOCKED until the next push or manual nudge, defeating
+          # the sweep's purpose.
+          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           PRS: ${{ steps.find.outputs.prs }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          source scripts/lib/gh-retry-helpers.sh
           had_infra_error=0
           while IFS= read -r PR; do
             [ -z "$PR" ] && continue
@@ -341,9 +413,9 @@ jobs:
             case "$rc" in
               0)
                 echo "Gate passes — removing needs-external-review label."
-                if gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
+                if with_gh_retry gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
                   comment_body='**Automated label removal (scheduled sweep).** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD between event triggers (typical: Codex 👍 after the last push, with no synchronize / review / workflow_run event to fire the event-driven path). Removed `needs-external-review`. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#197) for the sweep doctrine.'
-                  gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
+                  with_gh_retry gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
                     || echo "::warning::Failed to post attribution comment for PR #$PR"
                 else
                   # Gate passed but the removal failed — infra error,
@@ -359,4 +431,26 @@ jobs:
             esac
             echo "::endgroup::"
           done <<<"$PRS"
+          # Surface the infra-error sentinel to the next step (#324)
+          # so the check-run can be posted without re-deriving state.
+          echo "HAD_INFRA_ERROR=$had_infra_error" >> "$GITHUB_ENV"
           exit "$had_infra_error"
+
+      - name: Surface infra failure as check-run
+        # Run even when the prior step failed — `if: always()` + the
+        # HAD_INFRA_ERROR sentinel so we only post a failed check-run
+        # when the prior step actually hit an infra error.
+        if: always() && env.HAD_INFRA_ERROR == '1'
+        env:
+          # check-run POST works with GITHUB_TOKEN + `checks: write`.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${{ github.repository }}/check-runs" \
+            -X POST \
+            -f name='auto-clear-blocking-labels' \
+            -f head_sha='${{ github.sha }}' \
+            -f status='completed' \
+            -f conclusion='failure' \
+            -F 'output[title]=Auto-clear hit an infrastructure error (scheduled sweep)' \
+            -F 'output[summary]=See workflow run logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -192,6 +192,7 @@ jobs:
           # PR hit it, so the workflow doesn't go green when gate
           # evaluation was actually impossible.
           had_infra_error=0
+          failing_prs=""
           while IFS= read -r PR; do
             [ -z "$PR" ] && continue
             echo "::group::Evaluating PR #$PR"
@@ -208,6 +209,7 @@ jobs:
               # Major, #271.)
               echo "::error::Failed to query labels for PR #$PR — cannot evaluate."
               had_infra_error=1
+              failing_prs="$failing_prs $PR"
               echo "::endgroup::"
               continue
             fi
@@ -233,6 +235,7 @@ jobs:
                   # Major, #271.)
                   echo "::error::Failed to remove needs-external-review on PR #$PR — label still stuck."
                   had_infra_error=1
+                  failing_prs="$failing_prs $PR"
                   echo "::endgroup::"
                   continue
                 fi
@@ -252,6 +255,7 @@ jobs:
                 # PRs on a multi-PR workflow_run trigger. But set
                 # the sentinel so the job exits non-zero at the end.
                 had_infra_error=1
+                failing_prs="$failing_prs $PR"
                 ;;
               *)
                 echo "::error::codex-review-check.sh unexpected rc=$rc on PR #$PR (contract drift — failing job)"
@@ -259,21 +263,36 @@ jobs:
                 # Better to fail loudly than leave the label stuck
                 # behind a silently-broken gate. CR Major on PR #202 r3.
                 had_infra_error=1
+                failing_prs="$failing_prs $PR"
                 ;;
             esac
             echo "::endgroup::"
           done <<<"$PR_NUMBERS"
-          # Surface the infra-error sentinel to the next step (#324)
-          # so the check-run can be posted without re-deriving state.
+          # Surface the infra-error sentinel + per-PR list to the next
+          # step (#324 round 2 codex P2) so the check-run can be posted
+          # with the correct head SHA per PR. failing_prs is space-
+          # separated, may have a leading space — `echo` collapses it.
           echo "HAD_INFRA_ERROR=$had_infra_error" >> "$GITHUB_ENV"
+          # shellcheck disable=SC2086  # intentional word-splitting to trim
+          echo "HAD_INFRA_ERROR_PRS=$(echo $failing_prs)" >> "$GITHUB_ENV"
           exit "$had_infra_error"
 
-      - name: Surface infra failure as check-run
+      - name: Surface infra failure as per-PR check-runs
         # Run even when the prior step failed — `if: always()` + the
-        # HAD_INFRA_ERROR sentinel so we only post a failed check-run
+        # HAD_INFRA_ERROR sentinel so we only post failed check-runs
         # when the prior step actually hit an infra error (not when
         # everything was clean or only gate-evaluation said "not yet
         # met").
+        #
+        # Per-PR check-runs (#324 round 2 codex P2): the prior version
+        # used `head_sha: ${{ github.sha }}`, but on workflow_run /
+        # pull_request_target / schedule, github.sha resolves to a
+        # default-branch commit, not the affected PR's head, so the
+        # annotation landed on the wrong commit and missed the target
+        # PR's Checks tab. Posting one check-run per failing PR fixes
+        # both the wrong-commit problem and the lost-visibility
+        # problem, at the cost of one extra `gh pr view` per failure
+        # (cheap, only on the error path).
         if: always() && env.HAD_INFRA_ERROR == '1'
         env:
           # check-run POST works with GITHUB_TOKEN + `checks: write`
@@ -281,14 +300,36 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          gh api "repos/${{ github.repository }}/check-runs" \
-            -X POST \
-            -f name='auto-clear-blocking-labels' \
-            -f head_sha='${{ github.sha }}' \
-            -f status='completed' \
-            -f conclusion='failure' \
-            -F 'output[title]=Auto-clear hit an infrastructure error' \
-            -F 'output[summary]=See workflow run logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          # shellcheck disable=SC1091
+          source scripts/lib/gh-retry-helpers.sh
+          REPO='${{ github.repository }}'
+          RUN_URL='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          # HAD_INFRA_ERROR_PRS is a space-separated list set by the
+          # prior step at each had_infra_error=1 site. Empty list →
+          # nothing to surface (defensive: should not happen given
+          # HAD_INFRA_ERROR is set).
+          if [ -z "${HAD_INFRA_ERROR_PRS:-}" ]; then
+            echo "::warning::HAD_INFRA_ERROR=1 but HAD_INFRA_ERROR_PRS is empty — skipping check-run emission."
+            exit 0
+          fi
+          for PR in $HAD_INFRA_ERROR_PRS; do
+            echo "::group::Posting infra-failure check-run for PR #$PR"
+            if ! HEAD_SHA=$(with_gh_retry gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid); then
+              echo "::warning::Failed to resolve head SHA for PR #$PR — skipping check-run."
+              echo "::endgroup::"
+              continue
+            fi
+            with_gh_retry gh api "repos/$REPO/check-runs" \
+              -X POST \
+              -f name='auto-clear-blocking-labels' \
+              -f "head_sha=$HEAD_SHA" \
+              -f status='completed' \
+              -f conclusion='failure' \
+              -F "output[title]=Auto-clear hit an infrastructure error" \
+              -F "output[summary]=PR #$PR — see workflow run logs: $RUN_URL" \
+              || echo "::warning::Failed to post check-run for PR #$PR (annotation lost; workflow log still surfaces the failure)."
+            echo "::endgroup::"
+          done
 
   scheduled-sweep:
     name: Periodic sweep for stale needs-external-review labels
@@ -403,6 +444,7 @@ jobs:
           set -euo pipefail
           source scripts/lib/gh-retry-helpers.sh
           had_infra_error=0
+          failing_prs=""
           while IFS= read -r PR; do
             [ -z "$PR" ] && continue
             echo "::group::Sweep PR #$PR"
@@ -423,34 +465,55 @@ jobs:
                   # sweep must not report success. (CodeRabbit Major, #271.)
                   echo "::error::Failed to remove needs-external-review on PR #$PR — label still stuck."
                   had_infra_error=1
+                  failing_prs="$failing_prs $PR"
                 fi
                 ;;
               1) echo "Gate not yet met — leaving label in place." ;;
-              3) echo "::error::codex-review-check.sh rc=3 on PR #$PR"; had_infra_error=1 ;;
-              *) echo "::error::unexpected rc=$rc on PR #$PR"; had_infra_error=1 ;;
+              3) echo "::error::codex-review-check.sh rc=3 on PR #$PR"; had_infra_error=1; failing_prs="$failing_prs $PR" ;;
+              *) echo "::error::unexpected rc=$rc on PR #$PR"; had_infra_error=1; failing_prs="$failing_prs $PR" ;;
             esac
             echo "::endgroup::"
           done <<<"$PRS"
-          # Surface the infra-error sentinel to the next step (#324)
-          # so the check-run can be posted without re-deriving state.
+          # Surface the infra-error sentinel + per-PR list to the next
+          # step (#324 round 2 codex P2). See evaluate-and-clear job
+          # for the rationale (correct head SHA per failing PR).
           echo "HAD_INFRA_ERROR=$had_infra_error" >> "$GITHUB_ENV"
+          # shellcheck disable=SC2086  # intentional word-splitting to trim
+          echo "HAD_INFRA_ERROR_PRS=$(echo $failing_prs)" >> "$GITHUB_ENV"
           exit "$had_infra_error"
 
-      - name: Surface infra failure as check-run
-        # Run even when the prior step failed — `if: always()` + the
-        # HAD_INFRA_ERROR sentinel so we only post a failed check-run
-        # when the prior step actually hit an infra error.
+      - name: Surface infra failure as per-PR check-runs
+        # Mirrors evaluate-and-clear's surfacing step. See that step's
+        # comments for the per-PR check-run rationale (#324 round 2 P2).
         if: always() && env.HAD_INFRA_ERROR == '1'
         env:
           # check-run POST works with GITHUB_TOKEN + `checks: write`.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          gh api "repos/${{ github.repository }}/check-runs" \
-            -X POST \
-            -f name='auto-clear-blocking-labels' \
-            -f head_sha='${{ github.sha }}' \
-            -f status='completed' \
-            -f conclusion='failure' \
-            -F 'output[title]=Auto-clear hit an infrastructure error (scheduled sweep)' \
-            -F 'output[summary]=See workflow run logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          # shellcheck disable=SC1091
+          source scripts/lib/gh-retry-helpers.sh
+          REPO='${{ github.repository }}'
+          RUN_URL='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          if [ -z "${HAD_INFRA_ERROR_PRS:-}" ]; then
+            echo "::warning::HAD_INFRA_ERROR=1 but HAD_INFRA_ERROR_PRS is empty — skipping check-run emission."
+            exit 0
+          fi
+          for PR in $HAD_INFRA_ERROR_PRS; do
+            echo "::group::Posting infra-failure check-run for PR #$PR (sweep)"
+            if ! HEAD_SHA=$(with_gh_retry gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid); then
+              echo "::warning::Failed to resolve head SHA for PR #$PR — skipping check-run."
+              echo "::endgroup::"
+              continue
+            fi
+            with_gh_retry gh api "repos/$REPO/check-runs" \
+              -X POST \
+              -f name='auto-clear-blocking-labels' \
+              -f "head_sha=$HEAD_SHA" \
+              -f status='completed' \
+              -f conclusion='failure' \
+              -F "output[title]=Auto-clear hit an infrastructure error (scheduled sweep)" \
+              -F "output[summary]=PR #$PR — see workflow run logs: $RUN_URL" \
+              || echo "::warning::Failed to post check-run for PR #$PR (annotation lost; workflow log still surfaces the failure)."
+            echo "::endgroup::"
+          done

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -219,6 +219,15 @@ paths:
   - path: scripts/lib/preflight-helpers.sh
     type: canonical
     consumers: all
+  # Sourced by codex-review-check.sh (the statusCheckRollup read) and
+  # by the inline bash in .github/workflows/auto-clear-blocking-labels.yml
+  # (label-list reads, label-removal writes, attribution-comment posts).
+  # Provides `with_gh_retry` — 3×30s retry on transient gh failures
+  # (HTTP 5xx, rate-limit, "Resource not accessible by integration").
+  # See mergepath#324 for the propagation closure rationale.
+  - path: scripts/lib/gh-retry-helpers.sh
+    type: canonical
+    consumers: all
   - path: scripts/coderabbit-wait.sh
     type: canonical
     consumers: all
@@ -228,6 +237,14 @@ paths:
   - path: scripts/codex-review-check.sh
     type: canonical
     consumers: all
+    # Sources scripts/lib/gh-retry-helpers.sh on startup to wrap the
+    # statusCheckRollup read in 3×30s retry on transient gh failures
+    # (#324). Without the helper present in the consumer, the
+    # `source` line is silently skipped (existence-guarded), but the
+    # retry semantics are lost — every transient failure becomes a
+    # hard rc=3 and the auto-clear stalls.
+    requires:
+      - "scripts/lib/gh-retry-helpers.sh"
   - path: scripts/phase-4b-classifier.sh
     type: canonical
     consumers: all
@@ -427,6 +444,14 @@ paths:
   - path: .github/workflows/auto-clear-blocking-labels.yml
     type: canonical
     consumers: all
+    # The workflow's inline bash steps `source
+    # scripts/lib/gh-retry-helpers.sh` to wrap gh reads/writes in
+    # retry (#324). Without the helper in the consumer, the source
+    # line aborts the run block under `set -euo pipefail` and the
+    # auto-clear is dead. Same closure logic as codex-review-check.sh
+    # above.
+    requires:
+      - "scripts/lib/gh-retry-helpers.sh"
   - path: .github/workflows/pr-audit.yml
     type: canonical
     consumers: all

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -75,12 +75,12 @@ fi
 # any `schedule:` / `cron:` text anywhere) so a comment couldn't
 # satisfy the assertion.
 if grep -qE "^[[:space:]]+schedule:" "$WORKFLOW" && \
-   grep -qF -- "- cron: '*/15 * * * *'" "$WORKFLOW"; then
+   grep -qF -- "- cron: '*/5 * * * *'" "$WORKFLOW"; then
   pass=$((pass + 1))
-  echo "  PASS: schedule trigger configured with 15-min cron (#197)"
+  echo "  PASS: schedule trigger configured with 5-min cron (#197/#324)"
 else
   fail=$((fail + 1))
-  echo "  FAIL: missing schedule trigger or expected cron entry (#197 sub-C of #191)" >&2
+  echo "  FAIL: missing schedule trigger or expected cron entry (5-min cron per #324)" >&2
 fi
 
 # scheduled-sweep job exists and is gated to schedule-only events.
@@ -137,8 +137,9 @@ fi
 # CR Major on PR #213 r2: sweep must capture `gh pr list` exit
 # status separately, not via process substitution into mapfile (which
 # swallows the producer's exit code, silently turning a gh failure
-# into "0 PRs found").
-if grep -qE -- 'if ! prs_raw=\$\(gh pr list' "$WORKFLOW" && \
+# into "0 PRs found"). #324 wrapped the gh call in
+# `with_gh_retry`; tolerate either form.
+if grep -qE -- 'if ! prs_raw=\$\((with_gh_retry )?gh pr list' "$WORKFLOW" && \
    grep -qE -- 'echo "::error::Failed to list open PRs' "$WORKFLOW"; then
   pass=$((pass + 1))
   echo "  PASS: sweep captures gh pr list exit status (no silent failure on gh error)"
@@ -194,7 +195,11 @@ perm_block=$(
 # drill into statusCheckRollup.checkSuite.workflowRun requires it
 # in addition to `checks: read`. See the inline rationale comment
 # next to the new permission in auto-clear-blocking-labels.yml.
-expected_perms=$'actions: read\nchecks: read\ncontents: read\npull-requests: write'
+# `checks: write` added in #324 — the "Surface infra failure as
+# check-run" step posts a failed check-run when this workflow hits
+# an infrastructure error, so flake recurrences are visible on the
+# PR's checks tab without grepping workflow logs.
+expected_perms=$'actions: read\nchecks: read\nchecks: write\ncontents: read\npull-requests: write'
 if [ "$perm_block" = "$expected_perms" ]; then
   pass=$((pass + 1))
   echo "  PASS: workflow permissions exactly match the least-privilege set"

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -98,6 +98,23 @@ if [ -r "$__CODEX_CHECK_DIR/lib/preflight-helpers.sh" ]; then
   preflight_require_token reviewer || true
 fi
 
+# --- gh retry helper (#324) ------------------------------------------------
+# Wrap gh calls (statusCheckRollup read in particular) in 3×30s retry on
+# transient failures (HTTP 5xx, rate-limit, "Resource not accessible by
+# integration"). Permanent 4xx errors break out immediately. The
+# canonical helper lives at scripts/lib/gh-retry-helpers.sh and is
+# declared as a `requires:` dep of this script in .mergepath-sync.yml,
+# so propagated consumers always carry it. The existence-guarded
+# fallback below means a hand-built or partial install still runs
+# (without retry) rather than aborting with "with_gh_retry: command
+# not found" at the call site.
+if [ -r "$__CODEX_CHECK_DIR/lib/gh-retry-helpers.sh" ]; then
+  # shellcheck source=lib/gh-retry-helpers.sh
+  . "$__CODEX_CHECK_DIR/lib/gh-retry-helpers.sh"
+else
+  with_gh_retry() { "$@"; }
+fi
+
 # --- argument parsing -------------------------------------------------------
 
 if [ $# -lt 1 ] || [ $# -gt 2 ]; then
@@ -521,7 +538,7 @@ log "gate (a): checking CI state"
 # state. A check still running (no conclusion yet) is treated as not-green
 # — the caller should wait or retry. SKIPPED is treated as success because
 # many Agent Review Pipeline jobs skip by design when the label is set.
-ROLLUP_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json statusCheckRollup 2>&1) \
+ROLLUP_JSON=$(with_gh_retry gh pr view "$PR_NUMBER" --repo "$REPO" --json statusCheckRollup 2>&1) \
   || die 3 "failed to fetch statusCheckRollup: $ROLLUP_JSON"
 
 # statusCheckRollup mixes two entry types:

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -538,8 +538,15 @@ log "gate (a): checking CI state"
 # state. A check still running (no conclusion yet) is treated as not-green
 # — the caller should wait or retry. SKIPPED is treated as success because
 # many Agent Review Pipeline jobs skip by design when the label is set.
-ROLLUP_JSON=$(with_gh_retry gh pr view "$PR_NUMBER" --repo "$REPO" --json statusCheckRollup 2>&1) \
-  || die 3 "failed to fetch statusCheckRollup: $ROLLUP_JSON"
+# Drop `2>&1`: with_gh_retry emits per-attempt diagnostics to stderr on
+# transient failures, and merging those lines into ROLLUP_JSON would
+# corrupt the jq parse below — a transient 5xx + successful retry would
+# look like an infra error (gate (a) fail) when the retry actually
+# recovered. Caught by codex P1 on PR #328 round 1. The retry diagnostics
+# still surface in the workflow log via stderr, so the visibility cost
+# is zero.
+ROLLUP_JSON=$(with_gh_retry gh pr view "$PR_NUMBER" --repo "$REPO" --json statusCheckRollup) \
+  || die 3 "failed to fetch statusCheckRollup (see stderr above for retry diagnostics)"
 
 # statusCheckRollup mixes two entry types:
 #   - CheckRun (GitHub Actions jobs): uses .name, .workflowName,

--- a/scripts/lib/gh-retry-helpers.sh
+++ b/scripts/lib/gh-retry-helpers.sh
@@ -68,12 +68,33 @@ with_gh_retry() {
     fi
 
     # Classify the failure. Permanent failures break out immediately.
-    # The 4xx matcher covers the full 400-499 range (CR Minor #328
-    # round 2): the prior `4(0[0-9]|1[0-9])` form only matched
-    # 400-419 and silently retried 4xx like 422 / 451 as transient.
-    if printf '%s' "$output" | grep -qE 'HTTP 4[0-9]{2}' \
-       && ! printf '%s' "$output" | grep -qE 'HTTP (403|429)' \
-       && ! printf '%s' "$output" | grep -q 'Resource not accessible by integration'; then
+    #
+    # Retry only:
+    #   - HTTP 5xx (server-side, transient)
+    #   - HTTP 429 (rate-limit, always)
+    #   - HTTP 403 with "rate limit" in the body (GitHub rate-limit
+    #     can surface as 403 in some flows)
+    # Fail-fast on:
+    #   - HTTP 4xx other than 429 or rate-limited 403 (auth, perms,
+    #     validation — retrying is futile and costs sweep budget)
+    #   - "Resource not accessible by integration" (token permission
+    #     issue, fixed by adding the perm to the workflow — codex P2
+    #     #328 round 3 caught the prior pattern wasting 2×30s sleeps
+    #     on this surface, missing the auto-clear window)
+    is_permanent=false
+    if printf '%s' "$output" | grep -q 'Resource not accessible by integration'; then
+      is_permanent=true
+    elif printf '%s' "$output" | grep -qE 'HTTP 4[0-9]{2}'; then
+      if printf '%s' "$output" | grep -qE 'HTTP 429'; then
+        : # transient rate-limit
+      elif printf '%s' "$output" | grep -qE 'HTTP 403' \
+           && printf '%s' "$output" | grep -qiE 'rate.?limit'; then
+        : # transient rate-limit surfaced as 403
+      else
+        is_permanent=true
+      fi
+    fi
+    if $is_permanent; then
       printf '%s' "$output" >&2
       return "$rc"
     fi

--- a/scripts/lib/gh-retry-helpers.sh
+++ b/scripts/lib/gh-retry-helpers.sh
@@ -23,6 +23,17 @@ set -euo pipefail
 with_gh_retry() {
   local attempts=${GH_RETRY_ATTEMPTS:-3}
   local backoff=${GH_RETRY_BACKOFF_SECONDS:-30}
+  # Validate env knobs (CR Major #328 round 2). Non-numeric or
+  # non-positive values previously could skip the loop entirely
+  # (returning success with empty output) or break `sleep` under
+  # `set -e`. Fall back to the defaults with a stderr warning rather
+  # than silently no-op'ing.
+  case "$attempts" in
+    ''|*[!0-9]*|0) printf '[gh-retry] WARN: GH_RETRY_ATTEMPTS=%q invalid; using default 3\n' "$attempts" >&2; attempts=3 ;;
+  esac
+  case "$backoff" in
+    ''|*[!0-9]*) printf '[gh-retry] WARN: GH_RETRY_BACKOFF_SECONDS=%q invalid; using default 30\n' "$backoff" >&2; backoff=30 ;;
+  esac
   local attempt=1
   local rc=0
   local output=""
@@ -41,7 +52,10 @@ with_gh_retry() {
     fi
 
     # Classify the failure. Permanent failures break out immediately.
-    if printf '%s' "$output" | grep -qE 'HTTP 4(0[0-9]|1[0-9])' \
+    # The 4xx matcher covers the full 400-499 range (CR Minor #328
+    # round 2): the prior `4(0[0-9]|1[0-9])` form only matched
+    # 400-419 and silently retried 4xx like 422 / 451 as transient.
+    if printf '%s' "$output" | grep -qE 'HTTP 4[0-9]{2}' \
        && ! printf '%s' "$output" | grep -qE 'HTTP (403|429)' \
        && ! printf '%s' "$output" | grep -q 'Resource not accessible by integration'; then
       printf '%s' "$output" >&2

--- a/scripts/lib/gh-retry-helpers.sh
+++ b/scripts/lib/gh-retry-helpers.sh
@@ -23,17 +23,33 @@ set -euo pipefail
 with_gh_retry() {
   local attempts=${GH_RETRY_ATTEMPTS:-3}
   local backoff=${GH_RETRY_BACKOFF_SECONDS:-30}
-  # Validate env knobs (CR Major #328 round 2). Non-numeric or
-  # non-positive values previously could skip the loop entirely
-  # (returning success with empty output) or break `sleep` under
-  # `set -e`. Fall back to the defaults with a stderr warning rather
-  # than silently no-op'ing.
+  # Validate env knobs (CR Major #328 round 2, Minor round 3). Non-
+  # numeric or non-positive values previously could skip the loop
+  # entirely (returning success with empty output) or break `sleep`
+  # under `set -e`. Fall back to the defaults with a stderr warning
+  # rather than silently no-op'ing.
+  #
+  # Two-phase validation: first reject non-numeric strings via case
+  # pattern, then reject non-positive integers via arithmetic. The
+  # arithmetic phase closes the leading-zero hole CR caught on round
+  # 2 — `case "00" in 0)` doesn't match (case patterns are literal,
+  # not numeric) but bash arithmetic treats "00" as 0, so the prior
+  # validation passed but the while loop never entered.
   case "$attempts" in
-    ''|*[!0-9]*|0) printf '[gh-retry] WARN: GH_RETRY_ATTEMPTS=%q invalid; using default 3\n' "$attempts" >&2; attempts=3 ;;
+    ''|*[!0-9]*) printf '[gh-retry] WARN: GH_RETRY_ATTEMPTS=%q non-numeric; using default 3\n' "$attempts" >&2; attempts=3 ;;
   esac
+  if [ "$attempts" -le 0 ] 2>/dev/null; then
+    printf '[gh-retry] WARN: GH_RETRY_ATTEMPTS=%q non-positive; using default 3\n' "$attempts" >&2
+    attempts=3
+  fi
   case "$backoff" in
-    ''|*[!0-9]*) printf '[gh-retry] WARN: GH_RETRY_BACKOFF_SECONDS=%q invalid; using default 30\n' "$backoff" >&2; backoff=30 ;;
+    ''|*[!0-9]*) printf '[gh-retry] WARN: GH_RETRY_BACKOFF_SECONDS=%q non-numeric; using default 30\n' "$backoff" >&2; backoff=30 ;;
   esac
+  # Backoff can legitimately be 0 (no sleep between retries — useful
+  # for tests), so the arithmetic-positivity check applies only to
+  # `attempts`. A negative `backoff` would only occur if a user
+  # passed e.g. `-1`, which fails the case pattern above and is
+  # already caught.
   local attempt=1
   local rc=0
   local output=""

--- a/scripts/lib/gh-retry-helpers.sh
+++ b/scripts/lib/gh-retry-helpers.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# scripts/lib/gh-retry-helpers.sh
+#
+# with_gh_retry — wrap a gh/gh-api call in 3-attempt retry with 30s backoff.
+# Distinguishes transient (HTTP 5xx, rate-limit, "Resource not accessible by
+# integration") from permanent (HTTP 4xx other than 429/403, malformed JSON)
+# failures. Only retries the transient class.
+#
+# Usage:
+#   with_gh_retry gh pr view 123 --json statusCheckRollup
+#   with_gh_retry gh api ...
+#
+# Exit codes:
+#   0  — call succeeded on attempt N
+#   non-zero — call failed after 3 attempts or hit a permanent error
+#
+# Env tuning:
+#   GH_RETRY_ATTEMPTS (default 3)
+#   GH_RETRY_BACKOFF_SECONDS (default 30)
+
+set -euo pipefail
+
+with_gh_retry() {
+  local attempts=${GH_RETRY_ATTEMPTS:-3}
+  local backoff=${GH_RETRY_BACKOFF_SECONDS:-30}
+  local attempt=1
+  local rc=0
+  local output=""
+
+  while [ "$attempt" -le "$attempts" ]; do
+    # Capture stdout+stderr AND the exit code in one shot. Using
+    # `if output=...; then` would discard `$?` after the failed
+    # `if` test (bash resets $? to 0 in that position), so we
+    # invoke + check separately. `|| rc=$?` keeps `set -e` happy
+    # because the `||` short-circuit consumes the non-zero exit.
+    rc=0
+    output=$("$@" 2>&1) || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      printf '%s' "$output"
+      return 0
+    fi
+
+    # Classify the failure. Permanent failures break out immediately.
+    if printf '%s' "$output" | grep -qE 'HTTP 4(0[0-9]|1[0-9])' \
+       && ! printf '%s' "$output" | grep -qE 'HTTP (403|429)' \
+       && ! printf '%s' "$output" | grep -q 'Resource not accessible by integration'; then
+      printf '%s' "$output" >&2
+      return "$rc"
+    fi
+
+    if [ "$attempt" -lt "$attempts" ]; then
+      printf '[gh-retry] attempt %d/%d failed (rc=%d), sleeping %ds before retry. tail: %s\n' \
+        "$attempt" "$attempts" "$rc" "$backoff" "$(printf '%s' "$output" | tail -1)" >&2
+      sleep "$backoff"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  printf '%s' "$output" >&2
+  return "$rc"
+}
+
+export -f with_gh_retry


### PR DESCRIPTION
Closes #324. Also closes #315 (bundled per the implementation plan).

## Summary

Three orthogonal fixes for the \`auto-clear-blocking-labels\` workflow, addressing the flakiness observed across the #250 Phase D fanout (3 of 6 propagation PRs needed manual \`request-label-removal.sh\`):

1. **\`scripts/lib/gh-retry-helpers.sh\`** — new \`with_gh_retry\` helper that retries gh calls on transient failures (5xx, rate-limit, \`Resource not accessible by integration\`) with 3 × 30s backoff. Applied to the \`statusCheckRollup\` read in \`scripts/codex-review-check.sh\` and the label-removal \`gh pr edit\` calls in the workflow itself.

2. **PAT-switch (closes #315):** label removal now uses \`REVIEWER_ASSIGNMENT_TOKEN\` instead of \`GITHUB_TOKEN\`. PAT-driven events trigger downstream workflows (pr-review-policy.yml's Label Gate re-fires automatically), so \`mergeStateStatus\` flips to \`CLEAN\` within seconds rather than waiting for the scheduled sweep or a manual \`request-label-removal.sh\`.

3. **Scheduled sweep tightened 15 → 5 min.** Closes the 👍-after-last-push window where the event-driven path missed and the sweep was the only backstop. 3× the API quota cost but a meaningfully shorter blocker window.

Also surfaces infra-error workflow runs as a failed check-run on the PR's checks tab so flake recurrences are visible without grepping workflow logs.

## Notable extras beyond the spec

- **Sync-manifest propagation closure.** The new \`scripts/lib/gh-retry-helpers.sh\` is a canonical entry in \`.mergepath-sync.yml\` (consumers: all); both \`scripts/codex-review-check.sh\` and \`.github/workflows/auto-clear-blocking-labels.yml\` declare it as a \`requires:\` dep so the #264 closure invariant guards future propagation.
- **Defensive fallback in \`codex-review-check.sh\`.** Mirroring the existing existence-guarded \`preflight-helpers.sh\` source pattern, added a no-op fallback \`with_gh_retry() { \"\$@\"; }\` if the helper is missing — so a hand-built or partial install runs without retry rather than aborting with \`command not found\`.
- **Bug fixed mid-implementation:** the initial retry-helper draft used \`if output=\$(...); then ... fi; rc=\$?\` — but bash resets \`\$?\` to 0 after a failed \`if\` test condition, so the captured \`rc\` was always 0 and permanent-4xx classification never fired. Replaced with \`output=\$(...) || rc=\$?\` which preserves the exit code under \`set -e\`.
- **\`check_auto_clear_workflow\` test updates:** cron literal updated to \`*/5 * * * *\`, \`expected_perms\` updated to include \`checks: write\` (needed for the check-run emission), and \`gh pr list\` regex relaxed to tolerate the new \`with_gh_retry\` prefix.

## Why

Two root causes of auto-clear flakiness observed in #250 Phase D:
1. Transient gh API failures (especially \`Resource not accessible by integration\` from the statusCheckRollup drill, addressed by #311 token-scope but still flake on rate-limit / 5xx).
2. \`GITHUB_TOKEN\`-driven label removal doesn't trigger downstream workflows (GitHub recursion-prevention rule), so Label Gate stays stuck on stale state until the next push or the 15-min sweep — #315 territory.

Bundling both fixes here per implementation plan: same workflow, same lifecycle, lower review overhead than two PRs.

Authoring-Agent: claude

## Self-Review

- **Correctness:** Retry helper logic carefully classifies transient vs permanent failures. PAT-switch confirmed against \`.github/workflows/daily-feedback-rollup.yml\` (same secret name and use pattern). Check-run emission requires \`checks: write\` permission which is now declared.
- **Regression risk:** Medium. Changes to a workflow that affects every PR's merge gate. The retry helper has a defensive fallback if missing. The PAT-switch could trigger more downstream workflow runs (intended behavior) — monitor for runaway loops post-merge.
- **Style:** Bash conventions match existing scripts (\`set -euo pipefail\`, helper sourcing pattern). YAML formatting matches existing workflow files.
- **Test coverage:** \`check_auto_clear_workflow\` (26/26 PASS), \`tests/test_helper_autosource.sh\` (7/7 PASS), ad-hoc functional tests of \`with_gh_retry\` covering permanent/transient/success/rate-limit/resource-not-accessible cases all PASS.
- **Security/dependency hygiene:** \`REVIEWER_ASSIGNMENT_TOKEN\` already provisioned per daily-feedback-rollup.yml — no new secrets needed. \`with_gh_retry\` uses no eval/source of untrusted input. No new external dependencies.

## Test plan

- [x] All syntax checks pass (\`bash -n\` + yq YAML validation).
- [x] \`check_auto_clear_workflow\`: 26/26 PASS.
- [x] \`check_sync_manifest\`: PASS (45 entries, +1 from new helper).
- [x] \`check_codex_scripts\`, \`check_ci_scripts_wired\`, \`check_workflow_parsers\`, \`check_canonical_bugs_263caf3\`: all PASS.
- [x] Ad-hoc functional test of \`with_gh_retry\`: all 5 failure classes handled correctly.
- [ ] Post-merge: open a small follow-up PR (or wait for next propagation PR) and confirm auto-clear fires + Label Gate re-evaluates within seconds.
- [ ] Post-merge after 24h: \`gh run list --workflow=auto-clear-blocking-labels.yml --limit 50 --json conclusion\` — count failures vs baseline.