### PR TITLE
Guard reviewer byline drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,12 @@ This repository uses a multi-identity AI agent code review system. The full poli
    # Read-path API call (uses cached PAT, no biometric):
    GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq .login
 
-   # Write-path API call (gh keyring active = nathanpayne-{your-agent}):
+   # Reviewer write path. The hook environment should set
+   # GH_PR_GUARD_EXPECTED_REVIEWER=nathanpayne-{your-agent}; when in
+   # doubt, use gh-as-reviewer.sh so the wrapper switches/verifies.
    gh pr review <PR#> --comment --body "..."
+   GH_AS_REVIEWER_IDENTITY=nathanpayne-{your-agent} \
+     scripts/gh-as-reviewer.sh -- gh pr review <PR#> --comment --body "..."
 
    # Author write (temporary switch via the gh-as-author.sh wrapper):
    scripts/gh-as-author.sh -- gh pr create ...
@@ -59,21 +63,25 @@ This repository uses a multi-identity AI agent code review system. The full poli
    Set the gh keyring active account once per machine: `gh auth switch
    -u nathanpayne-{your-agent}`. Then read-path commands use
    `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"`; write paths use the
-   keyring active. For author-identity writes (PR create/merge/label
-   edits), MUST wrap the call in `scripts/gh-as-author.sh -- gh pr
-   create ...` — a single bash process that switches, runs, and
-   switches back via `trap EXIT`. Splitting the sequence across two
-   Bash tool calls lands the PR under the wrong identity (#241). The
-   `gh-pr-guard.sh` PreToolUse hook now blocks `gh pr create` when
-   the keyring's active is not `nathanjohnpayne`. See REVIEW_POLICY.md
-   § Reviewer PAT Quick Start for the full convention and § Recovery:
-   PR created under the wrong identity for what to do if a PR already
-   landed under the wrong account.
+   keyring active. Bare reviewer-byline writes (`gh pr comment`,
+   `gh pr review`, `gh issue comment`) are blocked unless the active
+   keyring account exactly matches `GH_PR_GUARD_EXPECTED_REVIEWER`;
+   use `scripts/gh-as-reviewer.sh` when the harness env is uncertain.
+   For author-identity writes (PR create/merge/label edits), MUST
+   wrap the call in `scripts/gh-as-author.sh -- gh pr create ...` — a
+   single bash process that switches, runs, and switches back via
+   `trap EXIT`. Splitting the sequence across two Bash tool calls
+   lands the PR under the wrong identity (#241). The `gh-pr-guard.sh`
+   PreToolUse hook now blocks `gh pr create` when the keyring's active
+   is not `nathanjohnpayne`. See REVIEW_POLICY.md § Reviewer PAT Quick
+   Start for the full convention and § Recovery: PR created under the
+   wrong identity for what to do if a PR already landed under the
+   wrong account.
 
    Run `scripts/op-preflight.sh --agent {your-agent} --purge` (or
    `--purge-all`) at end of session to delete the cached PATs.
 1. Author code as nathanjohnpayne. File a PR.
-2. Review the PR under your reviewer identity. With your agent identity active per the convention above, just run `gh pr review <PR#> --comment --body "..."` — the byline is your reviewer identity. Post comments.
+2. Review the PR under your reviewer identity. With your agent identity active and `GH_PR_GUARD_EXPECTED_REVIEWER` set to that same identity, bare `gh pr review <PR#> --comment --body "..."` attributes correctly. If the hook environment is uncertain, wrap the call with `GH_AS_REVIEWER_IDENTITY=nathanpayne-{your-agent} scripts/gh-as-reviewer.sh -- gh pr review ...`. Post comments.
 3. Address each comment via fix commits (commits use git config, no gh auth involved — byline stays nathanjohnpayne).
 4. Repeat steps 2–3 until the reviewer identity approves with no outstanding issues. The mechanism: for under-threshold PRs (step 6), `gh pr review --approve` from your reviewer identity is the intended path — it satisfies branch protection without bouncing a small PR to an external agent. For above-threshold PRs (step 7), post `gh pr review --comment` only; Phase 4 carries the cross-agent gate. See REVIEW_POLICY.md § No-self-approve scoping.
 5. If this repo has `coderabbit.enabled: true` in `.github/review-policy.yml`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,9 @@ This repository uses a multi-identity AI agent code review system. The full poli
    # Read-path API call (uses cached PAT, no biometric):
    GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq .login
 
-   # Reviewer write path. The hook environment should set
-   # GH_PR_GUARD_EXPECTED_REVIEWER=nathanpayne-{your-agent}; when in
-   # doubt, use gh-as-reviewer.sh so the wrapper switches/verifies.
+   # Reviewer write path. The hook derives the expected reviewer from
+   # GH_PR_GUARD_EXPECTED_REVIEWER, then MERGEPATH_AGENT, then claude;
+   # when in doubt, use gh-as-reviewer.sh so the wrapper switches/verifies.
    gh pr review <PR#> --comment --body "..."
    GH_AS_REVIEWER_IDENTITY=nathanpayne-{your-agent} \
      scripts/gh-as-reviewer.sh -- gh pr review <PR#> --comment --body "..."
@@ -65,8 +65,10 @@ This repository uses a multi-identity AI agent code review system. The full poli
    `GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT"`; write paths use the
    keyring active. Bare reviewer-byline writes (`gh pr comment`,
    `gh pr review`, `gh issue comment`) are blocked unless the active
-   keyring account exactly matches `GH_PR_GUARD_EXPECTED_REVIEWER`;
-   use `scripts/gh-as-reviewer.sh` when the harness env is uncertain.
+   keyring account exactly matches the expected reviewer resolved from
+   `GH_PR_GUARD_EXPECTED_REVIEWER`, then `MERGEPATH_AGENT`, then the
+   `claude` default; use `scripts/gh-as-reviewer.sh` when the harness
+   env is uncertain.
    For author-identity writes (PR create/merge/label edits), MUST
    wrap the call in `scripts/gh-as-author.sh -- gh pr create ...` — a
    single bash process that switches, runs, and switches back via
@@ -81,7 +83,7 @@ This repository uses a multi-identity AI agent code review system. The full poli
    Run `scripts/op-preflight.sh --agent {your-agent} --purge` (or
    `--purge-all`) at end of session to delete the cached PATs.
 1. Author code as nathanjohnpayne. File a PR.
-2. Review the PR under your reviewer identity. With your agent identity active and `GH_PR_GUARD_EXPECTED_REVIEWER` set to that same identity, bare `gh pr review <PR#> --comment --body "..."` attributes correctly. If the hook environment is uncertain, wrap the call with `GH_AS_REVIEWER_IDENTITY=nathanpayne-{your-agent} scripts/gh-as-reviewer.sh -- gh pr review ...`. Post comments.
+2. Review the PR under your reviewer identity. With your agent identity active and either `MERGEPATH_AGENT={your-agent}` or `GH_PR_GUARD_EXPECTED_REVIEWER=nathanpayne-{your-agent}` set, bare `gh pr review <PR#> --comment --body "..."` attributes correctly. If the hook environment is uncertain, wrap the call with `GH_AS_REVIEWER_IDENTITY=nathanpayne-{your-agent} scripts/gh-as-reviewer.sh -- gh pr review ...`. Post comments.
 3. Address each comment via fix commits (commits use git config, no gh auth involved — byline stays nathanjohnpayne).
 4. Repeat steps 2–3 until the reviewer identity approves with no outstanding issues. The mechanism: for under-threshold PRs (step 6), `gh pr review --approve` from your reviewer identity is the intended path — it satisfies branch protection without bouncing a small PR to an external agent. For above-threshold PRs (step 7), post `gh pr review --comment` only; Phase 4 carries the cross-agent gate. See REVIEW_POLICY.md § No-self-approve scoping.
 5. If this repo has `coderabbit.enabled: true` in `.github/review-policy.yml`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,10 @@ time `gh auth login` per identity per machine). With this convention:
 
 - Reviewer-identity writes (`gh pr review --comment` from your agent
   identity) require active keyring = that reviewer identity AND the
-  hook environment's `GH_PR_GUARD_EXPECTED_REVIEWER` matching that
-  identity. If either is uncertain, use `scripts/gh-as-reviewer.sh`.
+  hook's expected reviewer resolving to that identity. The hook checks
+  `GH_PR_GUARD_EXPECTED_REVIEWER`, then `MERGEPATH_AGENT`, then the
+  `claude` default. If either is uncertain, use
+  `scripts/gh-as-reviewer.sh`.
 - Author-identity writes (`gh pr create`, `gh pr merge`, `gh pr edit`
   for label changes) **MUST** use `scripts/gh-as-author.sh` — a single
   bash process that switches to the author identity, runs the wrapped
@@ -95,7 +97,8 @@ keyring active is your agent identity. No switch needed for commits.
    GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq .login
 
    # Reviewer write path. Use gh-as-reviewer.sh when the hook env
-   # may not have GH_PR_GUARD_EXPECTED_REVIEWER=nathanpayne-<agent>.
+   # may not identify the expected reviewer via
+   # GH_PR_GUARD_EXPECTED_REVIEWER or MERGEPATH_AGENT.
    gh pr review <PR#> --comment --body "..."
    GH_AS_REVIEWER_IDENTITY=nathanpayne-<agent> \
      scripts/gh-as-reviewer.sh -- gh pr review <PR#> --comment --body "..."
@@ -141,7 +144,8 @@ keyring active is your agent identity. No switch needed for commits.
 ## After opening the PR
 
 4. Review the PR under your reviewer identity. With your agent identity
-   active and `GH_PR_GUARD_EXPECTED_REVIEWER` set to that same identity,
+   active and the hook's expected reviewer resolving to that same
+   identity via `GH_PR_GUARD_EXPECTED_REVIEWER` or `MERGEPATH_AGENT`,
    `gh pr review <PR#> --repo owner/repo --comment --body "..."`
    attributes correctly. If the hook environment is uncertain, wrap
    the call with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,9 @@ gh account, set once per machine: `gh auth switch -u nathanpayne-claude`
 time `gh auth login` per identity per machine). With this convention:
 
 - Reviewer-identity writes (`gh pr review --comment` from your agent
-  identity) just work — no `GH_TOKEN` switch, no `gh auth switch`.
+  identity) require active keyring = that reviewer identity AND the
+  hook environment's `GH_PR_GUARD_EXPECTED_REVIEWER` matching that
+  identity. If either is uncertain, use `scripts/gh-as-reviewer.sh`.
 - Author-identity writes (`gh pr create`, `gh pr merge`, `gh pr edit`
   for label changes) **MUST** use `scripts/gh-as-author.sh` — a single
   bash process that switches to the author identity, runs the wrapped
@@ -92,8 +94,11 @@ keyring active is your agent identity. No switch needed for commits.
    # Read-path API call (uses cached PAT, no biometric):
    GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq .login
 
-   # Write-path API call (gh keyring active = nathanpayne-<agent>):
+   # Reviewer write path. Use gh-as-reviewer.sh when the hook env
+   # may not have GH_PR_GUARD_EXPECTED_REVIEWER=nathanpayne-<agent>.
    gh pr review <PR#> --comment --body "..."
+   GH_AS_REVIEWER_IDENTITY=nathanpayne-<agent> \
+     scripts/gh-as-reviewer.sh -- gh pr review <PR#> --comment --body "..."
 
    # Author write (temporary switch via the gh-as-author.sh wrapper):
    scripts/gh-as-author.sh -- gh pr create ...
@@ -136,9 +141,11 @@ keyring active is your agent identity. No switch needed for commits.
 ## After opening the PR
 
 4. Review the PR under your reviewer identity. With your agent identity
-   active per the convention above, just run:
-   `gh pr review <PR#> --repo owner/repo --comment --body "..."`.
-   The review is correctly attributed to the agent reviewer identity.
+   active and `GH_PR_GUARD_EXPECTED_REVIEWER` set to that same identity,
+   `gh pr review <PR#> --repo owner/repo --comment --body "..."`
+   attributes correctly. If the hook environment is uncertain, wrap
+   the call with
+   `GH_AS_REVIEWER_IDENTITY=nathanpayne-<agent> scripts/gh-as-reviewer.sh -- gh pr review ...`.
 5. Post comments on any issues found.
 6. Address each comment via fix commits (commits use git config, no
    gh auth involved — byline stays nathanjohnpayne).

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -98,8 +98,12 @@ GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq '.login'
 # expected: nathanpayne-<agent>
 
 # Write-path: with the agent identity active, GH_TOKEN is irrelevant
-# for the byline. Just run the command.
+# for the byline. Bare reviewer writes also require the hook env
+# GH_PR_GUARD_EXPECTED_REVIEWER=nathanpayne-<agent>; otherwise use
+# gh-as-reviewer.sh to switch/verify in one process.
 gh pr review <PR#> --repo <owner/repo> --comment --body "Review comment"
+GH_AS_REVIEWER_IDENTITY=nathanpayne-<agent> \
+  scripts/gh-as-reviewer.sh -- gh pr review <PR#> --repo <owner/repo> --comment --body "Review comment"
 
 # Author-identity write: MUST use scripts/gh-as-author.sh, which
 # switches + runs + restores inside ONE bash process via trap EXIT.
@@ -258,6 +262,16 @@ running:
   (`gh auth switch -u <login>`), wrapped via `scripts/gh-as-author.sh`
   or `scripts/gh-as-reviewer.sh` for safety.
 
+  Reviewer-byline commands (`gh pr comment`, `gh pr review`, and
+  `gh issue comment`) are hook-guarded against cross-agent keyring
+  drift: `scripts/hooks/gh-pr-guard.sh` requires the active keyring
+  account to exactly match `GH_PR_GUARD_EXPECTED_REVIEWER` (default
+  `nathanpayne-claude`; set by the agent harness to
+  `nathanpayne-<agent>`). If the harness cannot set that environment,
+  use `scripts/gh-as-reviewer.sh -- gh ...`; the wrapper switches and
+  verifies the reviewer identity internally and avoids the bare-write
+  guard path.
+
 - **PAT-attributed writes.** `gh api graphql` mutations (the most
   common is `resolveReviewThread`) attribute their byline to the
   identity that owns the **PAT in `GH_TOKEN`**, NOT the keyring's
@@ -275,14 +289,14 @@ affect the byline for that row; the byline follows `GH_TOKEN`.
 | `gh pr merge` (squash/rebase) | `nathanjohnpayne` (use `scripts/gh-as-author.sh`) | any author-readable PAT |
 | `gh pr edit` (general — title/body) | `nathanjohnpayne` (use `scripts/gh-as-author.sh`) | any author-readable PAT |
 | `gh pr edit --remove-label <protected>` | **BLOCKED** by `scripts/hooks/label-removal-guard.sh` for `needs-external-review` / `needs-human-review` / `policy-violation` / `human-hold`; use `scripts/request-label-removal.sh` | n/a |
-| `gh pr comment` | `nathanpayne-<agent>` (agent identity); blocked when active is `nathanjohnpayne` per `scripts/hooks/gh-pr-guard.sh` (#284) | reviewer PAT (`$OP_PREFLIGHT_REVIEWER_PAT`) |
-| `gh pr review --comment` | `nathanpayne-<agent>`; blocked when active is `nathanjohnpayne` (#284) | reviewer PAT |
+| `gh pr comment` | `nathanpayne-<agent>` (agent identity); blocked unless active exactly matches `GH_PR_GUARD_EXPECTED_REVIEWER` per `scripts/hooks/gh-pr-guard.sh` (#284/#363) | reviewer PAT (`$OP_PREFLIGHT_REVIEWER_PAT`) |
+| `gh pr review --comment` | `nathanpayne-<agent>`; blocked unless active exactly matches `GH_PR_GUARD_EXPECTED_REVIEWER` (#284/#363) | reviewer PAT |
 | `gh pr review --approve` (under-threshold) | `nathanpayne-<agent>`; allowed when PR's `Authoring-Agent:` matches the agent (the intended path) | reviewer PAT |
 | `gh pr review --approve` (over-threshold, same agent) | **BLOCKED** by `scripts/hooks/gh-pr-guard.sh` per § No-self-approve scoping (#284) | n/a |
 | `gh pr review --approve` (over-threshold, cross-agent) | `nathanpayne-<other-agent>`; the cross-agent reviewer identity per Phase 4 | reviewer PAT |
 | `gh pr view` (read) | any (does not write) | any read-capable PAT |
 | `gh issue create` | any — **not hook-gated** (#317 byline guard reverted); issues may be filed under the author identity (`nathanjohnpayne`) or an agent identity, e.g. post-merge follow-ups per AGENTS.md step 11 | author or reviewer PAT |
-| `gh issue comment` | `nathanpayne-<agent>`; blocked when active is `nathanjohnpayne` (#284) | reviewer PAT |
+| `gh issue comment` | `nathanpayne-<agent>`; blocked unless active exactly matches `GH_PR_GUARD_EXPECTED_REVIEWER` (#284/#363) | reviewer PAT |
 | `gh issue close` | any (out of #284 scope — not yet hook-gated) | any |
 | `gh api GET ...` | irrelevant (read-only) | any read-capable PAT |
 | `gh api -X POST repos/.../issues/<N>/comments` | keyring-active byline (same as `gh pr comment`) | reviewer PAT for auth |
@@ -982,8 +996,12 @@ GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-request.sh <PR#>
 
 # ── Write-path: active keyring is the byline; GH_TOKEN is ignored ──
 
-# Reviewer-identity write (your agent identity is active by default):
+# Reviewer-identity write. Bare form requires active keyring AND
+# GH_PR_GUARD_EXPECTED_REVIEWER to match this agent; wrapper form is
+# safer when the hook environment is uncertain:
 gh pr review <PR#> --repo <owner/repo> --comment --body "Review comment"
+GH_AS_REVIEWER_IDENTITY=nathanpayne-<agent> \
+  scripts/gh-as-reviewer.sh -- gh pr review <PR#> --repo <owner/repo> --comment --body "Review comment"
 
 # Author-identity write: MUST use scripts/gh-as-author.sh, which
 # switches + runs + restores inside ONE bash process via trap EXIT.

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -98,8 +98,9 @@ GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq '.login'
 # expected: nathanpayne-<agent>
 
 # Write-path: with the agent identity active, GH_TOKEN is irrelevant
-# for the byline. Bare reviewer writes also require the hook env
-# GH_PR_GUARD_EXPECTED_REVIEWER=nathanpayne-<agent>; otherwise use
+# for the byline. Bare reviewer writes also require the hook's expected
+# reviewer to resolve to nathanpayne-<agent> via
+# GH_PR_GUARD_EXPECTED_REVIEWER or MERGEPATH_AGENT; otherwise use
 # gh-as-reviewer.sh to switch/verify in one process.
 gh pr review <PR#> --repo <owner/repo> --comment --body "Review comment"
 GH_AS_REVIEWER_IDENTITY=nathanpayne-<agent> \
@@ -265,10 +266,11 @@ running:
   Reviewer-byline commands (`gh pr comment`, `gh pr review`, and
   `gh issue comment`) are hook-guarded against cross-agent keyring
   drift: `scripts/hooks/gh-pr-guard.sh` requires the active keyring
-  account to exactly match `GH_PR_GUARD_EXPECTED_REVIEWER` (default
-  `nathanpayne-claude`; set by the agent harness to
-  `nathanpayne-<agent>`). If the harness cannot set that environment,
-  use `scripts/gh-as-reviewer.sh -- gh ...`; the wrapper switches and
+  account to exactly match the expected reviewer. The hook resolves
+  that expected reviewer from `GH_PR_GUARD_EXPECTED_REVIEWER`, then
+  `nathanpayne-$MERGEPATH_AGENT`, then `nathanpayne-claude`. If the
+  harness cannot set either environment value, use
+  `scripts/gh-as-reviewer.sh -- gh ...`; the wrapper switches and
   verifies the reviewer identity internally and avoids the bare-write
   guard path.
 
@@ -289,14 +291,14 @@ affect the byline for that row; the byline follows `GH_TOKEN`.
 | `gh pr merge` (squash/rebase) | `nathanjohnpayne` (use `scripts/gh-as-author.sh`) | any author-readable PAT |
 | `gh pr edit` (general — title/body) | `nathanjohnpayne` (use `scripts/gh-as-author.sh`) | any author-readable PAT |
 | `gh pr edit --remove-label <protected>` | **BLOCKED** by `scripts/hooks/label-removal-guard.sh` for `needs-external-review` / `needs-human-review` / `policy-violation` / `human-hold`; use `scripts/request-label-removal.sh` | n/a |
-| `gh pr comment` | `nathanpayne-<agent>` (agent identity); blocked unless active exactly matches `GH_PR_GUARD_EXPECTED_REVIEWER` per `scripts/hooks/gh-pr-guard.sh` (#284/#363) | reviewer PAT (`$OP_PREFLIGHT_REVIEWER_PAT`) |
-| `gh pr review --comment` | `nathanpayne-<agent>`; blocked unless active exactly matches `GH_PR_GUARD_EXPECTED_REVIEWER` (#284/#363) | reviewer PAT |
+| `gh pr comment` | `nathanpayne-<agent>` (agent identity); blocked unless active exactly matches the reviewer resolved from `GH_PR_GUARD_EXPECTED_REVIEWER` or `MERGEPATH_AGENT` per `scripts/hooks/gh-pr-guard.sh` (#284/#363) | reviewer PAT (`$OP_PREFLIGHT_REVIEWER_PAT`) |
+| `gh pr review --comment` | `nathanpayne-<agent>`; blocked unless active exactly matches the reviewer resolved from `GH_PR_GUARD_EXPECTED_REVIEWER` or `MERGEPATH_AGENT` (#284/#363) | reviewer PAT |
 | `gh pr review --approve` (under-threshold) | `nathanpayne-<agent>`; allowed when PR's `Authoring-Agent:` matches the agent (the intended path) | reviewer PAT |
 | `gh pr review --approve` (over-threshold, same agent) | **BLOCKED** by `scripts/hooks/gh-pr-guard.sh` per § No-self-approve scoping (#284) | n/a |
 | `gh pr review --approve` (over-threshold, cross-agent) | `nathanpayne-<other-agent>`; the cross-agent reviewer identity per Phase 4 | reviewer PAT |
 | `gh pr view` (read) | any (does not write) | any read-capable PAT |
 | `gh issue create` | any — **not hook-gated** (#317 byline guard reverted); issues may be filed under the author identity (`nathanjohnpayne`) or an agent identity, e.g. post-merge follow-ups per AGENTS.md step 11 | author or reviewer PAT |
-| `gh issue comment` | `nathanpayne-<agent>`; blocked unless active exactly matches `GH_PR_GUARD_EXPECTED_REVIEWER` (#284/#363) | reviewer PAT |
+| `gh issue comment` | `nathanpayne-<agent>`; blocked unless active exactly matches the reviewer resolved from `GH_PR_GUARD_EXPECTED_REVIEWER` or `MERGEPATH_AGENT` (#284/#363) | reviewer PAT |
 | `gh issue close` | any (out of #284 scope — not yet hook-gated) | any |
 | `gh api GET ...` | irrelevant (read-only) | any read-capable PAT |
 | `gh api -X POST repos/.../issues/<N>/comments` | keyring-active byline (same as `gh pr comment`) | reviewer PAT for auth |
@@ -996,8 +998,9 @@ GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-request.sh <PR#>
 
 # ── Write-path: active keyring is the byline; GH_TOKEN is ignored ──
 
-# Reviewer-identity write. Bare form requires active keyring AND
-# GH_PR_GUARD_EXPECTED_REVIEWER to match this agent; wrapper form is
+# Reviewer-identity write. Bare form requires active keyring AND the
+# hook's expected reviewer (GH_PR_GUARD_EXPECTED_REVIEWER, then
+# MERGEPATH_AGENT, then claude) to match this agent; wrapper form is
 # safer when the hook environment is uncertain:
 gh pr review <PR#> --repo <owner/repo> --comment --body "Review comment"
 GH_AS_REVIEWER_IDENTITY=nathanpayne-<agent> \

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -47,8 +47,9 @@
 #     - gh issue comment <issue#> --body "..."
 #
 #   For all three, the keyring's active account must exactly match the
-#   operating agent's REVIEWER identity (nathanpayne-<agent>, default
-#   nathanpayne-claude; override via GH_PR_GUARD_EXPECTED_REVIEWER).
+#   operating agent's REVIEWER identity. The expected reviewer resolves
+#   as: explicit GH_PR_GUARD_EXPECTED_REVIEWER override, else
+#   nathanpayne-$MERGEPATH_AGENT, else nathanpayne-claude.
 #   Posting these as the AUTHOR identity (nathanjohnpayne), or as the
 #   wrong reviewer identity after cross-session keyring drift, breaks
 #   the audit-trail convention REVIEW_POLICY.md depends on — reviewer
@@ -650,7 +651,18 @@ fi
 # The `gh pr review --approve` self-approve sub-guard runs after this
 # block — only if we made it past the basic byline check does the
 # self-approve question even arise.
-EXPECTED_REVIEWER="${GH_PR_GUARD_EXPECTED_REVIEWER:-nathanpayne-claude}"
+if [ -n "${GH_PR_GUARD_EXPECTED_REVIEWER:-}" ]; then
+  EXPECTED_REVIEWER="$GH_PR_GUARD_EXPECTED_REVIEWER"
+  EXPECTED_REVIEWER_SOURCE="GH_PR_GUARD_EXPECTED_REVIEWER"
+else
+  EXPECTED_REVIEWER_AGENT="${MERGEPATH_AGENT:-claude}"
+  EXPECTED_REVIEWER="nathanpayne-$EXPECTED_REVIEWER_AGENT"
+  if [ -n "${MERGEPATH_AGENT:-}" ]; then
+    EXPECTED_REVIEWER_SOURCE="MERGEPATH_AGENT"
+  else
+    EXPECTED_REVIEWER_SOURCE="default"
+  fi
+fi
 if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS_ISSUE_COMMENT" -eq 1 ]; then
   if [ "${BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK:-0}" != "1" ]; then
     ACTIVE_GH_USER=$(gh config get -h github.com user 2>/dev/null || echo "")
@@ -676,11 +688,11 @@ if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS
       echo "BLOCKED: $cmd_label is about to run under active account '$ACTIVE_GH_USER' ($active_role)." >&2
       echo "" >&2
       echo "  Reviewer-byline commands (pr comment / pr review / issue comment)" >&2
-      echo "  must attribute to the operating agent's REVIEWER identity ('$EXPECTED_REVIEWER' for this hook invocation)." >&2
+      echo "  must attribute to the operating agent's REVIEWER identity ('$EXPECTED_REVIEWER' for this hook invocation, from $EXPECTED_REVIEWER_SOURCE)." >&2
       echo "  Posting as '$ACTIVE_GH_USER' breaks the audit-trail convention REVIEW_POLICY.md depends on." >&2
       echo "" >&2
       echo "  Fix once: gh auth switch -u $EXPECTED_REVIEWER" >&2
-      echo "  Or set GH_PR_GUARD_EXPECTED_REVIEWER=$ACTIVE_GH_USER only if that is this agent's true reviewer identity." >&2
+      echo "  Or set MERGEPATH_AGENT=<agent> / GH_PR_GUARD_EXPECTED_REVIEWER=$ACTIVE_GH_USER only if that is this agent's true reviewer identity." >&2
       echo "  Or wrap the single call: scripts/gh-as-reviewer.sh -- $cmd_label ..." >&2
       echo "  See REVIEW_POLICY.md § Operation-to-Identity Matrix." >&2
       exit 2

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -46,13 +46,14 @@
 #     - gh pr review <PR#> --comment / --approve / --request-changes
 #     - gh issue comment <issue#> --body "..."
 #
-#   For all three, the keyring's active account must be the agent's
-#   REVIEWER identity (nathanpayne-<agent>, default nathanpayne-claude;
-#   override via GH_PR_GUARD_EXPECTED_REVIEWER). Posting these as the
-#   AUTHOR identity (nathanjohnpayne) breaks the audit-trail
-#   convention REVIEW_POLICY.md depends on — reviewer comments must
-#   attribute to the reviewer. The check fires before the keyring
-#   write so misattributed comments never land.
+#   For all three, the keyring's active account must exactly match the
+#   operating agent's REVIEWER identity (nathanpayne-<agent>, default
+#   nathanpayne-claude; override via GH_PR_GUARD_EXPECTED_REVIEWER).
+#   Posting these as the AUTHOR identity (nathanjohnpayne), or as the
+#   wrong reviewer identity after cross-session keyring drift, breaks
+#   the audit-trail convention REVIEW_POLICY.md depends on — reviewer
+#   comments must attribute to the reviewer. The check fires before
+#   the keyring write so misattributed comments never land.
 #
 #   `gh issue create` is intentionally NOT in this set. It was briefly
 #   guarded (#317, after the mergepath#315 misattribution) but that
@@ -636,10 +637,10 @@ fi
 # --- byline guard for pr comment / pr review / issue comment ---
 #
 # These three subcommands share a single policy: the keyring's active
-# account must be the agent's REVIEWER identity (not the author
-# identity). Posting any of them under nathanjohnpayne mis-attributes
-# the byline in a way that breaks the audit-trail invariant
-# REVIEW_POLICY.md depends on.
+# account must exactly match the operating agent's REVIEWER identity.
+# Posting any of them under nathanjohnpayne OR the wrong reviewer
+# identity mis-attributes the byline in a way that breaks the
+# audit-trail invariant REVIEW_POLICY.md depends on.
 #
 # `gh issue create` is deliberately excluded — it was briefly guarded
 # here (#317, after the mergepath#315 misattribution) but reverted,
@@ -659,27 +660,27 @@ if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS
       echo "  Run 'gh auth login' for the $EXPECTED_REVIEWER identity, then retry." >&2
       exit 2
     fi
-    # Block when active is the author identity. Any other identity is
-    # allowed through here (the reviewer-vs-author split is the
-    # load-bearing distinction in this codebase); a downstream consumer
-    # that wires up a third identity per agent can override
-    # GH_PR_GUARD_EXPECTED_REVIEWER to match.
     EXPECTED_AUTHOR_FOR_BLOCK="${GH_PR_GUARD_EXPECTED_AUTHOR:-nathanjohnpayne}"
-    if [ "$ACTIVE_GH_USER" = "$EXPECTED_AUTHOR_FOR_BLOCK" ]; then
+    if [ "$ACTIVE_GH_USER" != "$EXPECTED_REVIEWER" ]; then
       cmd_label=""
       case "$PR_SUBCOMMAND" in
         comment) cmd_label="gh pr comment" ;;
         review)  cmd_label="gh pr review" ;;
       esac
       [ "$IS_ISSUE_COMMENT" -eq 1 ] && cmd_label="gh issue comment"
-      echo "BLOCKED: $cmd_label is about to run under active account '$ACTIVE_GH_USER' (the AUTHOR identity)." >&2
+      if [ "$ACTIVE_GH_USER" = "$EXPECTED_AUTHOR_FOR_BLOCK" ]; then
+        active_role="the AUTHOR identity"
+      else
+        active_role="not the expected reviewer identity"
+      fi
+      echo "BLOCKED: $cmd_label is about to run under active account '$ACTIVE_GH_USER' ($active_role)." >&2
       echo "" >&2
       echo "  Reviewer-byline commands (pr comment / pr review / issue comment)" >&2
-      echo "  must attribute to the agent's REVIEWER identity ('$EXPECTED_REVIEWER' by default)," >&2
-      echo "  not the author identity. Posting as '$EXPECTED_AUTHOR_FOR_BLOCK' breaks the audit-" >&2
-      echo "  trail convention REVIEW_POLICY.md depends on." >&2
+      echo "  must attribute to the operating agent's REVIEWER identity ('$EXPECTED_REVIEWER' for this hook invocation)." >&2
+      echo "  Posting as '$ACTIVE_GH_USER' breaks the audit-trail convention REVIEW_POLICY.md depends on." >&2
       echo "" >&2
       echo "  Fix once: gh auth switch -u $EXPECTED_REVIEWER" >&2
+      echo "  Or set GH_PR_GUARD_EXPECTED_REVIEWER=$ACTIVE_GH_USER only if that is this agent's true reviewer identity." >&2
       echo "  Or wrap the single call: scripts/gh-as-reviewer.sh -- $cmd_label ..." >&2
       echo "  See REVIEW_POLICY.md § Operation-to-Identity Matrix." >&2
       exit 2

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -162,6 +162,26 @@ run_hook_review() {
     bash "$HOOK" <<<"$payload"
 }
 
+run_hook_agent_context() {
+  local cmd="$1"
+  local stub_user="${2:-nathanpayne-claude}"
+  local agent="${3:-}"
+  local expected_reviewer="${4:-}"
+  local skip_id="${5:-0}"
+  local merge_state="${6:-CLEAN}"
+  local labels="${7:-}"
+  local payload
+  payload=$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}')
+  PATH="$STUB_DIR:$PATH" \
+  STUB_ACTIVE_USER="$stub_user" \
+  STUB_MERGE_STATE="$merge_state" \
+  STUB_LABELS="$labels" \
+  MERGEPATH_AGENT="$agent" \
+  GH_PR_GUARD_EXPECTED_REVIEWER="$expected_reviewer" \
+  BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK="$skip_id" \
+    bash "$HOOK" <<<"$payload"
+}
+
 # ---------------------------------------------------------------------------
 # Test 1: gh pr create with correct identity + required body → exit 0
 # ---------------------------------------------------------------------------
@@ -526,6 +546,57 @@ if [ "$rc" -eq 0 ]; then
   pass "pr comment + expected-reviewer override: codex active allowed when expected=codex"
 else
   fail "pr comment + expected-reviewer override: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 18c2: MERGEPATH_AGENT fallback — codex is valid when the
+# operating agent is codex even if GH_PR_GUARD_EXPECTED_REVIEWER is
+# unset/empty. This keeps the hook aligned with identity-check.sh
+# --expect-reviewer.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook_agent_context 'gh pr comment 123 --body "ping"' "nathanpayne-codex" "codex" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "pr comment + MERGEPATH_AGENT fallback: codex active allowed when agent=codex"
+else
+  fail "pr comment + MERGEPATH_AGENT fallback: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 18c3: explicit expected-reviewer override wins over
+# MERGEPATH_AGENT. This preserves harness-controlled review sessions
+# where the expected reviewer is intentionally pinned.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook_agent_context 'gh pr comment 123 --body "ping"' "nathanpayne-codex" "codex" "nathanpayne-claude" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "pr comment + explicit override precedence: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -q "GH_PR_GUARD_EXPECTED_REVIEWER"; then
+  fail "pr comment + explicit override precedence: diagnostic missing override source; output: $out"
+else
+  pass "pr comment + explicit override precedence: expected-reviewer override beats MERGEPATH_AGENT"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 18c4: MERGEPATH_AGENT fallback blocks a different active
+# reviewer identity, and the diagnostic names the derived reviewer.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook_agent_context 'gh pr comment 123 --body "ping"' "nathanpayne-claude" "cursor" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "pr comment + MERGEPATH_AGENT mismatch: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -q "nathanpayne-cursor"; then
+  fail "pr comment + MERGEPATH_AGENT mismatch: diagnostic missing derived cursor reviewer; output: $out"
+elif ! echo "$out" | grep -q "MERGEPATH_AGENT"; then
+  fail "pr comment + MERGEPATH_AGENT mismatch: diagnostic missing MERGEPATH_AGENT source; output: $out"
+else
+  pass "pr comment + MERGEPATH_AGENT mismatch: blocks wrong active reviewer"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -122,12 +122,14 @@ run_hook() {
   local skip_id="${3:-0}"
   local merge_state="${4:-CLEAN}"
   local labels="${5:-}"
+  local expected_reviewer="${6:-nathanpayne-claude}"
   local payload
   payload=$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}')
   PATH="$STUB_DIR:$PATH" \
   STUB_ACTIVE_USER="$stub_user" \
   STUB_MERGE_STATE="$merge_state" \
   STUB_LABELS="$labels" \
+  GH_PR_GUARD_EXPECTED_REVIEWER="$expected_reviewer" \
   BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK="$skip_id" \
     bash "$HOOK" <<<"$payload"
 }
@@ -145,6 +147,7 @@ run_hook_review() {
   local deletions="${6:-0}"
   local pr_head="${7:-feature/some-branch}"
   local pr_author="${8:-nathanjohnpayne}"
+  local expected_reviewer="${9:-nathanpayne-claude}"
   local payload
   payload=$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}')
   PATH="$STUB_DIR:$PATH" \
@@ -154,6 +157,7 @@ run_hook_review() {
   STUB_PR_DELETIONS="$deletions" \
   STUB_PR_HEAD="$pr_head" \
   STUB_PR_AUTHOR="$pr_author" \
+  GH_PR_GUARD_EXPECTED_REVIEWER="$expected_reviewer" \
   BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK="$skip_id" \
     bash "$HOOK" <<<"$payload"
 }
@@ -491,6 +495,56 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 18b: gh pr comment with the WRONG reviewer identity active →
+# blocked. This closes #363: cross-agent keyring drift (claude session
+# with active=nathanpayne-codex) must not silently post under the wrong
+# reviewer byline.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr comment 123 --body "ping"' "nathanpayne-codex" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "pr comment + wrong reviewer identity: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "not the expected reviewer identity"; then
+  fail "pr comment + wrong reviewer identity: diagnostic missing expected-reviewer mismatch; output: $out"
+elif ! echo "$out" | grep -q "gh-as-reviewer.sh"; then
+  fail "pr comment + wrong reviewer identity: diagnostic missing gh-as-reviewer.sh remediation; output: $out"
+else
+  pass "pr comment + wrong reviewer identity: blocked with reviewer mismatch diagnostic"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 18c: GH_PR_GUARD_EXPECTED_REVIEWER override — codex is valid
+# when the operating agent is codex and the hook env says so.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr comment 123 --body "ping"' "nathanpayne-codex" "0" "CLEAN" "" "nathanpayne-codex" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "pr comment + expected-reviewer override: codex active allowed when expected=codex"
+else
+  fail "pr comment + expected-reviewer override: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 18d: wrapped reviewer writes are allowed by the tokenizer. The
+# hook sees scripts/gh-as-reviewer.sh in command position and the gh
+# command only as an argument; the wrapper is responsible for switching
+# and verifying the identity internally.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'scripts/gh-as-reviewer.sh -- gh pr comment 123 --body "ping"' "nathanpayne-codex" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "wrapped pr comment via gh-as-reviewer.sh: allowed"
+else
+  fail "wrapped pr comment via gh-as-reviewer.sh: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
 # Test 19: gh pr review --comment with AUTHOR identity → blocked.
 # ---------------------------------------------------------------------------
 set +e
@@ -519,6 +573,22 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 20b: gh pr review --comment with the wrong reviewer identity
+# active → blocked. Same #363 drift guard as pr comment, but on review.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr review 123 --comment --body "review"' "nathanpayne-codex" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "pr review --comment + wrong reviewer identity: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "not the expected reviewer identity"; then
+  fail "pr review --comment + wrong reviewer identity: diagnostic missing expected-reviewer mismatch; output: $out"
+else
+  pass "pr review --comment + wrong reviewer identity: blocked"
+fi
+
+# ---------------------------------------------------------------------------
 # Test 21: gh issue comment with AUTHOR identity → blocked.
 # ---------------------------------------------------------------------------
 set +e
@@ -544,6 +614,22 @@ if [ "$rc" -eq 0 ]; then
   pass "issue comment + reviewer identity: allowed"
 else
   fail "issue comment + reviewer identity: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 22b: gh issue comment with the wrong reviewer identity active →
+# blocked.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh issue comment 7 --body "thanks"' "nathanpayne-codex" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "issue comment + wrong reviewer identity: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "not the expected reviewer identity"; then
+  fail "issue comment + wrong reviewer identity: diagnostic missing expected-reviewer mismatch; output: $out"
+else
+  pass "issue comment + wrong reviewer identity: blocked"
 fi
 
 # ---------------------------------------------------------------------------
@@ -640,7 +726,7 @@ fi
 # ---------------------------------------------------------------------------
 set +e
 out=$(run_hook_review 'gh pr review 123 --approve --body "lgtm"' "nathanpayne-codex" "0" \
-  "Authoring-Agent: claude" "5000" "0" 2>&1)
+  "Authoring-Agent: claude" "5000" "0" "feature/some-branch" "nathanjohnpayne" "nathanpayne-codex" 2>&1)
 rc=$?
 set -e
 if [ "$rc" -eq 0 ]; then


### PR DESCRIPTION
Fixes #363.

## Summary
- require bare reviewer-byline commands to run under the exact expected reviewer identity, not merely "not the author"
- keep `gh issue create` out of scope and preserve the existing skip escape hatch
- document `GH_PR_GUARD_EXPECTED_REVIEWER` / `gh-as-reviewer.sh` usage across the review-policy docs
- extend `tests/test_gh_pr_guard.sh` for wrong-reviewer drift, expected-reviewer override, and wrapper pass-through

## Validation
- `tests/test_gh_pr_guard.sh`
- `scripts/ci/check_gh_as_author`
- `scripts/ci/check_ci_scripts_wired`
- `scripts/ci/check_duplicate_docs` (passes with existing warnings)
- `bash -n scripts/hooks/gh-pr-guard.sh tests/test_gh_pr_guard.sh`
- `git diff --check`

Authoring-Agent: codex

## Self-Review
- Correctness: bare `gh pr comment`, `gh pr review`, and `gh issue comment` now fail closed unless active keyring matches `GH_PR_GUARD_EXPECTED_REVIEWER`; wrapper and skip paths remain available.
- Regression risk: moderate because this changes reviewer write guard behavior; tests cover existing author-block behavior, wrong-reviewer block, override allow, and wrapped command allow.
- Style: follows the existing hook structure and diagnostic style.
- Test coverage: focused hook unit coverage plus the existing `check_gh_as_author` wrapper/guard suite.
- Security/dependency hygiene: no new dependencies; improves audit-trail integrity by making keyring drift visible before writes land.
