### PR TITLE
fix(hooks): gh-pr-guard.sh covers `gh issue create` byline (#317)

### DIFF
--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -41,14 +41,17 @@
 #     - gh pr comment <PR#> --body "..."
 #     - gh pr review <PR#> --comment / --approve / --request-changes
 #     - gh issue comment <issue#> --body "..."
+#     - gh issue create --title "..." --body "..."     (#317)
 #
-#   For all three, the keyring's active account must be the agent's
+#   For all four, the keyring's active account must be the agent's
 #   REVIEWER identity (nathanpayne-<agent>, default nathanpayne-claude;
 #   override via GH_PR_GUARD_EXPECTED_REVIEWER). Posting these as the
 #   AUTHOR identity (nathanjohnpayne) breaks the audit-trail
 #   convention REVIEW_POLICY.md depends on — reviewer comments must
-#   attribute to the reviewer. The check fires before the keyring
-#   write so misattributed comments never land.
+#   attribute to the reviewer, and an agent filing their own bug must
+#   attribute to that agent (not to the author identity). The check
+#   fires before the keyring write so misattributed comments / issues
+#   never land.
 #
 #   Additionally, `gh pr review --approve` is blocked when the
 #   target PR is OVER-threshold AND the keyring is the agent's own
@@ -62,12 +65,21 @@
 #   over-threshold so the self-approve block fires on safer side.
 #
 #   These guards are scoped to `gh pr comment` / `gh pr review` /
-#   `gh issue comment` exactly. Raw `gh api -X POST .../comments` is
-#   intentionally NOT covered in this PR — the token/keyring auth
-#   matrix for raw `gh api` writes is not yet precise enough to
-#   block on without false positives. See REVIEW_POLICY.md
-#   § Operation-to-Identity Matrix (graphql write — PAT-attributed)
-#   for the auth-split context and the follow-up tracked under #284.
+#   `gh issue comment` / `gh issue create` exactly. `gh issue create`
+#   was added by #317 after the concrete misattribution of mergepath
+#   #315 — a `nathanpayne-claude` agent session filed a bug, but the
+#   keyring had drifted to `nathanpayne-codex` from the prior Phase
+#   4b CLI run, and the issue landed under the wrong byline. The
+#   guard treats `gh issue create` the same as `gh issue comment`:
+#   keyring active must be the REVIEWER identity (an agent posting
+#   their own work).
+#
+#   Raw `gh api -X POST .../comments` is still intentionally NOT
+#   covered — the token/keyring auth matrix for raw `gh api` writes
+#   is not yet precise enough to block on without false positives.
+#   See REVIEW_POLICY.md § Operation-to-Identity Matrix (graphql
+#   write — PAT-attributed) for the auth-split context and the
+#   follow-up tracked under #284.
 #
 # The identity check (1a) honors a
 # BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK=1 escape hatch for tests
@@ -576,44 +588,61 @@ EFFECTIVE_CODEX_CLEARED="${CODEX_CLEARED:-${INLINE_CODEX_CLEARED:-}}"
 EFFECTIVE_BREAK_GLASS_ADMIN="${BREAK_GLASS_ADMIN:-${INLINE_BREAK_GLASS_ADMIN:-}}"
 EFFECTIVE_BREAK_GLASS_MERGE_STATE="${BREAK_GLASS_MERGE_STATE:-${INLINE_BREAK_GLASS_MERGE_STATE:-}}"
 
-# Distinguish `gh pr comment` from `gh issue comment` — both share the
-# same subcommand label `comment` but route through different parent
-# tokens. We track this with IS_ISSUE_COMMENT so downstream guard
-# branches can emit the right diagnostic label.
+# Distinguish `gh pr comment` from `gh issue comment` (both share the
+# subcommand label `comment` but route through different parent
+# tokens) AND `gh pr create` from `gh issue create` (same shape, with
+# `gh issue create` added by #317). Downstream guard branches use
+# these flags to pick the right diagnostic label and the right
+# expected-identity policy.
 IS_ISSUE_COMMENT=0
+IS_ISSUE_CREATE=0
 if [ "$SAW_ISSUE" -eq 1 ] && [ "$PR_SUBCOMMAND" = "comment" ]; then
   IS_ISSUE_COMMENT=1
 fi
+if [ "$SAW_ISSUE" -eq 1 ] && [ "$PR_SUBCOMMAND" = "create" ]; then
+  IS_ISSUE_CREATE=1
+fi
 
 # A `gh issue <X>` invocation where X is anything OTHER than `comment`
-# (issue create / close / view / list / etc.) is out of scope for this
-# PR. Allow.
-if [ "$SAW_ISSUE" -eq 1 ] && [ "$IS_ISSUE_COMMENT" -eq 0 ]; then
+# or `create` (issue close / view / list / edit / etc.) is out of
+# scope for this hook. Allow.
+if [ "$SAW_ISSUE" -eq 1 ] && [ "$IS_ISSUE_COMMENT" -eq 0 ] && [ "$IS_ISSUE_CREATE" -eq 0 ]; then
   exit 0
 fi
 
-# Not a covered command? Allow.
+# Not a covered command? Allow. `gh pr create` and `gh issue create`
+# both have PR_SUBCOMMAND=="create"; the IS_ISSUE_CREATE flag is what
+# routes them to different identity expectations below (author for pr,
+# reviewer for issue).
 if [ "$PR_SUBCOMMAND" != "create" ] && \
    [ "$PR_SUBCOMMAND" != "merge" ] && \
    [ "$PR_SUBCOMMAND" != "comment" ] && \
    [ "$PR_SUBCOMMAND" != "review" ] && \
-   [ "$IS_ISSUE_COMMENT" -eq 0 ]; then
+   [ "$IS_ISSUE_COMMENT" -eq 0 ] && \
+   [ "$IS_ISSUE_CREATE" -eq 0 ]; then
   exit 0
 fi
 
-# --- byline guard for pr comment / pr review / issue comment ----------
+# --- byline guard for pr comment / pr review / issue comment / issue create ---
 #
-# These three subcommands share a single policy: the keyring's active
+# These four subcommands share a single policy: the keyring's active
 # account must be the agent's REVIEWER identity (not the author
 # identity). Posting any of them under nathanjohnpayne mis-attributes
 # the byline in a way that breaks the audit-trail invariant
 # REVIEW_POLICY.md depends on.
 #
+# `gh issue create` was added by #317 after mergepath#315 landed
+# under the wrong byline (a nathanpayne-claude agent filed the bug
+# but the keyring had drifted to nathanpayne-codex from a prior
+# Phase 4b CLI session). Same byline-attribution rule as the other
+# three: an agent filing their own bug must attribute to their
+# REVIEWER identity.
+#
 # The `gh pr review --approve` self-approve sub-guard runs after this
 # block — only if we made it past the basic byline check does the
 # self-approve question even arise.
 EXPECTED_REVIEWER="${GH_PR_GUARD_EXPECTED_REVIEWER:-nathanpayne-claude}"
-if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS_ISSUE_COMMENT" -eq 1 ]; then
+if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS_ISSUE_COMMENT" -eq 1 ] || [ "$IS_ISSUE_CREATE" -eq 1 ]; then
   if [ "${BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK:-0}" != "1" ]; then
     ACTIVE_GH_USER=$(gh config get -h github.com user 2>/dev/null || echo "")
     if [ -z "$ACTIVE_GH_USER" ]; then
@@ -635,12 +664,19 @@ if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS
         review)  cmd_label="gh pr review" ;;
       esac
       [ "$IS_ISSUE_COMMENT" -eq 1 ] && cmd_label="gh issue comment"
+      [ "$IS_ISSUE_CREATE" -eq 1 ] && cmd_label="gh issue create"
       echo "BLOCKED: $cmd_label is about to run under active account '$ACTIVE_GH_USER' (the AUTHOR identity)." >&2
       echo "" >&2
-      echo "  Reviewer-byline commands (pr comment / pr review / issue comment) must attribute to the" >&2
-      echo "  agent's REVIEWER identity ('$EXPECTED_REVIEWER' by default), not the author identity." >&2
-      echo "  Posting as '$EXPECTED_AUTHOR_FOR_BLOCK' breaks the audit-trail convention" >&2
-      echo "  REVIEW_POLICY.md depends on." >&2
+      echo "  Reviewer-byline commands (pr comment / pr review / issue comment / issue create)" >&2
+      echo "  must attribute to the agent's REVIEWER identity ('$EXPECTED_REVIEWER' by default)," >&2
+      echo "  not the author identity. Posting as '$EXPECTED_AUTHOR_FOR_BLOCK' breaks the audit-" >&2
+      echo "  trail convention REVIEW_POLICY.md depends on." >&2
+      if [ "$IS_ISSUE_CREATE" -eq 1 ]; then
+        echo "" >&2
+        echo "  Concrete instance: mergepath#315 landed under nathanpayne-codex despite being" >&2
+        echo "  filed by a nathanpayne-claude agent session, because the keyring had drifted" >&2
+        echo "  from a prior Phase 4b CLI run. This hook closes that gap (#317)." >&2
+      fi
       echo "" >&2
       echo "  Fix once: gh auth switch -u $EXPECTED_REVIEWER" >&2
       echo "  Or wrap the single call: scripts/gh-as-reviewer.sh -- $cmd_label ..." >&2
@@ -648,6 +684,17 @@ if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS
       exit 2
     fi
   fi
+fi
+
+# --- gh issue create: exit cleanly after the byline check ------------
+#
+# `gh issue create` shares PR_SUBCOMMAND=="create" with `gh pr create`,
+# so without this short-circuit it would fall through into the pr-create
+# branch below (which expects the AUTHOR identity, not the REVIEWER
+# identity — opposite of what `gh issue create` wants). Exit 0 here so
+# downstream pr-create logic doesn't fire.
+if [ "$IS_ISSUE_CREATE" -eq 1 ]; then
+  exit 0
 fi
 
 # --- gh pr review --approve self-approve sub-guard --------------------

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -509,18 +509,91 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 23: gh issue close (non-comment issue subcommand) → allowed.
-# Regression: the issue parent recognizer must NOT swallow `close`,
-# `view`, etc.
+# Test 23: gh issue close (non-comment, non-create issue subcommand) →
+# allowed. Regression: the issue parent recognizer must NOT swallow
+# `close`, `view`, `list`, `edit`, etc.
 # ---------------------------------------------------------------------------
 set +e
 out=$(run_hook 'gh issue close 7' "nathanjohnpayne" "0" 2>&1)
 rc=$?
 set -e
 if [ "$rc" -eq 0 ]; then
-  pass "issue close: allowed (only 'issue comment' is guarded)"
+  pass "issue close: allowed (only 'issue comment' and 'issue create' are guarded)"
 else
   fail "issue close: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 23a: gh issue create with AUTHOR identity → blocked (#317).
+# Closes the mergepath#315 misattribution gap: a nathanpayne-claude
+# agent session filed an issue, but the keyring had drifted to
+# nathanpayne-codex from the prior Phase 4b CLI run, and the issue
+# landed under the wrong byline. The hook should now catch this:
+# any keyring active = the AUTHOR identity (nathanjohnpayne) is
+# blocked because issue creation should attribute to a REVIEWER
+# (agent) identity.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh issue create --title "Bug report" --body "saw the thing"' "nathanjohnpayne" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "issue create + author identity: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "gh issue create"; then
+  fail "issue create + author identity: diagnostic missing 'gh issue create'; output: $out"
+elif ! echo "$out" | grep -qi "mergepath#315"; then
+  fail "issue create + author identity: diagnostic missing #315 reference; output: $out"
+else
+  pass "issue create + author identity: blocked with #317 diagnostic"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 23b: gh issue create with REVIEWER identity → allowed (#317).
+# The happy path: the keyring is the agent's reviewer identity, the
+# issue posts under that byline, no block.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh issue create --title "Bug report" --body "saw the thing"' "nathanpayne-claude" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "issue create + reviewer identity: allowed"
+else
+  fail "issue create + reviewer identity: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 23c: gh issue create with bypass set → allowed even under
+# AUTHOR identity (test/CI escape hatch parity with the other
+# reviewer-byline checks).
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh issue create --title "Bug" --body "..."' "nathanjohnpayne" "1" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "issue create + author identity + bypass: allowed (escape hatch)"
+else
+  fail "issue create + bypass: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 23d: gh issue create must NOT fall through to the pr-create
+# branch's body checks. `gh pr create` requires Authoring-Agent: and
+# ## Self-Review in the body; `gh issue create` has neither convention.
+# Regression: PR_SUBCOMMAND=="create" alone is insufficient to decide
+# the branch — the IS_ISSUE_CREATE flag must route correctly.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh issue create --title "Bug" --body "no Authoring-Agent line here"' "nathanpayne-claude" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "issue create: did not fall through to pr-create body checks"
+elif echo "$out" | grep -qi "Authoring-Agent"; then
+  fail "issue create: incorrectly fell through to pr-create body checks; output: $out"
+else
+  fail "issue create: unexpected exit $rc; output: $out"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #317.

## Summary

Extends \`scripts/hooks/gh-pr-guard.sh\` to cover \`gh issue create\` alongside the existing \`gh pr create\` / \`gh pr comment\` / \`gh pr review\` / \`gh issue comment\` byline checks. Closes the misattribution gap that landed mergepath#315 under nathanpayne-codex (filed by a nathanpayne-claude agent session whose keyring had drifted to codex from a prior Phase 4b CLI run).

## What changed

- **State machine**: new \`IS_ISSUE_CREATE\` flag, mirroring the existing \`IS_ISSUE_COMMENT\` recognizer. The \`gh issue\` walker now routes \`create\` and \`comment\` subcommands distinctly from \`close\`/\`view\`/\`list\`/etc. (which still fall through to allow).
- **Byline guard**: \`gh issue create\` joins the reviewer-byline command list. Same policy: keyring active must be the REVIEWER identity (nathanpayne-<agent>), not the AUTHOR identity (nathanjohnpayne). Diagnostic includes a #315 pointer when the trigger is \`gh issue create\` specifically — surfaces the concrete failure case in the help text.
- **Short-circuit after issue-create check**: prevents fall-through to the pr-create branch (which expects the AUTHOR identity and runs body-content checks for \`Authoring-Agent\` / \`## Self-Review\` — neither applies to issue creation).
- **Header comments updated** to reflect the expanded coverage and the #315/#317 history.

## What's deferred (per #317 sequencing)

- **Raw \`gh api -X POST .../comments\`** — still deferred per the existing header comment. The token/keyring auth matrix for raw \`gh api\` writes is not yet precise enough to block without false positives. Flagged for future #284 follow-up.
- **"Filed by: <identity>" body-content convention** — separate docs-only PR. The hook is the load-bearing fix; the convention is an additive belt-and-braces.

## Test plan

- [x] \`bash tests/test_gh_pr_guard.sh\` — 32/32 PASS, including 4 new cases for \`gh issue create\`.
- [x] \`bash scripts/ci/check_gh_as_author\` — PASS (wraps the same test suite).
- [x] Hook syntax check via \`bash -n\`.

Authoring-Agent: claude

## Self-Review

- **Correctness:** The state machine extension is symmetric with the existing \`gh issue comment\` recognizer. The short-circuit after the issue-create check is necessary because \`gh pr create\` and \`gh issue create\` both have \`PR_SUBCOMMAND==\"create\"\`; the IS_ISSUE_CREATE flag is what routes them. Tested explicitly via Case 23d (issue create must not fall through to pr-create body checks).
- **Regression risk:** Low. The existing 28 tests all still pass. The new behavior only fires on \`gh issue create\` invocations — \`gh issue close\`/\`view\`/\`list\`/etc. continue to allow.
- **Style:** Matches the existing hook structure (state-machine flags, EXPECTED_REVIEWER lookup, diagnostic format). Comments explain both the change and the historical incident driving it.
- **Test coverage:** 4 new cases — author identity blocked, reviewer identity allowed, BOOTSTRAP escape hatch, and the regression for not falling through to pr-create body checks.
- **Security/dependency hygiene:** No new dependencies. No secrets touched. The hook is a defense-in-depth additive — a strictly tighter guard than before, never looser.