### PR TITLE
fix(eslint-template): remove orphan disable block + `<<<` from CJS template

### DIFF
--- a/examples/eslint.config.cjs.js
+++ b/examples/eslint.config.cjs.js
@@ -311,15 +311,6 @@ module.exports = [
 // don't reference react-hooks/* on files where the plugin isn't
 // loaded — codex P1 #327 round 3). The standalone block previously
 // at this position has been removed.
-  {
-    rules: {
-      "react-hooks/set-state-in-effect": "off",
-      "react-hooks/preserve-manual-memoization": "off",
-      "react-hooks/refs": "off",
-      "react-hooks/immutability": "off",
-    },
-  },
-// <<<
 
 // >>> if testing contains vitest
   // Vitest globals — applied to common test file patterns. Without

--- a/tests/test_template_substitution.sh
+++ b/tests/test_template_substitution.sh
@@ -693,6 +693,78 @@ react-hooks/set-state-in-effect: off
 expect_output "12h react_compiler=true does NOT suppress disable block (v1 limitation)" "$r" "react-hooks/set-state-in-effect: off"
 
 # ---------------------------------------------------------------------------
+# 13. ESM/CJS template parity: render the real examples/eslint.config.{js,
+#     cjs.js} files against every meaningful facts combination. The render
+#     itself must succeed (parse-level marker balance is the load-bearing
+#     check) AND the ESM and CJS rendered bodies must match modulo the
+#     import/export shape. Without these guards, an edit that drifts the
+#     CJS template's `>>> if` / `<<<` structure away from the ESM (e.g.
+#     deletes the opener but leaves an orphan closer — observed during
+#     the #327 round-3 cleanup, caught only when sync-to-downstream.sh
+#     --sync-all hit ffb/swipewatch in prod) passes the existing fixture-
+#     based tests but breaks every templated propagation.
+# ---------------------------------------------------------------------------
+TEMPLATE_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ESM_TEMPLATE="$TEMPLATE_REPO_ROOT/examples/eslint.config.js"
+CJS_TEMPLATE="$TEMPLATE_REPO_ROOT/examples/eslint.config.cjs.js"
+
+# Quick parse-level guard: marker counts must match within each file AND
+# between the two files. This is the cheapest check that catches the
+# orphan-`<<<` bug class without needing a renderer.
+ESM_OPEN=$(grep -cE '^// >>> if' "$ESM_TEMPLATE")
+ESM_CLOSE=$(grep -cE '^// <<<' "$ESM_TEMPLATE")
+CJS_OPEN=$(grep -cE '^// >>> if' "$CJS_TEMPLATE")
+CJS_CLOSE=$(grep -cE '^// <<<' "$CJS_TEMPLATE")
+if [ "$ESM_OPEN" -ne "$ESM_CLOSE" ]; then
+  FAIL=$((FAIL + 1))
+  echo "FAIL: 13a ESM template has $ESM_OPEN open markers vs $ESM_CLOSE close markers" >&2
+elif [ "$CJS_OPEN" -ne "$CJS_CLOSE" ]; then
+  FAIL=$((FAIL + 1))
+  echo "FAIL: 13a CJS template has $CJS_OPEN open markers vs $CJS_CLOSE close markers" >&2
+elif [ "$ESM_OPEN" -ne "$CJS_OPEN" ]; then
+  FAIL=$((FAIL + 1))
+  echo "FAIL: 13a ESM/CJS templates drifted (ESM: $ESM_OPEN markers, CJS: $CJS_OPEN markers)" >&2
+else
+  echo "PASS: 13a ESM/CJS template markers balanced + matched ($ESM_OPEN open + $ESM_OPEN close in each)"
+  PASS=$((PASS + 1))
+fi
+
+# Render-level guard: run template_substitution::render on each template
+# under every load-bearing facts combination from the manifest. Render
+# success (rc=0) is the actual proof that the markers parse cleanly. We
+# don't byte-compare ESM vs CJS bodies here — the import/export shape
+# differs by design — but a render failure on either file is a regression
+# that would have caught the orphan-`<<<` bug.
+RENDER_CASES=(
+  "react"                    # ffb / dpr / matchline / swipewatch family
+  "react typescript"         # matchline
+  "typescript"               # nathanpaynedotcom (Astro+TS subset)
+  "astro typescript"         # nathanpaynedotcom full
+  ""                         # swipewatch + overridebroadway (no frameworks)
+)
+RENDER_FAIL=0
+for facts in "${RENDER_CASES[@]}"; do
+  for tpl in "$ESM_TEMPLATE" "$CJS_TEMPLATE"; do
+    (
+      reset_facts
+      export MERGEPATH_FACT_FRAMEWORKS="$facts"
+      # shellcheck disable=SC1090
+      source "$LIB"
+      template_substitution::render "$tpl" >/dev/null 2>&1
+    ) || {
+      RENDER_FAIL=1
+      echo "FAIL: 13b render failed for $(basename "$tpl") with frameworks='$facts'" >&2
+    }
+  done
+done
+if [ "$RENDER_FAIL" -eq 0 ]; then
+  echo "PASS: 13b ESM + CJS templates render cleanly under all ${#RENDER_CASES[@]} fact combos"
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

Caught by today's first \`scripts/sync-to-downstream.sh --sync-all\` run after the #327 wave merged: 2 of 8 consumers (\`friends-and-family-billing\`, \`swipewatch\`) failed render with \`unexpected \`<<<\` (no open \`>>> if\`)\`. Both are the CJS-template consumers. Root cause: the #327 round-3 codex P1 fix (inline React Compiler disables into the React blocks, delete the standalone block) landed correctly on \`examples/eslint.config.js\` but only partially on \`examples/eslint.config.cjs.js\` — only the \`// >>> if frameworks contains react\` opener was removed; the body + closing \`// <<<\` were left behind, producing both a parse error AND a latent unconditional rules block.

This PR deletes the orphan content from the CJS template (the templates were supposed to be byte-identical modulo import/export shape) and adds two guard tests so this drift class can't recur silently.

## Changes

- \`examples/eslint.config.cjs.js\` — delete the orphan rules block (lines 314-321) + the orphan \`// <<<\` (line 322). The pointer-comment block remains, matching ESM.
- \`tests/test_template_substitution.sh\`:
  - **13a**: marker-count parity check across both templates. ESM and CJS must each have balanced \`// >>> if\` / \`// <<<\` counts, AND the totals must match between the two files.
  - **13b**: render-success check on the actual \`examples/eslint.config.{js,cjs.js}\` files under every load-bearing fact combination from the manifest. Render-time parsing is the load-bearing proof.

## Why the existing tests didn't catch it

The previous tests (12a–12h) exercised the template lib against \*synthetic fixtures\*, not against \`examples/eslint.config.*.js\`. The orphan-\`<<<\` was in the real template but invisible to fixture-based tests. 13b closes that gap; 13a is the cheaper marker-count check that would have flagged the imbalance even without invoking the renderer.

## Test plan

- [x] \`bash tests/test_template_substitution.sh\` — 55/55 PASS (was 53/53; +2 new guard cases).
- [x] Marker counts equal: 22=22 (11 open + 11 close in each file).
- [ ] Post-merge: re-run \`scripts/sync-to-downstream.sh --sync-all\` to fan out to friends-and-family-billing and swipewatch (the 2 consumers that failed in the first round).

Authoring-Agent: claude

## Self-Review

- **Correctness:** The deleted lines exactly match the orphan content that has no opener in the template-substitution lib's marker grammar. Confirmed by diff against the ESM template (which is now structurally aligned with the CJS template post-fix).
- **Regression risk:** Low. The deleted lines were rendering an unconditional rules block referencing react-hooks/* — a latent correctness bug that would have broken consumer ESLint runs if the parse error hadn't blocked rendering entirely. Removing it brings CJS to parity with ESM's correct shape.
- **Style:** Matches existing test structure (\`PASS:\` / \`FAIL:\` output, \`reset_facts\` + sourced \`\$LIB\` pattern, render in subshell for fact isolation).
- **Test coverage:** Two new guards. 13a is a cheap text-grep check; 13b actually invokes the renderer to confirm parse-clean under real consumer facts. Either would have caught the orphan-\`<<<\` bug at the unit-test layer instead of in prod.
- **Security/dependency hygiene:** No new dependencies. No secrets. The fix removes content, doesn't add any.