### PR TITLE
chore(review-policy): require Phase 4b approval on all PRs (1P arc, temporary)

### DIFF
--- a/.ai_context.md
+++ b/.ai_context.md
@@ -47,7 +47,7 @@ chmod +x ~/.local/bin/gcloud ~/.local/bin/op-firebase-deploy ~/.local/bin/op-fir
 - The 1Password-first deploy-auth model is a deliberate default for repos created from this template and should not be reversed without explicit human approval
 - The local `gcloud` wrapper resolves source credentials through a narrower 3-step chain (`GOOGLE_APPLICATION_CREDENTIALS` → shared 1Password ADC → local ADC file) so normal `gcloud` commands work without routine browser login prompts. The wrapper does NOT consult per-project Firebase-vault SA keys; that step is specific to `op-firebase-deploy`
 - No deploy service-account key is committed to a repo (the SA key lives in 1Password and is materialized only as a tempfile during a single deploy invocation)
-- Runtime application secrets can still use `op://` references and `op inject` when a repo needs 1Password-managed secrets unrelated to deploy auth
+- Runtime application secrets follow a two-lane 1Password model, reconciled with 1Password docs as of 2026-05-21: attended local agents should use 1Password Environments and the client-specific adapter that applies (Codex MCP where available, the 1Password local `.env` validation hook for supported non-Codex agents); CI/headless workflows should use explicitly scoped service-account tokens only after the relevant decision ticket approves the scope. Shell scripts may continue to use `op://` references, `op run`, and `op inject` where a generated runtime file is genuinely required.
 
 ### Usage
 

--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -15,7 +15,12 @@
 #
 # Set to 0 to require external review on every PR.
 # Set to a very high number (e.g., 999999) to effectively disable.
-external_review_threshold: 300
+#
+# TEMP (1P audit arc — revert via #360): forced to 0 so EVERY PR enters
+# the external-review lane and gets `needs-external-review`, blocking the
+# under-threshold auto-merge that landed #358 without a 4b review (#359).
+# Restore to 300 when the arc completes.
+external_review_threshold: 0
 
 # ---------------------------------------------------------------------------
 # Protected Paths
@@ -249,7 +254,12 @@ coderabbit:
 #      See #29 for the observational evidence behind the Codex bot
 #      behavior, and #218 for the Phase 4b substitute path.
 codex:
-  enabled: true
+  # TEMP (1P audit arc — revert via #360): disabled so the Codex 4a
+  # auto-pass cannot clear the merge gate; with this off, the ONLY way to
+  # clear `needs-external-review` is a human/CLI Phase 4b APPROVED on the
+  # current HEAD (allow_phase_4b_substitute below). Restore to true when
+  # the arc completes.
+  enabled: false
 
   # GitHub login of the Codex GitHub App bot. Reviews posted by this login
   # satisfy the external-review requirement in `.github/workflows/pr-audit.yml`.
@@ -384,7 +394,11 @@ codex:
 # Existing repos without this field default to `fallback-only` per
 # scripts/codex-review-check.sh's parser — no behavior change without
 # explicit opt-in. See REVIEW_POLICY.md § Migration for existing consumers.
-phase_4b_default: complex-changes
+# TEMP (1P audit arc — revert via #360): forced to `always` so every
+# threshold PR requires the Phase 4b handoff (a human/CLI APPROVED),
+# not just classifier-selected ones. Restore to `complex-changes` when
+# the arc completes.
+phase_4b_default: always
 
 # ---------------------------------------------------------------------------
 # Auto-clear blocking labels (#195/#197)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -81,7 +81,7 @@ cd ~/Documents/GitHub
 for repo in $repos; do
   git clone "https://github.com/nathanjohnpayne/$repo.git" 2>/dev/null || (cd "$repo" && git pull)
   cd "$repo"
-  ./scripts/bootstrap.sh    # restores .env.local from 1Password via op inject
+  ./scripts/bootstrap.sh    # restores generated config from 1Password templates
   cd ..
 done
 ```
@@ -90,6 +90,12 @@ The bootstrap script for each repo:
 - Resolves `op://` references in `.env.tpl` → writes `.env.local` (via `op inject`)
 - Runs `npm install`
 - Runs `npm run build` (if applicable)
+
+For new runtime application secrets, prefer the current 1Password
+Environments model described in [Runtime 1Password secrets and AI
+agents](#runtime-1password-secrets-and-ai-agents). Keep
+`.env.tpl`/`op inject` for repos that still need a generated,
+gitignored file on disk.
 
 ### 5. Verify
 
@@ -696,8 +702,67 @@ Each project's SA key is stored in the 1Password **Firebase** vault with the nam
 
 - No API keys or secrets should be committed to the repository.
 - **Deploy auth uses the project Firebase-vault SA key as the default credential** (#154 — codified after recurring `firebase login --reauth` friction from #137 traced to RAPT/refresh-token expiry on the shared 1Password ADC). The SA key lives in the 1Password Firebase vault — it's not stored on disk except as a tempfile during a single deploy invocation, and never committed to a repo. Impersonated credentials remain available for cases where the SA key isn't provisioned, but the policy default is to provision the key per-project per § Provisioning the Firebase-vault SA key below.
-- Runtime secrets can still use `op://Private/<item>/<field>` references in committed template files and `op inject` into gitignored runtime files when a repo actually needs 1Password-managed application secrets.
+- Runtime application secrets should use the two-lane 1Password model below. Prefer 1Password Environments for project/stage variable sets, use secret references and `op inject` when a repo genuinely needs generated files, and reserve service-account tokens for explicitly scoped headless workflows.
 - Never commit resolved secret output, service-account JSON, or ADC credentials.
+
+### Runtime 1Password secrets and AI agents
+
+Reconciled against 1Password Environments / MCP Server for Codex docs
+as of 2026-05-21. This section is descriptive; adoption decisions for
+the new access model live in the 1Password audit ADR workstream
+(#347/#355/#356/#357).
+
+Reference docs:
+[1Password Environments](https://www.1password.dev/environments),
+[MCP Server for Codex](https://www.1password.dev/environments/mcp-codex-server),
+[local `.env` validation hook](https://www.1password.dev/environments/agent-hook-validate),
+and [`op run` secret loading](https://www.1password.dev/cli/secrets-environment-variables).
+
+Mergepath uses a portable core with per-client adapters:
+
+- **Portable core:** 1Password Environments, `op://` secret
+  references, `op run --environment <environment_id> -- <command>`,
+  `op inject` for generated config files, and scoped service-account
+  tokens for non-interactive runners. These primitives are useful to
+  any shell-capable agent or CI system.
+- **Attended Codex:** the 1Password Environments MCP Server for Codex
+  is the documented adapter for Codex. It lets Codex create and manage
+  Environments, list variable names, and run applications with runtime
+  injection while 1Password keeps raw secret values out of the model
+  context and off disk.
+- **Other attended agents:** Claude Code, Cursor, GitHub Copilot, and
+  Windsurf can use the 1Password local `.env` validation hook when a
+  repo relies on mounted 1Password Environment files.
+- **CI/headless:** use a scoped 1Password service account or
+  pre-materialized CI secret only after a ticket explicitly approves
+  the scope. Do not hand `OP_SERVICE_ACCOUNT_TOKEN` to local attended
+  agents as a convenience fallback.
+- **Existing shell scripts:** keep `op read`, `op run`, and
+  `op inject` shell-outs for repo automation. There is no current
+  requirement to migrate these scripts to a language SDK.
+
+Compatibility matrix:
+
+| Capability | Codex | Claude Code | Cursor | GitHub Copilot | Windsurf | CI/headless |
+|---|---|---|---|---|---|---|
+| 1Password Environments MCP Server | Officially documented for Codex | Not documented here | Not documented here | Not documented here | Not documented here | No |
+| 1Password local `.env` validation hook | Not listed in the hook support matrix | Supported | Supported | Supported | Supported | No |
+| `op run --environment` / secret references | Works if shell-capable | Works if shell-capable | Works if shell-capable | Works if shell-capable | Works if shell-capable | Works with scoped service account |
+| Service-account token | Headless only; explicit opt-in | Headless only; explicit opt-in | Headless only; explicit opt-in | Headless only; explicit opt-in | Headless only; explicit opt-in | Preferred non-interactive path |
+| Mergepath `op-preflight.sh` review mode | Configured | Configured | Configured | Not configured | Not configured | Planned only after token-mode work |
+
+Operational guardrails:
+
+- Never ask a human to paste raw secrets into an agent chat or issue.
+- Never print resolved secret values in logs, PR bodies, or review
+  comments.
+- Use 1Password Environments for sets of runtime variables that need
+  to move across developers, stages, or agents.
+- Use `.env.tpl` plus `op inject` only when the application or tool
+  truly requires a materialized config file.
+- Treat legacy Secure Note `notesPlain` bootstrap as a compatibility
+  path pending the #344/#350/#351/#352 migration, not as the target
+  model for new repos.
 
 ### Provisioning the Firebase-vault SA key
 

--- a/docs/agents/bootstrap-runbook.md
+++ b/docs/agents/bootstrap-runbook.md
@@ -144,6 +144,17 @@ Implementation: `scripts/bootstrap/github-infra.sh`.
 5. Prompt for and provision optional LLM secrets (`ANTHROPIC_API_KEY`,
    `OPENAI_API_KEY`) with skip option.
 
+For runtime application secrets in newly bootstrapped repos, prefer
+1Password Environments over new Secure Note / `notesPlain` bootstrap
+entries. The shared model is: use Environments and `op run` for
+runtime variable sets, use the 1Password MCP Server only for attended
+Codex Environment workflows, use the 1Password local `.env` validation
+hook for supported non-Codex agents that read mounted Environment
+files, and use `.env.tpl` + `op inject` only when the repo truly needs
+a generated config file on disk. Adoption decisions for these adapters
+belong to the 1Password audit ADR workstream; this runbook records the
+current compatibility guidance.
+
 All write-path `gh` calls run under the author identity
 (`nathanjohnpayne`) via a stage-scope `gh auth switch` wrap. The
 prior active account is captured at stage entry and restored at every

--- a/docs/agents/deployment-process.md
+++ b/docs/agents/deployment-process.md
@@ -19,6 +19,33 @@ If the project uses Firebase or Google Cloud, prefer the canonical
   for a deploy session.
 - If an `op` command fails with a sign-in or biometric error during deploy, follow the pause-and-prompt procedure in [operating-rules.md](operating-rules.md#1password-cli-authentication-failures). Do not retry or work around the failure without the human present.
 
+## Runtime 1Password secrets for agents
+
+As of the 2026-05-21 reconciliation against 1Password Environments
+and the 1Password Environments MCP Server for Codex docs, use this
+descriptive model when advising repos:
+
+- Portable core: 1Password Environments, secret references,
+  `op run --environment <environment_id> -- <command>`, `op inject`
+  for generated config files, and scoped service-account tokens for
+  CI/headless work.
+- Codex: use the official 1Password Environments MCP Server for Codex
+  where available; it is Codex-specific today and should not be
+  described as a universal agent adapter.
+- Claude Code, Cursor, GitHub Copilot, and Windsurf: use the
+  1Password local `.env` validation hook when the repo uses mounted
+  1Password Environment files.
+- CI/headless: use service-account tokens only when an approved ticket
+  has scoped the token, vault/Environment access, rotation, and log
+  masking. Do not use service-account tokens as a convenience fallback
+  for attended local agents.
+- Existing Mergepath scripts: shelling out to `op read`, `op run`, or
+  `op inject` remains acceptable. Do not introduce a language-SDK
+  migration unless a separate design decision calls for it.
+
+Never ask a human to paste raw secrets into chat or issue comments, and
+never print resolved secret values in logs.
+
 ## Credential source debugging
 
 When `op-firebase-deploy` runs, it prints a single line on stderr identifying which step in the [Deploy credential precedence](../../DEPLOYMENT.md#deploy-credential-precedence-canonical) won:

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -21,10 +21,12 @@
 #   4. Installs npm dependencies and runs the build.
 #
 # Best practices (from https://developer.1password.com/llms.txt):
-#   - Prefer .env.tpl with op:// references over Secure Note storage
-#   - Use `op run --env-file` for dev servers instead of writing .env
+#   - Prefer 1Password Environments for runtime variable sets
+#   - Use `op run --environment <env_id> -- <command>` for runtime use
+#   - Use mounted Environment .env files when the tool requires dotenv
 #   - Never pass secrets as CLI arguments (use stdin or --template)
-#   - Use `op inject` to resolve op:// references in template files
+#   - Use `op inject` only when generating a gitignored file is required
+#   - Treat Secure Note notesPlain storage as legacy compatibility
 # ──────────────────────────────────────────────────────────────
 set -eo pipefail
 


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
Temporarily reconfigures `.github/review-policy.yml` so **every** PR requires a human/CLI **Phase 4b APPROVED** before merge, for the duration of the 1Password audit arc. This closes the gap that let #358 auto-merge on a single under-threshold self-approval with no cross-agent review (#359).

Three values change:
- `external_review_threshold: 300 → 0` — every PR enters the external-review lane and gets `needs-external-review`, which the `auto-merge-on-approval` job refuses to merge past.
- `phase_4b_default: complex-changes → always` — every threshold PR requires the Phase 4b handoff, not just classifier-selected ones.
- `codex.enabled: true → false` — disables the Codex 4a auto-pass so it can't clear the gate; with `allow_phase_4b_substitute: true` (unchanged), the only way to clear `needs-external-review` is a Phase 4b `APPROVED` on the current HEAD from a non-author reviewer.

## Why temporary
Left in place, this would require a 4b review on *every* future PR in the repo forever. It should be reverted once the arc lands. Change-back is tracked in #360, triggered by the last arc umbrella (#344 / #346 / #347) closing.

## Self-Review
- **Correctness:** Verified the three values parse via `yq` (threshold=0, phase_4b=always, codex.enabled=false) and that `codex.allow_phase_4b_substitute` remains `true` — without it, gate (c) would have no clearance path with Codex disabled and `needs-external-review` could only be cleared by hand. Each change carries an inline `TEMP (1P arc — revert via #360)` comment.
- **Regression risk:** Config-only; no script/workflow logic changed. Repo-wide effect is intended (every PR → 4b). No CI check gates on these values (`check_review_policy_exists` only asserts the file parses/exists; `check_codex_*` assert script/test presence, not `codex.enabled`).
- **Style:** Minimal diff; preserves the existing explanatory comment blocks and adds scoped TEMP notes.
- **Test coverage:** No tests added — this is declarative config. YAML validity confirmed locally with `yq`.
- **Security/dependency hygiene:** No secrets, no dependencies, no credentials. Tightens the merge gate (strictly more review), so the change is risk-reducing.

## Note
`.github/review-policy.yml` matches `external_review_paths: .github/**`, so this PR will itself require a Phase 4b review to merge — by design. Do not auto-merge.

Refs #359. Revert tracked in #360.
