### PR TITLE
[#353] Add op-preflight service account token mode

### DIFF
--- a/scripts/ci/check_op_preflight_contract
+++ b/scripts/ci/check_op_preflight_contract
@@ -18,6 +18,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 TESTS=(
   "tests/test_op_preflight_check.sh"
+  "tests/test_op_preflight_token_mode.sh"
   "tests/test_helper_autosource.sh"
 )
 

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -71,6 +71,12 @@
 #                             "# preflight: cache hit, no biometric
 #                             burned" message replaces it. Refresh
 #                             notices and warnings are unaffected. #282
+#   OP_SERVICE_ACCOUNT_TOKEN  Explicit CI/headless lane. When set,
+#                             review mode reads ONLY the scoped reviewer
+#                             PAT through the 1Password CLI service-
+#                             account auth path. Author PAT, deploy
+#                             secrets, SSH warming, and gh keyring
+#                             repair stay out of scope.
 #
 # Session file:
 #   Path:        $cache_dir/op-preflight-<agent>.env
@@ -217,6 +223,11 @@ if ! [[ "$TTL_SECONDS" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+SERVICE_ACCOUNT_TOKEN_MODE=false
+if [[ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+  SERVICE_ACCOUNT_TOKEN_MODE=true
+fi
+
 # ── Cache paths (deterministic per agent) ─────────────────────────────
 SESSION_FILE="$CACHE_DIR/op-preflight-$AGENT.env"
 ADC_TMPFILE="$CACHE_DIR/op-preflight-$AGENT-adc.json"
@@ -237,8 +248,9 @@ if [[ ! "$SSH_WARM_TTL_SECONDS" =~ ^[0-9]+$ ]]; then
 fi
 
 # ── Biometric trigger log (#282) ──────────────────────────────────────
-# Append a one-line record every time we trigger a fresh op fetch (i.e.
-# every time `op inject` or `op read` is invoked for cache population).
+# Append a one-line record every time the interactive lane triggers a
+# fresh op fetch (i.e. every time `op inject` or deploy `op read` is
+# invoked for cache population).
 # Format: `<ISO8601> agent=<agent> mode=<mode> reason=<reason>` so a
 # session audit can correlate biometric prompts against agent behavior.
 # Always-on (independent of OP_PREFLIGHT_QUIET) — the file is local-only
@@ -262,6 +274,11 @@ if $PURGE; then
   rm -f "$SESSION_FILE" "$ADC_TMPFILE" "$SSH_WARM_MARKER"
   echo "# Purged session file + ADC tempfile + SSH-warm marker for agent=$AGENT" >&2
   exit 0
+fi
+
+if $SERVICE_ACCOUNT_TOKEN_MODE && [[ "$MODE" != "review" ]]; then
+  echo "Error: OP_SERVICE_ACCOUNT_TOKEN mode is scoped to reviewer PAT reads only; mode '$MODE' is out of scope." >&2
+  exit 2
 fi
 
 # ── Dry run ───────────────────────────────────────────────────────────
@@ -292,9 +309,16 @@ if $DRY_RUN; then
   fi
   echo "#" >&2
   if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
-    echo "# Would read: reviewer PAT ($(reviewer_pat_item_for "$AGENT"))" >&2
-    echo "# Would read: author PAT ($AUTHOR_PAT_ITEM)" >&2
-    if ! $SKIP_SSH; then
+    if $SERVICE_ACCOUNT_TOKEN_MODE; then
+      echo "# Would read: reviewer PAT ($(reviewer_pat_item_for "$AGENT")) via OP_SERVICE_ACCOUNT_TOKEN" >&2
+      echo "# Would skip: author PAT (out of token-mode scope)" >&2
+      echo "# Would skip: SSH warming (out of token-mode scope)" >&2
+      echo "# Would skip: gh keyring repair (out of token-mode scope)" >&2
+    else
+      echo "# Would read: reviewer PAT ($(reviewer_pat_item_for "$AGENT"))" >&2
+      echo "# Would read: author PAT ($AUTHOR_PAT_ITEM)" >&2
+    fi
+    if ! $SKIP_SSH && ! $SERVICE_ACCOUNT_TOKEN_MODE; then
       echo "# Would warm SSH: $SSH_AUTHOR_HOST (author key)" >&2
       echo "# Would warm SSH: $(ssh_host_for "$AGENT") (reviewer key)" >&2
     fi
@@ -322,6 +346,11 @@ session_is_fresh() {
   now=$(date +%s)
   age=$((now - created_at))
   [[ "$age" -lt "$TTL_SECONDS" ]]
+}
+
+session_is_token_mode() {
+  [[ -f "$SESSION_FILE" ]] || return 1
+  grep -q '^OP_PREFLIGHT_TOKEN_MODE=1$' "$SESSION_FILE" 2>/dev/null
 }
 
 # Validate that a materialized ADC file still mints a token. Mirrors the
@@ -516,6 +545,7 @@ emit_from_session_file() (
   unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
   unset CF_API_TOKEN
   unset OP_PREFLIGHT_DONE OP_PREFLIGHT_AGENT OP_PREFLIGHT_MODE
+  unset OP_PREFLIGHT_TOKEN_MODE
   unset OP_PREFLIGHT_CREATED_AT_EPOCH OP_PREFLIGHT_TTL_SECONDS
 
   # Source the session file and re-emit only the vars we own, so a
@@ -536,8 +566,17 @@ emit_from_session_file() (
   # unauthenticated. Return non-zero to trigger the refresh path in
   # each case. See #141 round-1 Codex finding (P1, line 223).
   if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
-    if [[ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]] || [[ -z "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]]; then
+    if $SERVICE_ACCOUNT_TOKEN_MODE && [[ "${OP_PREFLIGHT_TOKEN_MODE:-0}" != "1" ]]; then
       exit 2
+    fi
+    if [[ "${OP_PREFLIGHT_TOKEN_MODE:-0}" == "1" ]]; then
+      if [[ "$MODE" == "all" ]] || [[ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]]; then
+        exit 2
+      fi
+    else
+      if [[ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]] || [[ -z "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]]; then
+        exit 2
+      fi
     fi
   fi
   if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
@@ -584,6 +623,8 @@ emit_from_session_file() (
     printf 'export OP_PREFLIGHT_REVIEWER_PAT=%q\n' "$OP_PREFLIGHT_REVIEWER_PAT"
   [[ -n "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]] && \
     printf 'export OP_PREFLIGHT_AUTHOR_PAT=%q\n' "$OP_PREFLIGHT_AUTHOR_PAT"
+  [[ "${OP_PREFLIGHT_TOKEN_MODE:-0}" == "1" ]] && \
+    printf 'export OP_PREFLIGHT_TOKEN_MODE=1\n'
   [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] && \
     printf 'export GOOGLE_APPLICATION_CREDENTIALS=%q\n' "$GOOGLE_APPLICATION_CREDENTIALS"
   [[ -n "${OP_PREFLIGHT_ADC_TMPFILE:-}" ]] && \
@@ -734,12 +775,19 @@ if ! $REFRESH && session_is_fresh; then
     else
       age=$now
     fi
+    CACHE_TOKEN_MODE=false
+    if session_is_token_mode; then
+      CACHE_TOKEN_MODE=true
+    fi
     # Warm SSH keys on the cache-hit path too. The cached PATs are
     # worthless for git push/pull if SSH auth isn't also primed, and
     # the prior implementation skipped this step entirely on cache
     # hit — a repro surfaced on the consumer-repo propagation PRs.
     SUMMARY=()
-    if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH; then
+    if $CACHE_TOKEN_MODE; then
+      SUMMARY+=("Service-account token cache: reviewer PAT only; SSH/keyring skipped")
+    fi
+    if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH && ! $CACHE_TOKEN_MODE; then
       warm_ssh_keys
     fi
     if [[ "${OP_PREFLIGHT_QUIET:-0}" == "1" ]]; then
@@ -748,7 +796,9 @@ if ! $REFRESH && session_is_fresh; then
       # Refresh notices and warnings remain unaffected; only this
       # routine cache-hit block collapses.
       echo "# preflight: cache hit, no biometric burned" >&2
-      warn_active_account_mismatch
+      if ! $CACHE_TOKEN_MODE; then
+        warn_active_account_mismatch
+      fi
     else
       echo "" >&2
       echo "# ── Preflight cached hit (age ${age}s / TTL ${TTL_SECONDS}s) ──" >&2
@@ -757,7 +807,9 @@ if ! $REFRESH && session_is_fresh; then
         echo "#   $line" >&2
       done
       echo "# Run with --refresh to force a new biometric fetch." >&2
-      warn_active_account_mismatch
+      if ! $CACHE_TOKEN_MODE; then
+        warn_active_account_mismatch
+      fi
       echo "# ──────────────────────────────────────────────────────────" >&2
     fi
     exit 0
@@ -801,40 +853,54 @@ SUMMARY=()
 if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
   reviewer_item="$(reviewer_pat_item_for "$AGENT")"
 
-  # Build an op inject template for both PATs. op inject resolves all
-  # op:// references in a single process — one biometric prompt covers
-  # both reads.
-  tpl_file="$(mktemp "${TMPDIR:-/tmp}/op-preflight-tpl-XXXXXX")"
-  trap 'rm -f "$tpl_file"' EXIT
+  if $SERVICE_ACCOUNT_TOKEN_MODE; then
+    echo "# Preflight: reading reviewer PAT via OP_SERVICE_ACCOUNT_TOKEN..." >&2
+    if ! reviewer_pat="$(op read "op://Private/${reviewer_item}/token" 2>/dev/null)" || [[ -z "$reviewer_pat" ]]; then
+      echo "Error: failed to read reviewer PAT for $AGENT via OP_SERVICE_ACCOUNT_TOKEN." >&2
+      exit 1
+    fi
+    EXPORTS+=("export OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
+    EXPORTS+=("export OP_PREFLIGHT_TOKEN_MODE=1")
+    SESSION_LINES+=("OP_PREFLIGHT_TOKEN_MODE=1")
+    SESSION_LINES+=("OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
+    SUMMARY+=("Reviewer PAT ($AGENT): loaded via service account token")
+    SUMMARY+=("Author PAT: skipped (service account token mode)")
+  else
+    # Build an op inject template for both PATs. op inject resolves all
+    # op:// references in a single process — one biometric prompt covers
+    # both reads.
+    tpl_file="$(mktemp "${TMPDIR:-/tmp}/op-preflight-tpl-XXXXXX")"
+    trap 'rm -f "$tpl_file"' EXIT
 
-  cat > "$tpl_file" <<TPL
+    cat > "$tpl_file" <<TPL
 REVIEWER_PAT={{ op://Private/${reviewer_item}/token }}
 AUTHOR_PAT={{ op://Private/${AUTHOR_PAT_ITEM}/token }}
 TPL
 
-  echo "# Preflight: reading PATs (one biometric prompt)..." >&2
-  log_biometric_trigger "$BIOMETRIC_REASON"
-  resolved="$(op inject -i "$tpl_file")"
-  rm -f "$tpl_file"
+    echo "# Preflight: reading PATs (one biometric prompt)..." >&2
+    log_biometric_trigger "$BIOMETRIC_REASON"
+    resolved="$(op inject -i "$tpl_file")"
+    rm -f "$tpl_file"
 
-  reviewer_pat="$(echo "$resolved" | grep '^REVIEWER_PAT=' | cut -d= -f2-)"
-  author_pat="$(echo "$resolved" | grep '^AUTHOR_PAT=' | cut -d= -f2-)"
+    reviewer_pat="$(echo "$resolved" | grep '^REVIEWER_PAT=' | cut -d= -f2-)"
+    author_pat="$(echo "$resolved" | grep '^AUTHOR_PAT=' | cut -d= -f2-)"
 
-  if [[ -z "$reviewer_pat" ]]; then
-    echo "Error: failed to read reviewer PAT for $AGENT." >&2
-    exit 1
+    if [[ -z "$reviewer_pat" ]]; then
+      echo "Error: failed to read reviewer PAT for $AGENT." >&2
+      exit 1
+    fi
+    if [[ -z "$author_pat" ]]; then
+      echo "Error: failed to read author PAT." >&2
+      exit 1
+    fi
+
+    EXPORTS+=("export OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
+    EXPORTS+=("export OP_PREFLIGHT_AUTHOR_PAT=$(printf '%q' "$author_pat")")
+    SESSION_LINES+=("OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
+    SESSION_LINES+=("OP_PREFLIGHT_AUTHOR_PAT=$(printf '%q' "$author_pat")")
+    SUMMARY+=("Reviewer PAT ($AGENT): loaded")
+    SUMMARY+=("Author PAT: loaded")
   fi
-  if [[ -z "$author_pat" ]]; then
-    echo "Error: failed to read author PAT." >&2
-    exit 1
-  fi
-
-  EXPORTS+=("export OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
-  EXPORTS+=("export OP_PREFLIGHT_AUTHOR_PAT=$(printf '%q' "$author_pat")")
-  SESSION_LINES+=("OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
-  SESSION_LINES+=("OP_PREFLIGHT_AUTHOR_PAT=$(printf '%q' "$author_pat")")
-  SUMMARY+=("Reviewer PAT ($AGENT): loaded")
-  SUMMARY+=("Author PAT: loaded")
 fi
 
 if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
@@ -886,8 +952,10 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
 fi
 
 # ── Phase 2: SSH key warming ──────────────────────────────────────────
-if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH; then
+if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH && ! $SERVICE_ACCOUNT_TOKEN_MODE; then
   warm_ssh_keys
+elif $SERVICE_ACCOUNT_TOKEN_MODE; then
+  SUMMARY+=("SSH/keyring: skipped (service account token mode)")
 fi
 
 # ── Persist session file ──────────────────────────────────────────────
@@ -926,6 +994,8 @@ for line in "${SUMMARY[@]}"; do
 done
 echo "# Session file: $SESSION_FILE (TTL ${TTL_SECONDS}s)" >&2
 echo "# OP_PREFLIGHT_DONE=1" >&2
-warn_active_account_mismatch
+if ! $SERVICE_ACCOUNT_TOKEN_MODE; then
+  warn_active_account_mismatch
+fi
 echo "# Human can step away." >&2
 echo "# ──────────────────────────────────────────────────────" >&2

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -353,6 +353,23 @@ session_is_token_mode() {
   grep -q '^OP_PREFLIGHT_TOKEN_MODE=1$' "$SESSION_FILE" 2>/dev/null
 }
 
+scrub_op_error() {
+  local file="${1:-}" raw token
+  [[ -n "$file" && -f "$file" ]] || return 0
+  raw="$(tr '\n' ' ' < "$file" | cut -c1-500 || true)"
+  token="${OP_SERVICE_ACCOUNT_TOKEN:-}"
+  if [[ -n "$raw" && -n "$token" ]]; then
+    awk -v s="$raw" -v token="$token" 'BEGIN {
+      while ((i = index(s, token)) > 0) {
+        s = substr(s, 1, i - 1) "[redacted]" substr(s, i + length(token))
+      }
+      print s
+    }'
+  else
+    printf '%s\n' "$raw"
+  fi
+}
+
 # Validate that a materialized ADC file still mints a token. Mirrors the
 # source_cred_is_usable check in scripts/firebase/op-firebase-deploy so a
 # stale 1Password ADC item (refresh_token expired by Google) gets caught
@@ -567,6 +584,9 @@ emit_from_session_file() (
   # each case. See #141 round-1 Codex finding (P1, line 223).
   if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
     if $SERVICE_ACCOUNT_TOKEN_MODE && [[ "${OP_PREFLIGHT_TOKEN_MODE:-0}" != "1" ]]; then
+      exit 2
+    fi
+    if ! $SERVICE_ACCOUNT_TOKEN_MODE && [[ "${OP_PREFLIGHT_TOKEN_MODE:-0}" == "1" ]]; then
       exit 2
     fi
     if [[ "${OP_PREFLIGHT_TOKEN_MODE:-0}" == "1" ]]; then
@@ -855,10 +875,24 @@ if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
 
   if $SERVICE_ACCOUNT_TOKEN_MODE; then
     echo "# Preflight: reading reviewer PAT via OP_SERVICE_ACCOUNT_TOKEN..." >&2
-    if ! reviewer_pat="$(op read "op://Private/${reviewer_item}/token" 2>/dev/null)" || [[ -z "$reviewer_pat" ]]; then
+    op_err_file="$(mktemp "${TMPDIR:-/tmp}/op-preflight-read-err-XXXXXX")"
+    reviewer_pat=""
+    op_read_rc=0
+    if reviewer_pat="$(op read "op://Private/${reviewer_item}/token" 2>"$op_err_file")"; then
+      op_read_rc=0
+    else
+      op_read_rc=$?
+    fi
+    if [[ "$op_read_rc" -ne 0 || -z "$reviewer_pat" ]]; then
+      op_error="$(scrub_op_error "$op_err_file")"
+      rm -f "$op_err_file"
       echo "Error: failed to read reviewer PAT for $AGENT via OP_SERVICE_ACCOUNT_TOKEN." >&2
+      if [[ -n "$op_error" ]]; then
+        echo "1Password CLI: $op_error" >&2
+      fi
       exit 1
     fi
+    rm -f "$op_err_file"
     EXPORTS+=("export OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
     EXPORTS+=("export OP_PREFLIGHT_TOKEN_MODE=1")
     SESSION_LINES+=("OP_PREFLIGHT_TOKEN_MODE=1")

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -354,20 +354,21 @@ session_is_token_mode() {
 }
 
 scrub_op_error() {
-  local file="${1:-}" raw token
+  local file="${1:-}" raw token redacted
   [[ -n "$file" && -f "$file" ]] || return 0
-  raw="$(tr '\n' ' ' < "$file" | cut -c1-500 || true)"
+  raw="$(tr '\n' ' ' < "$file" || true)"
   token="${OP_SERVICE_ACCOUNT_TOKEN:-}"
   if [[ -n "$raw" && -n "$token" ]]; then
-    awk -v s="$raw" -v token="$token" 'BEGIN {
+    redacted="$(awk -v s="$raw" -v token="$token" 'BEGIN {
       while ((i = index(s, token)) > 0) {
         s = substr(s, 1, i - 1) "[redacted]" substr(s, i + length(token))
       }
       print s
-    }'
+    }')"
   else
-    printf '%s\n' "$raw"
+    redacted="$raw"
   fi
+  printf '%s\n' "${redacted:0:500}"
 }
 
 # Validate that a materialized ADC file still mints a token. Mirrors the

--- a/tests/test_op_preflight_token_mode.sh
+++ b/tests/test_op_preflight_token_mode.sh
@@ -48,6 +48,11 @@ case "\${1:-}" in
       echo "FATAL: OP_SERVICE_ACCOUNT_TOKEN missing" >&2
       exit 65
     fi
+    if [[ "\${OP_STUB_FAIL_READ:-0}" == "long" ]]; then
+      long_prefix="\$(printf '%0495d' 0 | tr '0' A)"
+      echo "\${long_prefix}\${OP_SERVICE_ACCOUNT_TOKEN}" >&2
+      exit 72
+    fi
     if [[ "\${OP_STUB_FAIL_READ:-0}" == "1" ]]; then
       echo "expired service token: \${OP_SERVICE_ACCOUNT_TOKEN}" >&2
       exit 71
@@ -418,6 +423,22 @@ test_token_mode_op_error_scrubbed() {
     fail "test_token_mode_op_error_scrubbed: service account token leaked in diagnostics"
     return
   fi
+
+  reset_logs
+  rc=0
+  PATH="$STUB_DIR:$PATH" \
+    OP_PREFLIGHT_CACHE_DIR="$WORKDIR/op-long-error-cache" \
+    OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_TOKEN" \
+    OP_STUB_FAIL_READ=long \
+    "$SCRIPT" --agent codex --mode review >"$WORKDIR/op-long-error.out" 2>"$WORKDIR/op-long-error.err" || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    fail "test_token_mode_op_error_scrubbed: long failed op read unexpectedly succeeded"
+    return
+  fi
+  if grep -q "${SERVICE_TOKEN:0:5}" "$WORKDIR/op-long-error.err" "$WORKDIR/op-long-error.out"; then
+    fail "test_token_mode_op_error_scrubbed: token fragment leaked after truncation"
+    return
+  fi
   pass "test_token_mode_op_error_scrubbed: failed op read reports scrubbed diagnostic"
 }
 
@@ -480,6 +501,7 @@ test_token_mode_helper_scope() {
     OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_TOKEN" \
     "$SCRIPT" --agent codex --mode review >"$WORKDIR/helper-fill.out" 2>"$WORKDIR/helper-fill.err"
 
+  local rc=0
   (
     export OP_PREFLIGHT_CACHE_DIR="$cache_dir"
     export MERGEPATH_AGENT=codex
@@ -499,8 +521,7 @@ test_token_mode_helper_scope() {
       echo "author scope unexpectedly loaded from token-mode cache" >&2
       exit 1
     fi
-  ) >"$WORKDIR/helper-scope.out" 2>"$WORKDIR/helper-scope.err"
-  local rc=$?
+  ) >"$WORKDIR/helper-scope.out" 2>"$WORKDIR/helper-scope.err" || rc=$?
   if [[ "$rc" -ne 0 ]]; then
     fail "test_token_mode_helper_scope: rc=$rc stderr=$(cat "$WORKDIR/helper-scope.err")"
     return

--- a/tests/test_op_preflight_token_mode.sh
+++ b/tests/test_op_preflight_token_mode.sh
@@ -42,12 +42,16 @@ cat > "$STUB_DIR/op" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "\$*" >> "$OP_LOG"
-if [[ -z "\${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
-  echo "FATAL: OP_SERVICE_ACCOUNT_TOKEN missing" >&2
-  exit 65
-fi
 case "\${1:-}" in
   read)
+    if [[ -z "\${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+      echo "FATAL: OP_SERVICE_ACCOUNT_TOKEN missing" >&2
+      exit 65
+    fi
+    if [[ "\${OP_STUB_FAIL_READ:-0}" == "1" ]]; then
+      echo "expired service token: \${OP_SERVICE_ACCOUNT_TOKEN}" >&2
+      exit 71
+    fi
     case "\${2:-}" in
       op://Private/pvbq24vl2h6gl7yjclxy2hbote/token) printf '%s\n' "reviewer-pat-claude" ;;
       op://Private/bslrih4spwxgookzfy6zedz5g4/token) printf '%s\n' "reviewer-pat-cursor" ;;
@@ -67,8 +71,12 @@ case "\${1:-}" in
     esac
     ;;
   inject)
-    echo "FATAL: token mode invoked op inject" >&2
-    exit 69
+    if [[ -n "\${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+      echo "FATAL: token mode invoked op inject" >&2
+      exit 69
+    fi
+    printf '%s\n' "REVIEWER_PAT=interactive-reviewer"
+    printf '%s\n' "AUTHOR_PAT=interactive-author"
     ;;
   *)
     echo "FATAL: unexpected op command: \$*" >&2
@@ -89,6 +97,10 @@ chmod +x "$STUB_DIR/ssh"
 cat > "$STUB_DIR/gh" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$GH_LOG"
+if [[ "\${1:-}" == "config" && "\${2:-}" == "get" && "\${3:-}" == "-h" && "\${4:-}" == "github.com" && "\${5:-}" == "user" ]]; then
+  printf '%s\n' "nathanpayne-codex"
+  exit 0
+fi
 echo "FATAL: token mode invoked gh with args: \$*" >&2
 exit 97
 EOF
@@ -124,6 +136,24 @@ OP_PREFLIGHT_MODE=review
 OP_PREFLIGHT_DONE=1
 OP_PREFLIGHT_REVIEWER_PAT=interactive-reviewer
 OP_PREFLIGHT_AUTHOR_PAT=interactive-author
+EOF
+  chmod 600 "$dir/op-preflight-$agent.env"
+}
+
+make_token_cache() {
+  local dir="$1" agent="$2" reviewer_pat="${3:-reviewer-pat-codex}"
+  mkdir -p "$dir"
+  chmod 700 "$dir"
+  local epoch
+  epoch=$(date +%s)
+  cat > "$dir/op-preflight-$agent.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=$agent
+OP_PREFLIGHT_MODE=review
+OP_PREFLIGHT_DONE=1
+OP_PREFLIGHT_TOKEN_MODE=1
+OP_PREFLIGHT_REVIEWER_PAT=$reviewer_pat
 EOF
   chmod 600 "$dir/op-preflight-$agent.env"
 }
@@ -218,6 +248,7 @@ test_token_mode_cache_and_check() {
   local rc=0
   PATH="$STUB_DIR:$PATH" \
     OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+    OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_TOKEN" \
     "$SCRIPT" --agent codex --mode review >"$WORKDIR/cache-hit.out" 2>"$WORKDIR/cache-hit.err" || rc=$?
   if [[ "$rc" -ne 0 ]]; then
     fail "test_token_mode_cache_and_check: cache hit expected rc=0, got rc=$rc; stderr=$(cat "$WORKDIR/cache-hit.err")"
@@ -236,6 +267,7 @@ test_token_mode_cache_and_check() {
   rc=0
   PATH="$STUB_DIR:$PATH" \
     OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+    OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_TOKEN" \
     "$SCRIPT" --agent codex --check >"$WORKDIR/check.out" 2>"$WORKDIR/check.err" || rc=$?
   if [[ "$rc" -ne 0 ]]; then
     fail "test_token_mode_cache_and_check: --check expected rc=0, got rc=$rc; stderr=$(cat "$WORKDIR/check.err")"
@@ -309,7 +341,88 @@ test_token_mode_replaces_interactive_cache() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 4: unknown agents and out-of-scope modes fail before op is invoked.
+# Test 4: interactive mode does not reuse a token-mode cache.
+# ---------------------------------------------------------------------------
+test_interactive_mode_replaces_token_cache() {
+  local cache_dir="$WORKDIR/token-cache"
+  make_token_cache "$cache_dir" codex "token-cache-reviewer"
+  reset_logs
+  local rc=0
+  PATH="$STUB_DIR:$PATH" \
+    OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+    "$SCRIPT" --agent codex --mode review --skip-ssh >"$WORKDIR/token-refresh.out" 2>"$WORKDIR/token-refresh.err" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    fail "test_interactive_mode_replaces_token_cache: expected refresh rc=0, got rc=$rc; stderr=$(cat "$WORKDIR/token-refresh.err")"
+    return
+  fi
+  if ! grep -q "export OP_PREFLIGHT_REVIEWER_PAT=interactive-reviewer" "$WORKDIR/token-refresh.out"; then
+    fail "test_interactive_mode_replaces_token_cache: did not emit interactive reviewer PAT"
+    return
+  fi
+  if ! grep -q "export OP_PREFLIGHT_AUTHOR_PAT=interactive-author" "$WORKDIR/token-refresh.out"; then
+    fail "test_interactive_mode_replaces_token_cache: did not emit interactive author PAT"
+    return
+  fi
+  if grep -q "OP_PREFLIGHT_TOKEN_MODE\\|token-cache-reviewer" "$WORKDIR/token-refresh.out" "$cache_dir/op-preflight-codex.env"; then
+    fail "test_interactive_mode_replaces_token_cache: reused token cache or retained token marker"
+    return
+  fi
+  if ! grep -q "inject" "$OP_LOG"; then
+    fail "test_interactive_mode_replaces_token_cache: interactive refresh did not call op inject"
+    return
+  fi
+  if [[ -s "$SSH_LOG" ]]; then
+    fail "test_interactive_mode_replaces_token_cache: --skip-ssh path invoked ssh"
+    return
+  fi
+
+  local check_cache="$WORKDIR/token-check-cache"
+  make_token_cache "$check_cache" codex "token-check-reviewer"
+  reset_logs
+  rc=0
+  PATH="$STUB_DIR:$PATH" \
+    OP_PREFLIGHT_CACHE_DIR="$check_cache" \
+    "$SCRIPT" --agent codex --check >"$WORKDIR/token-check.out" 2>"$WORKDIR/token-check.err" || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    fail "test_interactive_mode_replaces_token_cache: --check accepted token cache under interactive env"
+    return
+  fi
+  if [[ -s "$OP_LOG" || -s "$SSH_LOG" || -s "$GH_LOG" ]]; then
+    fail "test_interactive_mode_replaces_token_cache: --check invoked op/ssh/gh"
+    return
+  fi
+  pass "test_interactive_mode_replaces_token_cache: interactive env replaces token-mode cache"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: token read failures expose scrubbed op stderr.
+# ---------------------------------------------------------------------------
+test_token_mode_op_error_scrubbed() {
+  reset_logs
+  local cache_dir="$WORKDIR/op-error-cache"
+  local rc=0
+  PATH="$STUB_DIR:$PATH" \
+    OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+    OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_TOKEN" \
+    OP_STUB_FAIL_READ=1 \
+    "$SCRIPT" --agent codex --mode review >"$WORKDIR/op-error.out" 2>"$WORKDIR/op-error.err" || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    fail "test_token_mode_op_error_scrubbed: failed op read unexpectedly succeeded"
+    return
+  fi
+  if ! grep -q "expired service token" "$WORKDIR/op-error.err"; then
+    fail "test_token_mode_op_error_scrubbed: stderr missing op failure reason"
+    return
+  fi
+  if grep -q "$SERVICE_TOKEN" "$WORKDIR/op-error.err" "$WORKDIR/op-error.out"; then
+    fail "test_token_mode_op_error_scrubbed: service account token leaked in diagnostics"
+    return
+  fi
+  pass "test_token_mode_op_error_scrubbed: failed op read reports scrubbed diagnostic"
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: unknown agents and out-of-scope modes fail before op is invoked.
 # ---------------------------------------------------------------------------
 test_token_mode_fail_closed_scope() {
   reset_logs
@@ -356,7 +469,7 @@ test_token_mode_fail_closed_scope() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 5: helper auto-source accepts reviewer scope but not author scope.
+# Test 7: helper auto-source accepts reviewer scope but not author scope.
 # ---------------------------------------------------------------------------
 test_token_mode_helper_scope() {
   local cache_dir="$WORKDIR/helper-cache"
@@ -398,6 +511,8 @@ test_token_mode_helper_scope() {
 test_token_mode_agents
 test_token_mode_cache_and_check
 test_token_mode_replaces_interactive_cache
+test_interactive_mode_replaces_token_cache
+test_token_mode_op_error_scrubbed
 test_token_mode_fail_closed_scope
 test_token_mode_helper_scope
 

--- a/tests/test_op_preflight_token_mode.sh
+++ b/tests/test_op_preflight_token_mode.sh
@@ -1,0 +1,400 @@
+#!/usr/bin/env bash
+# tests/test_op_preflight_token_mode.sh
+#
+# Unit tests for the explicit OP_SERVICE_ACCOUNT_TOKEN lane added for #353.
+#
+# The contract:
+#   - token mode activates only when OP_SERVICE_ACCOUNT_TOKEN is set
+#   - only claude/cursor/codex reviewer PAT items are readable
+#   - author PAT, deploy secrets, SSH warming, and gh keyring repair are
+#     outside this lane
+#   - token-mode session files are chmod 600 and never persist/log the
+#     service-account token itself
+#   - --check remains probe-free and accepts a reviewer-only token-mode cache
+#
+# Bash 3.2 portable.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/op-preflight.sh"
+LIB="$ROOT/scripts/lib/preflight-helpers.sh"
+
+[[ -x "$SCRIPT" ]] || { echo "missing or non-executable $SCRIPT" >&2; exit 1; }
+[[ -r "$LIB" ]] || { echo "missing $LIB" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/op-preflight-token-mode-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+STUB_DIR="$WORKDIR/stub-bin"
+mkdir -p "$STUB_DIR"
+OP_LOG="$WORKDIR/op.log"
+SSH_LOG="$WORKDIR/ssh.log"
+GH_LOG="$WORKDIR/gh.log"
+SERVICE_TOKEN="stub-service-account-token"
+
+cat > "$STUB_DIR/op" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >> "$OP_LOG"
+if [[ -z "\${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+  echo "FATAL: OP_SERVICE_ACCOUNT_TOKEN missing" >&2
+  exit 65
+fi
+case "\${1:-}" in
+  read)
+    case "\${2:-}" in
+      op://Private/pvbq24vl2h6gl7yjclxy2hbote/token) printf '%s\n' "reviewer-pat-claude" ;;
+      op://Private/bslrih4spwxgookzfy6zedz5g4/token) printf '%s\n' "reviewer-pat-cursor" ;;
+      op://Private/o6ekjxjjl5gq6rmcneomrjahpu/token) printf '%s\n' "reviewer-pat-codex" ;;
+      op://Private/sm5kopwk6t6p3xmu2igesndzhe/token)
+        echo "FATAL: token mode attempted author PAT read" >&2
+        exit 66
+        ;;
+      op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential|op://Private/4x6wslp3f6pal5t6h3jhhe63ie/credential)
+        echo "FATAL: token mode attempted deploy secret read" >&2
+        exit 67
+        ;;
+      *)
+        echo "FATAL: unexpected op read target: \${2:-}" >&2
+        exit 68
+        ;;
+    esac
+    ;;
+  inject)
+    echo "FATAL: token mode invoked op inject" >&2
+    exit 69
+    ;;
+  *)
+    echo "FATAL: unexpected op command: \$*" >&2
+    exit 70
+    ;;
+esac
+EOF
+chmod +x "$STUB_DIR/op"
+
+cat > "$STUB_DIR/ssh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$SSH_LOG"
+echo "FATAL: token mode invoked ssh with args: \$*" >&2
+exit 98
+EOF
+chmod +x "$STUB_DIR/ssh"
+
+cat > "$STUB_DIR/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$GH_LOG"
+echo "FATAL: token mode invoked gh with args: \$*" >&2
+exit 97
+EOF
+chmod +x "$STUB_DIR/gh"
+
+reset_logs() {
+  : > "$OP_LOG"
+  : > "$SSH_LOG"
+  : > "$GH_LOG"
+}
+
+mode_for_file() {
+  stat -f %Lp "$1" 2>/dev/null || stat -c %a "$1"
+}
+
+make_interactive_cache() {
+  local dir="$1" agent="$2"
+  mkdir -p "$dir"
+  chmod 700 "$dir"
+  local epoch
+  epoch=$(date +%s)
+  cat > "$dir/op-preflight-$agent.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=$agent
+OP_PREFLIGHT_MODE=review
+OP_PREFLIGHT_DONE=1
+OP_PREFLIGHT_REVIEWER_PAT=interactive-reviewer
+OP_PREFLIGHT_AUTHOR_PAT=interactive-author
+EOF
+  chmod 600 "$dir/op-preflight-$agent.env"
+}
+
+assert_no_service_token_leak() {
+  local label="$1"; shift
+  local file
+  for file in "$@"; do
+    if [[ -f "$file" ]] && grep -q "$SERVICE_TOKEN" "$file"; then
+      fail "$label: service account token leaked into $file"
+      return 1
+    fi
+  done
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: token mode loads only each configured agent's reviewer PAT.
+# ---------------------------------------------------------------------------
+test_token_mode_agents() {
+  local agent expected cache_dir session out err perms
+  for agent in claude cursor codex; do
+    reset_logs
+    cache_dir="$WORKDIR/agent-$agent-cache"
+    mkdir -p "$cache_dir"
+    out="$WORKDIR/agent-$agent.out"
+    err="$WORKDIR/agent-$agent.err"
+    local rc=0
+    PATH="$STUB_DIR:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_TOKEN" \
+      "$SCRIPT" --agent "$agent" --mode review >"$out" 2>"$err" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+      fail "test_token_mode_agents($agent): expected rc=0, got rc=$rc; stderr=$(cat "$err")"
+      return
+    fi
+    expected="reviewer-pat-$agent"
+    session="$cache_dir/op-preflight-$agent.env"
+    if ! grep -q "export OP_PREFLIGHT_REVIEWER_PAT=$expected" "$out"; then
+      fail "test_token_mode_agents($agent): stdout missing reviewer PAT export"
+      return
+    fi
+    if grep -q "OP_PREFLIGHT_AUTHOR_PAT" "$out" "$session"; then
+      fail "test_token_mode_agents($agent): token mode exported or cached author PAT"
+      return
+    fi
+    if ! grep -q "OP_PREFLIGHT_TOKEN_MODE=1" "$out" || ! grep -q "^OP_PREFLIGHT_TOKEN_MODE=1$" "$session"; then
+      fail "test_token_mode_agents($agent): token mode marker missing"
+      return
+    fi
+    perms="$(mode_for_file "$session")"
+    if [[ "$perms" != "600" ]]; then
+      fail "test_token_mode_agents($agent): session permissions expected 600, got $perms"
+      return
+    fi
+    if [[ -s "$SSH_LOG" || -s "$GH_LOG" ]]; then
+      fail "test_token_mode_agents($agent): token mode invoked ssh/gh"
+      return
+    fi
+    if grep -q "inject" "$OP_LOG"; then
+      fail "test_token_mode_agents($agent): token mode used op inject"
+      return
+    fi
+    if grep -q "sm5kopwk6t6p3xmu2igesndzhe\\|c2v6emkwppjzjjaq2bdqk3wnlm\\|4x6wslp3f6pal5t6h3jhhe63ie" "$OP_LOG"; then
+      fail "test_token_mode_agents($agent): token mode attempted out-of-scope op item"
+      return
+    fi
+    if [[ -f "$cache_dir/biometric-log" ]]; then
+      fail "test_token_mode_agents($agent): token mode wrote biometric log"
+      return
+    fi
+    if ! assert_no_service_token_leak "test_token_mode_agents($agent)" "$out" "$err" "$session" "$OP_LOG" "$SSH_LOG" "$GH_LOG"; then
+      return
+    fi
+  done
+  pass "test_token_mode_agents: reviewer-only token mode works for claude/cursor/codex"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: token-mode cache hits and --check do not invoke op/ssh/gh.
+# ---------------------------------------------------------------------------
+test_token_mode_cache_and_check() {
+  local cache_dir="$WORKDIR/cache-hit"
+  mkdir -p "$cache_dir"
+  reset_logs
+  PATH="$STUB_DIR:$PATH" \
+    OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+    OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_TOKEN" \
+    "$SCRIPT" --agent codex --mode review >"$WORKDIR/cache-fill.out" 2>"$WORKDIR/cache-fill.err"
+
+  reset_logs
+  local rc=0
+  PATH="$STUB_DIR:$PATH" \
+    OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+    "$SCRIPT" --agent codex --mode review >"$WORKDIR/cache-hit.out" 2>"$WORKDIR/cache-hit.err" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    fail "test_token_mode_cache_and_check: cache hit expected rc=0, got rc=$rc; stderr=$(cat "$WORKDIR/cache-hit.err")"
+    return
+  fi
+  if [[ -s "$OP_LOG" || -s "$SSH_LOG" || -s "$GH_LOG" ]]; then
+    fail "test_token_mode_cache_and_check: cache hit invoked op/ssh/gh"
+    return
+  fi
+  if grep -q "OP_PREFLIGHT_AUTHOR_PAT" "$WORKDIR/cache-hit.out"; then
+    fail "test_token_mode_cache_and_check: cache hit emitted author PAT"
+    return
+  fi
+
+  reset_logs
+  rc=0
+  PATH="$STUB_DIR:$PATH" \
+    OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+    "$SCRIPT" --agent codex --check >"$WORKDIR/check.out" 2>"$WORKDIR/check.err" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    fail "test_token_mode_cache_and_check: --check expected rc=0, got rc=$rc; stderr=$(cat "$WORKDIR/check.err")"
+    return
+  fi
+  if [[ -s "$OP_LOG" || -s "$SSH_LOG" || -s "$GH_LOG" ]]; then
+    fail "test_token_mode_cache_and_check: --check invoked op/ssh/gh"
+    return
+  fi
+  if ! grep -q "export OP_PREFLIGHT_REVIEWER_PAT=reviewer-pat-codex" "$WORKDIR/check.out"; then
+    fail "test_token_mode_cache_and_check: --check missing reviewer PAT export"
+    return
+  fi
+  if grep -q "OP_PREFLIGHT_AUTHOR_PAT" "$WORKDIR/check.out"; then
+    fail "test_token_mode_cache_and_check: --check emitted author PAT"
+    return
+  fi
+  pass "test_token_mode_cache_and_check: token cache and --check remain probe-free"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: OP_SERVICE_ACCOUNT_TOKEN does not reuse an interactive cache.
+# ---------------------------------------------------------------------------
+test_token_mode_replaces_interactive_cache() {
+  local cache_dir="$WORKDIR/interactive-cache"
+  make_interactive_cache "$cache_dir" codex
+  reset_logs
+  local rc=0
+  PATH="$STUB_DIR:$PATH" \
+    OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+    OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_TOKEN" \
+    "$SCRIPT" --agent codex --mode review >"$WORKDIR/interactive-refresh.out" 2>"$WORKDIR/interactive-refresh.err" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    fail "test_token_mode_replaces_interactive_cache: expected refresh rc=0, got rc=$rc; stderr=$(cat "$WORKDIR/interactive-refresh.err")"
+    return
+  fi
+  if ! grep -q "export OP_PREFLIGHT_REVIEWER_PAT=reviewer-pat-codex" "$WORKDIR/interactive-refresh.out"; then
+    fail "test_token_mode_replaces_interactive_cache: did not emit token-mode reviewer PAT"
+    return
+  fi
+  if grep -q "interactive-reviewer\\|interactive-author\\|OP_PREFLIGHT_AUTHOR_PAT" "$WORKDIR/interactive-refresh.out" "$cache_dir/op-preflight-codex.env"; then
+    fail "test_token_mode_replaces_interactive_cache: reused interactive cache or retained author PAT"
+    return
+  fi
+  if ! grep -q "^OP_PREFLIGHT_TOKEN_MODE=1$" "$cache_dir/op-preflight-codex.env"; then
+    fail "test_token_mode_replaces_interactive_cache: refreshed cache missing token marker"
+    return
+  fi
+  if [[ -s "$SSH_LOG" || -s "$GH_LOG" ]]; then
+    fail "test_token_mode_replaces_interactive_cache: token refresh invoked ssh/gh"
+    return
+  fi
+
+  local check_cache="$WORKDIR/interactive-check-cache"
+  make_interactive_cache "$check_cache" codex
+  reset_logs
+  rc=0
+  PATH="$STUB_DIR:$PATH" \
+    OP_PREFLIGHT_CACHE_DIR="$check_cache" \
+    OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_TOKEN" \
+    "$SCRIPT" --agent codex --check >"$WORKDIR/interactive-check.out" 2>"$WORKDIR/interactive-check.err" || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    fail "test_token_mode_replaces_interactive_cache: --check accepted interactive cache under token env"
+    return
+  fi
+  if [[ -s "$OP_LOG" || -s "$SSH_LOG" || -s "$GH_LOG" ]]; then
+    fail "test_token_mode_replaces_interactive_cache: --check invoked op/ssh/gh"
+    return
+  fi
+  pass "test_token_mode_replaces_interactive_cache: explicit token env replaces interactive cache"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: unknown agents and out-of-scope modes fail before op is invoked.
+# ---------------------------------------------------------------------------
+test_token_mode_fail_closed_scope() {
+  reset_logs
+  local rc=0
+  PATH="$STUB_DIR:$PATH" \
+    OP_PREFLIGHT_CACHE_DIR="$WORKDIR/unknown-cache" \
+    OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_TOKEN" \
+    "$SCRIPT" --agent unknown --mode review >"$WORKDIR/unknown.out" 2>"$WORKDIR/unknown.err" || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    fail "test_token_mode_fail_closed_scope: unknown agent unexpectedly succeeded"
+    return
+  fi
+  if ! grep -q "unknown agent" "$WORKDIR/unknown.err"; then
+    fail "test_token_mode_fail_closed_scope: unknown agent missing diagnostic"
+    return
+  fi
+  if [[ -s "$OP_LOG" ]]; then
+    fail "test_token_mode_fail_closed_scope: unknown agent invoked op"
+    return
+  fi
+
+  local mode
+  for mode in deploy all; do
+    reset_logs
+    rc=0
+    PATH="$STUB_DIR:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$WORKDIR/out-of-scope-$mode-cache" \
+      OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_TOKEN" \
+      "$SCRIPT" --agent codex --mode "$mode" >"$WORKDIR/out-of-scope-$mode.out" 2>"$WORKDIR/out-of-scope-$mode.err" || rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+      fail "test_token_mode_fail_closed_scope: mode $mode unexpectedly succeeded"
+      return
+    fi
+    if ! grep -q "out of scope" "$WORKDIR/out-of-scope-$mode.err"; then
+      fail "test_token_mode_fail_closed_scope: mode $mode missing out-of-scope diagnostic"
+      return
+    fi
+    if [[ -s "$OP_LOG" || -s "$SSH_LOG" || -s "$GH_LOG" ]]; then
+      fail "test_token_mode_fail_closed_scope: mode $mode invoked op/ssh/gh"
+      return
+    fi
+  done
+  pass "test_token_mode_fail_closed_scope: unknown agents and deploy/all fail closed"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: helper auto-source accepts reviewer scope but not author scope.
+# ---------------------------------------------------------------------------
+test_token_mode_helper_scope() {
+  local cache_dir="$WORKDIR/helper-cache"
+  mkdir -p "$cache_dir"
+  reset_logs
+  PATH="$STUB_DIR:$PATH" \
+    OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+    OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_TOKEN" \
+    "$SCRIPT" --agent codex --mode review >"$WORKDIR/helper-fill.out" 2>"$WORKDIR/helper-fill.err"
+
+  (
+    export OP_PREFLIGHT_CACHE_DIR="$cache_dir"
+    export MERGEPATH_AGENT=codex
+    unset GH_TOKEN OP_PREFLIGHT_REVIEWER_PAT OP_PREFLIGHT_AUTHOR_PAT
+    # shellcheck source=../scripts/lib/preflight-helpers.sh
+    . "$LIB"
+    if ! preflight_require_token reviewer; then
+      echo "reviewer scope did not load from token-mode cache" >&2
+      exit 1
+    fi
+    if [[ "${GH_TOKEN:-}" != "reviewer-pat-codex" ]]; then
+      echo "reviewer scope loaded wrong token: '${GH_TOKEN:-}'" >&2
+      exit 1
+    fi
+    unset GH_TOKEN
+    if preflight_require_token author; then
+      echo "author scope unexpectedly loaded from token-mode cache" >&2
+      exit 1
+    fi
+  ) >"$WORKDIR/helper-scope.out" 2>"$WORKDIR/helper-scope.err"
+  local rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    fail "test_token_mode_helper_scope: rc=$rc stderr=$(cat "$WORKDIR/helper-scope.err")"
+    return
+  fi
+  pass "test_token_mode_helper_scope: helper reviewer scope works and author scope fails"
+}
+
+test_token_mode_agents
+test_token_mode_cache_and_check
+test_token_mode_replaces_interactive_cache
+test_token_mode_fail_closed_scope
+test_token_mode_helper_scope
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test_op_preflight_token_mode.sh
+++ b/tests/test_op_preflight_token_mode.sh
@@ -101,7 +101,13 @@ reset_logs() {
 }
 
 mode_for_file() {
-  stat -f %Lp "$1" 2>/dev/null || stat -c %a "$1"
+  local mode
+  mode="$(stat -c %a "$1" 2>/dev/null || true)"
+  if [[ -n "$mode" ]]; then
+    printf '%s\n' "$mode"
+    return 0
+  fi
+  stat -f %Lp "$1"
 }
 
 make_interactive_cache() {


### PR DESCRIPTION
Authoring-Agent: codex

## Summary
- add an explicit `OP_SERVICE_ACCOUNT_TOKEN` lane to `scripts/op-preflight.sh` for CI/headless review-mode preflight
- keep the interactive Touch ID path as the default, while token mode reads only the scoped reviewer PAT and skips author PAT, deploy secrets, SSH warming, and gh keyring repair
- refresh on cache-mode mismatch in both directions, so token envs never reuse interactive caches and interactive envs never reuse token-mode caches
- add token-mode regression coverage for `claude`, `cursor`, `codex`, unknown-agent fail-closed behavior, cache reuse/mismatch behavior, `--check`, helper reviewer/author scope, and scrubbed `op read` diagnostics

## Self-Review
- Scoped to #353 plus the Phase 4b follow-up tracked in #366; no downstream sync or propagation work included.
- Verified token mode is explicit-only and reviewer-only; existing interactive local behavior remains the default when `OP_SERVICE_ACCOUNT_TOKEN` is unset.
- Verified token mode fails closed for unknown agents and out-of-scope `deploy` / `all` modes.
- Verified cache-mode mismatches refresh instead of reusing the wrong cache shape.
- Verified current-head self-review was posted by `nathanpayne-codex` on `0b76964`.

## Validation
- `tests/test_op_preflight_token_mode.sh`
- `scripts/ci/check_op_preflight_contract`
- `scripts/ci/check_ci_scripts_wired`
- `scripts/ci/check_required_root_files`
- `scripts/ci/check_spec_test_alignment`
- `scripts/ci/check_mktemp_portability`
- `scripts/ci/check_no_forbidden_top_level_dirs`
- `scripts/ci/check_duplicate_docs`
- `git diff --check`

## Notes
- #355 is human-accepted, so this implementation lane is unblocked.
- Sync/propagation work is intentionally paused until the end per operator direction.

Closes #353
Closes #366
