### PR TITLE
feat(propagation): verify-propagation-pr.sh re-renders templated entries (#323)

### DIFF
--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -131,6 +131,16 @@ jobs:
       - name: check_verify_propagation_pr
         run: ./scripts/ci/check_verify_propagation_pr
 
+      # check_workflow_verify_propagation_templated exercises the
+      # templated-surface arm of verify-propagation-pr.sh (#323) —
+      # the re-render + byte-verify path that closes the propagation
+      # lane gate for type:templated entries. Same lane-eligibility
+      # security teeth as check_verify_propagation_pr above; runs
+      # alongside it so a regression in either surface lights up CI
+      # independently.
+      - name: check_workflow_verify_propagation_templated
+        run: ./scripts/ci/check_workflow_verify_propagation_templated
+
       - name: check_phase_4b_classifier
         run: ./scripts/ci/check_phase_4b_classifier
 

--- a/docs/agents/templated-propagation.md
+++ b/docs/agents/templated-propagation.md
@@ -1,6 +1,6 @@
 # Templated propagation — Layer 5 substitution lib
 
-Status: **lib + sync/audit integration landed.** Propagation-lane verification of templated PRs is deferred to a follow-up (templated PRs go through normal Phase 4 review in v1).
+Status: **lib + sync/audit integration + propagation-lane verification landed.** Templated propagation PRs are now lane-eligible alongside canonical/kit — the verifier re-renders against `mergepath@<sha>` with the consumer's facts and byte-compares against the PR's dest.
 
 This doc covers `scripts/lib/template-substitution.sh` — the rendering engine that activates `type: templated` entries in `.mergepath-sync.yml` — plus the sync integration that wires it into `scripts/sync-to-downstream.sh` for both audit and materialize.
 
@@ -118,7 +118,7 @@ Real templates will accumulate optional-fact references over time (`{{node_versi
 
 - **No live templated entry in the manifest yet.** The lib + sync integration are wired (audit, materialize for per-commit + sync-all), but `.mergepath-sync.yml` has zero entries of `type: templated` today. Phase C adds the first one (`examples/eslint.config.js` → `eslint.config.js`) to unblock the [mergepath#250](https://github.com/nathanjohnpayne/mergepath/issues/250) ESLint rollout.
 - **The lib doesn't know about consumer name or repo.** Facts must be uniform across consumers (e.g., `frameworks`, `node_version`); per-consumer name substitution (`mergepath` → `<consumer>`) still goes through `scripts/bootstrap/substitute.sh`'s allow-list-driven path. Long-term, both should share a single substitution lib (per [#168 Layer 5's original sketch](https://github.com/nathanjohnpayne/mergepath/issues/168) — "factor the substitution logic into `scripts/lib/template-substitution.sh` so bootstrap and sync share the lib"), but that consolidation is non-trivial because the two callers have different semantics (literal name allow-list vs. fact-driven substitution). Tracked as future work.
-- **Propagation-lane verification not yet implemented for templated.** See § Propagation-lane verification — v1 limitation below. Templated propagation PRs route to normal Phase 4 review until `verify-propagation-pr.sh` learns to re-render + byte-verify.
+- **Per-consumer name substitution still goes through `scripts/bootstrap/substitute.sh`.** The templating lib is fact-driven (`MERGEPATH_FACT_*`); consumer-name substitution at bootstrap time still goes through the allow-list-driven bootstrap path. Long-term consolidation tracked in [#168 Layer 5](https://github.com/nathanjohnpayne/mergepath/issues/168).
 
 ## Sync integration — what's wired up
 
@@ -155,17 +155,40 @@ paths:
 
 A render for matchline exports `MERGEPATH_FACT_FRAMEWORKS="react typescript"` and `MERGEPATH_FACT_NODE_VERSION=20`, then runs the lib against `examples/eslint.config.js`. The output lands at `eslint.config.js` in the consumer's PR branch.
 
-## Propagation-lane verification — v1 limitation
+## Propagation-lane verification
 
-The `propagation_prs` review-lane exemption in `.github/review-policy.yml` (#264) currently does NOT cover templated entries: `scripts/workflow/verify-propagation-pr.sh` and its `parse_manifest_paths.sh` helper emit only mergepath-side `.path` values, so a PR touching a templated `dest` (which doesn't equal `.path`) reads as "off propagation surface" and the lane gate denies exemption — the PR routes to normal Phase 4 review.
+The `propagation_prs` review-lane exemption in `.github/review-policy.yml` (#264) covers templated entries via a re-render + byte-verify path that lives alongside the canonical/kit byte-compare ([#323](https://github.com/nathanjohnpayne/mergepath/issues/323)).
 
-This is the **intentional v1 behavior**: templated rendering is new infrastructure, and an external review per templated propagation PR is appropriate while we build confidence. A follow-up PR will extend `verify-propagation-pr.sh` to re-render the source against `mergepath@<sha>` with the consumer's facts and byte-verify the PR content, at which point templated PRs become lane-eligible.
+How it works:
 
-Until then, expect templated propagation PRs to carry `needs-external-review`; they're not stuck — Phase 4a (Codex) or 4b (CLI handoff) will clear the gate normally.
+1. `scripts/workflow/verify-propagation-pr.sh` parses templated entries from the trusted mergepath checkout's manifest.
+2. For each templated entry whose `dest` appears in the PR's diff AND whose consumer matches this PR's repo, the verifier:
+   - resolves the consumer via `$MERGEPATH_CONSUMER` (test/CI escape hatch) OR the consumer dir's `origin` remote URL matched against `.consumers[].repo`,
+   - sources `scripts/lib/manifest-fact-helpers.sh` from the trusted mergepath checkout and calls `export_consumer_facts <consumer> <manifest>` to populate `MERGEPATH_FACT_*`,
+   - sources `scripts/lib/template-substitution.sh` from the trusted mergepath checkout and calls `template_substitution::render <source>` to produce the expected output,
+   - `git show ${HEAD_SHA}:${dest}` to pull the PR's dest content, and byte-compares with `diff -q`.
+3. On match, the verified `dest` is added to a `VERIFIED_TEMPLATED_DESTS` list so the canonical-loop path-confinement check below it skips that file (templated `dest` doesn't equal any `.path`, so without this exemption the canonical check would false-fail it).
+4. On match, a structured stdout line is emitted for the calling workflow to post as a thread tag-reply:
+
+   ```text
+   [mergepath-verify: templated-render] <dest> <consumer> <source>
+   ```
+
+5. Failures fall into three typed buckets in the verifier's stderr summary:
+   - **Canonical / kit drift** — pre-existing canonical surface.
+   - **Templated re-render mismatch** — rendered output differs from PR dest content.
+   - **Templated re-render error** — malformed template, missing source at mergepath@<sha>, or strict-mode unset fact.
+
+Consumer-inference fallback: if neither `$MERGEPATH_CONSUMER` is set nor the `origin` remote matches a `.consumers[].repo` field, the templated arm is skipped with a stderr note. The canonical/kit arm still runs, and the templated dest will then fail the path-confinement check, routing the PR to normal Phase 4 review (pre-#323 status quo).
+
+Wire-up:
+
+- CI gate: `scripts/ci/check_workflow_verify_propagation_templated` (test: `tests/test_verify_propagation_pr_templated.sh`) covers the four cases — pass, drift, template syntax error, strict-mode unset fact. Wired into `.github/workflows/repo_lint.yml` alongside `check_verify_propagation_pr`.
+- Rollup attribution: the `templated-render` tag class lives in `scripts/lib/daily-feedback-rollup-helpers.sh` (mapped to `skip` in `tag_class_action`, same routing as `canonical-coverage`) and `scripts/resolve-pr-threads.sh`'s `derive_tag_class` ladder (slotted at rung 1b, right after `canonical-coverage`). Findings on a templated dest are structurally a mergepath concern — fixes belong in the template or in the consumer's `facts:` block — so they route to mergepath rather than surfacing per-consumer.
 
 ## What's queued next
 
 1. **Phase C** — restructure `examples/eslint.config.js` into a conditional-block template, add `facts.frameworks` to all 8 consumer entries, add the manifest entry for `eslint.config.js`.
 2. **Phase D** — canary propagation to swipewatch (smallest JS surface), then fanout to the remaining 5 consumers. Each consumer's PR carries the rendered config + a devDeps install + findings triage per its consumer-side issue.
 3. **Phase E** — close the 6 consumer issues and the [mergepath#250](https://github.com/nathanjohnpayne/mergepath/issues/250) parent tracker; file a retrospective on Layer 5 cost vs. payoff for future "should we templated-ize X?" judgment calls.
-4. **Lane-eligibility for templated** — extend `verify-propagation-pr.sh` to re-render-and-verify templated entries. Order vs. Phase D is flexible; v1 doesn't block on it.
+4. ~~**Lane-eligibility for templated** — extend `verify-propagation-pr.sh` to re-render-and-verify templated entries.~~ **Landed in [#323](https://github.com/nathanjohnpayne/mergepath/issues/323)** — see § Propagation-lane verification above.

--- a/scripts/ci/check_workflow_verify_propagation_templated
+++ b/scripts/ci/check_workflow_verify_propagation_templated
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# scripts/ci/check_workflow_verify_propagation_templated — CI entry
+# point for the templated-surface arm of the propagation-PR review
+# lane's faithful-mirror verifier (#323).
+#
+# Wraps tests/test_verify_propagation_pr_templated.sh so the repo_lint
+# workflow's enumerated check_* list picks it up. The templated-surface
+# arm of scripts/workflow/verify-propagation-pr.sh closes the
+# propagation-lane gate for type:templated entries (previously routed
+# to normal Phase 4 review per the v1 limitation in
+# docs/agents/templated-propagation.md § Propagation-lane verification).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_verify_propagation_pr_templated.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  # Missing test script is a hard error, not a skip — silent-skip
+  # would let an accidental delete/rename disable this check
+  # without surfacing in CI.
+  echo "check_workflow_verify_propagation_templated: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/lib/daily-feedback-rollup-helpers.sh
+++ b/scripts/lib/daily-feedback-rollup-helpers.sh
@@ -92,7 +92,14 @@ extract_tag_class() {
 # (err on surface — future class additions are additive).
 tag_class_action() {
   case "$1" in
-    addressed-elsewhere|canonical-coverage|rebuttal-recorded) echo "skip" ;;
+    # templated-render — verify-propagation-pr.sh re-rendered the
+    # source against mergepath@<sha> with the consumer's facts and
+    # confirmed byte-equality with the PR dest (mergepath#323). Same
+    # "mergepath concern" class as canonical-coverage: a finding on a
+    # templated dest is structurally a mergepath concern (the template
+    # lives in mergepath), so route it to mergepath rather than
+    # surfacing on each consumer's daily rollup.
+    addressed-elsewhere|canonical-coverage|rebuttal-recorded|templated-render) echo "skip" ;;
     nitpick-noted|deferred-to-followup) echo "surface" ;;
     "") echo "" ;;  # no tag → caller falls through to heuristics
     *)  echo "surface" ;;  # unknown → surface

--- a/scripts/lib/manifest-fact-helpers.sh
+++ b/scripts/lib/manifest-fact-helpers.sh
@@ -1,0 +1,79 @@
+# scripts/lib/manifest-fact-helpers.sh
+#
+# Pure helper: export a consumer's facts:* from a .mergepath-sync.yml
+# manifest as MERGEPATH_FACT_* env vars in the current (sub)shell.
+# Extracted from scripts/sync-to-downstream.sh (#318) so both the sync
+# script AND scripts/workflow/verify-propagation-pr.sh can load the
+# same facts without duplicating the yq filter or sourcing the full
+# sync script (which carries top-level argument parsing + mode
+# dispatch side effects).
+#
+# Sourcing contract: NO top-level side effects, only function defs.
+# Safe to source from any shell that needs the helper.
+#
+# To use:
+#   source scripts/lib/manifest-fact-helpers.sh
+#   export_consumer_facts <consumer_name> <manifest_path>
+#
+# Regression-guarded by tests/test_export_consumer_facts.sh — that
+# test asserts the EXACT yq filter shape in this file and the literal
+# absence of the broken `if`-then-else form that mikefarah/yq's lexer
+# rejects (see the in-function NOTE on the broken-form history). The
+# test greps this file directly, so we deliberately avoid writing the
+# broken-form literal in any comment block.
+
+# Export a consumer's facts:* from the manifest as MERGEPATH_FACT_*
+# env vars in the current (sub)shell. Unsets any prior
+# MERGEPATH_FACT_* exports first so successive callers don't see
+# stale facts from a different consumer. List-valued facts (yaml
+# `[a, b]`) are serialized as space-separated, matching the lib's
+# `<key> contains <value>` expectations.
+#
+# Uses the `env(VAR)` mikefarah/yq form for consumer-name injection
+# (the `--arg` jq-compat flag works too but env-var is the
+# documented mikefarah idiom).
+#
+# KEEP IN SYNC with tests/test_export_consumer_facts.sh — that test
+# pins the documented mikefarah idiom (a `select(tag == "!!seq")`
+# branch combined with the `//` fallback) and rejects the broken
+# `if`-then-else form that mikefarah/yq's lexer silently emits
+# nothing for (#319). The test greps this file directly, so the
+# broken-form literal is deliberately not written out in any comment.
+export_consumer_facts() {
+  local consumer_name=$1
+  local manifest=$2
+
+  # Clean slate — prior consumer's facts must not leak in.
+  local var
+  for var in $(env | awk -F= '/^MERGEPATH_FACT_/ {print $1}'); do
+    unset "$var"
+  done
+
+  while IFS=$'\t' read -r key value; do
+    [ -z "$key" ] && continue
+    local upper
+    upper=$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+    export "MERGEPATH_FACT_$upper=$value"
+  done < <(MERGEPATH_CONSUMER_NAME="$consumer_name" yq -r '
+    env(MERGEPATH_CONSUMER_NAME) as $cn
+    | .consumers[] | select(.name == $cn) | .facts // {} | to_entries[]
+    | .key + "\t"
+      + ((.value | select(tag == "!!seq") | join(" "))
+         // (.value | tostring))
+  ' "$manifest")
+  # NOTE on the value-typed serialization: mikefarah/yq v4 does NOT
+  # accept a top-level `if`-then-else expression in this filter
+  # position (the lexer rejects `if` at column-after-pipe). An
+  # earlier draft of this query used that form, which silently
+  # produced empty output for every fact, which caused
+  # MERGEPATH_FACT_* to never get exported, which made every templated
+  # render fall through to the "no frameworks" baseline. swipewatch
+  # was the only consumer that didn't notice (its declared frameworks
+  # are []), so the swipewatch canary in Phase D fell-positive on
+  # the bug. The select+// fallback above is the documented
+  # mikefarah idiom for branching on a value's YAML tag.
+  #
+  # The regression-guard in tests/test_export_consumer_facts.sh
+  # greps THIS FILE for the broken-form literal string, so we
+  # deliberately do not write it out verbatim in the comment.
+}

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -634,11 +634,20 @@ path_matches_manifest() {
   return 1
 }
 
-# fetch_manifest_templated_dests — extract the dest paths of every
-# templated entry in the manifest (#323). Templated entries decouple
-# source from dest (the whole point), so a thread anchored on a
-# templated dest path doesn't match path_matches_manifest above (which
-# reads only .path). Cached.
+# fetch_manifest_templated_dests — extract dest + eligible consumer
+# slugs for every templated entry in the manifest (#323). Templated
+# entries decouple source from dest (the whole point), so a thread
+# anchored on a templated dest path doesn't match path_matches_manifest
+# above (which reads only .path). Cached.
+#
+# Cache format: one line per entry, `dest<TAB>repo1,repo2,...` where
+# each repoN is the full owner/name slug looked up from
+# `.consumers[].repo` via the entry's `.consumers[] (name)` list. The
+# repo-slug scoping closes the codex P2 from PR #329 round 1: without
+# it, ANY repo whose local file matched the dest path got the
+# `templated-render` class, even repos not opted into that entry —
+# suppressing substantive unresolved feedback on unrelated files in
+# the daily rollup.
 MANIFEST_TEMPLATED_DESTS_CACHE=""
 MANIFEST_TEMPLATED_FETCHED=false
 fetch_manifest_templated_dests() {
@@ -647,13 +656,31 @@ fetch_manifest_templated_dests() {
   local manifest="$REPO_ROOT_FOR_MANIFEST/.mergepath-sync.yml"
   [ -f "$manifest" ] || return 0
   if command -v yq >/dev/null 2>&1; then
+    # Resolve each entry's consumer-name list to repo slugs in one
+    # pass. `. as $root` exposes the top-level consumers table for
+    # the inner lookup. Output: `dest<TAB>repo,repo,...`. The yq
+    # `\t` is a literal tab in the format string.
     MANIFEST_TEMPLATED_DESTS_CACHE=$(yq -r '
-      .paths[] | select(.type == "templated") | (.dest // .path)
+      . as $root |
+      .paths[] | select(.type == "templated") |
+      [
+        (.dest // .path),
+        (.consumers // [] |
+          map(. as $name |
+            $root.consumers[] | select(.name == $name) | .repo) |
+          join(","))
+      ] | @tsv
     ' "$manifest" 2>/dev/null || true)
   else
     # awk fallback — mirrors the canonical-paths fallback above. Pair
     # `type:` and `dest:` (or fall back to `path:`) within a `paths:`
-    # block entry. Less precise than yq but enough for the no-yq case.
+    # block entry. Less precise than yq: the consumer-scope filter is
+    # SKIPPED because cross-referencing consumer names to repo slugs
+    # in awk is brittle. In the no-yq case we fall back to the
+    # pre-fix loose-match behavior (over-classify rather than
+    # under-classify); the rollup is advisory and over-classification
+    # is the more recoverable failure mode. Cache lines have empty
+    # consumer-list (tab + empty), interpreted as "match any repo".
     MANIFEST_TEMPLATED_DESTS_CACHE=$(awk '
       /^paths:/ { in_p = 1; next }
       in_p && /^[^[:space:]#]/ { in_p = 0 }
@@ -673,24 +700,43 @@ fetch_manifest_templated_dests() {
       }
       /^[[:space:]]*type:[[:space:]]*templated/ {
         cur_type = "templated"
-        print (cur_dest != "" ? cur_dest : cur_path)
+        printf "%s\t\n", (cur_dest != "" ? cur_dest : cur_path)
       }
     ' "$manifest")
   fi
 }
 
 # path_matches_templated_dest <file-path> → exit 0 if it matches a
-# templated entry's dest path, 1 otherwise. Used by derive_tag_class
-# to emit the `templated-render` class (#323).
+# templated entry's dest path AND the current repo ($REPO) is in that
+# entry's consumers list, 1 otherwise. Used by derive_tag_class to
+# emit the `templated-render` class (#323). The consumer-scope check
+# closes codex P2 from PR #329 round 1.
 path_matches_templated_dest() {
   local file_path="$1"
   [ -z "$file_path" ] && return 1
   [ "$file_path" = "(no path)" ] && return 1
   fetch_manifest_templated_dests
   [ -z "$MANIFEST_TEMPLATED_DESTS_CACHE" ] && return 1
-  while IFS= read -r d; do
-    [ -z "$d" ] && continue
-    [ "$file_path" = "$d" ] && return 0
+  local line dest consumers
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    # Split on the first tab. Two-field TSV: dest<TAB>repo1,repo2,...
+    dest="${line%%$'\t'*}"
+    consumers="${line#*$'\t'}"
+    [ "$file_path" = "$dest" ] || continue
+    # Empty consumers field (yq query returned no matches OR awk
+    # fallback emitted no scoping) — fall back to loose match. See
+    # awk fallback comment above for the trade-off.
+    if [ -z "$consumers" ]; then
+      return 0
+    fi
+    # The current repo ($REPO, populated from --repo arg or origin
+    # remote at module-load) MUST appear in the comma-separated
+    # consumers list. Anchored grep avoids partial-name false hits
+    # (e.g., `owner/matchline` vs `owner/matchline-app`).
+    if printf ',%s,' "$consumers" | grep -qF ",$REPO,"; then
+      return 0
+    fi
   done <<< "$MANIFEST_TEMPLATED_DESTS_CACHE"
   return 1
 }

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -634,6 +634,67 @@ path_matches_manifest() {
   return 1
 }
 
+# fetch_manifest_templated_dests — extract the dest paths of every
+# templated entry in the manifest (#323). Templated entries decouple
+# source from dest (the whole point), so a thread anchored on a
+# templated dest path doesn't match path_matches_manifest above (which
+# reads only .path). Cached.
+MANIFEST_TEMPLATED_DESTS_CACHE=""
+MANIFEST_TEMPLATED_FETCHED=false
+fetch_manifest_templated_dests() {
+  $MANIFEST_TEMPLATED_FETCHED && return 0
+  MANIFEST_TEMPLATED_FETCHED=true
+  local manifest="$REPO_ROOT_FOR_MANIFEST/.mergepath-sync.yml"
+  [ -f "$manifest" ] || return 0
+  if command -v yq >/dev/null 2>&1; then
+    MANIFEST_TEMPLATED_DESTS_CACHE=$(yq -r '
+      .paths[] | select(.type == "templated") | (.dest // .path)
+    ' "$manifest" 2>/dev/null || true)
+  else
+    # awk fallback — mirrors the canonical-paths fallback above. Pair
+    # `type:` and `dest:` (or fall back to `path:`) within a `paths:`
+    # block entry. Less precise than yq but enough for the no-yq case.
+    MANIFEST_TEMPLATED_DESTS_CACHE=$(awk '
+      /^paths:/ { in_p = 1; next }
+      in_p && /^[^[:space:]#]/ { in_p = 0 }
+      !in_p { next }
+      /^[[:space:]]*-[[:space:]]*path:/ {
+        cur_path = $0
+        sub(/^[[:space:]]*-[[:space:]]*path:[[:space:]]*/, "", cur_path)
+        sub(/[[:space:]]*#.*$/, "", cur_path)
+        gsub(/^[[:space:]]+|[[:space:]]+$|^"|"$/, "", cur_path)
+        cur_dest = ""; cur_type = ""
+      }
+      /^[[:space:]]*dest:/ {
+        cur_dest = $0
+        sub(/^[[:space:]]*dest:[[:space:]]*/, "", cur_dest)
+        sub(/[[:space:]]*#.*$/, "", cur_dest)
+        gsub(/^[[:space:]]+|[[:space:]]+$|^"|"$/, "", cur_dest)
+      }
+      /^[[:space:]]*type:[[:space:]]*templated/ {
+        cur_type = "templated"
+        print (cur_dest != "" ? cur_dest : cur_path)
+      }
+    ' "$manifest")
+  fi
+}
+
+# path_matches_templated_dest <file-path> → exit 0 if it matches a
+# templated entry's dest path, 1 otherwise. Used by derive_tag_class
+# to emit the `templated-render` class (#323).
+path_matches_templated_dest() {
+  local file_path="$1"
+  [ -z "$file_path" ] && return 1
+  [ "$file_path" = "(no path)" ] && return 1
+  fetch_manifest_templated_dests
+  [ -z "$MANIFEST_TEMPLATED_DESTS_CACHE" ] && return 1
+  while IFS= read -r d; do
+    [ -z "$d" ] && continue
+    [ "$file_path" = "$d" ] && return 0
+  done <<< "$MANIFEST_TEMPLATED_DESTS_CACHE"
+  return 1
+}
+
 # Module-load-time: pin the manifest base. We resolve REPO_ROOT_FOR_MANIFEST
 # from the script's on-disk location, NOT $REPO (which is the gh repo
 # slug). This intentionally reads the LOCAL working-tree manifest —
@@ -648,6 +709,15 @@ REPO_ROOT_FOR_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # Decision ladder (highest-confidence first; matches the
 # spec § Class taxonomy from issue #305):
 #   1. canonical-coverage     anchored path is in the manifest
+#   1b. templated-render      anchored path is a templated dest
+#                             (#323) — same "mergepath concern" class
+#                             as canonical-coverage but on the
+#                             templated surface; emitted only when the
+#                             path is NOT also matched by 1 (the dests
+#                             never appear as .path entries by
+#                             construction — source ≠ dest is the
+#                             point — so the two branches don't
+#                             overlap in practice).
 #   2. addressed-elsewhere    agent-author commit after createdAt
 #                             touching the anchored file
 #   3. rebuttal-recorded      ≥30-char agent-author reply on thread
@@ -672,6 +742,19 @@ derive_tag_class() {
   # 1. canonical-coverage
   if path_matches_manifest "$thread_path"; then
     echo "canonical-coverage"
+    return
+  fi
+
+  # 1b. templated-render (#323) — path matches a templated entry's
+  # dest. Same "mergepath concern" routing as canonical-coverage; the
+  # rendered output came from a template in mergepath, so the fix
+  # should land in mergepath too. We don't (and can't, from here)
+  # re-run verify-propagation-pr.sh to confirm the bytes match — but
+  # the path predicate alone is the right signal: if a thread is
+  # anchored on the templated dest, the durable fix is either in
+  # mergepath's template or in the consumer's facts:* block.
+  if path_matches_templated_dest "$thread_path"; then
+    echo "templated-render"
     return
   fi
 
@@ -796,6 +879,18 @@ synth_rationale() {
         echo "path $thread_path is propagated canonical content (.mergepath-sync.yml)."
       else
         echo "thread is on propagated canonical content (.mergepath-sync.yml)."
+      fi
+      ;;
+    templated-render)
+      # #323 — the dest is rendered from a mergepath template with
+      # consumer facts. verify-propagation-pr.sh re-renders and
+      # byte-compares as part of the propagation-lane gate; if a
+      # thread persists on a templated dest, the durable fix lives in
+      # mergepath's template or the consumer's facts:* block.
+      if [ -n "$thread_path" ] && [ "$thread_path" != "(no path)" ]; then
+        echo "$thread_path is a templated dest rendered from mergepath; fix belongs in the template or consumer facts."
+      else
+        echo "thread is on a templated dest rendered from mergepath; fix belongs in the template or consumer facts."
       fi
       ;;
     nitpick-noted)

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -674,18 +674,40 @@ fetch_manifest_templated_dests() {
   else
     # awk fallback — mirrors the canonical-paths fallback above. Pair
     # `type:` and `dest:` (or fall back to `path:`) within a `paths:`
-    # block entry. Less precise than yq: the consumer-scope filter is
-    # SKIPPED because cross-referencing consumer names to repo slugs
-    # in awk is brittle. In the no-yq case we fall back to the
-    # pre-fix loose-match behavior (over-classify rather than
-    # under-classify); the rollup is advisory and over-classification
-    # is the more recoverable failure mode. Cache lines have empty
-    # consumer-list (tab + empty), interpreted as "match any repo".
+    # block entry. Less precise than yq in two ways, both addressed
+    # below per CR Major #329 round 2:
+    #
+    # 1. Order-independent emission. The prior version emitted on the
+    #    `type: templated` line, which broke when `dest:` appeared
+    #    AFTER `type:` (legal YAML, common in manifest practice). Now
+    #    we emit at entry boundaries (start of next entry / end of
+    #    paths block / EOF) so `dest:` and `type:` can appear in any
+    #    order within an entry.
+    #
+    # 2. Strict no-match instead of loose-match. The prior version
+    #    emitted the dest with an empty consumers field, which
+    #    path_matches_templated_dest interpreted as "match any repo"
+    #    — reintroducing the exact cross-repo misclassification this
+    #    fix is trying to close. Now the awk path emits a sentinel
+    #    `__AWK_NO_CONSUMER_SCOPE__` token in the consumers field,
+    #    which path_matches_templated_dest treats as "no match" (the
+    #    cautious failure mode: under-classify rather than over-
+    #    classify; templated-render is a skip-class, and a missed
+    #    skip just falls back to the rollup's general heuristics).
     MANIFEST_TEMPLATED_DESTS_CACHE=$(awk '
+      function emit() {
+        if (cur_type == "templated") {
+          out = (cur_dest != "" ? cur_dest : cur_path)
+          if (out != "") {
+            printf "%s\t__AWK_NO_CONSUMER_SCOPE__\n", out
+          }
+        }
+      }
       /^paths:/ { in_p = 1; next }
-      in_p && /^[^[:space:]#]/ { in_p = 0 }
+      in_p && /^[^[:space:]#]/ { emit(); in_p = 0 }
       !in_p { next }
       /^[[:space:]]*-[[:space:]]*path:/ {
+        emit()
         cur_path = $0
         sub(/^[[:space:]]*-[[:space:]]*path:[[:space:]]*/, "", cur_path)
         sub(/[[:space:]]*#.*$/, "", cur_path)
@@ -700,8 +722,8 @@ fetch_manifest_templated_dests() {
       }
       /^[[:space:]]*type:[[:space:]]*templated/ {
         cur_type = "templated"
-        printf "%s\t\n", (cur_dest != "" ? cur_dest : cur_path)
       }
+      END { emit() }
     ' "$manifest")
   fi
 }
@@ -724,11 +746,22 @@ path_matches_templated_dest() {
     dest="${line%%$'\t'*}"
     consumers="${line#*$'\t'}"
     [ "$file_path" = "$dest" ] || continue
-    # Empty consumers field (yq query returned no matches OR awk
-    # fallback emitted no scoping) — fall back to loose match. See
-    # awk fallback comment above for the trade-off.
+    # The awk fallback emits this sentinel when it can't resolve
+    # consumer-name → repo-slug (cross-references in awk are
+    # brittle). Treat sentinel as "no scope information available"
+    # and DO NOT match — better to miss the templated-render skip
+    # tag (falling through to other heuristics in the rollup) than
+    # to over-classify and silently suppress substantive feedback
+    # on unrelated files. (CR Major #329 round 2.)
+    if [ "$consumers" = "__AWK_NO_CONSUMER_SCOPE__" ]; then
+      continue
+    fi
+    # Empty consumers field — yq returned no consumer matches for
+    # this entry (entry has no `consumers:` list, or none of the
+    # named consumers resolve to a repo). Treat as no-scope
+    # information, same as the awk sentinel: don't match.
     if [ -z "$consumers" ]; then
-      return 0
+      continue
     fi
     # The current repo ($REPO, populated from --repo arg or origin
     # remote at module-load) MUST appear in the comma-separated

--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -555,52 +555,17 @@ materialize_templated_targets() {
   done
 }
 
-# Export a consumer's facts:* from the manifest as MERGEPATH_FACT_*
-# env vars in the current (sub)shell. Unsets any prior
-# MERGEPATH_FACT_* exports first so successive callers don't see
-# stale facts from a different consumer. List-valued facts (yaml
-# `[a, b]`) are serialized as space-separated, matching the lib's
-# `<key> contains <value>` expectations.
+# export_consumer_facts lives in scripts/lib/manifest-fact-helpers.sh
+# so both this script AND scripts/workflow/verify-propagation-pr.sh
+# can load consumer facts from a manifest without duplicating the yq
+# filter. The lib has no top-level side effects (function defs only),
+# so sourcing it is cheap and safe.
 #
-# Uses the `env(VAR)` mikefarah/yq form for consumer-name injection
-# (the `--arg` jq-compat flag works too but env-var is the
-# documented mikefarah idiom).
-export_consumer_facts() {
-  local consumer_name=$1
-  local manifest=$2
-
-  # Clean slate — prior consumer's facts must not leak in.
-  local var
-  for var in $(env | awk -F= '/^MERGEPATH_FACT_/ {print $1}'); do
-    unset "$var"
-  done
-
-  while IFS=$'\t' read -r key value; do
-    [ -z "$key" ] && continue
-    local upper
-    upper=$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-    export "MERGEPATH_FACT_$upper=$value"
-  done < <(MERGEPATH_CONSUMER_NAME="$consumer_name" yq -r '
-    env(MERGEPATH_CONSUMER_NAME) as $cn
-    | .consumers[] | select(.name == $cn) | .facts // {} | to_entries[]
-    | .key + "\t"
-      + ((.value | select(tag == "!!seq") | join(" "))
-         // (.value | tostring))
-  ' "$manifest")
-  # NOTE on the value-typed serialization: mikefarah/yq v4 does NOT
-  # accept `if (tag == "!!X") then ... else ... end` in this filter
-  # position (the lexer rejects `if` at column-after-pipe). The
-  # earlier draft of this query used that form, which silently
-  # produced empty output for every fact, which caused
-  # MERGEPATH_FACT_* to never get exported, which made every templated
-  # render fall through to the "no frameworks" baseline. swipewatch
-  # was the only consumer that didn't notice (its declared frameworks
-  # are []), so the swipewatch canary in Phase D fell-positive on
-  # the bug. The select+// fallback above is the documented
-  # mikefarah idiom for branching on a value's YAML tag.
-  #
-  # Regression-guarded by tests/test_export_consumer_facts.sh.
-}
+# Regression-guarded by tests/test_export_consumer_facts.sh, which
+# greps the documented mikefarah-idiom yq filter directly out of
+# the lib file (the test was updated alongside #323).
+# shellcheck disable=SC1091
+source "$MERGEPATH_ROOT/scripts/lib/manifest-fact-helpers.sh"
 
 # Compare a kit directory: every file under Mergepath's path must
 # exist (byte-identical) in the consumer; consumer-only files are

--- a/scripts/workflow/verify-propagation-pr.sh
+++ b/scripts/workflow/verify-propagation-pr.sh
@@ -294,8 +294,8 @@ if [ "$TEMPLATED_SURFACE_ACTIVE" = "1" ] && [ -n "$CONSUMER_NAME" ]; then
 
       # Render in a subshell so the facts export + lib sourcing don't
       # leak between iterations.
-      rendered=$(mktemp -t "verify-prop-rendered.XXXXXX")
-      render_err=$(mktemp -t "verify-prop-render-err.XXXXXX")
+      rendered=$(mktemp "${TMPDIR:-/tmp}/verify-prop-rendered.XXXXXX")
+      render_err=$(mktemp "${TMPDIR:-/tmp}/verify-prop-render-err.XXXXXX")
       render_rc=0
       (
         export_consumer_facts "$CONSUMER_NAME" "$MANIFEST"
@@ -317,7 +317,7 @@ if [ "$TEMPLATED_SURFACE_ACTIVE" = "1" ] && [ -n "$CONSUMER_NAME" ]; then
       rm -f "$render_err"
 
       # Pull the PR's dest content at HEAD via `git show`.
-      pr_content=$(mktemp -t "verify-prop-pr.XXXXXX")
+      pr_content=$(mktemp "${TMPDIR:-/tmp}/verify-prop-pr.XXXXXX")
       if ! git -C "$CONSUMER_DIR" show "${HEAD_SHA}:${tpl_dest}" > "$pr_content" 2>/dev/null; then
         fail_templated_error "$tpl_dest — templated dest not present at PR HEAD (consumer=$CONSUMER_NAME)"
         rm -f "$rendered" "$pr_content"

--- a/scripts/workflow/verify-propagation-pr.sh
+++ b/scripts/workflow/verify-propagation-pr.sh
@@ -325,6 +325,23 @@ if [ "$TEMPLATED_SURFACE_ACTIVE" = "1" ] && [ -n "$CONSUMER_NAME" ]; then
       fi
 
       if diff -q "$rendered" "$pr_content" >/dev/null 2>&1; then
+        # Byte-compare cleared. Now check the tree entry's mode + type
+        # match the expected `100644 blob` shape — otherwise metadata-
+        # only tampering (chmod +x flip, regular-file ↔ symlink swap)
+        # passes lane verification while changing the consumer's
+        # on-disk file behavior. Codex P1 #329 round 2 caught this:
+        # the templated arm was byte-only while the canonical loop's
+        # tree-entry compare (mode + type + oid via `git ls-tree`)
+        # was being skipped via the VERIFIED_TEMPLATED_DESTS exempt.
+        tpl_consumer_entry=$(git -C "$CONSUMER_DIR" ls-tree "$HEAD_SHA" -- "$tpl_dest" 2>/dev/null | awk '{print $1, $2}')
+        if [ "$tpl_consumer_entry" != "100644 blob" ]; then
+          {
+            echo "verify-propagation-pr.sh: templated dest $tpl_dest has unexpected tree entry [$tpl_consumer_entry], expected [100644 blob] (mode/type tampering — chmod +x flip or symlink swap, not a faithful render)"
+          } >&2
+          fail_templated_drift "$tpl_dest — templated dest tree entry [$tpl_consumer_entry] differs from expected [100644 blob] (source=$tpl_source, consumer=$CONSUMER_NAME)"
+          rm -f "$rendered" "$pr_content"
+          continue
+        fi
         echo "verify-propagation-pr.sh: templated re-render matches PR content for $tpl_dest (consumer=$CONSUMER_NAME, source=$tpl_source)"
         # Emit structured tag-reply line for the calling workflow.
         # Format MUST stay parseable; see CLAUDE.md § resolve-pr-threads

--- a/scripts/workflow/verify-propagation-pr.sh
+++ b/scripts/workflow/verify-propagation-pr.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # verify-propagation-pr.sh — authoritative faithful-mirror check for
 # the propagation-PR review lane (REVIEW_POLICY.md § Propagation PR
-# review lane, mergepath#264 / #268).
+# review lane, mergepath#264 / #268 / #323).
 #
 # The lane exempts a sync PR from Phase 4 external review. That is
 # only safe if the PR is PROVABLY a verbatim mirror of mergepath's
@@ -17,6 +17,36 @@ set -euo pipefail
 # mergepath checkout (the immutable, public commit the PR's branch
 # name points at) — never from the PR's own checkout, which the PR
 # could have tampered with.
+#
+# Two verification surfaces:
+#
+#   A. Canonical / kit entries — byte-for-byte equality against
+#      mergepath@<sha>. Implemented as a `git ls-tree` mode+oid
+#      compare so an exec-bit flip is also caught.
+#
+#   B. Templated entries (#323) — render the source template at
+#      mergepath@<sha> with the consumer's facts (loaded from the
+#      mergepath-side manifest via export_consumer_facts) and
+#      byte-compare the rendered output against the PR's dest
+#      content. Drift, template syntax errors, and missing facts in
+#      strict mode all fail the verification with a typed
+#      diagnostic. On pass, a structured line of the form
+#      "[mergepath-verify: templated-render] <dest> <consumer> <source>"
+#      is emitted on stdout so a calling workflow can post it as a
+#      thread tag-reply. This script intentionally stays read-only —
+#      it does NOT post to GitHub.
+#
+# Consumer inference (templated surface only):
+#   1. $MERGEPATH_CONSUMER env override (test/CI escape hatch).
+#   2. consumer_dir's `origin` remote URL → matched against the
+#      manifest's .consumers[].repo field.
+#   3. If neither resolves, the templated surface is SKIPPED with a
+#      stderr note (the canonical/kit surface still runs). This is
+#      conservative: a templated entry whose consumer can't be
+#      identified is just left to the existing path-confinement
+#      check, which will fail because the templated dest doesn't
+#      equal the templated .path — the PR then routes to normal
+#      Phase 4 review, same as the pre-#323 status quo.
 #
 # Usage:
 #   verify-propagation-pr.sh <mergepath_dir> <consumer_dir> <base_sha> <head_sha>
@@ -34,11 +64,12 @@ set -euo pipefail
 # Exit codes:
 #   0  faithful mirror — every changed file is under a manifest path
 #      AND its end-state byte-matches mergepath@<sha> (both-present-
-#      equal, or both-absent). The PR is lane-eligible.
+#      equal, or both-absent), with templated dests matching their
+#      re-rendered output. The PR is lane-eligible.
 #   1  NOT a faithful mirror — at least one changed file is off-
-#      manifest or deviates from mergepath@<sha>. The PR must go
-#      through normal Phase 3/4 review. Deviations are listed on
-#      stderr.
+#      manifest, deviates from mergepath@<sha>, or its templated
+#      re-render diverges. The PR must go through normal Phase 3/4
+#      review. Deviations are listed on stderr.
 #   2  usage / environment error (bad args, missing manifest, etc.).
 #
 # Bash 3.2 portable: no `mapfile`, no associative arrays.
@@ -89,11 +120,241 @@ if [ -z "$CHANGED_FILES" ]; then
   exit 1
 fi
 
+# Failure aggregation. Three typed categories so the summary at exit
+# can distinguish the failure mode for diagnostics:
+#   CANONICAL_FAILURES  — off-manifest / mode-or-blob drift on
+#                         canonical or kit entries.
+#   TEMPLATED_FAILURES  — re-rendered output diverges from PR dest
+#                         content.
+#   TEMPLATED_ERRORS    — render itself failed (malformed template,
+#                         strict-mode unset fact, source missing
+#                         from mergepath@<sha>).
 FAILURES=""
-fail() { FAILURES="${FAILURES}  - $1"$'\n'; }
+CANONICAL_FAILURES=""
+TEMPLATED_FAILURES=""
+TEMPLATED_ERRORS=""
+fail() { FAILURES="${FAILURES}  - $1"$'\n'; CANONICAL_FAILURES="${CANONICAL_FAILURES}  - $1"$'\n'; }
+fail_templated_drift() { FAILURES="${FAILURES}  - $1"$'\n'; TEMPLATED_FAILURES="${TEMPLATED_FAILURES}  - $1"$'\n'; }
+fail_templated_error() { FAILURES="${FAILURES}  - $1"$'\n'; TEMPLATED_ERRORS="${TEMPLATED_ERRORS}  - $1"$'\n'; }
+
+# -------------------------------------------------------------------
+# Templated surface (#323) — handled BEFORE the canonical loop so
+# verified templated dests are exempted from the path-confinement
+# check (the dest doesn't equal any .path and would otherwise fail).
+# -------------------------------------------------------------------
+
+# VERIFIED_TEMPLATED_DESTS — list (newline-separated, sentinel-padded)
+# of consumer-side dest paths whose re-render matched. Checked in the
+# canonical loop below so we don't double-fail-them as off-manifest.
+VERIFIED_TEMPLATED_DESTS=""
+
+# infer_consumer_from_pr_context — determine which consumer this PR
+# belongs to, for templated render. Strategies, in order:
+#   1. $MERGEPATH_CONSUMER env override (test/CI escape hatch).
+#   2. consumer_dir's `origin` remote URL → matched against the
+#      manifest's .consumers[].repo field.
+# Echoes the consumer name on success (sets RC=0), empty on failure
+# (RC=1). The caller treats RC=1 as "skip templated verification" —
+# canonical/kit verification still runs.
+infer_consumer_from_pr_context() {
+  if [ -n "${MERGEPATH_CONSUMER:-}" ]; then
+    printf '%s' "$MERGEPATH_CONSUMER"
+    return 0
+  fi
+  # Read origin URL. `git remote get-url origin` is the modern form;
+  # older gits used `git config remote.origin.url` — both work here.
+  local remote_url
+  remote_url=$(git -C "$CONSUMER_DIR" remote get-url origin 2>/dev/null || \
+               git -C "$CONSUMER_DIR" config remote.origin.url 2>/dev/null || \
+               printf '')
+  [ -z "$remote_url" ] && return 1
+  # Normalize the URL to an "owner/repo" slug so we can string-match
+  # against the manifest's .consumers[].repo field. Handles:
+  #   https://github.com/owner/repo.git → owner/repo
+  #   git@github.com:owner/repo.git     → owner/repo
+  #   ssh://git@github.com/owner/repo   → owner/repo
+  local slug
+  # Strip scheme + host (https://, git@host:, ssh://git@host/).
+  slug=$(printf '%s' "$remote_url" | sed -E '
+    s|^https?://[^/]+/||
+    s|^ssh://git@[^/]+/||
+    s|^git@[^:]+:||
+    s|\.git$||
+  ')
+  # Lookup in the manifest. We don't have yq guaranteed at this
+  # surface (the canonical loop above uses an awk parser), so fall
+  # back to a simple awk-based lookup over the consumers block.
+  if command -v yq >/dev/null 2>&1; then
+    local name
+    name=$(yq -r ".consumers[] | select(.repo == \"$slug\") | .name" "$MANIFEST" 2>/dev/null | head -n1)
+    if [ -n "$name" ]; then
+      printf '%s' "$name"
+      return 0
+    fi
+  fi
+  # awk fallback — pairs `- name:` and `repo:` inside the
+  # `consumers:` block, prints the name when repo matches.
+  local name
+  name=$(awk -v target="$slug" '
+    /^consumers:/ { in_c = 1; next }
+    in_c && /^[^[:space:]#]/ { in_c = 0 }
+    !in_c { next }
+    /^[[:space:]]*-[[:space:]]*name:/ {
+      cur_name = $0
+      sub(/^[[:space:]]*-[[:space:]]*name:[[:space:]]*/, "", cur_name)
+      sub(/[[:space:]]*#.*$/, "", cur_name)
+      gsub(/^[[:space:]]+|[[:space:]]+$|^"|"$/, "", cur_name)
+    }
+    /^[[:space:]]*repo:/ {
+      cur_repo = $0
+      sub(/^[[:space:]]*repo:[[:space:]]*/, "", cur_repo)
+      sub(/[[:space:]]*#.*$/, "", cur_repo)
+      gsub(/^[[:space:]]+|[[:space:]]+$|^"|"$/, "", cur_repo)
+      if (cur_repo == target) { print cur_name; exit }
+    }
+  ' "$MANIFEST")
+  if [ -n "$name" ]; then
+    printf '%s' "$name"
+    return 0
+  fi
+  return 1
+}
+
+# Source the template lib and facts helper from the TRUSTED mergepath
+# checkout. Same provenance rule as the parser helpers above — never
+# from the PR's working tree.
+TEMPLATE_LIB="$MERGEPATH_DIR/scripts/lib/template-substitution.sh"
+FACTS_HELPER="$MERGEPATH_DIR/scripts/lib/manifest-fact-helpers.sh"
+
+# Only attempt the templated surface if both trusted helpers are
+# present in mergepath@<sha>. Missing helpers → fall through to the
+# canonical loop (which will fail-closed on the templated dest path).
+TEMPLATED_SURFACE_ACTIVE=0
+if [ -f "$TEMPLATE_LIB" ] && [ -f "$FACTS_HELPER" ] && command -v yq >/dev/null 2>&1; then
+  TEMPLATED_SURFACE_ACTIVE=1
+fi
+
+if [ "$TEMPLATED_SURFACE_ACTIVE" = "1" ]; then
+  # Resolve consumer. RC=1 → skip templated surface with a log line.
+  CONSUMER_NAME=""
+  if CONSUMER_NAME=$(infer_consumer_from_pr_context) && [ -n "$CONSUMER_NAME" ]; then
+    :
+  else
+    echo "verify-propagation-pr.sh: cannot infer consumer from PR context (no MERGEPATH_CONSUMER env, no origin remote match in manifest) — skipping templated re-render surface" >&2
+    CONSUMER_NAME=""
+  fi
+fi
+
+if [ "$TEMPLATED_SURFACE_ACTIVE" = "1" ] && [ -n "$CONSUMER_NAME" ]; then
+  # shellcheck disable=SC1090
+  source "$FACTS_HELPER"
+  # shellcheck disable=SC1090
+  source "$TEMPLATE_LIB"
+
+  # Pull templated entries (source, dest, consumers) as TSV.
+  TEMPLATED_TSV=$(yq -r '
+    .paths[]
+    | select(.type == "templated")
+    | [(.source // .path), (.dest // .path), ((.consumers // [] | type == "!!str") | tostring), (.consumers // [] | (select(type == "!!str") // (join(","))) | tostring)]
+    | @tsv
+  ' "$MANIFEST" 2>/dev/null || printf '')
+
+  if [ -n "$TEMPLATED_TSV" ]; then
+    while IFS=$'\t' read -r tpl_source tpl_dest is_str_consumers consumers_csv; do
+      [ -z "$tpl_source" ] && continue
+      [ -z "$tpl_dest" ] && continue
+      # consumers field can be the literal "all" or a CSV of names.
+      # is_str_consumers is "true" when the manifest used a scalar
+      # `consumers: all`, else "false" (i.e. it was a sequence).
+      consumer_matches=0
+      if [ "$is_str_consumers" = "true" ] && [ "$consumers_csv" = "all" ]; then
+        consumer_matches=1
+      elif [ "$is_str_consumers" = "false" ]; then
+        case ",$consumers_csv," in
+          *",$CONSUMER_NAME,"*) consumer_matches=1 ;;
+        esac
+      fi
+      [ "$consumer_matches" -eq 0 ] && continue
+
+      # Templated dest must actually be in the PR's changed files —
+      # otherwise there's nothing to verify for this entry.
+      dest_in_diff=0
+      while IFS= read -r cf; do
+        [ -z "$cf" ] && continue
+        if [ "$cf" = "$tpl_dest" ]; then dest_in_diff=1; break; fi
+      done <<< "$CHANGED_FILES"
+      [ "$dest_in_diff" -eq 0 ] && continue
+
+      # Source must exist in the trusted mergepath checkout.
+      mp_source_abs="$MERGEPATH_DIR/$tpl_source"
+      if [ ! -f "$mp_source_abs" ]; then
+        fail_templated_error "$tpl_dest — templated source '$tpl_source' missing from mergepath@<sha> (consumer=$CONSUMER_NAME)"
+        continue
+      fi
+
+      # Render in a subshell so the facts export + lib sourcing don't
+      # leak between iterations.
+      rendered=$(mktemp -t "verify-prop-rendered.XXXXXX")
+      render_err=$(mktemp -t "verify-prop-render-err.XXXXXX")
+      render_rc=0
+      (
+        export_consumer_facts "$CONSUMER_NAME" "$MANIFEST"
+        template_substitution::render "$mp_source_abs"
+      ) > "$rendered" 2> "$render_err" || render_rc=$?
+
+      if [ "$render_rc" != "0" ]; then
+        # Surface the renderer's stderr for diagnostics, then fail.
+        if [ -s "$render_err" ]; then
+          {
+            echo "verify-propagation-pr.sh: template render error for $tpl_source (consumer=$CONSUMER_NAME, rc=$render_rc):"
+            sed 's/^/    /' "$render_err"
+          } >&2
+        fi
+        fail_templated_error "$tpl_dest — templated render failed (source=$tpl_source, consumer=$CONSUMER_NAME, rc=$render_rc)"
+        rm -f "$rendered" "$render_err"
+        continue
+      fi
+      rm -f "$render_err"
+
+      # Pull the PR's dest content at HEAD via `git show`.
+      pr_content=$(mktemp -t "verify-prop-pr.XXXXXX")
+      if ! git -C "$CONSUMER_DIR" show "${HEAD_SHA}:${tpl_dest}" > "$pr_content" 2>/dev/null; then
+        fail_templated_error "$tpl_dest — templated dest not present at PR HEAD (consumer=$CONSUMER_NAME)"
+        rm -f "$rendered" "$pr_content"
+        continue
+      fi
+
+      if diff -q "$rendered" "$pr_content" >/dev/null 2>&1; then
+        echo "verify-propagation-pr.sh: templated re-render matches PR content for $tpl_dest (consumer=$CONSUMER_NAME, source=$tpl_source)"
+        # Emit structured tag-reply line for the calling workflow.
+        # Format MUST stay parseable; see CLAUDE.md § resolve-pr-threads
+        # tag class and #323 for the consumer of these lines.
+        printf '[mergepath-verify: templated-render] %s %s %s\n' "$tpl_dest" "$CONSUMER_NAME" "$tpl_source"
+        VERIFIED_TEMPLATED_DESTS="${VERIFIED_TEMPLATED_DESTS}${tpl_dest}"$'\n'
+      else
+        {
+          echo "verify-propagation-pr.sh: templated re-render diverges from PR content for $tpl_dest (consumer=$CONSUMER_NAME, source=$tpl_source). Diff (expected → PR):"
+          diff "$rendered" "$pr_content" | sed 's/^/    /' || true
+        } >&2
+        fail_templated_drift "$tpl_dest — templated re-render diverges from PR content (source=$tpl_source, consumer=$CONSUMER_NAME)"
+      fi
+      rm -f "$rendered" "$pr_content"
+    done <<< "$TEMPLATED_TSV"
+  fi
+fi
 
 while IFS= read -r f; do
   [ -z "$f" ] && continue
+
+  # #323: skip files already verified by the templated re-render
+  # surface above. Their dest path doesn't match any .path glob
+  # (which is the whole point of source ≠ dest), so the canonical
+  # path-confinement check below would false-fail them.
+  if [ -n "$VERIFIED_TEMPLATED_DESTS" ]; then
+    case $'\n'"$VERIFIED_TEMPLATED_DESTS" in
+      *$'\n'"$f"$'\n'*) continue ;;
+    esac
+  fi
 
   # 1. Path confinement: f must be under a manifest-declared path.
   if ! printf '%s\n' "$f" | bash "$MATCH_PATHS" "${MAN_PATTERNS[@]}" | grep -qxF "$f"; then
@@ -155,7 +416,22 @@ done <<< "$CHANGED_FILES"
 
 if [ -n "$FAILURES" ]; then
   echo "verify-propagation-pr.sh: NOT a faithful mirror — the PR is not lane-eligible:" >&2
-  printf '%s' "$FAILURES" >&2
+  # Typed sub-summaries so the reader can tell at a glance whether a
+  # failure is canonical-mismatch, templated-drift, or templated-error
+  # (#323). Categories are mutually exclusive — a given failure lands
+  # in exactly one bucket.
+  if [ -n "$CANONICAL_FAILURES" ]; then
+    echo "  Canonical / kit drift (path confinement + tree-entry compare):" >&2
+    printf '%s' "$CANONICAL_FAILURES" >&2
+  fi
+  if [ -n "$TEMPLATED_FAILURES" ]; then
+    echo "  Templated re-render mismatch (rendered output differs from PR dest):" >&2
+    printf '%s' "$TEMPLATED_FAILURES" >&2
+  fi
+  if [ -n "$TEMPLATED_ERRORS" ]; then
+    echo "  Templated re-render error (malformed template / missing source / strict-mode unset fact):" >&2
+    printf '%s' "$TEMPLATED_ERRORS" >&2
+  fi
   echo "  → this PR must go through normal Phase 3/4 review." >&2
   exit 1
 fi

--- a/tests/test_export_consumer_facts.sh
+++ b/tests/test_export_consumer_facts.sh
@@ -27,8 +27,16 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$ROOT/scripts/sync-to-downstream.sh"
+# The yq filter moved to scripts/lib/manifest-fact-helpers.sh in
+# mergepath#323 so both sync-to-downstream.sh and
+# scripts/workflow/verify-propagation-pr.sh can load consumer facts
+# from a shared helper without duplicating the filter. The regression-
+# guard greps the lib file now; we still confirm sync-to-downstream.sh
+# sources the lib so the wiring can't silently drift.
+LIB="$ROOT/scripts/lib/manifest-fact-helpers.sh"
 
 [[ -r "$SCRIPT" ]] || { echo "missing $SCRIPT" >&2; exit 1; }
+[[ -r "$LIB" ]] || { echo "missing $LIB" >&2; exit 1; }
 command -v yq >/dev/null 2>&1 || { echo "SKIP: yq not available" >&2; exit 0; }
 
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/export-facts-test.XXXXXX")"
@@ -117,23 +125,34 @@ else
   fail "Case 4: expected empty output, got:\n$out"
 fi
 
-# Case 5: the lib script's source MUST contain the documented
-# select-fallback idiom. If a future contributor reverts to the
-# `if then else end` form (which mikefarah/yq rejects), this
-# assertion catches it before the broken syntax ships.
-if grep -q 'select(tag == "!!seq") | join(" ")' "$SCRIPT"; then
-  pass "Case 5: lib script uses the select+// idiom (not the broken if/then/else form)"
+# Case 5: the lib MUST contain the documented select-fallback idiom.
+# If a future contributor reverts to the `if then else end` form
+# (which mikefarah/yq rejects), this assertion catches it before the
+# broken syntax ships. The filter moved to manifest-fact-helpers.sh
+# in #323; grep the lib, not the sync script.
+if grep -q 'select(tag == "!!seq") | join(" ")' "$LIB"; then
+  pass "Case 5: lib helper uses the select+// idiom (not the broken if/then/else form)"
 else
-  fail "Case 5: scripts/sync-to-downstream.sh no longer uses the select+// idiom — this regression-guard expects 'select(tag == \"!!seq\") | join(\" \")' in the script"
+  fail "Case 5: scripts/lib/manifest-fact-helpers.sh no longer uses the select+// idiom — this regression-guard expects 'select(tag == \"!!seq\") | join(\" \")' in the helper"
 fi
 
-# Case 6: explicit no-regression check — the script must NOT contain
+# Case 6: explicit no-regression check — the lib must NOT contain
 # the broken form `if (tag == "!!seq") then`. This is the literal
 # substring that caused the bug.
-if ! grep -qF 'if (tag == "!!seq") then' "$SCRIPT"; then
-  pass "Case 6: lib script does not contain the broken yq if/then/else form"
+if ! grep -qF 'if (tag == "!!seq") then' "$LIB"; then
+  pass "Case 6: lib helper does not contain the broken yq if/then/else form"
 else
-  fail "Case 6: lib script contains the broken 'if (tag == \"!!seq\") then ... else ... end' form — mikefarah/yq rejects this at the lexer"
+  fail "Case 6: lib helper contains the broken 'if (tag == \"!!seq\") then ... else ... end' form — mikefarah/yq rejects this at the lexer"
+fi
+
+# Case 7 (#323): sync-to-downstream.sh MUST source the lib so the
+# wiring is not silently lost in a future refactor. A missing source
+# would re-introduce the duplication this extraction was meant to
+# eliminate.
+if grep -q 'source "$MERGEPATH_ROOT/scripts/lib/manifest-fact-helpers.sh"' "$SCRIPT"; then
+  pass "Case 7: sync-to-downstream.sh sources the manifest-fact-helpers lib"
+else
+  fail "Case 7: sync-to-downstream.sh no longer sources scripts/lib/manifest-fact-helpers.sh — wiring lost"
 fi
 
 echo

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -33,19 +33,20 @@ trap 'rm -rf "$WORKDIR"' EXIT
 # Fixture: a minimal "mergepath" with two canonical files and one kit dir
 # ---------------------------------------------------------------------------
 MP="$WORKDIR/mergepath"
-mkdir -p "$MP/scripts/hooks" "$MP/scripts/ci" "$MP/scripts/sync" "$MP/.github/workflows"
+mkdir -p "$MP/scripts/hooks" "$MP/scripts/ci" "$MP/scripts/sync" "$MP/scripts/lib" "$MP/.github/workflows"
 echo "canonical-script-v1" >"$MP/scripts/keep-in-sync.sh"
 echo "canonical-hook-v1"   >"$MP/scripts/hooks/the-hook.sh"
 echo "kit-file-1" >"$MP/scripts/ci/check_one"
 echo "kit-file-2" >"$MP/scripts/ci/check_two"
 
-# sync-to-downstream.sh sources scripts/sync/apply-overrides.sh from
-# its MERGEPATH_ROOT at startup (#199 integration). Mirror the real
-# library into the synthetic fixture so the source line resolves
-# instead of failing with "No such file or directory" — that
-# regression would surface as the audit block tests above failing
-# their existence check on the consumer-header line.
+# sync-to-downstream.sh sources scripts/sync/apply-overrides.sh AND
+# scripts/lib/manifest-fact-helpers.sh from its MERGEPATH_ROOT at
+# startup (#199 / #323). Mirror both libs into the synthetic fixture
+# so the source lines resolve instead of failing with "No such file
+# or directory" — that regression would surface as the audit block
+# tests above failing their existence check on the consumer-header line.
 cp "$ROOT/scripts/sync/apply-overrides.sh" "$MP/scripts/sync/apply-overrides.sh"
+cp "$ROOT/scripts/lib/manifest-fact-helpers.sh" "$MP/scripts/lib/manifest-fact-helpers.sh"
 
 cat >"$MP/.mergepath-sync.yml" <<'EOF'
 version: 1
@@ -241,8 +242,9 @@ echo "$hostile_output" | grep -qE "it is a symbolic link|resolves outside MERGEP
 # ---------------------------------------------------------------------------
 sync_workdir="$WORKDIR/sync"
 SYNC_MP="$sync_workdir/mergepath"
-mkdir -p "$SYNC_MP/scripts/hooks" "$SYNC_MP/scripts/ci" "$SYNC_MP/scripts/sync" "$SYNC_MP/.github"
+mkdir -p "$SYNC_MP/scripts/hooks" "$SYNC_MP/scripts/ci" "$SYNC_MP/scripts/sync" "$SYNC_MP/scripts/lib" "$SYNC_MP/.github"
 cp "$ROOT/scripts/sync/apply-overrides.sh" "$SYNC_MP/scripts/sync/apply-overrides.sh"
+cp "$ROOT/scripts/lib/manifest-fact-helpers.sh" "$SYNC_MP/scripts/lib/manifest-fact-helpers.sh"
 cat >"$SYNC_MP/.mergepath-sync.yml" <<'YAML'
 version: 1
 consumers:
@@ -351,8 +353,9 @@ set -e
 # ---------------------------------------------------------------------------
 guard_workdir="$WORKDIR/guard"
 GUARD_MP="$guard_workdir/mergepath"
-mkdir -p "$GUARD_MP/scripts" "$GUARD_MP/scripts/sync" "$GUARD_MP/.github"
+mkdir -p "$GUARD_MP/scripts" "$GUARD_MP/scripts/sync" "$GUARD_MP/scripts/lib" "$GUARD_MP/.github"
 cp "$ROOT/scripts/sync/apply-overrides.sh" "$GUARD_MP/scripts/sync/apply-overrides.sh"
+cp "$ROOT/scripts/lib/manifest-fact-helpers.sh" "$GUARD_MP/scripts/lib/manifest-fact-helpers.sh"
 cat >"$GUARD_MP/.mergepath-sync.yml" <<'YAML'
 version: 1
 consumers:
@@ -637,8 +640,9 @@ grep -q 'trap .rm -rf "\$workspace". RETURN' "$SCRIPT" \
 syncall_workdir="$WORKDIR/syncall"
 SA_MP="$syncall_workdir/mergepath"
 SA_SIBLINGS="$syncall_workdir/siblings"
-mkdir -p "$SA_MP/scripts/hooks" "$SA_MP/scripts/ci" "$SA_MP/scripts/sync" "$SA_MP/.github"
+mkdir -p "$SA_MP/scripts/hooks" "$SA_MP/scripts/ci" "$SA_MP/scripts/sync" "$SA_MP/scripts/lib" "$SA_MP/.github"
 cp "$ROOT/scripts/sync/apply-overrides.sh" "$SA_MP/scripts/sync/apply-overrides.sh"
+cp "$ROOT/scripts/lib/manifest-fact-helpers.sh" "$SA_MP/scripts/lib/manifest-fact-helpers.sh"
 cat >"$SA_MP/.mergepath-sync.yml" <<'YAML'
 version: 1
 consumers:

--- a/tests/test_verify_propagation_pr_templated.sh
+++ b/tests/test_verify_propagation_pr_templated.sh
@@ -232,6 +232,49 @@ else
   pass "Case 4: strict-mode unset fact → exit 1, render-failure diagnostic"
 fi
 
+# ---------------------------------------------------------------------------
+# Case 5 — mode tampering (chmod +x): PR dest matches rendered bytes but
+# has tree entry mode 100755 instead of 100644. Without the tree-entry
+# check (codex P1 #329 round 2), the byte-only verifier let metadata
+# tampering pass; the new check should reject it.
+# ---------------------------------------------------------------------------
+TEMPLATE5='greeting={{name}}, frameworks={{frameworks}}
+'
+MP5="$WORKDIR/mp5"; build_mergepath "$MP5" "$TEMPLATE5" "react"
+C5="$WORKDIR/c5"
+RENDERED5='greeting=, frameworks=react
+'
+mkdir -p "$C5"
+git_quiet -C "$C5" init -q
+printf 'app code\n' >"$C5/app.ts"
+git_quiet -C "$C5" add -A
+git_quiet -C "$C5" commit -q -m base
+BASE_SHA=$(git -C "$C5" rev-parse HEAD)
+printf '%s' "$RENDERED5" >"$C5/rendered.txt"
+chmod +x "$C5/rendered.txt"
+git_quiet -C "$C5" add -A
+git_quiet -C "$C5" commit -q -m head
+HEAD_SHA=$(git -C "$C5" rev-parse HEAD)
+# Confirm fixture set the executable bit correctly before invoking
+# the verifier — `git update-index --chmod=+x` would also work but
+# `chmod +x` + `add -A` is the path most agents would use.
+fixture_entry=$(git -C "$C5" ls-tree HEAD -- rendered.txt | awk '{print $1, $2}')
+if [ "$fixture_entry" != "100755 blob" ]; then
+  fail "Case 5 fixture setup: expected 100755 blob, got [$fixture_entry] — chmod didn't take in the test repo"
+else
+  run_verify "$MP5" "$C5"
+  if [ "$RC" -ne 1 ]; then
+    fail "Case 5 mode-tampering: expected exit 1, got $RC"
+    echo "stdout:" >&2; sed 's/^/    /' "$STDOUT_FILE" >&2
+    echo "stderr:" >&2; sed 's/^/    /' "$STDERR_FILE" >&2
+  elif ! grep -q 'tree entry.*100755\|mode/type tampering' "$STDERR_FILE"; then
+    fail "Case 5 mode-tampering: stderr missing tree-entry diagnostic"
+    echo "stderr was:" >&2; sed 's/^/    /' "$STDERR_FILE" >&2
+  else
+    pass "Case 5: mode tampering (chmod +x) → exit 1, tree-entry diagnostic"
+  fi
+fi
+
 echo ""
 echo "test_verify_propagation_pr_templated: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test_verify_propagation_pr_templated.sh
+++ b/tests/test_verify_propagation_pr_templated.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# tests/test_verify_propagation_pr_templated.sh
+#
+# Fixture-driven tests for the templated-surface arm of
+# scripts/workflow/verify-propagation-pr.sh (#323). The templated
+# arm renders each templated entry's source against mergepath@<sha>
+# with the consumer's facts (loaded via export_consumer_facts) and
+# byte-compares against the PR's dest content.
+#
+# Each case builds a throwaway "mergepath" checkout containing the
+# template lib, facts helper, and parse/match helpers, plus a manifest
+# with one templated entry. A throwaway "consumer" git repo carries
+# the PR's dest content at HEAD. The script under test is invoked
+# with $MERGEPATH_CONSUMER set so the consumer-inference step
+# doesn't depend on a git remote configuration.
+#
+# Exit-code contract for the templated surface:
+#   0  — re-render matches PR dest content
+#   1  — re-render diverges OR render errors (malformed template,
+#        strict-mode unset fact, source missing)
+#   2  — usage / environment error (covered in the parent test)
+#
+# Bash 3.2 portable. Runs from
+# scripts/ci/check_workflow_verify_propagation_templated.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERIFY="$ROOT/scripts/workflow/verify-propagation-pr.sh"
+[ -x "$VERIFY" ] || { echo "missing or non-executable $VERIFY" >&2; exit 1; }
+command -v yq >/dev/null 2>&1 || { echo "SKIP: yq not available" >&2; exit 0; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/verify-prop-templated-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+git_quiet() { git -c init.defaultBranch=main -c user.email=t@t -c user.name=t -c commit.gpgsign=false "$@"; }
+
+# Build a throwaway "mergepath" checkout. Carries:
+#   - the trusted helpers (parse_manifest_paths, match_protected_paths,
+#     template-substitution, manifest-fact-helpers)
+#   - a manifest with one templated entry + one canonical entry
+#   - the templated source template
+# The manifest is rebuilt per case (different facts produce different
+# expected renders).
+build_mergepath() {
+  local mp="$1" template_body="$2" frameworks="$3"
+  mkdir -p "$mp/scripts/workflow" "$mp/scripts/lib" "$mp/examples"
+  cp "$ROOT/scripts/workflow/parse_manifest_paths.sh" "$mp/scripts/workflow/"
+  cp "$ROOT/scripts/workflow/match_protected_paths.sh" "$mp/scripts/workflow/"
+  cp "$ROOT/scripts/lib/template-substitution.sh" "$mp/scripts/lib/"
+  cp "$ROOT/scripts/lib/manifest-fact-helpers.sh" "$mp/scripts/lib/"
+  printf '%s' "$template_body" >"$mp/examples/source.tpl"
+  cat >"$mp/.mergepath-sync.yml" <<YAML
+version: 1
+consumers:
+  - name: alpha
+    repo: example/alpha
+    facts:
+      frameworks: [$frameworks]
+paths:
+  - path: examples/source.tpl
+    source: examples/source.tpl
+    dest: rendered.txt
+    type: templated
+    consumers:
+      - alpha
+YAML
+}
+
+# Build a consumer git repo with a base (no rendered.txt) → head
+# (rendered.txt added with the supplied content). Sets globals
+# BASE_SHA / HEAD_SHA.
+build_consumer() {
+  local cdir="$1" pr_content="$2"
+  mkdir -p "$cdir"
+  git_quiet -C "$cdir" init -q
+  printf 'app code\n' >"$cdir/app.ts"
+  git_quiet -C "$cdir" add -A
+  git_quiet -C "$cdir" commit -q -m base
+  BASE_SHA=$(git -C "$cdir" rev-parse HEAD)
+  printf '%s' "$pr_content" >"$cdir/rendered.txt"
+  git_quiet -C "$cdir" add -A
+  git_quiet -C "$cdir" commit -q -m head
+  HEAD_SHA=$(git -C "$cdir" rev-parse HEAD)
+}
+
+run_verify() {  # $1=mp $2=consumer; sets RC, STDOUT_FILE, STDERR_FILE
+  STDOUT_FILE=$(mktemp -t "verify-out.XXXXXX")
+  STDERR_FILE=$(mktemp -t "verify-err.XXXXXX")
+  set +e
+  MERGEPATH_CONSUMER=alpha "$VERIFY" "$1" "$2" "$BASE_SHA" "$HEAD_SHA" \
+    > "$STDOUT_FILE" 2> "$STDERR_FILE"
+  RC=$?
+  set -e
+}
+
+# ---------------------------------------------------------------------------
+# Case 1 — pass: PR dest matches re-render.
+#
+# Template has a `>>> if frameworks contains react` block; consumer
+# carries `frameworks: [react]`, so the block is included. The PR's
+# dest carries the exact rendered output. Expect:
+#   - exit 0
+#   - "[mergepath-verify: templated-render] rendered.txt alpha examples/source.tpl"
+#     on stdout
+# ---------------------------------------------------------------------------
+TEMPLATE_BODY='hello {{name}}
+// >>> if frameworks contains react
+react block
+// <<<
+trailing line
+'
+# What the template renders to with name=mergepath, frameworks=[react]:
+EXPECTED_RENDER='hello mergepath
+react block
+trailing line
+'
+MP1="$WORKDIR/mp1"; build_mergepath "$MP1" "$TEMPLATE_BODY" "react"
+# Append a `facts.name` so {{name}} resolves.
+# We rebuild the manifest carefully with both facts.
+cat >"$MP1/.mergepath-sync.yml" <<'YAML'
+version: 1
+consumers:
+  - name: alpha
+    repo: example/alpha
+    facts:
+      frameworks: [react]
+      name: mergepath
+paths:
+  - path: examples/source.tpl
+    source: examples/source.tpl
+    dest: rendered.txt
+    type: templated
+    consumers:
+      - alpha
+YAML
+C1="$WORKDIR/c1"
+build_consumer "$C1" "$EXPECTED_RENDER"
+run_verify "$MP1" "$C1"
+if [ "$RC" -ne 0 ]; then
+  fail "Case 1 pass: expected exit 0, got $RC"
+  echo "stdout:" >&2; sed 's/^/    /' "$STDOUT_FILE" >&2
+  echo "stderr:" >&2; sed 's/^/    /' "$STDERR_FILE" >&2
+elif ! grep -qF '[mergepath-verify: templated-render] rendered.txt alpha examples/source.tpl' "$STDOUT_FILE"; then
+  fail "Case 1 pass: missing structured tag-reply line on stdout"
+  echo "stdout was:" >&2; sed 's/^/    /' "$STDOUT_FILE" >&2
+else
+  pass "Case 1: PR dest matches re-render → exit 0, structured tag line emitted"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2 — drift: PR dest content differs from re-render.
+# Same fixtures as Case 1 but the PR dest carries an extra line.
+# Expect exit 1 + a divergence diagnostic in stderr.
+# ---------------------------------------------------------------------------
+C2="$WORKDIR/c2"
+build_consumer "$C2" "${EXPECTED_RENDER}HAND EDITED EXTRA LINE
+"
+run_verify "$MP1" "$C2"
+if [ "$RC" -ne 1 ]; then
+  fail "Case 2 drift: expected exit 1, got $RC"
+  echo "stdout:" >&2; sed 's/^/    /' "$STDOUT_FILE" >&2
+  echo "stderr:" >&2; sed 's/^/    /' "$STDERR_FILE" >&2
+elif ! grep -q 'diverges from PR content' "$STDERR_FILE"; then
+  fail "Case 2 drift: stderr missing 'diverges from PR content' diagnostic"
+  echo "stderr was:" >&2; sed 's/^/    /' "$STDERR_FILE" >&2
+elif ! grep -q 'Templated re-render mismatch' "$STDERR_FILE"; then
+  fail "Case 2 drift: stderr missing typed-summary header 'Templated re-render mismatch'"
+  echo "stderr was:" >&2; sed 's/^/    /' "$STDERR_FILE" >&2
+else
+  pass "Case 2: PR dest diverges from re-render → exit 1, typed diagnostic"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3 — template syntax error: malformed `>>> if` (no closing `<<<`).
+# Expect exit 1 + a template-error diagnostic in stderr.
+# ---------------------------------------------------------------------------
+BAD_TEMPLATE='line one
+// >>> if frameworks contains react
+unclosed block
+'
+MP3="$WORKDIR/mp3"; build_mergepath "$MP3" "$BAD_TEMPLATE" "react"
+C3="$WORKDIR/c3"
+# PR has SOMETHING for dest; content is irrelevant — render errors
+# before the byte-compare.
+build_consumer "$C3" "doesnt matter
+"
+run_verify "$MP3" "$C3"
+if [ "$RC" -ne 1 ]; then
+  fail "Case 3 template error: expected exit 1, got $RC"
+  echo "stderr:" >&2; sed 's/^/    /' "$STDERR_FILE" >&2
+elif ! grep -q 'template render error\|Templated re-render error' "$STDERR_FILE"; then
+  fail "Case 3 template error: stderr missing template-render error diagnostic"
+  echo "stderr was:" >&2; sed 's/^/    /' "$STDERR_FILE" >&2
+else
+  pass "Case 3: malformed template (unclosed >>> if) → exit 1, template error"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4 — strict-mode unset fact: template references {{undeclared}};
+# MERGEPATH_TEMPLATE_STRICT=1 makes the render fail with rc=3, which the
+# verifier surfaces as exit 1 with a render-error diagnostic.
+# ---------------------------------------------------------------------------
+STRICT_TEMPLATE='value: <{{undeclared}}>
+'
+MP4="$WORKDIR/mp4"; build_mergepath "$MP4" "$STRICT_TEMPLATE" "react"
+C4="$WORKDIR/c4"
+build_consumer "$C4" "doesnt matter
+"
+# Run with strict mode on. MERGEPATH_TEMPLATE_STRICT is honored by the
+# template lib at render time.
+STDOUT_FILE=$(mktemp -t "verify-out.XXXXXX")
+STDERR_FILE=$(mktemp -t "verify-err.XXXXXX")
+set +e
+MERGEPATH_CONSUMER=alpha MERGEPATH_TEMPLATE_STRICT=1 \
+  "$VERIFY" "$MP4" "$C4" "$BASE_SHA" "$HEAD_SHA" \
+  > "$STDOUT_FILE" 2> "$STDERR_FILE"
+RC=$?
+set -e
+if [ "$RC" -ne 1 ]; then
+  fail "Case 4 strict-mode: expected exit 1, got $RC"
+  echo "stderr:" >&2; sed 's/^/    /' "$STDERR_FILE" >&2
+elif ! grep -q 'render failed\|template render error\|Templated re-render error' "$STDERR_FILE"; then
+  fail "Case 4 strict-mode: stderr missing render-failure diagnostic"
+  echo "stderr was:" >&2; sed 's/^/    /' "$STDERR_FILE" >&2
+else
+  pass "Case 4: strict-mode unset fact → exit 1, render-failure diagnostic"
+fi
+
+echo ""
+echo "test_verify_propagation_pr_templated: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/tests/test_verify_propagation_pr_templated.sh
+++ b/tests/test_verify_propagation_pr_templated.sh
@@ -90,8 +90,8 @@ build_consumer() {
 }
 
 run_verify() {  # $1=mp $2=consumer; sets RC, STDOUT_FILE, STDERR_FILE
-  STDOUT_FILE=$(mktemp -t "verify-out.XXXXXX")
-  STDERR_FILE=$(mktemp -t "verify-err.XXXXXX")
+  STDOUT_FILE=$(mktemp "${TMPDIR:-/tmp}/verify-out.XXXXXX")
+  STDERR_FILE=$(mktemp "${TMPDIR:-/tmp}/verify-err.XXXXXX")
   set +e
   MERGEPATH_CONSUMER=alpha "$VERIFY" "$1" "$2" "$BASE_SHA" "$HEAD_SHA" \
     > "$STDOUT_FILE" 2> "$STDERR_FILE"
@@ -214,8 +214,8 @@ build_consumer "$C4" "doesnt matter
 "
 # Run with strict mode on. MERGEPATH_TEMPLATE_STRICT is honored by the
 # template lib at render time.
-STDOUT_FILE=$(mktemp -t "verify-out.XXXXXX")
-STDERR_FILE=$(mktemp -t "verify-err.XXXXXX")
+STDOUT_FILE=$(mktemp "${TMPDIR:-/tmp}/verify-out.XXXXXX")
+STDERR_FILE=$(mktemp "${TMPDIR:-/tmp}/verify-err.XXXXXX")
 set +e
 MERGEPATH_CONSUMER=alpha MERGEPATH_TEMPLATE_STRICT=1 \
   "$VERIFY" "$MP4" "$C4" "$BASE_SHA" "$HEAD_SHA" \


### PR DESCRIPTION
Closes #323.

## Summary

Closes the propagation-lane gate for \`type: templated\` manifest entries. Currently \`scripts/workflow/verify-propagation-pr.sh\` rejects templated dest paths because \`parse_manifest_paths.sh\` emits \`.path\` only — not the templated \`dest:\`. The new templated section parses templated entries from the manifest, exports the consumer's facts via \`export_consumer_facts\` (sourced from a new helper, no duplication), re-renders against mergepath@HEAD via \`template_substitution::render\`, and byte-compares against the PR's \`dest\` content.

## What's new

- **\`scripts/workflow/verify-propagation-pr.sh\`** — new templated-entry section before the canonical loop. Verified dests are exempted from the canonical compare. Failure summary distinguishes \`CANONICAL_FAILURES\` / \`TEMPLATED_FAILURES\` / \`TEMPLATED_ERRORS\`.
- **\`scripts/lib/manifest-fact-helpers.sh\`** (new) — extracted \`export_consumer_facts\` to a function-defs-only helper so both \`sync-to-downstream.sh\` and \`verify-propagation-pr.sh\` can source it without triggering top-level side effects.
- **\`scripts/ci/check_workflow_verify_propagation_templated\`** (new) — CI wrapper.
- **\`tests/test_verify_propagation_pr_templated.sh\`** (new) — 4 cases: pass / drift / template syntax error / strict-mode unset fact.
- **\`templated-render\` tag class** — added to \`tag_class_action()\` (mapped to \`skip\`) and \`derive_tag_class()\` (rung 1b, after \`canonical-coverage\`) with matching \`synth_rationale\` case. Closes the gap where templated-lane resolves were attributed to \`addressed-elsewhere\` / heuristic fallback.
- **\`.github/workflows/repo_lint.yml\`** — new \`check_workflow_verify_propagation_templated\` step alongside the existing \`check_verify_propagation_pr\`.
- **\`docs/agents/templated-propagation.md\`** — Status line updated, v1-limitation block removed, new § documenting the re-render-and-verify approach.

## Tag-reply mechanism

Keeps \`verify-propagation-pr.sh\` read-only (matches its existing contract — reads git refs, emits stdout/stderr, never writes to GitHub). Emits a structured stdout line on pass:

\`\`\`
[mergepath-verify: templated-render] <dest> <consumer> <source>
\`\`\`

A calling workflow step (or future wrapper) reads these lines and posts the actual GraphQL tag-reply. Documented as a design choice in the header comment.

## Consumer inference

Two-tier with skip-safe fallback:
1. \`\$MERGEPATH_CONSUMER\` env override (for CI / tests).
2. \`origin\` remote URL normalized to \`owner/repo\` slug → matched against \`.consumers[].repo\`.
3. On both failures: skip templated arm with stderr note; canonical arm still runs. Templated dests then fall through to the pre-#323 status quo (normal Phase 4 review).

## Helper extraction rationale

Sourcing the whole \`sync-to-downstream.sh\` script was not viable — it executes substantial top-level argument parsing, mode dispatch, and side-effect-producing helpers (\`require_yq\`, \`require_manifest\`, \`case \"\$MODE\"\`) once below the function definitions. The extracted helper is function-defs-only with zero side effects. The yq filter is byte-identical to the prior form; \`test_export_consumer_facts.sh\` now greps the helper file directly and adds a Case 7 regression-guard that asserts \`sync-to-downstream.sh\` still sources the helper.

## Why

The 6-repo ESLint rollout (#250) was the first real exercise of templated propagation. The lane gate didn't enforce on rendered outputs, so a future template change could silently produce inconsistent rendered output across consumers. Closing the gate before adding more templated entries to the manifest (e.g., #322 lands soon).

## Pre-existing failure noted

\`tests/test_sync_to_downstream.sh\` fails on \`--sync-all plan should note templated paths as deferred\`. Confirmed via \`git stash\` round-trip — the failure exists on \`main\` with the identical diagnostic, predating this branch. Out of scope for #323; flagging for triage.

Authoring-Agent: claude

## Self-Review

- **Correctness:** New templated arm runs BEFORE canonical loop; verified dests added to \`VERIFIED_TEMPLATED_DESTS\` and explicitly skipped at the top of the canonical loop so the path-confinement check doesn't false-fail them. Helper extraction maintains byte-identical yq filter — regression-guarded by \`test_export_consumer_facts.sh\` Case 7.
- **Regression risk:** Medium. Touches the propagation-lane verifier (every propagation PR hits this script) and adds a tag class to the daily-feedback rollup taxonomy. The pass case is byte-compare strict — any template change that doesn't match the consumer's rendered output will fail the lane, which is the intended behavior. **Reviewer should evaluate** whether the consumer-inference fallback (skip-safe) is the right default vs failing loud.
- **Style:** Bash conventions match existing workflow scripts. Helper extraction follows the existing \`scripts/lib/preflight-helpers.sh\` pattern (function defs + sourcing safety).
- **Test coverage:** New \`test_verify_propagation_pr_templated.sh\` (4/4 PASS). All regressions green: \`test_template_substitution.sh\` (45/45), \`test_export_consumer_facts.sh\` (7/7), \`check_sync_manifest\` (25), \`check_verify_propagation_pr\` (8/8), \`check_resolve_pr_threads\` (10), \`check_daily_feedback_rollup\` (61), \`check_ci_scripts_wired\`.
- **Security/dependency hygiene:** No new dependencies. Template-substitution lib unchanged — same trust model (sourced from \`\$MERGEPATH_DIR/scripts/lib/...\` like existing trusted helpers). Tag-class emission is read-only stdout — no GitHub writes.

## Test plan

- [x] \`bash tests/test_verify_propagation_pr_templated.sh\` — 4/4 PASS.
- [x] \`bash scripts/ci/check_workflow_verify_propagation_templated\` — 4/4 PASS.
- [x] \`bash scripts/ci/check_verify_propagation_pr\` — 8/8 PASS (canonical surface still green).
- [x] All regression tests green (see list above).
- [ ] Post-merge: manual sanity — run against a recent merged propagation PR (e.g., ffb#274) and confirm exit 0 with tag-reply line emitted.