### PR TITLE
test(workflow): lock Dependabot token guards

### DIFF
--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -58,6 +58,9 @@ assert_eq() {
 workflow_guard_block_contains_exit() {
   local file="$1" guard="$2" required="$3"
   awk -v guard="$guard" -v required="$required" '
+    /^[[:space:]]*#/ {
+      next
+    }
     index($0, guard) {
       in_block = 1
       saw_guard = 1
@@ -65,7 +68,7 @@ workflow_guard_block_contains_exit() {
     in_block && index($0, required) {
       saw_required = 1
     }
-    in_block && /exit 1/ {
+    in_block && /^[[:space:]]*exit[[:space:]]+1([[:space:]]|$)/ {
       saw_exit = 1
     }
     in_block && /^[[:space:]]*fi[[:space:]]*$/ {
@@ -581,7 +584,7 @@ fi
 
 if workflow_guard_block_contains_exit \
   "$dependabot_workflow" \
-  'if ! printf' \
+  "if ! printf '%s\\\\n' \"\$ALLOWED\" | grep -Fxq \"\$ACTING_AS\"; then" \
   'NOT in $POLICY available_reviewers'; then
   pass=$((pass + 1))
   echo "  PASS: Dependabot auto-merge exits when the reviewer token is not allowlisted"

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -520,6 +520,61 @@ else
   echo "  PASS: Dependabot auto-merge does not gate on github.actor"
 fi
 
+echo
+echo "dependabot-auto-merge.yml reviewer-token fail-closed regression (#374 Pattern A)"
+
+if grep -Fq 'if [ -z "${GH_TOKEN:-}" ]; then' "$dependabot_workflow" &&
+   awk '
+     /GH_TOKEN is empty\. REVIEWER_ASSIGNMENT_TOKEN secret is not set/ {saw_error=NR}
+     saw_error && /exit 1/ {found=1}
+     END {exit found ? 0 : 1}
+   ' "$dependabot_workflow"; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge exits when REVIEWER_ASSIGNMENT_TOKEN is empty"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must fail closed when REVIEWER_ASSIGNMENT_TOKEN/GH_TOKEN is empty" >&2
+fi
+
+if grep -Fq 'ACTING_AS=$(gh api user --jq .login' "$dependabot_workflow" &&
+   awk '
+     /gh api user returned empty/ {saw_error=NR}
+     saw_error && /exit 1/ {found=1}
+     END {exit found ? 0 : 1}
+   ' "$dependabot_workflow"; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge exits when REVIEWER_ASSIGNMENT_TOKEN cannot resolve an identity"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must fail closed when REVIEWER_ASSIGNMENT_TOKEN cannot resolve an identity" >&2
+fi
+
+if grep -Fq 'if [ "$ACTING_AS" = "$PR_AUTHOR" ]; then' "$dependabot_workflow" &&
+   awk '
+     /GitHub blocks self-approval/ {saw_error=NR}
+     saw_error && /exit 1/ {found=1}
+     END {exit found ? 0 : 1}
+   ' "$dependabot_workflow"; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge exits when the reviewer token resolves to the PR author"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must fail closed when REVIEWER_ASSIGNMENT_TOKEN resolves to the PR author" >&2
+fi
+
+if grep -Fq 'grep -Fxq "$ACTING_AS"' "$dependabot_workflow" &&
+   awk '
+     /NOT in \$POLICY available_reviewers/ {saw_error=NR}
+     saw_error && /exit 1/ {found=1}
+     END {exit found ? 0 : 1}
+   ' "$dependabot_workflow"; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge exits when the reviewer token is not allowlisted"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must fail closed when REVIEWER_ASSIGNMENT_TOKEN is not in available_reviewers" >&2
+fi
+
 if grep -Fq "!contains(github.event.pull_request.labels.*.name, 'human-hold')" "$dependabot_workflow"; then
   fail=$((fail + 1))
   echo "  FAIL: Dependabot auto-merge must not skip the whole job on trigger-time human-hold state" >&2

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -55,6 +55,28 @@ assert_eq() {
   fi
 }
 
+workflow_guard_block_contains_exit() {
+  local file="$1" guard="$2" required="$3"
+  awk -v guard="$guard" -v required="$required" '
+    index($0, guard) {
+      in_block = 1
+      saw_guard = 1
+    }
+    in_block && index($0, required) {
+      saw_required = 1
+    }
+    in_block && /exit 1/ {
+      saw_exit = 1
+    }
+    in_block && /^[[:space:]]*fi[[:space:]]*$/ {
+      exit
+    }
+    END {
+      exit (saw_guard && saw_required && saw_exit) ? 0 : 1
+    }
+  ' "$file"
+}
+
 # Classify a phase_4b_default value read from review-policy.yml.
 # Echoes "valid" or "invalid".
 #
@@ -523,12 +545,10 @@ fi
 echo
 echo "dependabot-auto-merge.yml reviewer-token fail-closed regression (#374 Pattern A)"
 
-if grep -Fq 'if [ -z "${GH_TOKEN:-}" ]; then' "$dependabot_workflow" &&
-   awk '
-     /GH_TOKEN is empty\. REVIEWER_ASSIGNMENT_TOKEN secret is not set/ {saw_error=NR}
-     saw_error && /exit 1/ {found=1}
-     END {exit found ? 0 : 1}
-   ' "$dependabot_workflow"; then
+if workflow_guard_block_contains_exit \
+  "$dependabot_workflow" \
+  'if [ -z "${GH_TOKEN:-}" ]; then' \
+  'GH_TOKEN is empty. REVIEWER_ASSIGNMENT_TOKEN secret is not set'; then
   pass=$((pass + 1))
   echo "  PASS: Dependabot auto-merge exits when REVIEWER_ASSIGNMENT_TOKEN is empty"
 else
@@ -537,11 +557,10 @@ else
 fi
 
 if grep -Fq 'ACTING_AS=$(gh api user --jq .login' "$dependabot_workflow" &&
-   awk '
-     /gh api user returned empty/ {saw_error=NR}
-     saw_error && /exit 1/ {found=1}
-     END {exit found ? 0 : 1}
-   ' "$dependabot_workflow"; then
+   workflow_guard_block_contains_exit \
+     "$dependabot_workflow" \
+     'if [ -z "$ACTING_AS" ]; then' \
+     'gh api user returned empty'; then
   pass=$((pass + 1))
   echo "  PASS: Dependabot auto-merge exits when REVIEWER_ASSIGNMENT_TOKEN cannot resolve an identity"
 else
@@ -549,12 +568,10 @@ else
   echo "  FAIL: Dependabot auto-merge must fail closed when REVIEWER_ASSIGNMENT_TOKEN cannot resolve an identity" >&2
 fi
 
-if grep -Fq 'if [ "$ACTING_AS" = "$PR_AUTHOR" ]; then' "$dependabot_workflow" &&
-   awk '
-     /GitHub blocks self-approval/ {saw_error=NR}
-     saw_error && /exit 1/ {found=1}
-     END {exit found ? 0 : 1}
-   ' "$dependabot_workflow"; then
+if workflow_guard_block_contains_exit \
+  "$dependabot_workflow" \
+  'if [ "$ACTING_AS" = "$PR_AUTHOR" ]; then' \
+  'GitHub blocks self-approval'; then
   pass=$((pass + 1))
   echo "  PASS: Dependabot auto-merge exits when the reviewer token resolves to the PR author"
 else
@@ -562,12 +579,10 @@ else
   echo "  FAIL: Dependabot auto-merge must fail closed when REVIEWER_ASSIGNMENT_TOKEN resolves to the PR author" >&2
 fi
 
-if grep -Fq 'grep -Fxq "$ACTING_AS"' "$dependabot_workflow" &&
-   awk '
-     /NOT in \$POLICY available_reviewers/ {saw_error=NR}
-     saw_error && /exit 1/ {found=1}
-     END {exit found ? 0 : 1}
-   ' "$dependabot_workflow"; then
+if workflow_guard_block_contains_exit \
+  "$dependabot_workflow" \
+  'if ! printf' \
+  'NOT in $POLICY available_reviewers'; then
   pass=$((pass + 1))
   echo "  PASS: Dependabot auto-merge exits when the reviewer token is not allowlisted"
 else

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -57,7 +57,11 @@ assert_eq() {
 
 workflow_guard_block_contains_exit() {
   local file="$1" guard="$2" required="$3"
-  awk -v guard="$guard" -v required="$required" '
+  WORKFLOW_GUARD="$guard" WORKFLOW_REQUIRED="$required" awk '
+    BEGIN {
+      guard = ENVIRON["WORKFLOW_GUARD"]
+      required = ENVIRON["WORKFLOW_REQUIRED"]
+    }
     /^[[:space:]]*#/ {
       next
     }
@@ -584,7 +588,7 @@ fi
 
 if workflow_guard_block_contains_exit \
   "$dependabot_workflow" \
-  "if ! printf '%s\\\\n' \"\$ALLOWED\" | grep -Fxq \"\$ACTING_AS\"; then" \
+  "if ! printf '%s\\n' \"\$ALLOWED\" | grep -Fxq \"\$ACTING_AS\"; then" \
   'NOT in $POLICY available_reviewers'; then
   pass=$((pass + 1))
   echo "  PASS: Dependabot auto-merge exits when the reviewer token is not allowlisted"


### PR DESCRIPTION
## Summary
- adds structural regression checks for #374 Pattern A so Dependabot auto-merge must fail closed when REVIEWER_ASSIGNMENT_TOKEN is empty, invalid, self-resolving, or not in available_reviewers
- keeps the existing human-hold checks in the same workflow parser section

Refs #374.

## Validation
- bash -n scripts/ci/check_workflow_parsers
- scripts/ci/check_workflow_parsers
- scripts/ci/check_ci_scripts_wired
- git diff --check

## Self-Review
- Scope is test-only and limited to the canonical workflow parser guard.
- No downstream syncs run.
- The assertions target the current fail-closed behavior in .github/workflows/dependabot-auto-merge.yml and would fail if any guard regresses back to logging without exit.

Authoring-Agent: codex