### PR TITLE
Fix sync-all PR audit exemption

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -234,9 +234,11 @@ jobs:
               //      the sync script's branch-naming convention
               //      (`mergepath-sync/<short-sha>`) and never used for
               //      hand-authored work.
-              //   4. PR title matches `(mergepath@[0-9a-f]{7,40})` — the
-              //      canonical title format the sync script emits,
-              //      identifying the upstream commit.
+              //   4. PR title contains `mergepath@[0-9a-f]{7,40}` — the
+              //      canonical title marker the sync script emits,
+              //      identifying the upstream commit. Per-commit sync PRs
+              //      use `(mergepath@<sha>)`; `--sync-all` PRs use
+              //      `to mergepath@<sha>`.
               //
               // Hand-creating all four signals at once is possible but is
               // an explicit, traceable action that would surface during
@@ -250,7 +252,7 @@ jobs:
                 pr.head && pr.head.ref &&
                 pr.head.ref.startsWith('mergepath-sync/');
               const hasMergepathMarker =
-                /\(mergepath@[0-9a-f]{7,40}\)/.test(pr.title || '');
+                /\bmergepath@[0-9a-f]{7,40}\b/.test(pr.title || '');
               const isMergepathSyncPR =
                 isTrustedSyncAuthor &&
                 isSameRepoHead &&

--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -178,6 +178,9 @@ jobs:
       - name: check_pr_audit_codex_clearance
         run: ./scripts/ci/check_pr_audit_codex_clearance
 
+      - name: check_pr_audit_sync_exemption
+        run: ./scripts/ci/check_pr_audit_sync_exemption
+
       - name: check_sweep_unresolved_feedback
         run: ./scripts/ci/check_sweep_unresolved_feedback
 

--- a/scripts/ci/check_pr_audit_sync_exemption
+++ b/scripts/ci/check_pr_audit_sync_exemption
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# check_pr_audit_sync_exemption — regression coverage for the
+# propagation-PR exemption in .github/workflows/pr-audit.yml.
+#
+# Issue #374 Pattern C: sync-all PRs use titles like
+# "sync: bulk reconcile to mergepath@b12e7d7" while the audit used to
+# require the parenthesized per-commit form "(mergepath@b12e7d7)".
+# The title marker is corroborating only; the trusted author,
+# same-repo head, and mergepath-sync/* branch guards remain required.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+WORKFLOW=".github/workflows/pr-audit.yml"
+
+if [ ! -e "$WORKFLOW" ]; then
+  echo "check_pr_audit_sync_exemption: missing $WORKFLOW" >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "check_pr_audit_sync_exemption: SKIP — node not on PATH" >&2
+  exit 0
+fi
+
+RUNNER=$(cat <<'NODE_EOF'
+const authorIdentity = 'nathanjohnpayne';
+const context = { repo: { owner: 'nathanjohnpayne', repo: 'matchline' } };
+
+function isMergepathSyncPR(pr) {
+  const isTrustedSyncAuthor =
+    pr.user && pr.user.login === authorIdentity;
+  const isSameRepoHead =
+    pr.head && pr.head.repo &&
+    pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+  const hasSyncBranchName =
+    pr.head && pr.head.ref &&
+    pr.head.ref.startsWith('mergepath-sync/');
+  const hasMergepathMarker =
+    /\bmergepath@[0-9a-f]{7,40}\b/.test(pr.title || '');
+  return Boolean(
+    isTrustedSyncAuthor &&
+    isSameRepoHead &&
+    hasSyncBranchName &&
+    hasMergepathMarker
+  );
+}
+
+function pr({ title, author = authorIdentity, headRef = 'mergepath-sync/sync-all-b12e7d7', headRepo = 'nathanjohnpayne/matchline' }) {
+  return {
+    title,
+    user: { login: author },
+    head: {
+      ref: headRef,
+      repo: { full_name: headRepo },
+    },
+  };
+}
+
+const cases = [
+  {
+    name: 'sync-all title without parentheses is exempt when all provenance guards match',
+    expected: true,
+    pr: pr({ title: 'sync: bulk reconcile to mergepath@b12e7d7' }),
+  },
+  {
+    name: 'per-commit parenthesized title remains exempt',
+    expected: true,
+    pr: pr({ title: 'sync: update helper (mergepath@b12e7d7)', headRef: 'mergepath-sync/b12e7d7' }),
+  },
+  {
+    name: 'ordinary branch mentioning mergepath marker is not exempt',
+    expected: false,
+    pr: pr({ title: 'docs: mention mergepath@b12e7d7 in notes', headRef: 'feature/mentions-mergepath' }),
+  },
+  {
+    name: 'wrong author with sync branch and marker is not exempt',
+    expected: false,
+    pr: pr({ title: 'sync: bulk reconcile to mergepath@b12e7d7', author: 'nathanpayne-codex' }),
+  },
+  {
+    name: 'fork head with sync branch and marker is not exempt',
+    expected: false,
+    pr: pr({ title: 'sync: bulk reconcile to mergepath@b12e7d7', headRepo: 'somebody/matchline' }),
+  },
+  {
+    name: 'sync branch without mergepath marker is not exempt',
+    expected: false,
+    pr: pr({ title: 'sync: bulk reconcile latest templates' }),
+  },
+];
+
+let failures = 0;
+for (const tc of cases) {
+  const actual = isMergepathSyncPR(tc.pr);
+  if (actual === tc.expected) {
+    console.log(`  PASS: ${tc.name}`);
+  } else {
+    failures += 1;
+    console.error(`  FAIL: ${tc.name} (expected=${tc.expected}, actual=${actual})`);
+  }
+}
+
+process.exit(failures === 0 ? 0 : 1);
+NODE_EOF
+)
+
+pass=0
+fail=0
+
+if node -e "$RUNNER"; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+fi
+
+if grep -qF '\bmergepath@[0-9a-f]{7,40}\b' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW accepts mergepath@<sha> title markers with or without parentheses"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must use the relaxed mergepath@<sha> title marker regex" >&2
+fi
+
+if grep -qF '\(mergepath@[0-9a-f]{7,40}\)' "$WORKFLOW"; then
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW still carries the old parenthesis-required marker regex" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW no longer requires parentheses around mergepath@<sha>"
+fi
+
+echo
+if [ "$fail" -gt 0 ]; then
+  echo "check_pr_audit_sync_exemption: $fail FAIL / $pass PASS" >&2
+  exit 1
+fi
+echo "check_pr_audit_sync_exemption: PASS ($pass test groups)"


### PR DESCRIPTION
Refs #374 (Pattern C only)

Authoring-Agent: codex

## Summary
- relax the Weekly PR Audit propagation-title marker from parenthesized-only `(mergepath@<sha>)` to any bounded `mergepath@<sha>` marker
- keep the provenance guards intact: author identity, same-repo head, and `mergepath-sync/` branch are still required before the audit exemption applies
- add `check_pr_audit_sync_exemption` with fixtures for sync-all titles, parenthesized per-commit titles, and false-positive cases
- wire the new check into `repo_lint.yml`

## Self-Review
- Correctness: matches both sync title formats currently emitted by `scripts/sync-to-downstream.sh` without relaxing the author/repo/branch provenance gates.
- Regression risk: low; the marker is corroborating only, and the new test explicitly rejects ordinary branches that merely mention `mergepath@<sha>`.
- Style: follows existing shell/Node fixture-check style in `scripts/ci`.
- Test coverage: added dedicated sync-exemption fixtures and reran the existing PR audit and workflow parser checks.
- Security/dependency hygiene: no new dependencies; no secret or runtime credential changes.

## Validation
- `scripts/ci/check_pr_audit_sync_exemption`
- `scripts/ci/check_pr_audit_codex_clearance`
- `scripts/ci/check_ci_scripts_wired`
- `scripts/ci/check_workflow_parsers`
- `scripts/ci/check_duplicate_docs` (passes with existing warnings)
- `bash -n scripts/ci/check_pr_audit_sync_exemption`
- `git diff --check`
