### PR TITLE
fix(sweep): avoid long-body pipefail

### DIFF
--- a/scripts/sweep-unresolved-feedback/enumerate.sh
+++ b/scripts/sweep-unresolved-feedback/enumerate.sh
@@ -97,7 +97,7 @@ echo "enumerate: scanning closed PRs since $SINCE (lookback=${LOOKBACK_DAYS}d)" 
 classify_severity() {
   # arg 1: body text (already trimmed)
   local body_head
-  body_head=$(printf '%s' "$1" | head -c 400)
+  body_head=${1:0:400}
   case "$body_head" in
     *[Pp]0*|*Critical*|*CRITICAL*) echo "P0"; return ;;
     *[Pp]1*|*Major*|*MAJOR*|*"Potential issue"*|*"⚠️"*) echo "P1"; return ;;
@@ -213,8 +213,11 @@ emit_findings_for_repo() {
       thread_url=$(printf '%s' "$line" | jq -r '.thread_url')
 
       # body_excerpt: first 200 chars, single-line, trimmed.
-      local body_excerpt
-      body_excerpt=$(printf '%s' "$body" | tr '\n\r\t' '   ' | head -c 200)
+      local body_excerpt single_line_body
+      single_line_body=${body//$'\n'/ }
+      single_line_body=${single_line_body//$'\r'/ }
+      single_line_body=${single_line_body//$'\t'/ }
+      body_excerpt=${single_line_body:0:200}
 
       local severity
       severity=$(classify_severity "$body")

--- a/tests/test_sweep_unresolved_feedback.sh
+++ b/tests/test_sweep_unresolved_feedback.sh
@@ -278,6 +278,74 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 1b: long bodies do not trip pipefail via early-closing pipelines.
+# ---------------------------------------------------------------------------
+LONG_BODY=$'Potential issue: first line\n\t'
+LONG_BODY="${LONG_BODY}$(printf '%0300d' 0 | tr '0' A)"
+
+cat >"$STUB_FIXTURES/pr-list-owner_long.json" <<'JSON'
+[
+  {"number": 9, "title": "Long review body", "url": "https://github.com/owner/long/pull/9"}
+]
+JSON
+
+jq -n --arg body "$LONG_BODY" '{
+  data: {
+    repository: {
+      pullRequest: {
+        reviewThreads: {
+          totalCount: 1,
+          pageInfo: {hasNextPage: false, endCursor: null},
+          nodes: [
+            {
+              id: "PRT_long_9_a",
+              isResolved: false,
+              isOutdated: false,
+              comments: {nodes: [{
+                author: {login: "coderabbitai[bot]"},
+                body: $body,
+                url: "https://github.com/owner/long/pull/9#discussion_r9001"
+              }]}
+            }
+          ]
+        }
+      }
+    }
+  }
+}' >"$STUB_FIXTURES/threads-owner_long_9.json"
+
+LONG_TARGETS="$WORKDIR/targets-long.txt"
+printf '%s\n' "owner/long" >"$LONG_TARGETS"
+LONG_NDJSON="$WORKDIR/findings-long.ndjson"
+
+set +e
+PATH="$STUB_DIR:$PATH" \
+GH_TOKEN="dummy-pat" \
+STUB_FIXTURES="$STUB_FIXTURES" \
+GH_CALLS_LOG="$GH_CALLS_LOG" \
+SWEEP_OUTPUT="$LONG_NDJSON" \
+  "$ENUMERATE" "$LONG_TARGETS" 2>"$WORKDIR/enum-long.stderr"
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ] && [ "$(wc -l < "$LONG_NDJSON" | tr -d ' ')" = "1" ]; then
+  pass "enumerate: long body does not fail under pipefail"
+else
+  fail "enumerate: long body exited $rc or emitted wrong count"
+  cat "$WORKDIR/enum-long.stderr" >&2
+fi
+
+if jq -e '(.body_excerpt | length) == 200
+          and ((.body_excerpt | contains("\n")) | not)
+          and ((.body_excerpt | contains("\r")) | not)
+          and ((.body_excerpt | contains("\t")) | not)' "$LONG_NDJSON" >/dev/null; then
+  pass "enumerate: long body_excerpt is capped and single-line"
+else
+  fail "enumerate: long body_excerpt not capped/single-line"
+  cat "$LONG_NDJSON" >&2
+fi
+
+# ---------------------------------------------------------------------------
 # Test 2: render.sh produces a body with expected markers + counts.
 # ---------------------------------------------------------------------------
 BODY_OUT="$WORKDIR/body.md"


### PR DESCRIPTION
## Summary

Fixes #339.

The 2026-05-18 weekly unresolved-feedback sweep failed in `enumerate.sh` with `tr: write error: Broken pipe`. The failing path built review-body excerpts with `tr ... | head -c 200` under `set -euo pipefail`; when `head` exited after 200 bytes, `tr` could receive SIGPIPE and make the whole workflow fail.

This PR removes the early-closing pipelines from `classify_severity` and `body_excerpt` creation by using Bash substring/parameter expansion instead.

## Validation

- `bash -n scripts/sweep-unresolved-feedback/enumerate.sh tests/test_sweep_unresolved_feedback.sh scripts/ci/check_sweep_unresolved_feedback`
- `scripts/ci/check_sweep_unresolved_feedback`
- `git diff --check`
- `scripts/ci/check_ci_scripts_wired`

## Self-Review

- Correctness: long review bodies are still truncated to the same 400-character severity window and 200-character single-line excerpt, but without producer-side SIGPIPE under `pipefail`.
- Regression risk: low; the change is localized to text truncation inside the sweep enumerator.
- Style: keeps the existing Bash 3.2-compatible shell implementation.
- Test coverage: adds a long-body fixture with newline/tab content and asserts the enumerator exits 0, emits one finding, and produces a capped single-line excerpt.
- Security/dependency hygiene: no new dependencies and no credential handling changes.

Authoring-Agent: codex
