### PR TITLE
chore(claude): allow author merge wrapper

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(scripts/gh-as-author.sh -- gh pr merge *)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "permissions": {
     "allow": [
-      "Bash(scripts/gh-as-author.sh -- gh pr merge *)"
+      "Bash(scripts/gh-as-author.sh -- gh pr merge * --squash --delete-branch)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary

Fixes #349.

The auto-clear root cause in #349 is no longer active: current `auto-clear-blocking-labels.yml` runs are succeeding, including review-triggered runs from today. The remaining Claude Code auto-mode blocker is the sanctioned merge command itself being denied. This PR adds a narrow Claude permission allowlist entry for the required author-wrapper merge path:

```text
Bash(scripts/gh-as-author.sh -- gh pr merge *)
```

It does not allow bare `gh pr merge`, label edits, `--admin`, or any non-wrapper merge path. The existing `gh-as-author.sh` wrapper and `gh-pr-guard.sh` merge checks still provide the identity and merge-state guardrails.

## Validation

- `jq . .claude/settings.json >/dev/null`
- `scripts/ci/check_no_tool_folder_instructions`
- `scripts/ci/check_gh_as_author`
- `git diff --check`

## Self-Review

- Correctness: permits the documented author-wrapper merge path that CLAUDE.md already instructs agents to use.
- Regression risk: low; the allowlist is scoped to one wrapper command and does not weaken the repo's merge hooks.
- Style: keeps `.claude/` as configuration only; no instructions added there.
- Test coverage: validates JSON, tool-folder policy, and the wrapper/guard test suite.
- Security/dependency hygiene: no new dependencies and no credential handling changes.

Authoring-Agent: codex
