### PR TITLE
fix(hooks): stop blocking gh issue create (revert #317 byline guard)

### DIFF
--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -281,7 +281,7 @@ affect the byline for that row; the byline follows `GH_TOKEN`.
 | `gh pr review --approve` (over-threshold, same agent) | **BLOCKED** by `scripts/hooks/gh-pr-guard.sh` per § No-self-approve scoping (#284) | n/a |
 | `gh pr review --approve` (over-threshold, cross-agent) | `nathanpayne-<other-agent>`; the cross-agent reviewer identity per Phase 4 | reviewer PAT |
 | `gh pr view` (read) | any (does not write) | any read-capable PAT |
-| `gh issue create` | `nathanpayne-<agent>` (agent files the issue, e.g. post-merge follow-ups per AGENTS.md step 11) | reviewer PAT |
+| `gh issue create` | any — **not hook-gated** (#317 byline guard reverted); issues may be filed under the author identity (`nathanjohnpayne`) or an agent identity, e.g. post-merge follow-ups per AGENTS.md step 11 | author or reviewer PAT |
 | `gh issue comment` | `nathanpayne-<agent>`; blocked when active is `nathanjohnpayne` (#284) | reviewer PAT |
 | `gh issue close` | any (out of #284 scope — not yet hook-gated) | any |
 | `gh api GET ...` | irrelevant (read-only) | any read-capable PAT |

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -41,17 +41,21 @@
 #     - gh pr comment <PR#> --body "..."
 #     - gh pr review <PR#> --comment / --approve / --request-changes
 #     - gh issue comment <issue#> --body "..."
-#     - gh issue create --title "..." --body "..."     (#317)
 #
-#   For all four, the keyring's active account must be the agent's
+#   For all three, the keyring's active account must be the agent's
 #   REVIEWER identity (nathanpayne-<agent>, default nathanpayne-claude;
 #   override via GH_PR_GUARD_EXPECTED_REVIEWER). Posting these as the
 #   AUTHOR identity (nathanjohnpayne) breaks the audit-trail
 #   convention REVIEW_POLICY.md depends on — reviewer comments must
-#   attribute to the reviewer, and an agent filing their own bug must
-#   attribute to that agent (not to the author identity). The check
-#   fires before the keyring write so misattributed comments / issues
-#   never land.
+#   attribute to the reviewer. The check fires before the keyring
+#   write so misattributed comments never land.
+#
+#   `gh issue create` is intentionally NOT in this set. It was briefly
+#   guarded (#317, after the mergepath#315 misattribution) but that
+#   overreached: filing issues under the author identity
+#   (nathanjohnpayne) is a long-standing, intended workflow, so the
+#   issue-create byline clause was reverted. Issue creation is allowed
+#   under any identity.
 #
 #   Additionally, `gh pr review --approve` is blocked when the
 #   target PR is OVER-threshold AND the keyring is the agent's own
@@ -79,14 +83,10 @@
 #   pr.sh; branch_prefix + author is sufficient signal at this layer.
 #
 #   These guards are scoped to `gh pr comment` / `gh pr review` /
-#   `gh issue comment` / `gh issue create` exactly. `gh issue create`
-#   was added by #317 after the concrete misattribution of mergepath
-#   #315 — a `nathanpayne-claude` agent session filed a bug, but the
-#   keyring had drifted to `nathanpayne-codex` from the prior Phase
-#   4b CLI run, and the issue landed under the wrong byline. The
-#   guard treats `gh issue create` the same as `gh issue comment`:
-#   keyring active must be the REVIEWER identity (an agent posting
-#   their own work).
+#   `gh issue comment` exactly. `gh issue create` was briefly added by
+#   #317 (after the mergepath#315 misattribution) but later reverted —
+#   see the byline-coverage note above — so issue creation is no
+#   longer gated by this hook.
 #
 #   Raw `gh api -X POST .../comments` is still intentionally NOT
 #   covered — the token/keyring auth matrix for raw `gh api` writes
@@ -604,59 +604,49 @@ EFFECTIVE_BREAK_GLASS_MERGE_STATE="${BREAK_GLASS_MERGE_STATE:-${INLINE_BREAK_GLA
 
 # Distinguish `gh pr comment` from `gh issue comment` (both share the
 # subcommand label `comment` but route through different parent
-# tokens) AND `gh pr create` from `gh issue create` (same shape, with
-# `gh issue create` added by #317). Downstream guard branches use
-# these flags to pick the right diagnostic label and the right
-# expected-identity policy.
+# tokens). `gh issue create` is intentionally NOT guarded (the #317
+# clause was reverted — see header), so it needs no flag of its own.
 IS_ISSUE_COMMENT=0
-IS_ISSUE_CREATE=0
 if [ "$SAW_ISSUE" -eq 1 ] && [ "$PR_SUBCOMMAND" = "comment" ]; then
   IS_ISSUE_COMMENT=1
 fi
-if [ "$SAW_ISSUE" -eq 1 ] && [ "$PR_SUBCOMMAND" = "create" ]; then
-  IS_ISSUE_CREATE=1
-fi
 
 # A `gh issue <X>` invocation where X is anything OTHER than `comment`
-# or `create` (issue close / view / list / edit / etc.) is out of
-# scope for this hook. Allow.
-if [ "$SAW_ISSUE" -eq 1 ] && [ "$IS_ISSUE_COMMENT" -eq 0 ] && [ "$IS_ISSUE_CREATE" -eq 0 ]; then
+# (issue create / close / view / list / edit / etc.) is out of scope
+# for this hook. Allow. `gh issue create` was briefly byline-guarded
+# (#317) but reverted — filing issues under the author identity is an
+# intended, long-standing workflow.
+if [ "$SAW_ISSUE" -eq 1 ] && [ "$IS_ISSUE_COMMENT" -eq 0 ]; then
   exit 0
 fi
 
-# Not a covered command? Allow. `gh pr create` and `gh issue create`
-# both have PR_SUBCOMMAND=="create"; the IS_ISSUE_CREATE flag is what
-# routes them to different identity expectations below (author for pr,
-# reviewer for issue).
+# Not a covered command? Allow.
 if [ "$PR_SUBCOMMAND" != "create" ] && \
    [ "$PR_SUBCOMMAND" != "merge" ] && \
    [ "$PR_SUBCOMMAND" != "comment" ] && \
    [ "$PR_SUBCOMMAND" != "review" ] && \
-   [ "$IS_ISSUE_COMMENT" -eq 0 ] && \
-   [ "$IS_ISSUE_CREATE" -eq 0 ]; then
+   [ "$IS_ISSUE_COMMENT" -eq 0 ]; then
   exit 0
 fi
 
-# --- byline guard for pr comment / pr review / issue comment / issue create ---
+# --- byline guard for pr comment / pr review / issue comment ---
 #
-# These four subcommands share a single policy: the keyring's active
+# These three subcommands share a single policy: the keyring's active
 # account must be the agent's REVIEWER identity (not the author
 # identity). Posting any of them under nathanjohnpayne mis-attributes
 # the byline in a way that breaks the audit-trail invariant
 # REVIEW_POLICY.md depends on.
 #
-# `gh issue create` was added by #317 after mergepath#315 landed
-# under the wrong byline (a nathanpayne-claude agent filed the bug
-# but the keyring had drifted to nathanpayne-codex from a prior
-# Phase 4b CLI session). Same byline-attribution rule as the other
-# three: an agent filing their own bug must attribute to their
-# REVIEWER identity.
+# `gh issue create` is deliberately excluded — it was briefly guarded
+# here (#317, after the mergepath#315 misattribution) but reverted,
+# since filing issues under the author identity is an intended,
+# long-standing workflow. See the header note.
 #
 # The `gh pr review --approve` self-approve sub-guard runs after this
 # block — only if we made it past the basic byline check does the
 # self-approve question even arise.
 EXPECTED_REVIEWER="${GH_PR_GUARD_EXPECTED_REVIEWER:-nathanpayne-claude}"
-if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS_ISSUE_COMMENT" -eq 1 ] || [ "$IS_ISSUE_CREATE" -eq 1 ]; then
+if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS_ISSUE_COMMENT" -eq 1 ]; then
   if [ "${BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK:-0}" != "1" ]; then
     ACTIVE_GH_USER=$(gh config get -h github.com user 2>/dev/null || echo "")
     if [ -z "$ACTIVE_GH_USER" ]; then
@@ -678,19 +668,12 @@ if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS
         review)  cmd_label="gh pr review" ;;
       esac
       [ "$IS_ISSUE_COMMENT" -eq 1 ] && cmd_label="gh issue comment"
-      [ "$IS_ISSUE_CREATE" -eq 1 ] && cmd_label="gh issue create"
       echo "BLOCKED: $cmd_label is about to run under active account '$ACTIVE_GH_USER' (the AUTHOR identity)." >&2
       echo "" >&2
-      echo "  Reviewer-byline commands (pr comment / pr review / issue comment / issue create)" >&2
+      echo "  Reviewer-byline commands (pr comment / pr review / issue comment)" >&2
       echo "  must attribute to the agent's REVIEWER identity ('$EXPECTED_REVIEWER' by default)," >&2
       echo "  not the author identity. Posting as '$EXPECTED_AUTHOR_FOR_BLOCK' breaks the audit-" >&2
       echo "  trail convention REVIEW_POLICY.md depends on." >&2
-      if [ "$IS_ISSUE_CREATE" -eq 1 ]; then
-        echo "" >&2
-        echo "  Concrete instance: mergepath#315 landed under nathanpayne-codex despite being" >&2
-        echo "  filed by a nathanpayne-claude agent session, because the keyring had drifted" >&2
-        echo "  from a prior Phase 4b CLI run. This hook closes that gap (#317)." >&2
-      fi
       echo "" >&2
       echo "  Fix once: gh auth switch -u $EXPECTED_REVIEWER" >&2
       echo "  Or wrap the single call: scripts/gh-as-reviewer.sh -- $cmd_label ..." >&2
@@ -698,17 +681,6 @@ if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS
       exit 2
     fi
   fi
-fi
-
-# --- gh issue create: exit cleanly after the byline check ------------
-#
-# `gh issue create` shares PR_SUBCOMMAND=="create" with `gh pr create`,
-# so without this short-circuit it would fall through into the pr-create
-# branch below (which expects the AUTHOR identity, not the REVIEWER
-# identity — opposite of what `gh issue create` wants). Exit 0 here so
-# downstream pr-create logic doesn't fire.
-if [ "$IS_ISSUE_CREATE" -eq 1 ]; then
-  exit 0
 fi
 
 # --- gh pr review --approve self-approve sub-guard --------------------

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -527,39 +527,31 @@ out=$(run_hook 'gh issue close 7' "nathanjohnpayne" "0" 2>&1)
 rc=$?
 set -e
 if [ "$rc" -eq 0 ]; then
-  pass "issue close: allowed (only 'issue comment' and 'issue create' are guarded)"
+  pass "issue close: allowed (only 'issue comment' is guarded; issue create is not)"
 else
   fail "issue close: exit $rc, expected 0; output: $out"
 fi
 
 # ---------------------------------------------------------------------------
-# Test 23a: gh issue create with AUTHOR identity → blocked (#317).
-# Closes the mergepath#315 misattribution gap: a nathanpayne-claude
-# agent session filed an issue, but the keyring had drifted to
-# nathanpayne-codex from the prior Phase 4b CLI run, and the issue
-# landed under the wrong byline. The hook should now catch this:
-# any keyring active = the AUTHOR identity (nathanjohnpayne) is
-# blocked because issue creation should attribute to a REVIEWER
-# (agent) identity.
+# Test 23a: gh issue create with AUTHOR identity → ALLOWED.
+# The #317 byline guard on issue creation was reverted: filing issues
+# under the author identity (nathanjohnpayne) is an intended, long-
+# standing workflow, so `gh issue create` is no longer gated by this
+# hook under any identity.
 # ---------------------------------------------------------------------------
 set +e
 out=$(run_hook 'gh issue create --title "Bug report" --body "saw the thing"' "nathanjohnpayne" "0" 2>&1)
 rc=$?
 set -e
-if [ "$rc" -ne 2 ]; then
-  fail "issue create + author identity: exit $rc, expected 2; output: $out"
-elif ! echo "$out" | grep -qi "gh issue create"; then
-  fail "issue create + author identity: diagnostic missing 'gh issue create'; output: $out"
-elif ! echo "$out" | grep -qi "mergepath#315"; then
-  fail "issue create + author identity: diagnostic missing #315 reference; output: $out"
+if [ "$rc" -eq 0 ]; then
+  pass "issue create + author identity: allowed (#317 byline guard reverted)"
 else
-  pass "issue create + author identity: blocked with #317 diagnostic"
+  fail "issue create + author identity: exit $rc, expected 0; output: $out"
 fi
 
 # ---------------------------------------------------------------------------
-# Test 23b: gh issue create with REVIEWER identity → allowed (#317).
-# The happy path: the keyring is the agent's reviewer identity, the
-# issue posts under that byline, no block.
+# Test 23b: gh issue create with REVIEWER identity → allowed.
+# Filing under an agent identity remains valid too.
 # ---------------------------------------------------------------------------
 set +e
 out=$(run_hook 'gh issue create --title "Bug report" --body "saw the thing"' "nathanpayne-claude" "0" 2>&1)
@@ -572,26 +564,11 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 23c: gh issue create with bypass set → allowed even under
-# AUTHOR identity (test/CI escape hatch parity with the other
-# reviewer-byline checks).
-# ---------------------------------------------------------------------------
-set +e
-out=$(run_hook 'gh issue create --title "Bug" --body "..."' "nathanjohnpayne" "1" 2>&1)
-rc=$?
-set -e
-if [ "$rc" -eq 0 ]; then
-  pass "issue create + author identity + bypass: allowed (escape hatch)"
-else
-  fail "issue create + bypass: exit $rc, expected 0; output: $out"
-fi
-
-# ---------------------------------------------------------------------------
 # Test 23d: gh issue create must NOT fall through to the pr-create
 # branch's body checks. `gh pr create` requires Authoring-Agent: and
 # ## Self-Review in the body; `gh issue create` has neither convention.
-# Regression: PR_SUBCOMMAND=="create" alone is insufficient to decide
-# the branch — the IS_ISSUE_CREATE flag must route correctly.
+# Regression: PR_SUBCOMMAND=="create" alone must not route issue
+# creation into the pr-create body requirements.
 # ---------------------------------------------------------------------------
 set +e
 out=$(run_hook 'gh issue create --title "Bug" --body "no Authoring-Agent line here"' "nathanpayne-claude" "0" 2>&1)


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

The #317 byline guard added `gh issue create` to `gh-pr-guard.sh`'s reviewer-identity block, so filing an issue under the author identity (`nathanjohnpayne`) was rejected. That overreached — creating issues under the author identity is a long-standing, intended workflow. This reverts the issue-create clause while leaving the `pr comment` / `pr review` / `issue comment` byline guards intact.

- `scripts/hooks/gh-pr-guard.sh`: drop `IS_ISSUE_CREATE` detection, routing, byline-guard membership, the issue-create diagnostic, and the now-dead pr-create short-circuit. All `gh issue` subcommands except `comment` are now allowed.
- `tests/test_gh_pr_guard.sh`: assert `gh issue create` is allowed under both author and reviewer identities; drop the bypass-parity case.
- `REVIEW_POLICY.md`: Operation-to-Identity Matrix row updated — `gh issue create` is no longer hook-gated.

Note: `gh-pr-guard.sh` is a canonical propagated file (`.mergepath-sync.yml`), so this relaxation flows to consumer repos via the normal propagation lane.

## Self-Review

- **Correctness:** `gh issue create` now exits 0 at the issue-routing block before the byline guard; no remaining `IS_ISSUE_CREATE` references; `bash -n` clean.
- **Regression risk:** Low — only the issue-create path changes. `pr comment` / `pr review` / `issue comment` byline guards, pr-create identity+body checks, merge-state/admin/label gates, and the self-approve sub-guard are untouched. Full suite: 35 passed, 0 failed.
- **Style:** Comments and the header byline-coverage note rewritten from "four" to "three" guarded commands.
- **Test coverage:** Tests 23a/23b flipped to assert allow; 23d (no fall-through to pr-create body checks) retained; redundant bypass-parity case removed.
- **Security/dependency hygiene:** Relaxes a byline-attribution control for issue creation only, per the repo owner's intent. No dependency changes. Reviewer-byline and pr-create/merge protections remain enforced.