### PR TITLE
docs: reconcile 1Password agent secret guidance

### DIFF
--- a/.ai_context.md
+++ b/.ai_context.md
@@ -47,7 +47,7 @@ chmod +x ~/.local/bin/gcloud ~/.local/bin/op-firebase-deploy ~/.local/bin/op-fir
 - The 1Password-first deploy-auth model is a deliberate default for repos created from this template and should not be reversed without explicit human approval
 - The local `gcloud` wrapper resolves source credentials through a narrower 3-step chain (`GOOGLE_APPLICATION_CREDENTIALS` → shared 1Password ADC → local ADC file) so normal `gcloud` commands work without routine browser login prompts. The wrapper does NOT consult per-project Firebase-vault SA keys; that step is specific to `op-firebase-deploy`
 - No deploy service-account key is committed to a repo (the SA key lives in 1Password and is materialized only as a tempfile during a single deploy invocation)
-- Runtime application secrets can still use `op://` references and `op inject` when a repo needs 1Password-managed secrets unrelated to deploy auth
+- Runtime application secrets follow a two-lane 1Password model, reconciled with 1Password docs as of 2026-05-21: attended local agents should use 1Password Environments and the client-specific adapter that applies (Codex MCP where available, the 1Password local `.env` validation hook for supported non-Codex agents); CI/headless workflows should use explicitly scoped service-account tokens only after the relevant decision ticket approves the scope. Shell scripts may continue to use `op://` references, `op run`, and `op inject` where a generated runtime file is genuinely required.
 
 ### Usage
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -81,7 +81,7 @@ cd ~/Documents/GitHub
 for repo in $repos; do
   git clone "https://github.com/nathanjohnpayne/$repo.git" 2>/dev/null || (cd "$repo" && git pull)
   cd "$repo"
-  ./scripts/bootstrap.sh    # restores .env.local from 1Password via op inject
+  ./scripts/bootstrap.sh    # restores generated config from 1Password templates
   cd ..
 done
 ```
@@ -90,6 +90,12 @@ The bootstrap script for each repo:
 - Resolves `op://` references in `.env.tpl` → writes `.env.local` (via `op inject`)
 - Runs `npm install`
 - Runs `npm run build` (if applicable)
+
+For new runtime application secrets, prefer the current 1Password
+Environments model described in [Runtime 1Password secrets and AI
+agents](#runtime-1password-secrets-and-ai-agents). Keep
+`.env.tpl`/`op inject` for repos that still need a generated,
+gitignored file on disk.
 
 ### 5. Verify
 
@@ -696,8 +702,67 @@ Each project's SA key is stored in the 1Password **Firebase** vault with the nam
 
 - No API keys or secrets should be committed to the repository.
 - **Deploy auth uses the project Firebase-vault SA key as the default credential** (#154 — codified after recurring `firebase login --reauth` friction from #137 traced to RAPT/refresh-token expiry on the shared 1Password ADC). The SA key lives in the 1Password Firebase vault — it's not stored on disk except as a tempfile during a single deploy invocation, and never committed to a repo. Impersonated credentials remain available for cases where the SA key isn't provisioned, but the policy default is to provision the key per-project per § Provisioning the Firebase-vault SA key below.
-- Runtime secrets can still use `op://Private/<item>/<field>` references in committed template files and `op inject` into gitignored runtime files when a repo actually needs 1Password-managed application secrets.
+- Runtime application secrets should use the two-lane 1Password model below. Prefer 1Password Environments for project/stage variable sets, use secret references and `op inject` when a repo genuinely needs generated files, and reserve service-account tokens for explicitly scoped headless workflows.
 - Never commit resolved secret output, service-account JSON, or ADC credentials.
+
+### Runtime 1Password secrets and AI agents
+
+Reconciled against 1Password Environments / MCP Server for Codex docs
+as of 2026-05-21. This section is descriptive; adoption decisions for
+the new access model live in the 1Password audit ADR workstream
+(#347/#355/#356/#357).
+
+Reference docs:
+[1Password Environments](https://www.1password.dev/environments),
+[MCP Server for Codex](https://www.1password.dev/environments/mcp-codex-server),
+[local `.env` validation hook](https://www.1password.dev/environments/agent-hook-validate),
+and [`op run` secret loading](https://www.1password.dev/cli/secrets-environment-variables).
+
+Mergepath uses a portable core with per-client adapters:
+
+- **Portable core:** 1Password Environments, `op://` secret
+  references, `op run --environment <environment_id> -- <command>`,
+  `op inject` for generated config files, and scoped service-account
+  tokens for non-interactive runners. These primitives are useful to
+  any shell-capable agent or CI system.
+- **Attended Codex:** the 1Password Environments MCP Server for Codex
+  is the documented adapter for Codex. It lets Codex create and manage
+  Environments, list variable names, and run applications with runtime
+  injection while 1Password keeps raw secret values out of the model
+  context and off disk.
+- **Other attended agents:** Claude Code, Cursor, GitHub Copilot, and
+  Windsurf can use the 1Password local `.env` validation hook when a
+  repo relies on mounted 1Password Environment files.
+- **CI/headless:** use a scoped 1Password service account or
+  pre-materialized CI secret only after a ticket explicitly approves
+  the scope. Do not hand `OP_SERVICE_ACCOUNT_TOKEN` to local attended
+  agents as a convenience fallback.
+- **Existing shell scripts:** keep `op read`, `op run`, and
+  `op inject` shell-outs for repo automation. There is no current
+  requirement to migrate these scripts to a language SDK.
+
+Compatibility matrix:
+
+| Capability | Codex | Claude Code | Cursor | GitHub Copilot | Windsurf | CI/headless |
+|---|---|---|---|---|---|---|
+| 1Password Environments MCP Server | Officially documented for Codex | Not documented here | Not documented here | Not documented here | Not documented here | No |
+| 1Password local `.env` validation hook | Not listed in the hook support matrix | Supported | Supported | Supported | Supported | No |
+| `op run --environment` / secret references | Works if shell-capable | Works if shell-capable | Works if shell-capable | Works if shell-capable | Works if shell-capable | Works with scoped service account |
+| Service-account token | Headless only; explicit opt-in | Headless only; explicit opt-in | Headless only; explicit opt-in | Headless only; explicit opt-in | Headless only; explicit opt-in | Preferred non-interactive path |
+| Mergepath `op-preflight.sh` review mode | Configured | Configured | Configured | Not configured | Not configured | Planned only after token-mode work |
+
+Operational guardrails:
+
+- Never ask a human to paste raw secrets into an agent chat or issue.
+- Never print resolved secret values in logs, PR bodies, or review
+  comments.
+- Use 1Password Environments for sets of runtime variables that need
+  to move across developers, stages, or agents.
+- Use `.env.tpl` plus `op inject` only when the application or tool
+  truly requires a materialized config file.
+- Treat legacy Secure Note `notesPlain` bootstrap as a compatibility
+  path pending the #344/#350/#351/#352 migration, not as the target
+  model for new repos.
 
 ### Provisioning the Firebase-vault SA key
 

--- a/docs/agents/bootstrap-runbook.md
+++ b/docs/agents/bootstrap-runbook.md
@@ -144,6 +144,17 @@ Implementation: `scripts/bootstrap/github-infra.sh`.
 5. Prompt for and provision optional LLM secrets (`ANTHROPIC_API_KEY`,
    `OPENAI_API_KEY`) with skip option.
 
+For runtime application secrets in newly bootstrapped repos, prefer
+1Password Environments over new Secure Note / `notesPlain` bootstrap
+entries. The shared model is: use Environments and `op run` for
+runtime variable sets, use the 1Password MCP Server only for attended
+Codex Environment workflows, use the 1Password local `.env` validation
+hook for supported non-Codex agents that read mounted Environment
+files, and use `.env.tpl` + `op inject` only when the repo truly needs
+a generated config file on disk. Adoption decisions for these adapters
+belong to the 1Password audit ADR workstream; this runbook records the
+current compatibility guidance.
+
 All write-path `gh` calls run under the author identity
 (`nathanjohnpayne`) via a stage-scope `gh auth switch` wrap. The
 prior active account is captured at stage entry and restored at every

--- a/docs/agents/deployment-process.md
+++ b/docs/agents/deployment-process.md
@@ -19,6 +19,33 @@ If the project uses Firebase or Google Cloud, prefer the canonical
   for a deploy session.
 - If an `op` command fails with a sign-in or biometric error during deploy, follow the pause-and-prompt procedure in [operating-rules.md](operating-rules.md#1password-cli-authentication-failures). Do not retry or work around the failure without the human present.
 
+## Runtime 1Password secrets for agents
+
+As of the 2026-05-21 reconciliation against 1Password Environments
+and the 1Password Environments MCP Server for Codex docs, use this
+descriptive model when advising repos:
+
+- Portable core: 1Password Environments, secret references,
+  `op run --environment <environment_id> -- <command>`, `op inject`
+  for generated config files, and scoped service-account tokens for
+  CI/headless work.
+- Codex: use the official 1Password Environments MCP Server for Codex
+  where available; it is Codex-specific today and should not be
+  described as a universal agent adapter.
+- Claude Code, Cursor, GitHub Copilot, and Windsurf: use the
+  1Password local `.env` validation hook when the repo uses mounted
+  1Password Environment files.
+- CI/headless: use service-account tokens only when an approved ticket
+  has scoped the token, vault/Environment access, rotation, and log
+  masking. Do not use service-account tokens as a convenience fallback
+  for attended local agents.
+- Existing Mergepath scripts: shelling out to `op read`, `op run`, or
+  `op inject` remains acceptable. Do not introduce a language-SDK
+  migration unless a separate design decision calls for it.
+
+Never ask a human to paste raw secrets into chat or issue comments, and
+never print resolved secret values in logs.
+
 ## Credential source debugging
 
 When `op-firebase-deploy` runs, it prints a single line on stderr identifying which step in the [Deploy credential precedence](../../DEPLOYMENT.md#deploy-credential-precedence-canonical) won:

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -21,10 +21,12 @@
 #   4. Installs npm dependencies and runs the build.
 #
 # Best practices (from https://developer.1password.com/llms.txt):
-#   - Prefer .env.tpl with op:// references over Secure Note storage
-#   - Use `op run --env-file` for dev servers instead of writing .env
+#   - Prefer 1Password Environments for runtime variable sets
+#   - Use `op run --environment <env_id> -- <command>` for runtime use
+#   - Use mounted Environment .env files when the tool requires dotenv
 #   - Never pass secrets as CLI arguments (use stdin or --template)
-#   - Use `op inject` to resolve op:// references in template files
+#   - Use `op inject` only when generating a gitignored file is required
+#   - Treat Secure Note notesPlain storage as legacy compatibility
 # ──────────────────────────────────────────────────────────────
 set -eo pipefail
 


### PR DESCRIPTION
Authoring-Agent: codex

## Summary
- Reconciles Mergepath's runtime secret guidance with the current 1Password Environments, Codex MCP, local agent-hook, and `op run` docs.
- Adds the portable-core / per-client-adapter model and compatibility matrix for Codex, Claude Code, Cursor, GitHub Copilot, Windsurf, and CI/headless use.
- Marks Secure Note `notesPlain` bootstrap as legacy compatibility guidance while keeping #345 descriptive; adoption decisions remain in #347/#355/#356/#357.

## Self-Review
- Correctness: The docs now distinguish Codex-specific MCP support from portable `op`/Environment primitives and non-Codex hook support.
- Regression risk: Doc and comment-only change; no runtime shell logic changed.
- Style: Kept guidance centralized in deployment/bootstrap docs and avoided putting adoption decisions in this ticket.
- Tests: `git diff --check`; `bash -n scripts/bootstrap.sh`; `scripts/ci/check_required_root_files`; `scripts/ci/check_no_forbidden_top_level_dirs`; `scripts/ci/check_dist_not_modified`; `scripts/ci/check_duplicate_docs`; `scripts/ci/check_no_tool_folder_instructions`; `scripts/ci/check_spec_test_alignment`; `scripts/ci/check_eslint_config_present`; `scripts/ci/check_eslint_config_policy`; `scripts/ci/check_ci_scripts_wired`; bootstrap board/wizard/github-infra/firebase/template-mirror checks.
- Security/dependency hygiene: No secrets, new dependencies, generated artifacts, or credential material added.

Closes #345.
