### PR TITLE
fix(hooks): gh-pr-guard recognizes propagation-lane PRs (#334)

### DIFF
--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -64,6 +64,20 @@
 #   if present; without the file the hook conservatively assumes
 #   over-threshold so the self-approve block fires on safer side.
 #
+#   The self-approve guard has one carve-out (#334): propagation-lane
+#   sync PRs are EXEMPT. A PR qualifies as a lane PR when (1) its
+#   branch name starts with `mergepath-sync/` (configurable via
+#   GH_PR_GUARD_PROPAGATION_BRANCH_PREFIX) and (2) its GitHub author
+#   is the configured `nathanjohnpayne` identity. For lane PRs, the
+#   self-approve guard returns exit 0 without checking
+#   Authoring-Agent, size, or threshold — REVIEW_POLICY.md
+#   § Propagation PR review lane explicitly allows internal reviewer-
+#   identity APPROVED regardless of size, because the content is a
+#   verbatim mirror that was already reviewed in the upstream
+#   mergepath PR. The manifest-confinement third lane criterion is
+#   intentionally deferred to scripts/workflow/verify-propagation-
+#   pr.sh; branch_prefix + author is sufficient signal at this layer.
+#
 #   These guards are scoped to `gh pr comment` / `gh pr review` /
 #   `gh issue comment` / `gh issue create` exactly. `gh issue create`
 #   was added by #317 after the concrete misattribution of mergepath
@@ -782,11 +796,16 @@ if [ "$PR_SUBCOMMAND" = "review" ]; then
     esac
 
     if [ -n "$KEYRING_AGENT" ]; then
-      # Fetch PR body + lines-changed to determine (a) the
-      # Authoring-Agent line and (b) over-threshold status.
-      review_gh_args=(pr view --json body,additions,deletions,files --jq '{body: .body, additions: .additions, deletions: .deletions, files: [.files[].path]}')
+      # Fetch PR body + lines-changed + headRefName + author for the
+      # self-approve check. headRefName + author drive the propagation-
+      # lane bypass (#334): lane PRs (branch starts with
+      # `mergepath-sync/`, author = nathanjohnpayne) are exempt from
+      # cross-agent review per REVIEW_POLICY.md § Propagation PR
+      # review lane, so the same-agent self-approve guard shouldn't
+      # fire on them regardless of size or Authoring-Agent body line.
+      review_gh_args=(pr view --json body,additions,deletions,files,headRefName,author --jq '{body: .body, additions: .additions, deletions: .deletions, files: [.files[].path], head: .headRefName, author: .author.login}')
       if [ -n "$REVIEW_PR_SELECTOR" ]; then
-        review_gh_args=(pr view "$REVIEW_PR_SELECTOR" --json body,additions,deletions,files --jq '{body: .body, additions: .additions, deletions: .deletions, files: [.files[].path]}')
+        review_gh_args=(pr view "$REVIEW_PR_SELECTOR" --json body,additions,deletions,files,headRefName,author --jq '{body: .body, additions: .additions, deletions: .deletions, files: [.files[].path], head: .headRefName, author: .author.login}')
       fi
       if [ -n "$REVIEW_REPO" ]; then
         review_gh_args+=(--repo "$REVIEW_REPO")
@@ -801,6 +820,40 @@ if [ "$PR_SUBCOMMAND" = "review" ]; then
         echo "  stderr: $(cat "$REVIEW_GH_STDERR")" >&2
         echo "  command: gh ${review_gh_args[*]}" >&2
         exit 2
+      fi
+
+      # Propagation-lane bypass (#334). The lane criteria are:
+      #   (1) branch name starts with the configured branch_prefix
+      #       (default `mergepath-sync/`; override via
+      #       GH_PR_GUARD_PROPAGATION_BRANCH_PREFIX)
+      #   (2) PR author = configured author identity (default
+      #       nathanjohnpayne; reuses GH_PR_GUARD_EXPECTED_AUTHOR)
+      #
+      # REVIEW_POLICY.md § Propagation PR review lane explicitly
+      # exempts these PRs from the cross-agent Phase 4 requirement,
+      # because the content is a verbatim mirror that was already
+      # reviewed in the upstream mergepath PR. The lane PR still
+      # needs an internal reviewer-identity APPROVED, which is what
+      # the agent is trying to post — so the self-approve guard
+      # MUST step aside for lane PRs even when active=reviewer-agent
+      # AND PR body has `Authoring-Agent: <agent>` AND size > threshold.
+      #
+      # We deliberately skip the manifest-confinement third lane
+      # criterion (every changed file under a manifest-declared
+      # path) — that check belongs in verify-propagation-pr.sh, not
+      # the local pre-write hook. Branch_prefix + author is enough
+      # signal that this is a sync PR and the agent's approve is
+      # the documented next step.
+      PR_HEAD_REF=$(printf '%s\n' "$REVIEW_PR_JSON" | grep -oE '"head":[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"head":[[:space:]]*"([^"]*)".*/\1/' || true)
+      PR_AUTHOR=$(printf '%s\n' "$REVIEW_PR_JSON" | grep -oE '"author":[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"author":[[:space:]]*"([^"]*)".*/\1/' || true)
+      LANE_BRANCH_PREFIX="${GH_PR_GUARD_PROPAGATION_BRANCH_PREFIX:-mergepath-sync/}"
+      LANE_AUTHOR="${GH_PR_GUARD_EXPECTED_AUTHOR:-nathanjohnpayne}"
+      if [ -n "$PR_HEAD_REF" ] && [ -n "$PR_AUTHOR" ] \
+         && [ "$PR_AUTHOR" = "$LANE_AUTHOR" ] \
+         && [ "${PR_HEAD_REF#"$LANE_BRANCH_PREFIX"}" != "$PR_HEAD_REF" ]; then
+        # Lane criteria met — skip the self-approve guard entirely.
+        # Allow the gh pr review --approve to proceed.
+        exit 0
       fi
 
       PR_AUTHORING_AGENT=$(printf '%s\n' "$REVIEW_PR_JSON" | grep -oiE 'Authoring-Agent:[[:space:]]*[A-Za-z0-9_-]+' | head -1 | sed -E 's/Authoring-Agent:[[:space:]]*//I' | tr '[:upper:]' '[:lower:]' || true)

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -77,17 +77,22 @@ case "$1 $2" in
       *body*)
         # Self-approve sub-guard fetch: emits a single JSON-ish blob.
         # The hook's --jq filter projects it into {body, additions,
-        # deletions, files} but our stub returns the same shape the
-        # hook then greps. Just emit raw fields the hook looks for.
+        # deletions, files, head, author} but our stub returns the
+        # same shape the hook then greps. Emit each field the hook
+        # looks for.
         body_safe="${STUB_PR_BODY:-}"
         additions="${STUB_PR_ADDITIONS:-0}"
         deletions="${STUB_PR_DELETIONS:-0}"
-        # The hook parses additions/deletions via regex on the
-        # "additions": NUM pattern, and reads PR_AUTHORING_AGENT from
-        # a body grep. Emit both in a single buffer.
+        # head + author drive the propagation-lane bypass (#334).
+        # Default head ref is a non-lane branch name; tests that
+        # exercise the lane override these explicitly via STUB_*.
+        head_ref="${STUB_PR_HEAD:-feature/some-branch}"
+        author="${STUB_PR_AUTHOR:-nathanjohnpayne}"
         printf '%s\n' "$body_safe"
         printf '"additions": %s\n' "$additions"
         printf '"deletions": %s\n' "$deletions"
+        printf '"head": "%s"\n' "$head_ref"
+        printf '"author": "%s"\n' "$author"
         exit 0
         ;;
       *)
@@ -138,6 +143,8 @@ run_hook_review() {
   local pr_body="${4:-}"
   local additions="${5:-0}"
   local deletions="${6:-0}"
+  local pr_head="${7:-feature/some-branch}"
+  local pr_author="${8:-nathanjohnpayne}"
   local payload
   payload=$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}')
   PATH="$STUB_DIR:$PATH" \
@@ -145,6 +152,8 @@ run_hook_review() {
   STUB_PR_BODY="$pr_body" \
   STUB_PR_ADDITIONS="$additions" \
   STUB_PR_DELETIONS="$deletions" \
+  STUB_PR_HEAD="$pr_head" \
+  STUB_PR_AUTHOR="$pr_author" \
   BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK="$skip_id" \
     bash "$HOOK" <<<"$payload"
 }
@@ -693,6 +702,100 @@ if [ "$rc" -eq 0 ]; then
   pass "byline guard: BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK=1 bypasses pr comment block"
 else
   fail "byline guard bypass: exit $rc, expected 0; output: $out"
+fi
+
+# ===========================================================================
+# Propagation-lane bypass (#334) — `gh pr review --approve` on a sync PR
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Test 29: propagation-lane PR (branch starts with mergepath-sync/,
+# author = nathanjohnpayne) MUST be approvable by the same agent that's
+# named in the body's Authoring-Agent line, EVEN when over-threshold.
+# REVIEW_POLICY.md § Propagation PR review lane explicitly allows internal
+# reviewer-identity APPROVED on these because the content is a verbatim
+# mirror that was already reviewed in the upstream mergepath PR. Closes #334.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook_review 'gh pr review 236 --approve --body "Propagation-lane approval."' \
+  "nathanpayne-claude" "0" \
+  "Sync to mergepath@b12e7d7. Authoring-Agent: claude" \
+  "5000" "0" \
+  "mergepath-sync/sync-all-b12e7d7" "nathanjohnpayne" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "propagation-lane: branch=mergepath-sync/* + author=nathanjohnpayne allows same-agent approve despite size + Authoring-Agent match"
+else
+  fail "propagation-lane bypass: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 30: lane bypass keys on BOTH criteria. Branch matches but author is
+# a different identity (e.g., a hijacked branch name) → bypass MUST NOT
+# fire; the self-approve guard still blocks. Defensive: a third-party
+# pushing to mergepath-sync/* shouldn't get free self-approve.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook_review 'gh pr review 99 --approve --body "Authoring-Agent: claude"' \
+  "nathanpayne-claude" "0" \
+  "Authoring-Agent: claude" \
+  "5000" "0" \
+  "mergepath-sync/sync-all-deadbeef" "some-other-author" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "lane bypass requires author match: exit $rc, expected 2 (block); output: $out"
+elif ! echo "$out" | grep -qi "self-approve detected"; then
+  fail "lane bypass requires author match: diagnostic missing 'self-approve detected'; output: $out"
+else
+  pass "propagation-lane: bypass requires BOTH branch_prefix AND author match (blocks when author wrong)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 31: lane bypass keys on BOTH criteria the other way. Author matches
+# but branch is a normal feature branch → bypass MUST NOT fire. Defensive:
+# a same-author feature branch is NOT a sync PR.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook_review 'gh pr review 99 --approve --body "Authoring-Agent: claude"' \
+  "nathanpayne-claude" "0" \
+  "Authoring-Agent: claude" \
+  "5000" "0" \
+  "feature/some-real-work" "nathanjohnpayne" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "lane bypass requires branch_prefix match: exit $rc, expected 2 (block); output: $out"
+elif ! echo "$out" | grep -qi "self-approve detected"; then
+  fail "lane bypass requires branch_prefix match: diagnostic missing 'self-approve detected'; output: $out"
+else
+  pass "propagation-lane: bypass requires BOTH branch_prefix AND author match (blocks when branch wrong)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 32: GH_PR_GUARD_PROPAGATION_BRANCH_PREFIX override. Customizing
+# the branch prefix to a non-default value (e.g., `sync/` for a fork that
+# uses a different convention) should make THAT prefix the lane signal.
+# ---------------------------------------------------------------------------
+set +e
+out=$(STUB_DIR_BAK="$STUB_DIR"; \
+      PATH="$STUB_DIR:$PATH" \
+      STUB_ACTIVE_USER="nathanpayne-claude" \
+      STUB_PR_BODY="Authoring-Agent: claude" \
+      STUB_PR_ADDITIONS="5000" \
+      STUB_PR_DELETIONS="0" \
+      STUB_PR_HEAD="sync/all-abc123" \
+      STUB_PR_AUTHOR="nathanjohnpayne" \
+      GH_PR_GUARD_PROPAGATION_BRANCH_PREFIX="sync/" \
+      BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK="0" \
+        bash "$HOOK" <<<"$(jq -n --arg c 'gh pr review 99 --approve --body "ok"' '{tool_input: {command: $c}}')" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "propagation-lane: GH_PR_GUARD_PROPAGATION_BRANCH_PREFIX override recognizes alternate prefix"
+else
+  fail "propagation-lane prefix override: exit $rc, expected 0; output: $out"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #334.

## Summary

Adds a propagation-lane bypass to the self-approve sub-guard in \`scripts/hooks/gh-pr-guard.sh\`. Sync PRs from \`scripts/sync-to-downstream.sh --sync-all\` have all three of (a) over-threshold size, (b) \`Authoring-Agent: claude\` in the body, and (c) same-agent reviewer trying to approve — which made the existing self-approve heuristic block the agent's APPROVED on every sync PR even though REVIEW_POLICY.md § Propagation PR review lane explicitly allows internal reviewer-identity APPROVED for them (content is a verbatim mirror, already reviewed upstream).

## What changed

- \`scripts/hooks/gh-pr-guard.sh\`:
  - The self-approve sub-guard's \`gh pr view\` call now also fetches \`headRefName\` and \`author\`.
  - Before running the same-agent self-approve check, the hook checks two lane criteria: branch starts with \`mergepath-sync/\` (configurable via \`GH_PR_GUARD_PROPAGATION_BRANCH_PREFIX\`) AND author = configured author identity (reuses \`GH_PR_GUARD_EXPECTED_AUTHOR\`, default nathanjohnpayne). Both must match.
  - If both match → exit 0 immediately (lane bypass).
  - If either fails → fall through to the existing same-agent self-approve check unchanged.
- \`tests/test_gh_pr_guard.sh\`:
  - Stub gh now emits \`head\` + \`author\` fields (defaults: non-lane branch / nathanjohnpayne).
  - \`run_hook_review\` takes two new optional positional args (\`pr_head\`, \`pr_author\`).
  - 4 new cases: positive lane bypass, two negative tests (only-branch / only-author should NOT bypass), and the \`GH_PR_GUARD_PROPAGATION_BRANCH_PREFIX\` override.

## Why scope keeps the manifest-confinement check OUT

The third lane criterion from REVIEW_POLICY.md (every changed file under a manifest-declared path) lives in \`scripts/workflow/verify-propagation-pr.sh\`. The hook is the wrong layer for that — it'd require parsing \`.mergepath-sync.yml\` from the consumer's working tree, which the hook doesn't have. branch_prefix + author is sufficient signal at this layer.

## Concrete instance the fix unblocks

Today's \`--sync-all\` opened 8 consumer PRs to mergepath@b12e7d7. 3 small ones merged directly (consumer branch protection didn't require an approving review for the \`mergepath-sync/*\` prefix on those repos). 5 large ones (device-source-of-truth, ffb, dpr, swipewatch, tadlock) were BLOCKED on missing approval and the agent's \`gh pr review --approve\` was blocked by this guard. With the fix, the agent posts the lane-exempt approval directly — no cross-agent codex CLI handoff needed for the lane.

## Test plan

- [x] \`bash tests/test_gh_pr_guard.sh\` — 36/36 PASS (was 32/32).
- [x] \`bash scripts/ci/check_gh_as_author\` — PASS (wraps the same suite).
- [x] Hook syntax check via \`bash -n\`.
- [ ] Post-merge: re-attempt \`gh pr review --approve\` on the 5 BLOCKED consumer sync PRs (#90, #275, #85, #54, #60). With the lane bypass live, the hook should allow them through. Then merge.

Authoring-Agent: claude

## Self-Review

- **Correctness:** Lane bypass keys on EXACTLY the two policy criteria (branch_prefix + author). The third criterion (manifest confinement) intentionally lives in verify-propagation-pr.sh per the in-code comment; documented as a layering decision.
- **Regression risk:** Low. The bypass is additive — it short-circuits BEFORE the existing same-agent check. Non-lane PRs (no branch match, OR no author match) go through the unchanged path. New negative tests confirm both halves of the AND condition are required.
- **Style:** Matches existing hook idioms (env var fallback pattern, single-grep + sed extraction for JSON-ish fields, exit 0 to allow). Header doc updated.
- **Test coverage:** 4 new cases — positive bypass, two independence checks (branch-only / author-only must NOT bypass), env override. The 32 pre-existing tests all still pass, confirming the bypass doesn't accidentally allow non-lane self-approves.
- **Security/dependency hygiene:** Tightens nothing; doesn't loosen anything beyond the documented lane policy. No new dependencies.