### PR TITLE
[#354] Add 1Password headless proof workflow

### DIFF
--- a/.github/workflows/onepassword-headless-proof.yml
+++ b/.github/workflows/onepassword-headless-proof.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check proof configuration
         env:

--- a/.github/workflows/onepassword-headless-proof.yml
+++ b/.github/workflows/onepassword-headless-proof.yml
@@ -1,0 +1,101 @@
+name: 1Password Headless Proof
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  op-service-account-proof:
+    name: Prove OP_SERVICE_ACCOUNT_TOKEN path
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check proof configuration
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OP_PREFLIGHT_CANARY_REF: ${{ vars.OP_PREFLIGHT_CANARY_REF }}
+          OP_PREFLIGHT_CANARY_SHA256: ${{ secrets.OP_PREFLIGHT_CANARY_SHA256 }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in OP_SERVICE_ACCOUNT_TOKEN OP_PREFLIGHT_CANARY_REF OP_PREFLIGHT_CANARY_SHA256; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is not configured for the 1Password headless proof."
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            cat <<'EOF'
+          Configure the proof before running this workflow:
+          - OP_SERVICE_ACCOUNT_TOKEN: encrypted Actions secret for the scoped 1Password service account
+          - OP_PREFLIGHT_CANARY_REF: Actions variable with the canary op:// reference
+          - OP_PREFLIGHT_CANARY_SHA256: encrypted Actions secret with the canary value's SHA-256 digest
+          EOF
+            exit 1
+          fi
+
+      - name: Install 1Password CLI
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl gnupg
+          curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
+            sudo gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | \
+            sudo tee /etc/apt/sources.list.d/1password.list >/dev/null
+          sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22/
+          curl -sS https://downloads.1password.com/linux/debian/debsig/1password.pol | \
+            sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol >/dev/null
+          sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
+          curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
+            sudo gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+          sudo apt-get update
+          sudo apt-get install -y 1password-cli
+          op --version
+
+      - name: Read canary without logging value
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OP_PREFLIGHT_CANARY_REF: ${{ vars.OP_PREFLIGHT_CANARY_REF }}
+          OP_PREFLIGHT_CANARY_SHA256: ${{ secrets.OP_PREFLIGHT_CANARY_SHA256 }}
+        run: |
+          set -euo pipefail
+          echo "::add-mask::$OP_SERVICE_ACCOUNT_TOKEN"
+          canary="$(op read "$OP_PREFLIGHT_CANARY_REF")"
+          echo "::add-mask::$canary"
+          digest="$(printf '%s' "$canary" | sha256sum | awk '{print $1}')"
+          if [ "$digest" != "$OP_PREFLIGHT_CANARY_SHA256" ]; then
+            echo "::error::Canary digest did not match OP_PREFLIGHT_CANARY_SHA256."
+            exit 1
+          fi
+          echo "1Password service-account canary read succeeded."
+
+      - name: Prove op-preflight token mode
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "::add-mask::$OP_SERVICE_ACCOUNT_TOKEN"
+          cache_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/op-preflight-proof.XXXXXX")"
+          trap 'rm -rf "$cache_dir"' EXIT
+          export OP_PREFLIGHT_CACHE_DIR="$cache_dir"
+          eval "$(scripts/op-preflight.sh --agent codex --mode review)"
+          echo "::add-mask::$OP_PREFLIGHT_REVIEWER_PAT"
+          if [ "${OP_PREFLIGHT_TOKEN_MODE:-0}" != "1" ]; then
+            echo "::error::op-preflight did not enter token mode."
+            exit 1
+          fi
+          if [ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]; then
+            echo "::error::op-preflight token mode did not export reviewer PAT."
+            exit 1
+          fi
+          if [ -n "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]; then
+            echo "::error::op-preflight token mode unexpectedly exported author PAT."
+            exit 1
+          fi
+          export OP_PREFLIGHT_QUIET=1
+          eval "$(scripts/op-preflight.sh --agent codex --check)"
+          echo "op-preflight token mode and --check succeeded without interactive auth."

--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -161,6 +161,9 @@ jobs:
       - name: check_op_preflight_contract
         run: ./scripts/ci/check_op_preflight_contract
 
+      - name: check_onepassword_headless_proof_workflow
+        run: ./scripts/ci/check_onepassword_headless_proof_workflow
+
       - name: check_eslint_config_present
         run: ./scripts/ci/check_eslint_config_present
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -750,7 +750,7 @@ Compatibility matrix:
 | 1Password local `.env` validation hook | Not listed in the hook support matrix | Supported | Supported | Supported | Supported | No |
 | `op run --environment` / secret references | Works if shell-capable | Works if shell-capable | Works if shell-capable | Works if shell-capable | Works if shell-capable | Works with scoped service account |
 | Service-account token | Headless only; explicit opt-in | Headless only; explicit opt-in | Headless only; explicit opt-in | Headless only; explicit opt-in | Headless only; explicit opt-in | Preferred non-interactive path |
-| Mergepath `op-preflight.sh` review mode | Configured | Configured | Configured | Not configured | Not configured | Planned only after token-mode work |
+| Mergepath `op-preflight.sh` review mode | Configured | Configured | Configured | Not configured | Not configured | Configured for `claude` / `cursor` / `codex` when `OP_SERVICE_ACCOUNT_TOKEN` is set |
 
 Operational guardrails:
 
@@ -763,6 +763,42 @@ Operational guardrails:
   truly requires a materialized config file.
 - Secure Note `notesPlain` whole-file bootstrap has been retired. Use
   `.env.tpl` plus `op inject` when a generated file is required.
+
+#### Headless `op-preflight` proof workflow
+
+`scripts/op-preflight.sh` has an explicit CI/headless lane for review
+credentials. When `OP_SERVICE_ACCOUNT_TOKEN` is present, review mode
+uses the 1Password CLI service-account path instead of biometric
+desktop approval, writes only `OP_PREFLIGHT_REVIEWER_PAT`, marks the
+cache with `OP_PREFLIGHT_TOKEN_MODE=1`, and skips SSH warming plus
+GitHub keyring repair. This mode is not an implicit fallback for local
+attended agents.
+
+The manual workflow
+`.github/workflows/onepassword-headless-proof.yml` proves the lane
+without exposing raw values in logs. Before dispatching it, configure:
+
+- `OP_SERVICE_ACCOUNT_TOKEN` as an encrypted GitHub Actions secret.
+  Scope the service account to the approved reviewer PAT items and
+  the dedicated canary item only.
+- `OP_PREFLIGHT_CANARY_REF` as a GitHub Actions variable containing a
+  non-sensitive `op://` reference to the proof canary field.
+- `OP_PREFLIGHT_CANARY_SHA256` as an encrypted GitHub Actions secret
+  containing the SHA-256 digest of the canary value.
+
+The workflow installs the 1Password CLI, reads the canary, compares
+only its digest, then runs:
+
+```bash
+eval "$(scripts/op-preflight.sh --agent codex --mode review)"
+export OP_PREFLIGHT_QUIET=1
+eval "$(scripts/op-preflight.sh --agent codex --check)"
+```
+
+The workflow is `workflow_dispatch` only. Run it after provisioning or
+rotating the service-account token; do not enable it as an automatic
+PR or push workflow unless the proof secrets are intentionally
+available to that event class.
 
 ### Provisioning the Firebase-vault SA key
 

--- a/docs/agents/deployment-process.md
+++ b/docs/agents/deployment-process.md
@@ -39,6 +39,12 @@ descriptive model when advising repos:
   has scoped the token, vault/Environment access, rotation, and log
   masking. Do not use service-account tokens as a convenience fallback
   for attended local agents.
+- Mergepath's CI/headless review-auth proof is manual-only:
+  `.github/workflows/onepassword-headless-proof.yml` reads a dedicated
+  canary via `OP_SERVICE_ACCOUNT_TOKEN`, compares a SHA-256 digest
+  without printing the value, and exercises `scripts/op-preflight.sh`
+  token mode in a throwaway cache. Dispatch it after provisioning or
+  rotating the service-account token.
 - Existing Mergepath scripts: shelling out to `op read`, `op run`, or
   `op inject` remains acceptable. Do not introduce a language-SDK
   migration unless a separate design decision calls for it.

--- a/scripts/ci/check_onepassword_headless_proof_workflow
+++ b/scripts/ci/check_onepassword_headless_proof_workflow
@@ -92,13 +92,17 @@ workflow_checkout_persist_credentials_disabled() {
     steps = doc.dig("jobs", "op-service-account-proof", "steps")
     exit 1 unless steps.is_a?(Array)
 
-    checkout = steps.find do |step|
+    checkouts = steps.select do |step|
       step.is_a?(Hash) && step["uses"].to_s.start_with?("actions/checkout@")
     end
+    exit 1 if checkouts.empty?
 
-    with_block = checkout.is_a?(Hash) ? checkout["with"] : nil
-    value = with_block.is_a?(Hash) ? with_block["persist-credentials"] : nil
-    exit(value == false || value.to_s == "false" ? 0 : 1)
+    ok = checkouts.all? do |checkout|
+      with_block = checkout["with"]
+      value = with_block.is_a?(Hash) ? with_block["persist-credentials"] : nil
+      value == false || value.to_s == "false"
+    end
+    exit(ok ? 0 : 1)
   ' "$file"
 }
 
@@ -179,6 +183,18 @@ jobs:
         run: 'echo "persist-credentials: false"'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 YAML
+cat >"$SCRATCH/checkout-persist-second-missing.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+jobs:
+  op-service-account-proof:
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+YAML
 
 assert_workflow_dispatch_only "$SCRATCH/dispatch-only.yml"
 assert_rejects_non_manual_trigger_fixture "$SCRATCH/pull-request-target.yml" "pull_request_target"
@@ -188,6 +204,7 @@ assert_rejects_non_manual_trigger_fixture "$SCRATCH/schedule.yml" "schedule"
 assert_rejects_non_manual_trigger_fixture "$SCRATCH/workflow-run.yml" "workflow_run"
 assert_checkout_disables_credential_persistence "$SCRATCH/checkout-persist-disabled.yml"
 assert_rejects_checkout_credential_fixture "$SCRATCH/checkout-persist-decoy.yml" "decoy persist-credentials"
+assert_rejects_checkout_credential_fixture "$SCRATCH/checkout-persist-second-missing.yml" "second checkout without persist-credentials"
 
 assert_checkout_disables_credential_persistence "$WORKFLOW"
 grep -q 'OP_SERVICE_ACCOUNT_TOKEN: \${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}' "$WORKFLOW" \

--- a/scripts/ci/check_onepassword_headless_proof_workflow
+++ b/scripts/ci/check_onepassword_headless_proof_workflow
@@ -89,11 +89,16 @@ workflow_checkout_persist_credentials_disabled() {
       exit 2
     end
 
-    steps = doc.dig("jobs", "op-service-account-proof", "steps")
-    exit 1 unless steps.is_a?(Array)
+    jobs = doc["jobs"]
+    exit 1 unless jobs.is_a?(Hash)
 
-    checkouts = steps.select do |step|
-      step.is_a?(Hash) && step["uses"].to_s.start_with?("actions/checkout@")
+    checkouts = jobs.values.flat_map do |job|
+      steps = job.is_a?(Hash) ? job["steps"] : nil
+      next [] unless steps.is_a?(Array)
+
+      steps.select do |step|
+        step.is_a?(Hash) && step["uses"].to_s.start_with?("actions/checkout@")
+      end
     end
     exit 1 if checkouts.empty?
 
@@ -195,6 +200,20 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 YAML
+cat >"$SCRATCH/checkout-persist-other-job-missing.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+jobs:
+  op-service-account-proof:
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+  later-proof:
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+YAML
 
 assert_workflow_dispatch_only "$SCRATCH/dispatch-only.yml"
 assert_rejects_non_manual_trigger_fixture "$SCRATCH/pull-request-target.yml" "pull_request_target"
@@ -205,6 +224,7 @@ assert_rejects_non_manual_trigger_fixture "$SCRATCH/workflow-run.yml" "workflow_
 assert_checkout_disables_credential_persistence "$SCRATCH/checkout-persist-disabled.yml"
 assert_rejects_checkout_credential_fixture "$SCRATCH/checkout-persist-decoy.yml" "decoy persist-credentials"
 assert_rejects_checkout_credential_fixture "$SCRATCH/checkout-persist-second-missing.yml" "second checkout without persist-credentials"
+assert_rejects_checkout_credential_fixture "$SCRATCH/checkout-persist-other-job-missing.yml" "checkout in another job without persist-credentials"
 
 assert_checkout_disables_credential_persistence "$WORKFLOW"
 grep -q 'OP_SERVICE_ACCOUNT_TOKEN: \${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}' "$WORKFLOW" \

--- a/scripts/ci/check_onepassword_headless_proof_workflow
+++ b/scripts/ci/check_onepassword_headless_proof_workflow
@@ -15,16 +15,41 @@ fail() {
 
 workflow_triggers() {
   local file="$1"
-  awk '
-    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
-    /^on:[[:space:]]*$/ { in_on = 1; next }
-    in_on && /^[^[:space:]#]/ { in_on = 0 }
-    in_on && /^  [A-Za-z0-9_-]+:[[:space:]]*($|#)/ {
-      line = $0
-      sub(/^[[:space:]]*/, "", line)
-      sub(/:.*/, "", line)
-      print line
-    }
+  ruby -ryaml -e '
+    file = ARGV.fetch(0)
+    begin
+      doc = YAML.safe_load(File.read(file), aliases: false)
+    rescue Psych::Exception => e
+      warn "YAML parse failed for #{file}: #{e.message}"
+      exit 2
+    end
+
+    unless doc.is_a?(Hash)
+      exit
+    end
+
+    # Psych parses the GitHub Actions key `on` as boolean true under YAML 1.1.
+    on_value = if doc.key?("on")
+                 doc["on"]
+               else
+                 doc[true]
+               end
+
+    triggers =
+      case on_value
+      when Hash
+        on_value.keys
+      when Array
+        on_value
+      when String, Symbol
+        [on_value]
+      when NilClass
+        []
+      else
+        [on_value]
+      end
+
+    triggers.map(&:to_s).each { |trigger| puts trigger }
   ' "$file"
 }
 
@@ -68,6 +93,16 @@ on:
   workflow_dispatch:
   pull_request_target:
 YAML
+cat >"$SCRATCH/quoted-pull-request-target.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+  "pull_request_target":
+YAML
+cat >"$SCRATCH/flow-pull-request-target.yml" <<'YAML'
+name: proof
+on: { workflow_dispatch: null, "pull_request_target": null }
+YAML
 cat >"$SCRATCH/schedule.yml" <<'YAML'
 name: proof
 on:
@@ -86,9 +121,13 @@ YAML
 
 assert_workflow_dispatch_only "$SCRATCH/dispatch-only.yml"
 assert_rejects_non_manual_trigger_fixture "$SCRATCH/pull-request-target.yml" "pull_request_target"
+assert_rejects_non_manual_trigger_fixture "$SCRATCH/quoted-pull-request-target.yml" "quoted pull_request_target"
+assert_rejects_non_manual_trigger_fixture "$SCRATCH/flow-pull-request-target.yml" "flow-style pull_request_target"
 assert_rejects_non_manual_trigger_fixture "$SCRATCH/schedule.yml" "schedule"
 assert_rejects_non_manual_trigger_fixture "$SCRATCH/workflow-run.yml" "workflow_run"
 
+grep -q 'persist-credentials: false' "$WORKFLOW" \
+  || fail "workflow checkout must disable credential persistence"
 grep -q 'OP_SERVICE_ACCOUNT_TOKEN: \${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}' "$WORKFLOW" \
   || fail "workflow must read OP_SERVICE_ACCOUNT_TOKEN from Actions secrets"
 grep -q 'OP_PREFLIGHT_CANARY_REF: \${{ vars.OP_PREFLIGHT_CANARY_REF }}' "$WORKFLOW" \

--- a/scripts/ci/check_onepassword_headless_proof_workflow
+++ b/scripts/ci/check_onepassword_headless_proof_workflow
@@ -13,12 +13,81 @@ fail() {
 
 [[ -f "$WORKFLOW" ]] || fail "missing $WORKFLOW"
 
-grep -q '^  workflow_dispatch:' "$WORKFLOW" \
-  || fail "workflow must be manual-only via workflow_dispatch"
-! grep -q '^  pull_request:' "$WORKFLOW" \
-  || fail "workflow must not run automatically on pull_request"
-! grep -q '^  push:' "$WORKFLOW" \
-  || fail "workflow must not run automatically on push"
+workflow_triggers() {
+  local file="$1"
+  awk '
+    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+    /^on:[[:space:]]*$/ { in_on = 1; next }
+    in_on && /^[^[:space:]#]/ { in_on = 0 }
+    in_on && /^  [A-Za-z0-9_-]+:[[:space:]]*($|#)/ {
+      line = $0
+      sub(/^[[:space:]]*/, "", line)
+      sub(/:.*/, "", line)
+      print line
+    }
+  ' "$file"
+}
+
+is_workflow_dispatch_only() {
+  local file="$1"
+  local triggers count
+  triggers=$(workflow_triggers "$file")
+  count=$(printf '%s\n' "$triggers" | sed '/^$/d' | wc -l | tr -d ' ')
+  [ "$count" -eq 1 ] && [ "$triggers" = "workflow_dispatch" ]
+}
+
+assert_workflow_dispatch_only() {
+  local file="$1"
+  local triggers
+  if ! is_workflow_dispatch_only "$file"; then
+    triggers=$(workflow_triggers "$file" | paste -sd ', ' -)
+    fail "workflow must be manual-only: expected only workflow_dispatch under on:, found [${triggers:-none}]"
+  fi
+}
+
+assert_rejects_non_manual_trigger_fixture() {
+  local file="$1"
+  local desc="$2"
+  if is_workflow_dispatch_only "$file"; then
+    fail "trigger allowlist failed to reject $desc fixture"
+  fi
+}
+
+assert_workflow_dispatch_only "$WORKFLOW"
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/onepassword-proof-workflow-check.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+cat >"$SCRATCH/dispatch-only.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+YAML
+cat >"$SCRATCH/pull-request-target.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+  pull_request_target:
+YAML
+cat >"$SCRATCH/schedule.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *'
+YAML
+cat >"$SCRATCH/workflow-run.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["repo-lint"]
+    types: [completed]
+YAML
+
+assert_workflow_dispatch_only "$SCRATCH/dispatch-only.yml"
+assert_rejects_non_manual_trigger_fixture "$SCRATCH/pull-request-target.yml" "pull_request_target"
+assert_rejects_non_manual_trigger_fixture "$SCRATCH/schedule.yml" "schedule"
+assert_rejects_non_manual_trigger_fixture "$SCRATCH/workflow-run.yml" "workflow_run"
 
 grep -q 'OP_SERVICE_ACCOUNT_TOKEN: \${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}' "$WORKFLOW" \
   || fail "workflow must read OP_SERVICE_ACCOUNT_TOKEN from Actions secrets"

--- a/scripts/ci/check_onepassword_headless_proof_workflow
+++ b/scripts/ci/check_onepassword_headless_proof_workflow
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Validate the 1Password headless proof workflow's safety-critical shape.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/onepassword-headless-proof.yml"
+
+fail() {
+  echo "check_onepassword_headless_proof_workflow: FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$WORKFLOW" ]] || fail "missing $WORKFLOW"
+
+grep -q '^  workflow_dispatch:' "$WORKFLOW" \
+  || fail "workflow must be manual-only via workflow_dispatch"
+! grep -q '^  pull_request:' "$WORKFLOW" \
+  || fail "workflow must not run automatically on pull_request"
+! grep -q '^  push:' "$WORKFLOW" \
+  || fail "workflow must not run automatically on push"
+
+grep -q 'OP_SERVICE_ACCOUNT_TOKEN: \${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}' "$WORKFLOW" \
+  || fail "workflow must read OP_SERVICE_ACCOUNT_TOKEN from Actions secrets"
+grep -q 'OP_PREFLIGHT_CANARY_REF: \${{ vars.OP_PREFLIGHT_CANARY_REF }}' "$WORKFLOW" \
+  || fail "workflow must read canary reference from Actions variables"
+grep -q 'OP_PREFLIGHT_CANARY_SHA256: \${{ secrets.OP_PREFLIGHT_CANARY_SHA256 }}' "$WORKFLOW" \
+  || fail "workflow must compare canary via secret SHA-256 digest"
+grep -q 'op read "$OP_PREFLIGHT_CANARY_REF"' "$WORKFLOW" \
+  || fail "workflow must perform a scoped op read canary proof"
+grep -q 'scripts/op-preflight.sh --agent codex --mode review' "$WORKFLOW" \
+  || fail "workflow must exercise op-preflight token mode"
+grep -q 'scripts/op-preflight.sh --agent codex --check' "$WORKFLOW" \
+  || fail "workflow must exercise op-preflight --check after token-mode fill"
+
+if grep -Eq 'echo "\$canary"|echo "\$\{canary' "$WORKFLOW"; then
+  fail "workflow must not print the canary value"
+fi
+
+echo "check_onepassword_headless_proof_workflow: PASS"

--- a/scripts/ci/check_onepassword_headless_proof_workflow
+++ b/scripts/ci/check_onepassword_headless_proof_workflow
@@ -78,6 +78,45 @@ assert_rejects_non_manual_trigger_fixture() {
   fi
 }
 
+workflow_checkout_persist_credentials_disabled() {
+  local file="$1"
+  ruby -ryaml -e '
+    file = ARGV.fetch(0)
+    begin
+      doc = YAML.safe_load(File.read(file), aliases: false) || {}
+    rescue Psych::Exception => e
+      warn "YAML parse failed for #{file}: #{e.message}"
+      exit 2
+    end
+
+    steps = doc.dig("jobs", "op-service-account-proof", "steps")
+    exit 1 unless steps.is_a?(Array)
+
+    checkout = steps.find do |step|
+      step.is_a?(Hash) && step["uses"].to_s.start_with?("actions/checkout@")
+    end
+
+    with_block = checkout.is_a?(Hash) ? checkout["with"] : nil
+    value = with_block.is_a?(Hash) ? with_block["persist-credentials"] : nil
+    exit(value == false || value.to_s == "false" ? 0 : 1)
+  ' "$file"
+}
+
+assert_checkout_disables_credential_persistence() {
+  local file="$1"
+  if ! workflow_checkout_persist_credentials_disabled "$file"; then
+    fail "workflow checkout must disable credential persistence on the actions/checkout step"
+  fi
+}
+
+assert_rejects_checkout_credential_fixture() {
+  local file="$1"
+  local desc="$2"
+  if workflow_checkout_persist_credentials_disabled "$file"; then
+    fail "checkout credential guard failed to reject $desc fixture"
+  fi
+}
+
 assert_workflow_dispatch_only "$WORKFLOW"
 
 SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/onepassword-proof-workflow-check.XXXXXX")"
@@ -118,6 +157,28 @@ on:
     workflows: ["repo-lint"]
     types: [completed]
 YAML
+cat >"$SCRATCH/checkout-persist-disabled.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+jobs:
+  op-service-account-proof:
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+YAML
+cat >"$SCRATCH/checkout-persist-decoy.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+jobs:
+  op-service-account-proof:
+    steps:
+      - name: Decoy
+        run: 'echo "persist-credentials: false"'
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+YAML
 
 assert_workflow_dispatch_only "$SCRATCH/dispatch-only.yml"
 assert_rejects_non_manual_trigger_fixture "$SCRATCH/pull-request-target.yml" "pull_request_target"
@@ -125,9 +186,10 @@ assert_rejects_non_manual_trigger_fixture "$SCRATCH/quoted-pull-request-target.y
 assert_rejects_non_manual_trigger_fixture "$SCRATCH/flow-pull-request-target.yml" "flow-style pull_request_target"
 assert_rejects_non_manual_trigger_fixture "$SCRATCH/schedule.yml" "schedule"
 assert_rejects_non_manual_trigger_fixture "$SCRATCH/workflow-run.yml" "workflow_run"
+assert_checkout_disables_credential_persistence "$SCRATCH/checkout-persist-disabled.yml"
+assert_rejects_checkout_credential_fixture "$SCRATCH/checkout-persist-decoy.yml" "decoy persist-credentials"
 
-grep -q 'persist-credentials: false' "$WORKFLOW" \
-  || fail "workflow checkout must disable credential persistence"
+assert_checkout_disables_credential_persistence "$WORKFLOW"
 grep -q 'OP_SERVICE_ACCOUNT_TOKEN: \${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}' "$WORKFLOW" \
   || fail "workflow must read OP_SERVICE_ACCOUNT_TOKEN from Actions secrets"
 grep -q 'OP_PREFLIGHT_CANARY_REF: \${{ vars.OP_PREFLIGHT_CANARY_REF }}' "$WORKFLOW" \


### PR DESCRIPTION
## Summary

Adds the #354 CI/headless proof path for the scoped 1Password service-account lane after #353 landed token mode in `scripts/op-preflight.sh`.

Changes:
- Adds `.github/workflows/onepassword-headless-proof.yml` as a manual-only `workflow_dispatch` proof workflow.
- Installs the 1Password CLI in CI using the official Linux APT setup, reads a dedicated canary via `OP_SERVICE_ACCOUNT_TOKEN`, and compares only a SHA-256 digest.
- Exercises the real `scripts/op-preflight.sh --agent codex --mode review` token branch in a throwaway cache, then verifies `--check`.
- Adds `scripts/ci/check_onepassword_headless_proof_workflow` and wires it into `repo_lint.yml` so the workflow shape cannot drift silently.
- Hardens that CI guard per #371: the workflow trigger block is now an allowlist that accepts only `workflow_dispatch`, with fixtures that reject `pull_request_target`, `schedule`, and `workflow_run`.
- Documents the required GitHub secret/variable setup and local-headless guardrails.

Closes #354.
Closes #371.
Part of #346.

## Human Setup Before Live Proof / Merge

This PR is ready for automated review, but the live proof still requires human-provisioned GitHub Actions inputs before merge:

- `OP_SERVICE_ACCOUNT_TOKEN`: encrypted Actions secret for the scoped 1Password service account approved in #355.
- `OP_PREFLIGHT_CANARY_REF`: Actions variable containing the canary `op://` reference.
- `OP_PREFLIGHT_CANARY_SHA256`: encrypted Actions secret containing the canary value's SHA-256 digest.

Then run `1Password Headless Proof` from the Actions tab and confirm it succeeds without printing token or canary values.

## Validation

Local validation run:
- `bash -n scripts/ci/check_onepassword_headless_proof_workflow`
- `scripts/ci/check_onepassword_headless_proof_workflow`
- `scripts/ci/check_ci_scripts_wired`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/onepassword-headless-proof.yml"); YAML.load_file(".github/workflows/repo_lint.yml")'`
- `scripts/ci/check_required_root_files`
- `scripts/ci/check_no_forbidden_top_level_dirs`
- `scripts/ci/check_spec_test_alignment`
- `scripts/ci/check_duplicate_docs`
- `scripts/ci/check_workflow_parsers`
- `scripts/ci/check_op_preflight_contract`
- `git diff --check`

The live proof workflow was not dispatched because the service-account token/canary Actions secrets are not visible to this session.

## Self-Review

Correctness: The proof workflow is manual-only, validates required inputs, reads a canary without printing it, and exercises the merged token-mode preflight branch with a temporary cache. The guard now allowlists `workflow_dispatch` instead of denylisting a few automatic triggers.

Regression risk: Low for normal CI because the workflow is `workflow_dispatch` only. The repo-lint addition only validates static workflow shape.

Style: Follows existing shell/YAML style and pins the checkout action consistently with other workflows.

Test coverage: Adds a CI check for the proof workflow's safety-critical structure, including fixtures that reject non-manual triggers, and wires it into repo-lint.

Security/dependency hygiene: Uses encrypted Actions secrets for token and expected digest, a non-secret Actions variable for the canary reference, `::add-mask::` for token-derived values, no automatic PR/push/target/scheduled/workflow_run trigger, and no raw secret logging.

Authoring-Agent: codex
