### PR TITLE
[#367] Add human-hold merge freeze label

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ Before opening or updating a pull request, perform a structured self-review and 
 - Review under your agent's reviewer identity (e.g., `nathanpayne-claude`).
 - Only `nathanjohnpayne` merges to the target branch.
 - Never approve your own PR. Self-approvals are automatically dismissed.
-- Never remove `needs-external-review` or `needs-human-review` labels.
+- Never remove `needs-external-review`, `needs-human-review`, `policy-violation`, or `human-hold` labels. Agents may add `human-hold` to freeze a PR.
 - When external review is required, post a handoff message as described in REVIEW_POLICY.md.
 - See REVIEW_POLICY.md for the complete workflow, handoff format, and post-merge issue rules.
 

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -436,7 +436,8 @@ jobs:
       github.event_name == 'pull_request_review' &&
       github.event.review.state == 'approved' &&
       !contains(github.event.pull_request.labels.*.name, 'needs-external-review') &&
-      !contains(github.event.pull_request.labels.*.name, 'needs-human-review')
+      !contains(github.event.pull_request.labels.*.name, 'needs-human-review') &&
+      !contains(github.event.pull_request.labels.*.name, 'human-hold')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -553,14 +554,14 @@ jobs:
           # present. Also check `policy-violation`, which is applied by the
           # block-self-approval job earlier in this same workflow run (and
           # again, the `if:` at job start wouldn't have seen it).
-          LABELS=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json labels --jq '[.labels[].name] | join(",")')
-          echo "Labels at merge time: [$LABELS]"
-          case ",$LABELS," in
-            *,needs-external-review,*|*,needs-human-review,*|*,policy-violation,*)
-              echo "::error::Blocking label present at merge time: $LABELS. Aborting auto-merge."
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json labels --jq '.labels[].name')
+          printf 'Labels at merge time:\n%s\n' "$LABELS"
+          for blocking_label in needs-external-review needs-human-review policy-violation human-hold; do
+            if printf '%s\n' "$LABELS" | grep -Fxq "$blocking_label"; then
+              echo "::error::Blocking label present at merge time: $blocking_label. Aborting auto-merge."
               exit 1
-              ;;
-          esac
+            fi
+          done
           echo "No blocking labels present — proceeding to merge."
 
       - name: Enable auto-merge

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -9,8 +9,8 @@ name: Auto-clear blocking labels
 # `gh pr edit <N> --remove-label needs-external-review` after agents
 # have done all the actual review work.
 #
-# Scope: ONLY removes `needs-external-review`. `needs-human-review`
-# and `policy-violation` remain manual-only by design (see
+# Scope: ONLY removes `needs-external-review`. `needs-human-review`,
+# `policy-violation`, and `human-hold` remain manual-only by design (see
 # REVIEW_POLICY.md § Agent prohibitions). The doctrine carve-out for
 # this workflow ships in #196.
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       # Check out the BASE ref (the target branch's tip), NOT the PR
       # HEAD. This workflow runs under pull_request_target which has
@@ -67,6 +67,23 @@ jobs:
             exit 1
           fi
           echo "::notice::Approving $PR_URL as $ACTING_AS (PR author: $PR_AUTHOR)"
+
+          has_human_hold() {
+            local labels
+            if ! labels=$(gh pr view "$PR_URL" --json labels --jq '.labels[].name'); then
+              echo "::error::Failed to read labels for $PR_URL while checking human-hold."
+              exit 1
+            fi
+            printf '%s\n' "$labels" | grep -Fxq human-hold
+          }
+
+          # `human-hold` is a human-remove-only hard freeze. Re-read
+          # labels at runtime so a hold added while this job is queued
+          # or waiting cannot be bypassed by the trigger-time payload.
+          if has_human_hold; then
+            echo "::notice::PR carries human-hold; skipping Dependabot auto-merge until the human removes the label."
+            exit 0
+          fi
 
           # Self-approval guard. The real condition is "the reviewer
           # token resolves to the PR's own author" — GitHub blocks
@@ -136,6 +153,10 @@ jobs:
           # returns exit 1 for all merge failures without a
           # distinguishing exit code, so we pattern-match stderr for
           # the documented auto-merge-unavailable GraphQL messages.
+          if has_human_hold; then
+            echo "::notice::PR carries human-hold immediately before --auto; skipping Dependabot auto-merge until the human removes the label."
+            exit 0
+          fi
           set +e
           AUTO_STDERR=$(gh pr merge --squash --auto "$PR_URL" 2>&1 1>/dev/null)
           AUTO_RC=$?
@@ -147,6 +168,10 @@ jobs:
           echo "$AUTO_STDERR" >&2
           if echo "$AUTO_STDERR" | grep -qiE 'auto[- ]?merge is not available|not in the correct state to enable auto[- ]?merge|auto[- ]?merge.*disabled|enablePullRequestAutoMerge'; then
             echo "::notice::--auto unavailable on this repo (likely no branch protection); falling back to immediate squash."
+            if has_human_hold; then
+              echo "::notice::PR carries human-hold immediately before fallback squash; skipping Dependabot auto-merge until the human removes the label."
+              exit 0
+            fi
             gh pr merge --squash "$PR_URL"
           else
             echo "::error::gh pr merge --auto failed for a non-auto-merge-unavailable reason. See stderr above. Not falling back to immediate squash; surface to audit."

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,7 +1,7 @@
 name: Weekly PR Audit
 
 # Cron-driven retroactive check that the previous week's merged PRs
-# satisfied the review policy. Five checks per merged PR:
+# satisfied the review policy. Six checks per merged PR:
 #
 #   1. Self-Review section present in PR body (Dependabot exempted)
 #   2. external-review-labeled PRs have either an APPROVED CLI
@@ -10,6 +10,7 @@ name: Weekly PR Audit
 #   3. No bot self-approval (reviewer identity approving its own PR)
 #   4. needs-human-review label not still present at merge time
 #   5. policy-violation label not still present at merge time
+#   6. human-hold label not still present at merge time
 #
 # Violations are aggregated into a single audit issue per run.
 # See REVIEW_POLICY.md, .github/review-policy.yml, and #36 for
@@ -115,6 +116,36 @@ jobs:
 
             const violations = [];
 
+            async function labelWasPresentAtMerge(pr, labelName) {
+              const events = await github.paginate(
+                github.rest.issues.listEvents,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  per_page: 100,
+                }
+              );
+              const mergedAt = new Date(pr.merged_at).getTime();
+              let present = false;
+              for (const event of events.sort(
+                (a, b) => new Date(a.created_at) - new Date(b.created_at)
+              )) {
+                if (new Date(event.created_at).getTime() > mergedAt) {
+                  continue;
+                }
+                if (!event.label || event.label.name !== labelName) {
+                  continue;
+                }
+                if (event.event === 'labeled') {
+                  present = true;
+                } else if (event.event === 'unlabeled') {
+                  present = false;
+                }
+              }
+              return present;
+            }
+
             for (const pr of mergedPRs) {
               const prViolations = [];
               const isDependabot = pr.user.login === 'dependabot[bot]';
@@ -152,9 +183,10 @@ jobs:
               // Skip for Dependabot PRs. Dependabot doesn't author a
               // body with the Self-Review template, and the
               // pre-merge gate in pr-review-policy.yml already
-              // skips Dependabot via `if: github.actor != 'dependabot[bot]'`
-              // (line 14). The audit was previously flagging every
-              // Dependabot PR as a false positive — see #20.
+              // skips Dependabot via the pull request author login
+              // (not github.actor, which can drift on reruns). The
+              // audit was previously flagging every Dependabot PR as
+              // a false positive — see #20.
               if (!isDependabot) {
                 if (!pr.body || !pr.body.match(/^## Self-Review/m)) {
                   prViolations.push('Missing `## Self-Review` section');
@@ -439,8 +471,9 @@ jobs:
               // resolves escalation by removing the label (which unblocks the
               // label-gate check). If the label is still present at merge time,
               // it means the label gate was bypassed.
-              const hadHumanLabel = pr.labels.some(
-                l => l.name === 'needs-human-review'
+              const hadHumanLabel = await labelWasPresentAtMerge(
+                pr,
+                'needs-human-review'
               );
 
               if (hadHumanLabel) {
@@ -450,13 +483,26 @@ jobs:
               }
 
               // Check 5: Had policy-violation label — should not have been merged
-              const hadPolicyViolation = pr.labels.some(
-                l => l.name === 'policy-violation'
+              const hadPolicyViolation = await labelWasPresentAtMerge(
+                pr,
+                'policy-violation'
               );
 
               if (hadPolicyViolation) {
                 prViolations.push(
                   'Merged with `policy-violation` label still present'
+                );
+              }
+
+              // Check 6: Had human-hold label — should not have been merged.
+              const hadHumanHold = await labelWasPresentAtMerge(
+                pr,
+                'human-hold'
+              );
+
+              if (hadHumanHold) {
+                prViolations.push(
+                  'Merged with `human-hold` label still present — human hard hold was bypassed'
                 );
               }
 

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -38,6 +38,7 @@ jobs:
               'needs-external-review',
               'needs-human-review',
               'policy-violation',
+              'human-hold',
             ];
             const prLabels = context.payload.pull_request.labels.map(l => l.name);
             const blockers = prLabels.filter(l => blockingLabels.includes(l));

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ This repository uses a multi-identity AI agent code review system. The full poli
 - Each agent reviews code under its own reviewer identity (e.g., nathanpayne-claude, nathanpayne-cursor, nathanpayne-codex).
 - An agent never reviews code under the same identity that authored it.
 - Only nathanjohnpayne merges to the target branch.
+- Agents may add `human-hold` to freeze a PR, but must never remove it. The label is human-remove-only and supersedes all merge paths.
 
 ### Workflow Summary
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -444,12 +444,14 @@ keyring active is your agent identity. No switch needed for commits.
 
 10.6. Never use `gh pr edit ... --remove-label` (or `--add-label`) for
      `needs-external-review`, `needs-human-review`, or
-     `policy-violation`. These are human-action labels; the
+     `policy-violation`. Agents may add `human-hold` to freeze a PR,
+     but must never remove it. These are human-action labels; the
      `scripts/hooks/label-removal-guard.sh` PreToolUse hook blocks
-     such calls regardless of chat authorization. To request removal,
-     run: `scripts/request-label-removal.sh <PR#> <label>` — the
-     human clears it from any device and auto-merge fires
-     immediately. See REVIEW_POLICY.md § Agent prohibitions.
+     prohibited calls regardless of chat authorization. To request
+     removal, run: `scripts/request-label-removal.sh <PR#> <label>` —
+     the human clears it from any device and the PR can proceed once
+     the normal merge gates are green. See REVIEW_POLICY.md § Agent
+     prohibitions.
 
      - For `needs-external-review` specifically, the auto-clear workflow
        (`.github/workflows/auto-clear-blocking-labels.yml`, #191/#195)
@@ -463,8 +465,10 @@ keyring active is your agent identity. No switch needed for commits.
      - `request-label-removal.sh` is the fallback when no triggering
        event arrived AND the sweep hasn't yet fired (or the gate is
        genuinely not yet met).
-     - `needs-human-review` and `policy-violation` remain manual-only
-       by design.
+     - `needs-human-review`, `policy-violation`, and `human-hold`
+       remain manual-only by design. `human-hold` supersedes every
+       merge path, including Codex clearance, reviewer approvals,
+       Dependabot auto-merge, and break-glass agent merge variables.
 
 ## After merging
 

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -274,7 +274,7 @@ affect the byline for that row; the byline follows `GH_TOKEN`.
 | `gh pr create` | `nathanjohnpayne` (use `scripts/gh-as-author.sh`) | any author-readable PAT |
 | `gh pr merge` (squash/rebase) | `nathanjohnpayne` (use `scripts/gh-as-author.sh`) | any author-readable PAT |
 | `gh pr edit` (general — title/body) | `nathanjohnpayne` (use `scripts/gh-as-author.sh`) | any author-readable PAT |
-| `gh pr edit --remove-label <protected>` | **BLOCKED** by `scripts/hooks/label-removal-guard.sh` for `needs-external-review` / `needs-human-review` / `policy-violation`; use `scripts/request-label-removal.sh` | n/a |
+| `gh pr edit --remove-label <protected>` | **BLOCKED** by `scripts/hooks/label-removal-guard.sh` for `needs-external-review` / `needs-human-review` / `policy-violation` / `human-hold`; use `scripts/request-label-removal.sh` | n/a |
 | `gh pr comment` | `nathanpayne-<agent>` (agent identity); blocked when active is `nathanjohnpayne` per `scripts/hooks/gh-pr-guard.sh` (#284) | reviewer PAT (`$OP_PREFLIGHT_REVIEWER_PAT`) |
 | `gh pr review --comment` | `nathanpayne-<agent>`; blocked when active is `nathanjohnpayne` (#284) | reviewer PAT |
 | `gh pr review --approve` (under-threshold) | `nathanpayne-<agent>`; allowed when PR's `Authoring-Agent:` matches the agent (the intended path) | reviewer PAT |
@@ -776,7 +776,7 @@ The agent never resolves a fired escalation signal on its own.
 
 ## Agent prohibitions
 
-Agents must never modify the `needs-external-review`, `needs-human-review`, or `policy-violation` labels on any PR — these are human-action labels. The `scripts/hooks/label-removal-guard.sh` PreToolUse hook enforces this at the mechanism layer; chat authorization does not bypass it. To request a label removal, run `scripts/request-label-removal.sh <PR#> <label>` — this posts a structured ask on the PR and (if `MERGEPATH_NOTIFY_IMESSAGE_TO` is set) pings the human via iMessage. The human clears the label from any device; auto-merge fires immediately.
+Agents must never modify the `needs-external-review`, `needs-human-review`, or `policy-violation` labels on any PR — these are human-action labels. Agents may add `human-hold` to freeze a PR, but must never remove it; `human-hold` is a human-remove-only hard hold that supersedes every merge gate, including Codex clearance, reviewer approvals, Dependabot auto-merge, and break-glass agent merge variables. The `scripts/hooks/label-removal-guard.sh` PreToolUse hook enforces this at the mechanism layer; chat authorization does not bypass it. To request a label removal, run `scripts/request-label-removal.sh <PR#> <label>` — this posts a structured ask on the PR and (if `MERGEPATH_NOTIFY_IMESSAGE_TO` is set) pings the human via iMessage. The human clears the label from any device; the PR can proceed once the normal merge gates are green.
 
 **Sanctioned automation exceptions.** Two — and only two — automated paths may remove `needs-external-review`. Both are GitHub Actions workflows (not interactive agent sessions); both are reconciling a label the policy automation itself is responsible for, which is categorically different from an agent clearing a human-action label.
 
@@ -784,7 +784,7 @@ Agents must never modify the `needs-external-review`, `needs-human-review`, or `
 
 2. **`pr-review-policy.yml`'s External Review Check** (the propagation-PR review lane, [#264](https://github.com/nathanjohnpayne/mergepath/issues/264) / [#268](https://github.com/nathanjohnpayne/mergepath/issues/268)) removes the label when a PR is verified to be a faithful propagation mirror — see [§ Phase 3.5](#phase-35-propagation-pr-review-lane). It does not consult the merge gate; it acts on the orthogonal fact that the PR's content was already reviewed upstream, established by `scripts/workflow/verify-propagation-pr.sh`'s byte-comparison against `mergepath@<sha>`. Same `github-actions[bot]` byline; same not-an-agent-override rationale.
 
-These exceptions apply ONLY to those two workflows. An interactive agent session (claude / cursor / codex) calling `gh pr edit --remove-label` for any of the three blocking labels remains forbidden — the `scripts/hooks/label-removal-guard.sh` PreToolUse hook enforces this independently. The hook intentionally only fires for `Bash` tool calls from agent sessions; a workflow's `gh` call inside a GitHub Actions runner does not pass through that surface, so the hook does not (and should not) block CI workflows. `needs-human-review` and `policy-violation` remain manual-only by design.
+These exceptions apply ONLY to those two workflows. An interactive agent session (claude / cursor / codex) calling `gh pr edit --remove-label` for any of the four protected labels remains forbidden — the `scripts/hooks/label-removal-guard.sh` PreToolUse hook enforces this independently. The hook intentionally only fires for `Bash` tool calls from agent sessions; a workflow's `gh` call inside a GitHub Actions runner does not pass through that surface, so the hook does not (and should not) block CI workflows. `needs-human-review`, `policy-violation`, and `human-hold` remain manual-only by design.
 
 **Disabling the scheduled sweep.** The 15-minute cron is opt-out via `auto_clear_labels.scheduled_sweep_enabled: false` in `.github/review-policy.yml`. Default is `true`. Set to `false` if your repo has high PR volume and the event-driven path is reliably fast enough that the cron becomes pure noise — but expect occasional stuck `needs-external-review` labels on the 👍-after-last-push case (which the sweep would otherwise catch). The event-driven path remains active regardless of this setting.
 
@@ -796,7 +796,7 @@ The workflows shipped under `.github/workflows/` ENFORCE merge gating only when 
 
 Each repo using this template must mark these as required on `main` (Settings → Branches → Branch protection rule):
 
-- **`Label Gate`** — fails when any of `needs-external-review`, `needs-human-review`, or `policy-violation` is on the PR. The hard gate behind the doctrine in [Agent prohibitions](#agent-prohibitions).
+- **`Label Gate`** — fails when any of `needs-external-review`, `needs-human-review`, `policy-violation`, or `human-hold` is on the PR. The hard gate behind the doctrine in [Agent prohibitions](#agent-prohibitions).
 - **`Self-Review Required`** — fails when the PR body lacks a `## Self-Review` section (Dependabot-exempt).
 
 Audit a repo's branch protection with `scripts/audit-branch-protection.sh` (read-only; exits 3 if any canonical check is not required, with a fix recipe). Re-run after every protection change.

--- a/docs/agents/bootstrap-runbook.md
+++ b/docs/agents/bootstrap-runbook.md
@@ -131,9 +131,9 @@ Implementation: `scripts/bootstrap/github-infra.sh`.
 1. `gh repo create --source=. --push` against the target dir — creates
    the remote and pushes the bootstrap commit. Legitimate push to main
    on a greenfield remote (no `main` to protect yet).
-2. Seed the 10 canonical labels (`needs-external-review`,
-   `needs-human-review`, `policy-violation`, `human-action`,
-   `agent-action`, `phase-0` through `phase-4`).
+2. Seed the 11 canonical labels (`needs-external-review`,
+   `needs-human-review`, `policy-violation`, `human-hold`,
+   `human-action`, `agent-action`, `phase-0` through `phase-4`).
 3. Invite reviewer-identity collaborators (`nathanpayne-claude`,
    `-cursor`, `-codex` per `--reviewers`). Each invite is async; the
    wizard pauses for the human to accept each in the agent account's
@@ -396,7 +396,7 @@ And on GitHub:
 
 - Remote repo `nathanjohnpayne/<repo>` with the bootstrap commit pushed
   to main.
-- 10 canonical labels.
+- 11 canonical labels.
 - Reviewer-identity collaborators invited.
 - `REVIEWER_ASSIGNMENT_TOKEN` repo secret set.
 - (When Firebase is enabled) per-project deployer SA keys minted +

--- a/scripts/audit-branch-protection.sh
+++ b/scripts/audit-branch-protection.sh
@@ -3,7 +3,8 @@
 # the canonical required status checks shipped by mergepath.
 #
 # Background: pr-review-policy.yml's `Label Gate` job FAILS when a blocking
-# label (`needs-human-review`, `policy-violation`, `needs-external-review`)
+# label (`needs-human-review`, `policy-violation`, `needs-external-review`,
+# `human-hold`)
 # is on the PR. But that failure only blocks merge if the workflow is
 # configured as a REQUIRED status check in branch protection. Without the
 # protection bit, the failed check is advisory and PRs merge anyway. This
@@ -346,7 +347,8 @@ echo ""
 echo "Without these as required, the corresponding workflows fire on PRs but"
 echo "their failures are advisory — PRs merge despite the failed check."
 echo "Specifically: 'Label Gate' enforces the prohibition on merging while"
-echo "'needs-human-review' / 'policy-violation' / 'needs-external-review' is"
+echo "'needs-human-review' / 'policy-violation' / 'needs-external-review' /"
+echo "'human-hold' is"
 echo "present (see nathanjohnpayne/mergepath#161)."
 echo ""
 echo "Fix: Settings → Branches → Branch protection rule for '$BRANCH'"

--- a/scripts/bootstrap/board-and-summary.sh
+++ b/scripts/bootstrap/board-and-summary.sh
@@ -416,7 +416,7 @@ bootstrap::_print_summary() {
         ;;
       github-infra)
         if [ "$in_state" = "1" ]; then
-          done_lines="$done_lines  [done] GitHub repo created ($visibility) + 10 labels + reviewer invites + secrets
+          done_lines="$done_lines  [done] GitHub repo created ($visibility) + 11 labels + reviewer invites + secrets
 "
         else
           skipped_lines="$skipped_lines  [skip] GitHub repo + labels + invites + secrets (not in state file)

--- a/scripts/bootstrap/github-infra.sh
+++ b/scripts/bootstrap/github-infra.sh
@@ -9,9 +9,9 @@
 #      push to main on a greenfield remote — the `gh-pr-guard.sh`
 #      "never push to main" hook does NOT apply because there's no
 #      `main` to protect yet.
-#   2. Seed the 10 canonical labels (needs-external-review,
-#      needs-human-review, policy-violation, human-action,
-#      agent-action, phase-0..4). Eliminates the first-PR
+#   2. Seed the 11 canonical labels (needs-external-review,
+#      needs-human-review, policy-violation, human-hold,
+#      human-action, agent-action, phase-0..4). Eliminates the first-PR
 #      "label not found" friction.
 #   3. Invite reviewer-identity collaborators (claude / cursor /
 #      codex per BOOTSTRAP_INPUT_REVIEWERS). Each invite is async;
@@ -54,6 +54,7 @@ BOOTSTRAP_LABELS=(
   "needs-external-review:bf0606:External review required before merge"
   "needs-human-review:7057ff:Awaiting human triage or decision"
   "policy-violation:b60205:Blocked by review-policy.yml violation"
+  "human-hold:000000:Hard merge freeze - human-remove-only; supersedes all gates"
   "human-action:0e8a16:Requires human attention"
   "agent-action:1d76db:Agent task — not blocked on human"
   "phase-0:c5def5:Phase 0: foundations"

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -251,7 +251,8 @@ fi
 # satisfy the match even if the executable line regressed).
 if grep -qE 'gh pr edit .+--remove-label needs-external-review' "$WORKFLOW" && \
    ! grep -qE 'gh pr edit .+--remove-label needs-human-review' "$WORKFLOW" && \
-   ! grep -qE 'gh pr edit .+--remove-label policy-violation' "$WORKFLOW"; then
+   ! grep -qE 'gh pr edit .+--remove-label policy-violation' "$WORKFLOW" && \
+   ! grep -qE 'gh pr edit .+--remove-label human-hold' "$WORKFLOW"; then
   pass=$((pass + 1))
   echo "  PASS: scope discipline — only needs-external-review is auto-removed (executable line)"
 else

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -581,6 +581,88 @@ else
 fi
 
 echo
+echo "Bug 3 regression: codex-review-check.sh exact blocking-label match"
+
+# Inline-literal pattern: this is the jq predicate used by
+# scripts/codex-review-check.sh's blocking-label preflight. It must
+# match exact label names, not substrings inside a CSV serialization.
+CODEX_LABEL_FILTER='any(.labels[].name; . == $label)'
+
+run_label_filter() {
+  # Args: $1 = PR JSON, $2 = label to test.
+  echo "$1" | jq -e --arg label "$2" "$CODEX_LABEL_FILTER" >/dev/null
+}
+
+LABELS_EXACT='{"labels":[{"name":"human-hold"}]}'
+LABELS_COMMA='{"labels":[{"name":"team,human-hold"}]}'
+LABELS_OTHER='{"labels":[{"name":"needs-human-review"},{"name":"policy-violation"}]}'
+LABELS_EMPTY='{"labels":[]}'
+
+set +e
+run_label_filter "$LABELS_EXACT" "human-hold"
+rc=$?
+set -e
+if [ "$rc" = "0" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: exact human-hold label matches"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: exact human-hold label did not match" >&2
+fi
+
+set +e
+run_label_filter "$LABELS_COMMA" "human-hold"
+rc=$?
+set -e
+if [ "$rc" != "0" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: label 'team,human-hold' does NOT false-match human-hold"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: comma-containing label false-matched human-hold" >&2
+fi
+
+set +e
+run_label_filter "$LABELS_OTHER" "policy-violation"
+rc=$?
+set -e
+if [ "$rc" = "0" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: exact policy-violation label matches"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: exact policy-violation label did not match" >&2
+fi
+
+set +e
+run_label_filter "$LABELS_EMPTY" "human-hold"
+rc=$?
+set -e
+if [ "$rc" != "0" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: empty labels do not match human-hold"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: empty labels unexpectedly matched human-hold" >&2
+fi
+
+if grep -Fq '[.labels[].name] | join(",")' "$CODEX_CHECK_SCRIPT"; then
+  fail=$((fail + 1))
+  echo "  FAIL: codex-review-check.sh still serializes labels as CSV before matching" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: codex-review-check.sh no longer serializes labels as CSV before matching"
+fi
+
+if grep -Fq 'any(.labels[].name; . == $label)' "$CODEX_CHECK_SCRIPT"; then
+  pass=$((pass + 1))
+  echo "  PASS: codex-review-check.sh uses the exact-name jq predicate"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: codex-review-check.sh is missing the exact-name jq predicate" >&2
+fi
+
+echo
 total=$((pass + fail))
 if [ "$fail" -gt 0 ]; then
   echo "check_canonical_bugs_263caf3: FAIL ($fail/$total failed)"

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -168,6 +168,28 @@ else
   echo "  FAIL: $WORKFLOW must call pulls.listReviews via github.paginate with per_page:100 (PR #255 P2)" >&2
 fi
 
+# Structural assertion: merge-time label checks must be derived from
+# issue label events, not from pr.labels. `pr.labels` is current state
+# at audit time, so a blocking label present during merge but removed
+# afterward would be missed.
+if grep -qF 'async function labelWasPresentAtMerge' "$WORKFLOW" && \
+   grep -qF 'github.rest.issues.listEvents,' "$WORKFLOW" && \
+   grep -qF "await labelWasPresentAtMerge(" "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW reconstructs blocking-label state from issue events at merge time"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must reconstruct blocking-label state from issue events at merge time" >&2
+fi
+
+if grep -qF "l => l.name === 'human-hold'" "$WORKFLOW"; then
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW still checks human-hold via current pr.labels" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW no longer checks human-hold via current pr.labels"
+fi
+
 echo
 if [ "$fail" -gt 0 ]; then
   echo "check_pr_audit_codex_clearance: $fail FAIL / $pass PASS" >&2

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -317,6 +317,93 @@ else
 fi
 
 echo
+echo "agent-review.yml blocking-label exact-match regression (#370)"
+
+# The pre-merge recheck must treat GitHub labels as an array of exact
+# names. A CSV join plus `case "*,human-hold,*"` false-matches a legal
+# label literally named `team,human-hold`, which can block unrelated PRs.
+workflow_label_query=$(grep -F -- "--jq '.labels[].name'" ".github/workflows/agent-review.yml" || true)
+if [ -n "$workflow_label_query" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: agent-review pre-merge recheck reads labels one per line"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: agent-review pre-merge recheck must read labels one per line with --jq '.labels[].name'" >&2
+fi
+
+legacy_csv_join=$(grep -F -- "--jq '[.labels[].name] | join(\",\")'" ".github/workflows/agent-review.yml" || true)
+if [ -z "$legacy_csv_join" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: agent-review pre-merge recheck does not collapse labels into CSV"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: agent-review pre-merge recheck still collapses labels into CSV" >&2
+  echo "$legacy_csv_join" | sed 's/^/    /' >&2
+fi
+
+exact_label_match=$(grep -F 'grep -Fxq "$blocking_label"' ".github/workflows/agent-review.yml" || true)
+if [ -n "$exact_label_match" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: agent-review pre-merge recheck uses fixed-string whole-line label matching"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: agent-review pre-merge recheck must use grep -Fxq for exact label names" >&2
+fi
+
+echo
+echo "dependabot-auto-merge.yml PR-author gate regression (#370)"
+
+dependabot_workflow=".github/workflows/dependabot-auto-merge.yml"
+if grep -Fq "github.event.pull_request.user.login == 'dependabot[bot]'" "$dependabot_workflow"; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge gates on pull_request.user.login"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must gate on github.event.pull_request.user.login" >&2
+fi
+
+if grep -Fq "github.actor == 'dependabot[bot]'" "$dependabot_workflow"; then
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge still gates on github.actor" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge does not gate on github.actor"
+fi
+
+if grep -Fq "!contains(github.event.pull_request.labels.*.name, 'human-hold')" "$dependabot_workflow"; then
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must not skip the whole job on trigger-time human-hold state" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge leaves human-hold enforcement to the runtime re-read"
+fi
+
+if grep -Fq "has_human_hold()" "$dependabot_workflow"; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge centralizes human-hold runtime checks"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must define a reusable has_human_hold runtime check" >&2
+fi
+
+if grep -Fq 'if ! labels=$(gh pr view "$PR_URL" --json labels --jq' "$dependabot_workflow"; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot human-hold lookup fails closed on label-read errors"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot human-hold lookup must fail closed when gh pr view cannot read labels" >&2
+fi
+
+hold_recheck_count=$(grep -Fc "if has_human_hold; then" "$dependabot_workflow" || true)
+if [ "$hold_recheck_count" -ge 3 ]; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge checks human-hold before queued work and both merge paths"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must check human-hold before queued work, --auto, and fallback squash (got $hold_recheck_count checks)" >&2
+fi
+
+echo
 if [ "$fail" -gt 0 ]; then
   echo "check_workflow_parsers: $fail FAIL / $pass PASS" >&2
   exit 1

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -500,20 +500,26 @@ log "reaction_threshold = $REACTION_THRESHOLD (source: $REACTION_THRESHOLD_SOURC
 # agent-review.yml when two reviewers have opposing opinionated states —
 # a human must resolve it. `policy-violation` is applied by
 # block-self-approval when a reviewer bot tries to approve its own PR.
-# Both block merge categorically and are not resolvable by Phase 4a flow.
+# `human-hold` is a manual hard freeze. All three block merge
+# categorically and are not resolvable by Phase 4a flow.
 #
 # Note: `needs-external-review` is NOT a blocking label from this script's
 # perspective — it's the signal that this script should run, not a block.
 # Gate (c) resolves whether the external review is actually complete.
-PR_LABELS=$(echo "$PR_JSON" | jq -r '[.labels[].name] | join(",")')
-case ",$PR_LABELS," in
-  *,needs-human-review,*)
-    fail_gate "blocking label 'needs-human-review' present — human disagreement resolution required"
-    ;;
-  *,policy-violation,*)
-    fail_gate "blocking label 'policy-violation' present — policy violation must be resolved"
-    ;;
-esac
+pr_has_label() {
+  local label="$1"
+  echo "$PR_JSON" | jq -e --arg label "$label" 'any(.labels[].name; . == $label)' >/dev/null
+}
+
+if pr_has_label "needs-human-review"; then
+  fail_gate "blocking label 'needs-human-review' present — human disagreement resolution required"
+fi
+if pr_has_label "policy-violation"; then
+  fail_gate "blocking label 'policy-violation' present — policy violation must be resolved"
+fi
+if pr_has_label "human-hold"; then
+  fail_gate "blocking label 'human-hold' present — human hard hold must be released"
+fi
 
 # --- gate (a): CI checks green ---------------------------------------------
 
@@ -527,8 +533,8 @@ log "gate (a): checking CI state"
 # filter out checks that are EXPECTED to be failing during Phase 4a flow:
 #
 #   - "Label Gate" (from the "PR Review Policy" workflow) fails by design
-#     whenever `needs-external-review`, `needs-human-review`, or
-#     `policy-violation` is present on the PR. During Phase 4a, the first
+#     whenever `needs-external-review`, `needs-human-review`,
+#     `policy-violation`, or `human-hold` is present on the PR. During Phase 4a, the first
 #     of those labels is always set by pr-review-policy.yml, so Label Gate
 #     will fail. It's the enforcement mechanism for "don't merge until
 #     external review clears" — NOT a code-quality signal. We verify
@@ -610,7 +616,7 @@ BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq --argjson required_names "${REQUIRED_JSON:
     # Filter out the known "expected to fail during Phase 4a" check.
     # Label Gate lives in the "PR Review Policy" workflow and fails by
     # design whenever needs-external-review / needs-human-review /
-    # policy-violation is set. That enforcement is what Phase 4a is
+    # policy-violation / human-hold is set. That enforcement is what Phase 4a is
     # trying to unblock; we verify clearance separately in gate (c).
     | select(
         (.workflow != "PR Review Policy") or

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # gh-pr-guard.sh — PreToolUse hook for Claude Code
 #
-# Gates four operations:
+# Gates five operations:
 #   1. gh pr create — blocks unless (a) the keyring's active gh
 #      account is the AUTHOR identity (nathanjohnpayne by default;
 #      override via GH_PR_GUARD_EXPECTED_AUTHOR), AND (b) the command
@@ -24,7 +24,11 @@
 #      blocks). Originated downstream (matchline #170/#171) and is
 #      unified into the canonical hook here so propagation no longer
 #      clobbers the feature — see the propagation-wave retro.
-#   4. gh pr merge (non-admin) — blocks when the target PR carries
+#   4. gh pr merge (any flavor) — blocks when the target PR carries
+#      `human-hold`, with no CODEX_CLEARED / BREAK_GLASS_* bypass.
+#      This is the human-controlled hard freeze: agents may add the
+#      label, but only the human releases it.
+#   5. gh pr merge (non-admin) — blocks when the target PR carries
 #      the `needs-external-review` label unless CODEX_CLEARED=1
 #      (agent must have just run scripts/codex-review-check.sh
 #      successfully). This enforces REVIEW_POLICY.md § Phase 4a
@@ -1125,6 +1129,17 @@ fi
 # gate further down — never re-join it into a delimited string.
 MERGE_STATE=$(printf '%s\n' "$GH_OUTPUT" | sed -n '1p')
 LABELS=$(printf '%s\n' "$GH_OUTPUT" | sed -n '2,$p')
+
+# `human-hold` is a human-controlled hard freeze. Check it before
+# mergeStateStatus, --admin, or needs-external-review handling so no
+# agent-side bypass variable can release the hold. The only release
+# path is the human removing the label.
+if printf '%s\n' "$LABELS" | grep -Fxq "human-hold"; then
+  echo "BLOCKED: PR carries 'human-hold'." >&2
+  echo "  This is a human-remove-only hard hold and supersedes all merge gates." >&2
+  echo "  Ask the human to remove the label before merging; no agent bypass is available." >&2
+  exit 2
+fi
 
 # mergeStateStatus check (#171 layer 2). API enum (full set per
 # GitHub GraphQL `MergeStateStatus`):

--- a/scripts/hooks/label-removal-guard.sh
+++ b/scripts/hooks/label-removal-guard.sh
@@ -2,16 +2,18 @@
 # label-removal-guard.sh — PreToolUse hook for Claude Code.
 #
 # Blocks `gh pr edit ... --remove-label <label>` calls (and the
-# add-label inverse for the same labels) for the human-action labels
+# add-label inverse for most of those labels) for the human-action labels
 # defined in REVIEW_POLICY.md § Agent prohibitions:
 #
 #   - needs-external-review
 #   - needs-human-review
 #   - policy-violation
+#   - human-hold (remove-blocked, add-allowed)
 #
 # Rationale: agents must never remove these labels, even when a human
 # authorizes it in chat. One-time chat authorization does not extrapolate
-# into standing permission. The sanctioned path is
+# into standing permission. `human-hold` is the lone asymmetric label:
+# adding a hold is fail-safe, but removing one is human-only. The sanctioned path is
 # `scripts/request-label-removal.sh <PR#> <label>`, which posts a
 # templated ask + optional iMessage ping, after which the human clears
 # the label from any device.
@@ -128,8 +130,9 @@ except ValueError:
   # gh-pr-guard.sh's tokenization failure path. (CodeRabbit Major, #271.)
   echo "BLOCKED: label-removal-guard could not tokenize the gh command (malformed shell quoting)." >&2
   echo "  The command matched the 'gh pr edit' screen but cannot be parsed to verify it" >&2
-  echo "  does not remove a human-action label (needs-external-review / needs-human-review /" >&2
-  echo "  policy-violation). Fix the quoting and retry." >&2
+  echo "  does not modify a protected human-action label (needs-external-review /" >&2
+  echo "  needs-human-review / policy-violation) or remove human-hold. Fix the" >&2
+  echo "  quoting and retry." >&2
   exit 2
 fi
 
@@ -165,12 +168,14 @@ done
 [ "$saw_edit" -eq 1 ] || exit 0
 
 # Scan tokens AFTER `edit` for --remove-label or --add-label values.
-# Both forms are blocked: removing a label bypasses human gating;
-# adding one (e.g. spuriously re-applying policy-violation) is also a
-# human action.
+# For needs-external-review / needs-human-review / policy-violation,
+# both forms are blocked: removing a label bypasses human gating; adding
+# one spuriously creates a human-action state. `human-hold` is different:
+# agents may add it because adding a hold is fail-safe, but removal is
+# human-only.
 #
 # Two block triggers:
-#   1. Literal value matches the prohibited set.
+#   1. Literal value matches a prohibited set for that flag.
 #   2. Value undergoes shell expansion (contains $, backtick, or starts
 #      with $') — Codex P1 on PR #172. The hook receives the literal
 #      command string before bash expands variables, so a value like
@@ -180,10 +185,12 @@ done
 #      label. Block any expansion-bearing value with a message
 #      directing the agent to use a literal label name (so the hook
 #      can see what's being modified) or scripts/request-label-removal.sh.
-PROHIBITED_RE='^(needs-external-review|needs-human-review|policy-violation)$'
+ADD_REMOVE_BLOCKED_RE='^(needs-external-review|needs-human-review|policy-violation)$'
+REMOVE_ONLY_BLOCKED_RE='^(human-hold)$'
 EXPANSION_RE='[$`]'
 walk_start=$((edit_index + 1))
 SKIP_AS=""  # "" | "label-flag-value"
+SKIP_ACTION=""  # "" | "add" | "remove"
 
 # Codex r1 on PR #172 caught: gh accepts `--remove-label A,B` as a
 # comma-separated list, but the regex above only matches the entire
@@ -192,13 +199,18 @@ SKIP_AS=""  # "" | "label-flag-value"
 # but bash splits and removes both labels. Check each comma-split
 # segment instead of the whole value.
 check_label_value() {
+  local action="$1"
+  shift
   local raw="$1"
   if [[ "$raw" =~ $EXPANSION_RE ]]; then block_expansion "$raw"; fi
   local IFS=','
   for sub in $raw; do
-    sub="${sub# }"; sub="${sub% }"   # trim incidental whitespace
+    sub="$(printf '%s' "$sub" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
     [[ -z "$sub" ]] && continue
-    if [[ "$sub" =~ $PROHIBITED_RE ]]; then block_prohibited "$sub"; fi
+    if [[ "$sub" =~ $ADD_REMOVE_BLOCKED_RE ]]; then block_prohibited "$sub"; fi
+    if [ "$action" = "remove" ] && [[ "$sub" =~ $REMOVE_ONLY_BLOCKED_RE ]]; then
+      block_remove_only "$sub"
+    fi
   done
 }
 
@@ -224,14 +236,31 @@ EOF
   exit 2
 }
 
+block_remove_only() {
+  local label="$1"
+  cat <<EOF >&2
+BLOCKED: agents must not remove the '$label' label on PRs.
+
+Per REVIEW_POLICY.md § Agent prohibitions, '$label' is a human-remove-only
+hard hold. Agents may add it to freeze a PR, but only the human may release it.
+
+When the PR is ready to release:
+  scripts/request-label-removal.sh <PR#> $label
+
+That helper posts a templated ask on the PR (and optionally iMessages
+the human). The human clears the label from any device.
+EOF
+  exit 2
+}
+
 block_expansion() {
   local val="$1"
   cat <<EOF >&2
 BLOCKED: --add-label / --remove-label value '$val' contains shell
 expansion (\$, backtick, or \$'…' quoting). The hook can't see what
 this expands to until bash runs the command — so it cannot verify the
-label isn't one of the prohibited set (needs-external-review,
-needs-human-review, policy-violation).
+label isn't one of the prohibited labels (needs-external-review,
+needs-human-review, policy-violation), or a human-hold removal.
 
 Use a literal label name so the guard can verify it, OR — if you
 intended to remove a prohibited label — run:
@@ -247,16 +276,27 @@ for j in "${!TOKENS[@]}"; do
   tok="${TOKENS[$j]}"
   if [ "$SKIP_AS" = "label-flag-value" ]; then
     SKIP_AS=""
-    check_label_value "$tok"
+    check_label_value "$SKIP_ACTION" "$tok"
+    SKIP_ACTION=""
     continue
   fi
   case "$tok" in
-    --remove-label|--add-label)
+    --remove-label)
       SKIP_AS="label-flag-value"
+      SKIP_ACTION="remove"
       continue
       ;;
-    --remove-label=*|--add-label=*)
-      check_label_value "${tok#*=}"
+    --add-label)
+      SKIP_AS="label-flag-value"
+      SKIP_ACTION="add"
+      continue
+      ;;
+    --remove-label=*)
+      check_label_value "remove" "${tok#*=}"
+      continue
+      ;;
+    --add-label=*)
+      check_label_value "add" "${tok#*=}"
       continue
       ;;
   esac

--- a/scripts/request-label-removal.sh
+++ b/scripts/request-label-removal.sh
@@ -2,8 +2,9 @@
 # request-label-removal.sh — post a structured label-removal ask on a PR.
 #
 # Background: REVIEW_POLICY.md prohibits agents from removing the
-# `needs-external-review`, `needs-human-review`, and `policy-violation`
-# labels — even when authorized in chat. Label removal is a human action.
+# `needs-external-review`, `needs-human-review`, `policy-violation`, and
+# `human-hold` labels — even when authorized in chat. Label removal is a
+# human action.
 # This helper turns the prohibition into a one-command ask: the agent
 # posts a templated PR comment and (optionally) pings the human via
 # iMessage so they can clear the label without opening a chat window.
@@ -16,8 +17,8 @@
 # (#197 — catches the 👍-after-last-push case). Use this script for
 # `needs-external-review` only when neither the event-driven path
 # nor the sweep has fired in a reasonable window — typically rare.
-# For `needs-human-review` and `policy-violation`, this script is
-# the only path; both remain manual-only by design.
+# For `needs-human-review`, `policy-violation`, and `human-hold`, this
+# script is the only path; all three remain manual-only by design.
 #
 # Usage:
 #   scripts/request-label-removal.sh <PR#> <label>
@@ -32,6 +33,8 @@
 #   scripts/request-label-removal.sh 182 needs-external-review
 #   scripts/request-label-removal.sh 182 needs-human-review \
 #     --reason "Codex cleared r3; CI green; only blocker is this label"
+#   scripts/request-label-removal.sh 182 human-hold \
+#     --reason "Morning 4b review approved the current HEAD"
 #   MERGEPATH_NOTIFY_IMESSAGE_TO="+15551234567" \
 #     scripts/request-label-removal.sh 182 needs-external-review
 #
@@ -54,7 +57,7 @@ if [ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ] && [ -r "$__REQUEST_LABEL_DIR/lib/pre
   auto_source_preflight
 fi
 
-ALLOWED_LABELS=(needs-external-review needs-human-review policy-violation)
+ALLOWED_LABELS=(needs-external-review needs-human-review policy-violation human-hold)
 
 # Escape a string for embedding inside an AppleScript double-quoted
 # literal. See the inline call site below for the full rationale on
@@ -82,7 +85,7 @@ usage() {
   cat <<'EOF' >&2
 Usage: scripts/request-label-removal.sh <PR#> <label> [--reason <text>] [--repo owner/name]
 
-Allowed labels: needs-external-review | needs-human-review | policy-violation
+Allowed labels: needs-external-review | needs-human-review | policy-violation | human-hold
 
 Posts a templated PR comment asking the human to remove the label.
 Sends an iMessage to MERGEPATH_NOTIFY_IMESSAGE_TO if set.
@@ -119,7 +122,7 @@ for ok in "${ALLOWED_LABELS[@]}"; do
   if [ "$LABEL" = "$ok" ]; then allowed=1; break; fi
 done
 if [ "$allowed" -ne 1 ]; then
-  echo "Refusing: '$LABEL' is not a human-action label." >&2
+  echo "Refusing: '$LABEL' is not a protected human-action label." >&2
   echo "Allowed: ${ALLOWED_LABELS[*]}" >&2
   echo "If this label is genuinely a no-op blocker, just remove it directly." >&2
   exit 1
@@ -184,7 +187,7 @@ Per [REVIEW_POLICY.md § Agent prohibitions](https://github.com/nathanjohnpayne/
 - GitHub UI: Labels sidebar → click \`x\` on \`$LABEL\`
 - CLI: \`gh pr edit $PR_NUM --remove-label $LABEL${REPO_HINT_FOR_BODY}\`
 
-Auto-merge will fire as soon as the label is gone.${REASON_BLOCK}${AUTOCLEAR_NOTE}
+The PR can proceed as soon as the label is gone and the normal merge gates are green.${REASON_BLOCK}${AUTOCLEAR_NOTE}
 
 — posted by \`scripts/request-label-removal.sh\`"
 

--- a/tests/test_bootstrap_github_infra.sh
+++ b/tests/test_bootstrap_github_infra.sh
@@ -10,7 +10,7 @@
 #
 #   1. `gh repo create` is invoked with the right flags (visibility,
 #      description, source, --push).
-#   2. All 10 canonical labels are seeded with --force (idempotency).
+#   2. All 11 canonical labels are seeded with --force (idempotency).
 #   3. Reviewer invitations land via `gh api -X PUT` to the right
 #      collaborator endpoint for each agent in BOOTSTRAP_INPUT_REVIEWERS.
 #   4. REVIEWER_ASSIGNMENT_TOKEN provisioning uses the inline-PAT
@@ -181,8 +181,8 @@ grep -q "^gh repo create nathanjohnpayne/test-repo --private --description a tes
   && pass "gh repo create invoked with --private + --source + --push" \
   || fail "gh repo create flags wrong; log: $(grep '^gh repo create' "$SHIM_LOG")"
 
-# --- assertion 2: all 10 labels seeded with --force ---
-expected_labels=(needs-external-review needs-human-review policy-violation human-action agent-action phase-0 phase-1 phase-2 phase-3 phase-4)
+# --- assertion 2: all 11 labels seeded with --force ---
+expected_labels=(needs-external-review needs-human-review policy-violation human-hold human-action agent-action phase-0 phase-1 phase-2 phase-3 phase-4)
 seeded=0
 for label in "${expected_labels[@]}"; do
   if grep -qE "^gh label create $label .* --force\$" "$SHIM_LOG"; then
@@ -191,9 +191,9 @@ for label in "${expected_labels[@]}"; do
     fail "label '$label' not seeded with --force; log: $(grep "label create $label" "$SHIM_LOG")"
   fi
 done
-[ "$seeded" -eq 10 ] \
-  && pass "all 10 canonical labels seeded with --force" \
-  || fail "expected 10 labels, got $seeded"
+[ "$seeded" -eq 11 ] \
+  && pass "all 11 canonical labels seeded with --force" \
+  || fail "expected 11 labels, got $seeded"
 
 # --- assertion 3: reviewer collaborator invites ---
 for agent in claude cursor codex; do

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -4,8 +4,8 @@
 # Unit tests for scripts/hooks/gh-pr-guard.sh — covers the #241
 # identity-check on `gh pr create`, the #170/#171 mergeStateStatus
 # guard on `gh pr merge`, and a regression net for the existing
-# Authoring-Agent / Self-Review body checks + needs-external-review
-# label check so the newer checks are additive (don't break old
+# Authoring-Agent / Self-Review body checks + needs-external-review /
+# human-hold label checks so the newer checks are additive (don't break old
 # behavior).
 #
 # The hook reads tool_input.command from a JSON envelope on stdin
@@ -409,6 +409,23 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 15b: human-hold blocks even when all agent-side bypass variables are
+# present. This label is human-remove-only and supersedes CODEX_CLEARED,
+# BREAK_GLASS_ADMIN, and BREAK_GLASS_MERGE_STATE.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'CODEX_CLEARED=1 BREAK_GLASS_ADMIN=1 BREAK_GLASS_MERGE_STATE=1 gh pr merge 123 --admin --squash' "nathanjohnpayne" "0" "DIRTY" "human-hold" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "merge + human-hold + bypass envs: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "human-hold"; then
+  fail "merge + human-hold: diagnostic missing label reference; output: $out"
+else
+  pass "merge + human-hold: hard hold blocks every agent-side bypass"
+fi
+
+# ---------------------------------------------------------------------------
 # Test 16: a label literally NAMED `team,needs-external-review` (commas
 # are legal in GitHub label names) must NOT false-match the real
 # `needs-external-review` gate. Regression net for the CSV-join
@@ -423,6 +440,18 @@ if [ "$rc" -eq 0 ]; then
   pass "label 'team,needs-external-review' does NOT false-match the needs-external-review gate"
 else
   fail "comma-in-label false-match: exit $rc, expected 0 (the label is not literally 'needs-external-review'); output: $out"
+fi
+
+# Same exact-match rule for human-hold: a comma in another label's
+# literal name must not trip the hard-hold gate.
+set +e
+out=$(run_hook 'gh pr merge 123 --squash' "nathanjohnpayne" "0" "CLEAN" "team,human-hold" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "label 'team,human-hold' does NOT false-match the human-hold gate"
+else
+  fail "comma-in-human-hold-label false-match: exit $rc, expected 0; output: $out"
 fi
 
 # ===========================================================================

--- a/tests/test_label_removal_guard.sh
+++ b/tests/test_label_removal_guard.sh
@@ -4,7 +4,7 @@
 # Unit tests for scripts/hooks/label-removal-guard.sh — the PreToolUse
 # hook that blocks `gh pr edit --remove-label / --add-label` for the
 # human-action labels (needs-external-review, needs-human-review,
-# policy-violation).
+# policy-violation) and the asymmetric human-hold label.
 #
 # Coverage focus is the consolidated `gh ... pr edit` detection plus
 # the `-R` / `--repo` interspersed-argument cases (#287). Earlier
@@ -90,6 +90,10 @@ assert_blocked "baseline: --remove-label policy-violation (bare)" \
   "gh pr edit 1 --remove-label policy-violation"
 assert_blocked "baseline: --add-label policy-violation (bare)" \
   "gh pr edit 1 --add-label policy-violation"
+assert_blocked "baseline: --remove-label human-hold (bare)" \
+  "gh pr edit 1 --remove-label human-hold"
+assert_allowed "baseline: --add-label human-hold (bare)" \
+  "gh pr edit 1 --add-label human-hold"
 
 # ─── -R / --repo interspersed BEFORE `pr edit` ──────────────────────
 # gh accepts a global -R/--repo before the subcommand. The simplified
@@ -117,6 +121,8 @@ assert_blocked "post-edit -R + --remove-label= form" \
   "gh pr edit 1 -R owner/repo --remove-label=needs-external-review"
 assert_blocked "pre-edit --repo + --remove-label= form" \
   "gh --repo owner/repo pr edit 1 --remove-label=policy-violation"
+assert_blocked "pre-edit --repo + --remove-label=human-hold form" \
+  "gh --repo owner/repo pr edit 1 --remove-label=human-hold"
 
 # ─── -R / --repo with comma-separated label list ────────────────────
 # Per the existing comma-split logic, each segment is checked. A
@@ -126,6 +132,14 @@ assert_blocked "comma-list with prohibited segment, -R after edit" \
   "gh pr edit 1 -R owner/repo --remove-label foo,needs-external-review,bar"
 assert_blocked "comma-list with prohibited segment, --repo before pr" \
   "gh --repo owner/repo pr edit 1 --remove-label foo,policy-violation"
+assert_blocked "comma-list with human-hold removal segment" \
+  "gh pr edit 1 --remove-label foo,human-hold,bar"
+padded_human_hold_remove=$'gh pr edit 1 --remove-label "foo,\t human-hold \t,bar"'
+assert_blocked "comma-list with whitespace-padded human-hold removal segment" \
+  "$padded_human_hold_remove"
+padded_policy_add=$'gh pr edit 1 --add-label "foo,\t policy-violation \t,bar"'
+assert_blocked "comma-list with whitespace-padded policy-violation add segment" \
+  "$padded_policy_add"
 
 # ─── Allow paths: -R / --repo present, non-prohibited label ─────────
 # The simplified pattern must not over-block — `gh pr edit` with a
@@ -139,6 +153,8 @@ assert_allowed "allow: --repo after edit, unrelated remove" \
   "gh pr edit 1 --repo owner/repo --remove-label some-unrelated-label"
 assert_allowed "allow: --add-label needs-foo (not in prohibited set)" \
   "gh pr edit 1 --add-label needs-foo"
+assert_allowed "allow: --add-label=human-hold (hard hold is agent-addable)" \
+  "gh pr edit 1 --add-label=human-hold"
 
 # ─── Allow paths: non-edit subcommands with -R / --repo ─────────────
 # `gh pr view`, `gh pr create` etc. must never be blocked by this


### PR DESCRIPTION
Authoring-Agent: codex

Closes #367.

## Summary
- Adds `human-hold` as an agent-addable, human-remove-only hard merge freeze.
- Blocks `human-hold` across the Label Gate, `gh-pr-guard`, Codex merge-gate checks, agent-review auto-merge, Dependabot auto-merge, and weekly PR audit.
- Updates label-removal/request helpers, bootstrap label seeding, and policy docs so new repos seed the label and agents have the correct asymmetric rule.
- Created/updated the live GitHub label `human-hold` with color `000000` and description `Hard merge freeze - human-remove-only; supersedes all gates`.

## Validation
- `bash -n scripts/hooks/label-removal-guard.sh tests/test_label_removal_guard.sh scripts/hooks/gh-pr-guard.sh tests/test_gh_pr_guard.sh scripts/request-label-removal.sh scripts/codex-review-check.sh scripts/bootstrap/github-infra.sh scripts/bootstrap/board-and-summary.sh scripts/audit-branch-protection.sh scripts/ci/check_auto_clear_workflow tests/test_bootstrap_github_infra.sh`
- `tests/test_label_removal_guard.sh`
- `tests/test_gh_pr_guard.sh`
- `tests/test_bootstrap_github_infra.sh`
- `scripts/ci/check_auto_clear_workflow`
- `scripts/ci/check_gh_as_author`
- `scripts/ci/check_workflow_parsers`
- `scripts/ci/check_canonical_bugs_263caf3`
- `tests/test_request_label_removal_escape.sh`
- `scripts/ci/check_ci_scripts_wired`
- `scripts/ci/check_required_root_files`
- `scripts/ci/check_no_forbidden_top_level_dirs` (known warnings: `bugs`, `examples`)
- `scripts/ci/check_spec_test_alignment`
- `scripts/ci/check_duplicate_docs` (known 4 tool-folder warnings)
- Ruby YAML parse for changed workflows and `.github/review-policy.yml`
- `scripts/ci/check_bootstrap_github_infra`
- `scripts/ci/check_bootstrap_board_and_summary`
- `scripts/ci/check_pr_audit_codex_clearance`
- `tests/test_audit_branch_protection.sh`
- `git diff --check`

## Self-Review
- Correctness: `human-hold` is blocked before merge-state/admin/Codex gates, so no agent bypass variable can release it; label-removal guard allows add and blocks remove.
- Regression risk: scoped to existing review-policy hooks/workflows/docs; existing protected-label tests still pass.
- Style/conventions: follows existing shell-test and workflow-guard patterns; no sync path was run.
- Test coverage: added focused hook tests for add/remove asymmetry, exact label matching, and bypass resistance; updated bootstrap label tests.
- Security/dependency hygiene: no dependencies added; workflow changes keep trusted-base checkout behavior and fail closed on label fetches where relevant.
