### PR TITLE
test(propagation): force exec bit via update-index in mode-tampering fixture (#329 follow-up)

### DIFF
--- a/tests/test_verify_propagation_pr_templated.sh
+++ b/tests/test_verify_propagation_pr_templated.sh
@@ -251,16 +251,23 @@ git_quiet -C "$C5" add -A
 git_quiet -C "$C5" commit -q -m base
 BASE_SHA=$(git -C "$C5" rev-parse HEAD)
 printf '%s' "$RENDERED5" >"$C5/rendered.txt"
-chmod +x "$C5/rendered.txt"
 git_quiet -C "$C5" add -A
+# Force the exec bit IN THE INDEX regardless of the filesystem's
+# core.filemode. The prior version used `chmod +x` alone, which only
+# updates the working tree — on a filesystem that ignores mode bits
+# (Windows/WSL, some networked filesystems) or in a repo with
+# `core.filemode=false`, git still records `100644 blob` and the
+# fixture-setup guard below fails BEFORE exercising the actual
+# mode-tampering check. `git update-index --chmod=+x` writes mode
+# 100755 directly into the index, capturing the executable bit on
+# the next commit even when filesystem mode bits are unavailable.
+# (CR Minor on PR #329, addressed as #329 follow-up.)
+git_quiet -C "$C5" update-index --chmod=+x rendered.txt
 git_quiet -C "$C5" commit -q -m head
 HEAD_SHA=$(git -C "$C5" rev-parse HEAD)
-# Confirm fixture set the executable bit correctly before invoking
-# the verifier — `git update-index --chmod=+x` would also work but
-# `chmod +x` + `add -A` is the path most agents would use.
 fixture_entry=$(git -C "$C5" ls-tree HEAD -- rendered.txt | awk '{print $1, $2}')
 if [ "$fixture_entry" != "100755 blob" ]; then
-  fail "Case 5 fixture setup: expected 100755 blob, got [$fixture_entry] — chmod didn't take in the test repo"
+  fail "Case 5 fixture setup: expected 100755 blob, got [$fixture_entry] — update-index --chmod=+x didn't take"
 else
   run_verify "$MP5" "$C5"
   if [ "$RC" -ne 1 ]; then


### PR DESCRIPTION
Follow-up to PR #329 (merged as commit 02b689b).

## Summary

CodeRabbit Minor on PR #329 caught that the new Case 5 mode-tampering fixture relies on \`chmod +x\` to set the executable bit. \`chmod +x\` only touches the working tree — on filesystems that ignore mode bits (Windows/WSL, some networked filesystems) or in repos with \`core.filemode=false\`, git still records \`100644 blob\` and the fixture's setup-guard fails before the actual mode-tampering verification surface runs.

Replaced \`chmod +x\` with \`git update-index --chmod=+x rendered.txt\` after \`git add\`. \`update-index\` writes mode 100755 directly into the index regardless of filesystem behavior.

## Why

The fixture is a regression guard for the templated-lane tree-entry check (codex P1 #329 round 2). If the fixture itself silently fails to set up the executable bit, the regression guard goes dark and the tree-entry check could regress unnoticed.

## Test plan

- [x] \`bash tests/test_verify_propagation_pr_templated.sh\` — 5/5 pass (default environment).
- [x] Same run under \`core.fileMode=false\` simulated env — 5/5 pass (the working-tree chmod path that previously masked the failure is now bypassed).

Authoring-Agent: claude

## Self-Review

- **Correctness:** \`git update-index --chmod=+x\` is the canonical way to record an executable bit in git's index regardless of filesystem. Verified in both default and \`core.fileMode=false\` environments.
- **Regression risk:** Test-only change. Zero runtime impact on the propagation lane itself. The new path is more robust than the old path; no risk of false-pass.
- **Style:** Matches the existing fixture pattern (\`git_quiet\` wrapper). The comment explains both the problem and the fix.
- **Test coverage:** Test-only change; existing test continues to exercise the same surface, just with reliable fixture setup.
- **Security/dependency hygiene:** No new dependencies. No secrets.