### PR TITLE
fix(coderabbit): block rate-limit fast path

### DIFF
--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -1277,12 +1277,37 @@ rc=$?
 set -e
 if [ "$rc" = "0" ] &&
    echo "$out" | grep -q '"status": "cleared"' &&
-   echo "$out" | grep -q "is older than status_created"; then
+   echo "$out" | grep -q "does not reference current HEAD headsha"; then
   pass=$((pass + 1))
-  echo "  PASS: newer StatusContext success clears despite an older non-HEAD rate-limit comment"
+  echo "  PASS: StatusContext success clears despite an unscoped non-HEAD rate-limit comment"
 else
   fail=$((fail + 1))
-  echo "  FAIL: stale rate-limit comment incorrectly suppressed a newer StatusContext success (rc=$rc)" >&2
+  echo "  FAIL: unscoped non-HEAD rate-limit comment incorrectly suppressed StatusContext success (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    STUB_COMMENT_CREATED_AT="2998-01-01T00:00:00Z" \
+    STUB_COMMENT_UPDATED_AT="2999-01-01T00:00:02Z" \
+    STUB_STATUS_CREATED_AT="2999-01-01T00:00:01Z" \
+    STUB_COMMENT_BODY_SUFFIX="" \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "0" ] &&
+   echo "$out" | grep -q '"status": "cleared"' &&
+   echo "$out" | grep -q "does not reference current HEAD headsha"; then
+  pass=$((pass + 1))
+  echo "  PASS: newer unscoped non-HEAD rate-limit comment does not suppress StatusContext success"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: fresh unscoped non-HEAD rate-limit comment incorrectly suppressed StatusContext success (rc=$rc)" >&2
   echo "$out" | sed 's/^/    /' >&2
 fi
 

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -42,7 +42,9 @@
 #          comment was a newer rate-limit notice. The helper returned
 #          cleared even though CodeRabbit explicitly had not reviewed
 #          the PR. The inverse matters too: an old rate-limit comment
-#          must not suppress a newer terminal SUCCESS status.
+#          must not suppress a newer terminal SUCCESS status. CodeRabbit
+#          edits its summary comment in place, so the regression uses
+#          updated_at/freshness rather than created_at alone.
 #
 # This check exercises the jq filter literals in isolation against
 # in-memory fixtures so a future edit can't silently regress either
@@ -1148,14 +1150,17 @@ case "$1" in
 JSON
           ;;
         repos/nathanjohnpayne/mergepath/issues/12345/comments)
-          comment_created_at="${STUB_COMMENT_CREATED_AT:-2999-01-01T00:00:00Z}"
+          comment_created_at="${STUB_COMMENT_CREATED_AT:-2998-01-01T00:00:00Z}"
+          comment_updated_at="${STUB_COMMENT_UPDATED_AT:-2999-01-01T00:00:00Z}"
+          comment_body_suffix="${STUB_COMMENT_BODY_SUFFIX- Reviewing files that changed from base and headsha.}"
           cat <<JSON
 [
   {
     "id": 6101,
     "created_at": "$comment_created_at",
+    "updated_at": "$comment_updated_at",
     "user": {"login": "coderabbitai[bot]"},
-    "body": "> [!WARNING]\n> ## Rate limit exceeded\n>\n> Please wait **10 minutes** before requesting another review."
+    "body": "> [!WARNING]\n> ## Rate limit exceeded\n>\n> Please wait **10 minutes** before requesting another review.$comment_body_suffix"
   }
 ]
 JSON
@@ -1241,8 +1246,10 @@ out=$(
     PATH="$SCRATCH:$PATH" \
     GH_TOKEN=fixture-token \
     CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
-    STUB_COMMENT_CREATED_AT="2999-01-01T00:00:00Z" \
+    STUB_COMMENT_CREATED_AT="2998-01-01T00:00:00Z" \
+    STUB_COMMENT_UPDATED_AT="2999-01-01T00:00:00Z" \
     STUB_STATUS_CREATED_AT="2999-01-01T00:00:01Z" \
+    STUB_COMMENT_BODY_SUFFIX="" \
     "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
 )
 rc=$?
@@ -1251,7 +1258,7 @@ if [ "$rc" = "0" ] &&
    echo "$out" | grep -q '"status": "cleared"' &&
    echo "$out" | grep -q "is older than status_created"; then
   pass=$((pass + 1))
-  echo "  PASS: newer StatusContext success clears despite an older rate-limit comment"
+  echo "  PASS: newer StatusContext success clears despite an older non-HEAD rate-limit comment"
 else
   fail=$((fail + 1))
   echo "  FAIL: stale rate-limit comment incorrectly suppressed a newer StatusContext success (rc=$rc)" >&2

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -39,8 +39,10 @@
 #
 #   Bug 6: scripts/coderabbit-wait.sh trusted a SUCCESS CodeRabbit
 #          StatusContext even when the current-head PR-level CodeRabbit
-#          comment was a rate-limit notice. The helper returned cleared
-#          even though CodeRabbit explicitly had not reviewed the PR.
+#          comment was a newer rate-limit notice. The helper returned
+#          cleared even though CodeRabbit explicitly had not reviewed
+#          the PR. The inverse matters too: an old rate-limit comment
+#          must not suppress a newer terminal SUCCESS status.
 #
 # This check exercises the jq filter literals in isolation against
 # in-memory fixtures so a future edit can't silently regress either
@@ -1133,23 +1135,25 @@ case "$1" in
           printf '[]\n'
           ;;
         repos/nathanjohnpayne/mergepath/commits/headsha/statuses)
-          cat <<'JSON'
+          status_created_at="${STUB_STATUS_CREATED_AT:-2999-01-01T00:00:00Z}"
+          cat <<JSON
 [
   {
     "context": "CodeRabbit",
     "state": "success",
-    "created_at": "2999-01-01T00:00:00Z",
+    "created_at": "$status_created_at",
     "creator": {"login": "coderabbitai[bot]"}
   }
 ]
 JSON
           ;;
         repos/nathanjohnpayne/mergepath/issues/12345/comments)
-          cat <<'JSON'
+          comment_created_at="${STUB_COMMENT_CREATED_AT:-2999-01-01T00:00:00Z}"
+          cat <<JSON
 [
   {
     "id": 6101,
-    "created_at": "2999-01-01T00:00:00Z",
+    "created_at": "$comment_created_at",
     "user": {"login": "coderabbitai[bot]"},
     "body": "> [!WARNING]\n> ## Rate limit exceeded\n>\n> Please wait **10 minutes** before requesting another review."
   }
@@ -1228,6 +1232,29 @@ if [ "$rc" = "5" ] &&
 else
   fail=$((fail + 1))
   echo "  FAIL: StatusContext success incorrectly cleared or masked a rate-limit comment (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    STUB_COMMENT_CREATED_AT="2999-01-01T00:00:00Z" \
+    STUB_STATUS_CREATED_AT="2999-01-01T00:00:01Z" \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "0" ] &&
+   echo "$out" | grep -q '"status": "cleared"' &&
+   echo "$out" | grep -q "is older than status_created"; then
+  pass=$((pass + 1))
+  echo "  PASS: newer StatusContext success clears despite an older rate-limit comment"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: stale rate-limit comment incorrectly suppressed a newer StatusContext success (rc=$rc)" >&2
   echo "$out" | sed 's/^/    /' >&2
 fi
 

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -37,6 +37,11 @@
 #          the helper still returned exit 2 from the status-context
 #          fast-path and stalled otherwise mergeable PRs.
 #
+#   Bug 6: scripts/coderabbit-wait.sh trusted a SUCCESS CodeRabbit
+#          StatusContext even when the current-head PR-level CodeRabbit
+#          comment was a rate-limit notice. The helper returned cleared
+#          even though CodeRabbit explicitly had not reviewed the PR.
+#
 # This check exercises the jq filter literals in isolation against
 # in-memory fixtures so a future edit can't silently regress either
 # guard. Inline-literal pattern matches check_workflow_parsers /
@@ -1109,6 +1114,121 @@ if [ "$review_count" = "1" ] && [ "$sha_count" = "1" ]; then
 else
   fail=$((fail + 1))
   echo "  FAIL: mixed fixture count incorrect (review=$review_count sha=$sha_count)" >&2
+fi
+
+echo
+echo "Bug 6 regression: coderabbit-wait does not fast-clear rate-limit notices"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$1" in
+  api)
+    shift
+    if [ "${1:-}" = "--paginate" ]; then
+      shift
+      case "${1:-}" in
+        repos/nathanjohnpayne/mergepath/issues/12345/timeline)
+          printf '[]\n'
+          ;;
+        repos/nathanjohnpayne/mergepath/commits/headsha/statuses)
+          cat <<'JSON'
+[
+  {
+    "context": "CodeRabbit",
+    "state": "success",
+    "created_at": "2999-01-01T00:00:00Z",
+    "creator": {"login": "coderabbitai[bot]"}
+  }
+]
+JSON
+          ;;
+        repos/nathanjohnpayne/mergepath/issues/12345/comments)
+          cat <<'JSON'
+[
+  {
+    "id": 6101,
+    "created_at": "2999-01-01T00:00:00Z",
+    "user": {"login": "coderabbitai[bot]"},
+    "body": "> [!WARNING]\n> ## Rate limit exceeded\n>\n> Please wait **10 minutes** before requesting another review."
+  }
+]
+JSON
+          ;;
+        repos/nathanjohnpayne/mergepath/pulls/12345/comments)
+          printf '[]\n'
+          ;;
+        repos/nathanjohnpayne/mergepath/pulls/12345/reviews)
+          printf '[]\n'
+          ;;
+        *)
+          printf 'unexpected paginated endpoint: %s\n' "${1:-}" >&2
+          exit 9
+          ;;
+      esac
+      exit 0
+    fi
+
+    case "${1:-}" in
+      repos/nathanjohnpayne/mergepath/pulls/12345)
+        cat <<'JSON'
+{"head":{"sha":"headsha"}}
+JSON
+        ;;
+      repos/nathanjohnpayne/mergepath/commits/headsha)
+        if [ "${2:-}" = "--jq" ]; then
+          printf '2999-01-01T00:00:00Z\n'
+        else
+          cat <<'JSON'
+{"commit":{"committer":{"date":"2999-01-01T00:00:00Z"}}}
+JSON
+        fi
+        ;;
+      *)
+        printf 'unexpected endpoint: %s\n' "${1:-}" >&2
+        exit 9
+        ;;
+    esac
+    ;;
+  *)
+    printf 'unexpected gh command: %s\n' "$1" >&2
+    exit 9
+    ;;
+esac
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+CODERABBIT_FASTPATH_ROOT="$SCRATCH/coderabbit-fastpath-root"
+mkdir -p "$CODERABBIT_FASTPATH_ROOT/.github"
+cat > "$CODERABBIT_FASTPATH_ROOT/.github/review-policy.yml" <<'YAML'
+coderabbit:
+  bot_login: "coderabbitai[bot]"
+  max_wait_seconds: 300
+  max_rate_limit_retries: 2
+  wallclock_freshness_window_seconds: 1800
+  trust_status_context_for_clearance: true
+YAML
+
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "5" ] &&
+   echo "$out" | grep -q '"status": "rate_limit_stalled"' &&
+   echo "$out" | grep -q "StatusContext success ignored"; then
+  pass=$((pass + 1))
+  echo "  PASS: StatusContext success does not clear a current-head rate-limit comment"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: StatusContext success incorrectly cleared or masked a rate-limit comment (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
 fi
 
 echo

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -1265,6 +1265,30 @@ else
   echo "$out" | sed 's/^/    /' >&2
 fi
 
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    STUB_COMMENT_CREATED_AT="2998-01-01T00:00:00Z" \
+    STUB_COMMENT_UPDATED_AT="2999-01-01T00:00:00Z" \
+    STUB_STATUS_CREATED_AT="2999-01-01T00:00:01Z" \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "0" ] &&
+   echo "$out" | grep -q '"status": "cleared"' &&
+   echo "$out" | grep -q "references current HEAD headsha but fresh_at=2999-01-01T00:00:00Z is older than status_created=2999-01-01T00:00:01Z"; then
+  pass=$((pass + 1))
+  echo "  PASS: newer StatusContext success clears despite an older current-head rate-limit comment"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: stale current-head rate-limit comment incorrectly suppressed a newer StatusContext success (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
 echo
 total=$((pass + fail))
 if [ "$fail" -gt 0 ]; then

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -1150,6 +1150,10 @@ case "$1" in
 JSON
           ;;
         repos/nathanjohnpayne/mergepath/issues/12345/comments)
+          if [ "${STUB_ISSUE_COMMENTS_EMPTY:-0}" = "1" ]; then
+            printf '[]\n'
+            exit 0
+          fi
           comment_created_at="${STUB_COMMENT_CREATED_AT:-2998-01-01T00:00:00Z}"
           comment_updated_at="${STUB_COMMENT_UPDATED_AT:-2999-01-01T00:00:00Z}"
           comment_body_suffix="${STUB_COMMENT_BODY_SUFFIX- Reviewing files that changed from base and headsha.}"
@@ -1166,7 +1170,24 @@ JSON
 JSON
           ;;
         repos/nathanjohnpayne/mergepath/pulls/12345/comments)
-          printf '[]\n'
+          if [ "${STUB_INLINE_POTENTIAL:-0}" = "1" ]; then
+            inline_created_at="${STUB_INLINE_CREATED_AT:-2999-01-01T00:00:00Z}"
+            cat <<JSON
+[
+  {
+    "id": 7201,
+    "created_at": "$inline_created_at",
+    "updated_at": "$inline_created_at",
+    "commit_id": "headsha",
+    "in_reply_to_id": null,
+    "user": {"login": "coderabbitai[bot]"},
+    "body": "_⚠️ Potential issue_\\n\\nFresh inline finding."
+  }
+]
+JSON
+          else
+            printf '[]\n'
+          fi
           ;;
         repos/nathanjohnpayne/mergepath/pulls/12345/reviews)
           printf '[]\n'
@@ -1286,6 +1307,53 @@ if [ "$rc" = "0" ] &&
 else
   fail=$((fail + 1))
   echo "  FAIL: stale current-head rate-limit comment incorrectly suppressed a newer StatusContext success (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    STUB_ISSUE_COMMENTS_EMPTY=1 \
+    STUB_INLINE_POTENTIAL=1 \
+    STUB_INLINE_CREATED_AT="2998-12-31T23:59:59Z" \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "0" ] &&
+   echo "$out" | grep -q '"status": "cleared"'; then
+  pass=$((pass + 1))
+  echo "  PASS: StatusContext fast path ignores pre-head inline findings remapped to HEAD"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: stale pre-head inline finding incorrectly blocked StatusContext fast path (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    STUB_ISSUE_COMMENTS_EMPTY=1 \
+    STUB_INLINE_POTENTIAL=1 \
+    STUB_INLINE_CREATED_AT="2999-01-01T00:00:01Z" \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "2" ] &&
+   echo "$out" | grep -q '"status": "findings"' &&
+   echo "$out" | grep -q '"potential_issue_count": 1'; then
+  pass=$((pass + 1))
+  echo "  PASS: StatusContext fast path still reports fresh current-head inline findings"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: fresh current-head inline finding was not reported (rc=$rc)" >&2
   echo "$out" | sed 's/^/    /' >&2
 fi
 

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -427,7 +427,9 @@ classify_comment() {
 }
 
 # Scan the PR-level `issues/{pr}/comments` endpoint for the latest
-# CodeRabbit comment on or after HEAD_ANCHOR. Emits JSON to stdout.
+# CodeRabbit comment on or after HEAD_ANCHOR. CodeRabbit edits its
+# summary comment in place, so freshness is max(created_at, updated_at)
+# rather than created_at alone. Emits JSON to stdout.
 # Empty object {} if nothing qualifying yet.
 #
 # Only the issues endpoint is the terminal-state source. CodeRabbit's
@@ -448,9 +450,10 @@ scan_latest_comment() {
   latest=$(echo "$issue_comments" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
     [ .[]
       | select(.user.login == $bot)
-      | select(.created_at >= $after)
+      | . + {fresh_at: ([.created_at, (.updated_at // .created_at)] | max)}
+      | select(.fresh_at >= $after)
     ]
-    | sort_by(.created_at)
+    | sort_by(.fresh_at)
     | last // null
   ')
 
@@ -458,7 +461,7 @@ scan_latest_comment() {
     echo '{}'
     return
   fi
-  echo "$latest" | jq '{id, created_at, endpoint: "issues", body}'
+  echo "$latest" | jq '{id, created_at, updated_at, fresh_at, endpoint: "issues", body}'
 }
 
 # Count unaddressed "Potential issue" / ⚠️ markers in the pulls inline
@@ -579,7 +582,7 @@ iso_on_or_after() {
 
 status_context_fast_path_blocked_by_comment() {
   local status_created_at=$1
-  local latest class comment_id comment_created
+  local latest class comment_id comment_fresh_at comment_body
   latest=$(scan_latest_comment)
   if [ "$(echo "$latest" | jq 'length')" = "0" ]; then
     return 1
@@ -589,12 +592,17 @@ status_context_fast_path_blocked_by_comment() {
   case "$class" in
     rate_limit|in_progress)
       comment_id=$(echo "$latest" | jq -r '.id')
-      comment_created=$(echo "$latest" | jq -r '.created_at')
-      if iso_on_or_after "$comment_created" "$status_created_at"; then
-        log "StatusContext success ignored because latest CodeRabbit comment id=$comment_id class=$class created=$comment_created is not older than status_created=$status_created_at"
+      comment_fresh_at=$(echo "$latest" | jq -r '.fresh_at // .updated_at // .created_at')
+      comment_body=$(echo "$latest" | jq -r '.body')
+      if printf '%s' "$comment_body" | grep -Fq "$HEAD_SHA"; then
+        log "StatusContext success ignored because latest CodeRabbit comment id=$comment_id class=$class explicitly references current HEAD $HEAD_SHA"
         return 0
       fi
-      log "StatusContext success remains authoritative because latest CodeRabbit comment id=$comment_id class=$class created=$comment_created is older than status_created=$status_created_at"
+      if iso_on_or_after "$comment_fresh_at" "$status_created_at"; then
+        log "StatusContext success ignored because latest CodeRabbit comment id=$comment_id class=$class fresh_at=$comment_fresh_at is not older than status_created=$status_created_at"
+        return 0
+      fi
+      log "StatusContext success remains authoritative because latest CodeRabbit comment id=$comment_id class=$class fresh_at=$comment_fresh_at is older than status_created=$status_created_at"
       return 1
       ;;
   esac
@@ -818,9 +826,10 @@ while :; do
   COMMENT_BODY=$(echo "$LATEST" | jq -r '.body')
   COMMENT_ENDPOINT=$(echo "$LATEST" | jq -r '.endpoint')
   COMMENT_CREATED=$(echo "$LATEST" | jq -r '.created_at')
+  COMMENT_FRESH_AT=$(echo "$LATEST" | jq -r '.fresh_at // .updated_at // .created_at')
 
   CLASS=$(classify_comment "$COMMENT_BODY")
-  log "latest CodeRabbit comment id=$COMMENT_ID endpoint=$COMMENT_ENDPOINT class=$CLASS created=$COMMENT_CREATED"
+  log "latest CodeRabbit comment id=$COMMENT_ID endpoint=$COMMENT_ENDPOINT class=$CLASS created=$COMMENT_CREATED fresh_at=$COMMENT_FRESH_AT"
 
   case "$CLASS" in
     rate_limit)

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -595,8 +595,12 @@ status_context_fast_path_blocked_by_comment() {
       comment_fresh_at=$(echo "$latest" | jq -r '.fresh_at // .updated_at // .created_at')
       comment_body=$(echo "$latest" | jq -r '.body')
       if printf '%s' "$comment_body" | grep -Fq "$HEAD_SHA"; then
-        log "StatusContext success ignored because latest CodeRabbit comment id=$comment_id class=$class explicitly references current HEAD $HEAD_SHA"
-        return 0
+        if iso_on_or_after "$comment_fresh_at" "$status_created_at"; then
+          log "StatusContext success ignored because latest CodeRabbit comment id=$comment_id class=$class explicitly references current HEAD $HEAD_SHA and fresh_at=$comment_fresh_at is not older than status_created=$status_created_at"
+          return 0
+        fi
+        log "StatusContext success remains authoritative because latest CodeRabbit comment id=$comment_id class=$class explicitly references current HEAD $HEAD_SHA but fresh_at=$comment_fresh_at is older than status_created=$status_created_at"
+        return 1
       fi
       if iso_on_or_after "$comment_fresh_at" "$status_created_at"; then
         log "StatusContext success ignored because latest CodeRabbit comment id=$comment_id class=$class fresh_at=$comment_fresh_at is not older than status_created=$status_created_at"

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -363,6 +363,7 @@ if [ -n "$LATEST_FORCE_PUSH_TIME" ] && [[ "$LATEST_FORCE_PUSH_TIME" > "$HEAD_ANC
   HEAD_ANCHOR="$LATEST_FORCE_PUSH_TIME"
   ANCHOR_SOURCE="head_ref_force_pushed @ $LATEST_FORCE_PUSH_TIME"
 fi
+HEAD_IDENTITY_ANCHOR="$HEAD_ANCHOR"
 
 # Layer 2 — wallclock freshness floor.
 EPOCH_NOW=$(date +%s)
@@ -516,22 +517,29 @@ count_potential_issues() {
   '
 }
 
-# SHA-scoped variant of count_potential_issues, used by the
-# StatusContext fast-path. Counts CodeRabbit inline findings whose
-# `commit_id` (the SHA GitHub considers the comment currently anchored
-# to, after rebases / new commits) equals the given SHA — independent
-# of HEAD_ANCHOR's wallclock floor.
+# SHA-scoped variant of count_potential_issues, used by the StatusContext
+# fast-path. Counts CodeRabbit inline findings whose `commit_id` (the SHA
+# GitHub considers the comment currently anchored to, after rebases / new
+# commits) equals the given SHA and whose creation time is not older than
+# HEAD_IDENTITY_ANCHOR.
 #
 # Why this is needed (codex CHANGES_REQUESTED on PR #224 round 2 +
 # CodeRabbit ⚠️ Major @ line 581): the freshness-anchored count_potential_
-# issues filters reviews with `submitted_at >= HEAD_ANCHOR`. Once the
-# same unchanged HEAD sits longer than `coderabbit.wallclock_freshness_
-# window_seconds` (default 1800s / 30 min), HEAD_ANCHOR advances past
-# the prior CodeRabbit review's submitted_at, latest_review_id becomes
-# null, and the helper returns 0 — false-clearing the fast-path even
-# while the same SHA still has unresolved Potential issue/⚠️ inline
-# findings. The fast-path is the only caller that has authoritative
-# per-SHA scope (from the StatusContext check) and should leverage it.
+# issues filters reviews with `submitted_at >= HEAD_ANCHOR`. Once the same
+# unchanged HEAD sits longer than `coderabbit.wallclock_freshness_window_
+# seconds` (default 1800s / 30 min), HEAD_ANCHOR advances past the prior
+# CodeRabbit review's submitted_at, latest_review_id becomes null, and the
+# helper returns 0 — false-clearing the fast-path even while the same SHA
+# still has unresolved Potential issue/⚠️ inline findings. The fast-path is
+# the only caller that has authoritative per-SHA scope (from the StatusContext
+# check) and should leverage it.
+#
+# Why still keep a non-wallclock freshness floor: GitHub can preserve or
+# remap inline review comments across a rebase/force-push so an old comment
+# appears to have `commit_id == HEAD_SHA`. HEAD_IDENTITY_ANCHOR is captured
+# before the moving wallclock floor is applied, so stale pre-head inline
+# comments are ignored without losing genuine old-but-still-current findings
+# on an unchanged head.
 #
 # Filter shape: root inline review comments where the bot author posted
 # a comment whose `commit_id == HEAD_SHA` (i.e., GitHub still considers
@@ -547,7 +555,8 @@ count_potential_issues_for_sha() {
   pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
   echo "$pulls_comments" | jq \
     --arg bot "$BOT_LOGIN" \
-    --arg sha "$sha" '
+    --arg sha "$sha" \
+    --arg after "$HEAD_IDENTITY_ANCHOR" '
     [ .[]
       | select(.user.login == $bot)
       | select(.in_reply_to_id != null)
@@ -557,6 +566,7 @@ count_potential_issues_for_sha() {
     | [ .[]
       | select(.user.login == $bot)
       | select(.commit_id == $sha)
+      | select((.created_at // "") >= $after)
       | select(.in_reply_to_id == null)
       | select((.body // "") | test("Potential issue|⚠️"; "i"))
       | select(.id as $id | ($addressed_root_ids | index($id)) == null)

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -248,10 +248,12 @@ fetch_api_array() {
 }
 
 # Fetch the CodeRabbit `StatusContext` check on the current HEAD SHA.
-# Emits one of: success | failure | pending | error | missing
-# on stdout. `missing` covers both the no-statuses-yet case and any
-# transient API hiccup (network, 5xx, etc.) — caller treats it as
-# "fall through to the existing comment-driven path."
+# Emits compact JSON with:
+#   { "state": "success|failure|pending|error|missing", "created_at": "..." }
+#
+# `missing` covers both the no-statuses-yet case and any transient API
+# hiccup (network, 5xx, etc.) — caller treats it as "fall through to
+# the existing comment-driven path."
 #
 # Two defensive guards (CodeRabbit ⚠️ Critical on PR #224 round 1):
 #
@@ -272,8 +274,8 @@ fetch_api_array() {
 # `/commits/{sha}/status` rolls up state but omits per-status creator
 # fields, which would defeat guard 1. Confirmed empirically — see
 # PR #224 round 2.
-check_status_context() {
-  local resp state
+check_status_context_record() {
+  local resp
   # Pagination (CodeRabbit ⚠️ Minor @ line 267 on PR #224 round 2):
   # `/commits/{ref}/statuses` defaults to per_page=30 and returns
   # statuses in reverse chronological order. Without `--paginate`, a
@@ -284,23 +286,26 @@ check_status_context() {
   # the context+creator filter runs.
   resp=$(gh api --paginate "repos/$REPO/commits/$HEAD_SHA/statuses" 2>/dev/null \
     | jq -s 'add // []' 2>/dev/null) || {
-    echo "missing"
+    jq -nc '{state: "missing", created_at: ""}'
     return
   }
-  state=$(echo "$resp" | jq -r --arg bot "$BOT_LOGIN" '
+  echo "$resp" | jq -c --arg bot "$BOT_LOGIN" '
     [ .[]?
       | select(.context == "CodeRabbit")
       | select((.creator.login // "") == $bot)
     ]
     | sort_by(.created_at)
     | last
-    | .state // ""
-  ')
-  if [ -z "$state" ]; then
-    echo "missing"
-    return
-  fi
-  echo "$state"
+    | if . == null then
+        {state: "missing", created_at: ""}
+      else
+        {state: (.state // "missing"), created_at: (.created_at // "")}
+      end
+  '
+}
+
+check_status_context() {
+  check_status_context_record | jq -r '.state'
 }
 
 # --- fetch PR metadata ------------------------------------------------------
@@ -556,7 +561,24 @@ count_potential_issues_for_sha() {
   '
 }
 
+iso_on_or_after() {
+  local lhs=$1 rhs=$2 rc
+  if [ -z "$lhs" ] || [ "$lhs" = "null" ] || [ -z "$rhs" ] || [ "$rhs" = "null" ]; then
+    return 0
+  fi
+
+  jq -en --arg lhs "$lhs" --arg rhs "$rhs" \
+    '($lhs | fromdateiso8601) >= ($rhs | fromdateiso8601)' >/dev/null 2>&1
+  rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 status_context_fast_path_blocked_by_comment() {
+  local status_created_at=$1
   local latest class comment_id comment_created
   latest=$(scan_latest_comment)
   if [ "$(echo "$latest" | jq 'length')" = "0" ]; then
@@ -568,8 +590,12 @@ status_context_fast_path_blocked_by_comment() {
     rate_limit|in_progress)
       comment_id=$(echo "$latest" | jq -r '.id')
       comment_created=$(echo "$latest" | jq -r '.created_at')
-      log "StatusContext success ignored because latest CodeRabbit comment id=$comment_id class=$class created=$comment_created still requires the comment-driven state machine"
-      return 0
+      if iso_on_or_after "$comment_created" "$status_created_at"; then
+        log "StatusContext success ignored because latest CodeRabbit comment id=$comment_id class=$class created=$comment_created is not older than status_created=$status_created_at"
+        return 0
+      fi
+      log "StatusContext success remains authoritative because latest CodeRabbit comment id=$comment_id class=$class created=$comment_created is older than status_created=$status_created_at"
+      return 1
       ;;
   esac
 
@@ -744,10 +770,12 @@ emit_status_context_verdict() {
 # poll burned the full 300s budget on every clean fix-up push because
 # CodeRabbit doesn't re-narrate when there's nothing new to flag.
 if [ "$TRUST_STATUS_CONTEXT" = "true" ]; then
-  INITIAL_CTX=$(check_status_context)
+  INITIAL_CTX_RECORD=$(check_status_context_record)
+  INITIAL_CTX=$(echo "$INITIAL_CTX_RECORD" | jq -r '.state')
+  INITIAL_CTX_CREATED=$(echo "$INITIAL_CTX_RECORD" | jq -r '.created_at')
   log "initial CodeRabbit StatusContext = $INITIAL_CTX on $HEAD_SHA"
   if [ "$INITIAL_CTX" = "success" ]; then
-    if ! status_context_fast_path_blocked_by_comment; then
+    if ! status_context_fast_path_blocked_by_comment "$INITIAL_CTX_CREATED"; then
       log "StatusContext success — entering fast-path verdict (scans inline findings before clearance)"
       emit_status_context_verdict "$INITIAL_CTX"
     fi
@@ -767,9 +795,11 @@ while :; do
   # API call than `scan_latest_comment` so it's worth doing first each
   # iteration; falls through to the comment scan if not success/failure.
   if [ "$TRUST_STATUS_CONTEXT" = "true" ]; then
-    LOOP_CTX=$(check_status_context)
+    LOOP_CTX_RECORD=$(check_status_context_record)
+    LOOP_CTX=$(echo "$LOOP_CTX_RECORD" | jq -r '.state')
+    LOOP_CTX_CREATED=$(echo "$LOOP_CTX_RECORD" | jq -r '.created_at')
     if [ "$LOOP_CTX" = "success" ]; then
-      if ! status_context_fast_path_blocked_by_comment; then
+      if ! status_context_fast_path_blocked_by_comment "$LOOP_CTX_CREATED"; then
         log "CodeRabbit StatusContext flipped to success mid-loop on $HEAD_SHA — entering fast-path verdict"
         emit_status_context_verdict "$LOOP_CTX"
       fi

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -556,6 +556,26 @@ count_potential_issues_for_sha() {
   '
 }
 
+status_context_fast_path_blocked_by_comment() {
+  local latest class comment_id comment_created
+  latest=$(scan_latest_comment)
+  if [ "$(echo "$latest" | jq 'length')" = "0" ]; then
+    return 1
+  fi
+
+  class=$(classify_comment "$(echo "$latest" | jq -r '.body')")
+  case "$class" in
+    rate_limit|in_progress)
+      comment_id=$(echo "$latest" | jq -r '.id')
+      comment_created=$(echo "$latest" | jq -r '.created_at')
+      log "StatusContext success ignored because latest CodeRabbit comment id=$comment_id class=$class created=$comment_created still requires the comment-driven state machine"
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
 post_retry_trigger() {
   # Strip the `[bot]` suffix that GitHub REST uses for App logins —
   # @-mentions address the user-facing handle (`@coderabbitai`), not
@@ -727,8 +747,10 @@ if [ "$TRUST_STATUS_CONTEXT" = "true" ]; then
   INITIAL_CTX=$(check_status_context)
   log "initial CodeRabbit StatusContext = $INITIAL_CTX on $HEAD_SHA"
   if [ "$INITIAL_CTX" = "success" ]; then
-    log "StatusContext success — entering fast-path verdict (scans inline findings before clearance)"
-    emit_status_context_verdict "$INITIAL_CTX"
+    if ! status_context_fast_path_blocked_by_comment; then
+      log "StatusContext success — entering fast-path verdict (scans inline findings before clearance)"
+      emit_status_context_verdict "$INITIAL_CTX"
+    fi
   fi
 fi
 
@@ -747,8 +769,10 @@ while :; do
   if [ "$TRUST_STATUS_CONTEXT" = "true" ]; then
     LOOP_CTX=$(check_status_context)
     if [ "$LOOP_CTX" = "success" ]; then
-      log "CodeRabbit StatusContext flipped to success mid-loop on $HEAD_SHA — entering fast-path verdict"
-      emit_status_context_verdict "$LOOP_CTX"
+      if ! status_context_fast_path_blocked_by_comment; then
+        log "CodeRabbit StatusContext flipped to success mid-loop on $HEAD_SHA — entering fast-path verdict"
+        emit_status_context_verdict "$LOOP_CTX"
+      fi
     fi
   fi
 
@@ -793,17 +817,17 @@ while :; do
       SLEEP_FOR=$((WINDOW_SECONDS + RATE_LIMIT_BUFFER_SECONDS))
       # Clamp against remaining budget — if the published rate-limit
       # window exceeds max_wait_seconds anyway, there's no point
-      # burning through the entire sleep only to time out on the next
-      # iteration. Time out immediately instead so the caller sees a
-      # prompt, well-formed timeout rather than a stalled process.
-      # See #140 round-2 Codex finding (P2, line 392).
+      # burning through the entire sleep. Surface it as the same hard
+      # rate-limit stalled state callers already treat as non-advisory
+      # instead of a generic timeout that auto-merge may skip past.
+      # See #140 round-2 Codex finding (P2, line 392), then #386.
       NOW_EPOCH=$(date +%s)
       ELAPSED=$((NOW_EPOCH - START_EPOCH))
       REMAINING=$((MAX_WAIT_SECONDS - ELAPSED))
       if [ "$SLEEP_FOR" -ge "$REMAINING" ]; then
-        log "rate-limit window (${SLEEP_FOR}s) exceeds remaining budget (${REMAINING}s) — timing out"
+        log "rate-limit window (${SLEEP_FOR}s) exceeds remaining budget (${REMAINING}s) — stalling"
         RATE_LIMIT_REVIEW=$(echo "$LATEST" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
-        emit_json_and_exit "timeout" 4 "$RATE_LIMIT_REVIEW" 0
+        emit_json_and_exit "rate_limit_stalled" 5 "$RATE_LIMIT_REVIEW" 0
       fi
       log "rate-limited; sleeping ${SLEEP_FOR}s (window=${WINDOW_SECONDS}s + ${RATE_LIMIT_BUFFER_SECONDS}s buffer)"
       sleep "$SLEEP_FOR"

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -612,11 +612,7 @@ status_context_fast_path_blocked_by_comment() {
         log "StatusContext success remains authoritative because latest CodeRabbit comment id=$comment_id class=$class explicitly references current HEAD $HEAD_SHA but fresh_at=$comment_fresh_at is older than status_created=$status_created_at"
         return 1
       fi
-      if iso_on_or_after "$comment_fresh_at" "$status_created_at"; then
-        log "StatusContext success ignored because latest CodeRabbit comment id=$comment_id class=$class fresh_at=$comment_fresh_at is not older than status_created=$status_created_at"
-        return 0
-      fi
-      log "StatusContext success remains authoritative because latest CodeRabbit comment id=$comment_id class=$class fresh_at=$comment_fresh_at is older than status_created=$status_created_at"
+      log "StatusContext success remains authoritative because latest CodeRabbit comment id=$comment_id class=$class does not reference current HEAD $HEAD_SHA"
       return 1
       ;;
   esac


### PR DESCRIPTION
## Summary
- fixes `scripts/coderabbit-wait.sh` so a current-head CodeRabbit rate-limit/in-progress PR-level comment suppresses the StatusContext success fast path
- reports a published rate-limit window that exceeds the remaining wait budget as `rate_limit_stalled` / exit 5 instead of an advisory timeout or clearance
- adds Bug 6 regression coverage with a fake `gh` fixture matching the #385 failure mode

Fixes #386.

## Validation
- bash -n scripts/coderabbit-wait.sh scripts/ci/check_canonical_bugs_263caf3
- scripts/ci/check_canonical_bugs_263caf3
- scripts/ci/check_coderabbit_config
- scripts/ci/check_codex_scripts
- scripts/ci/check_ci_scripts_wired
- git diff --check

## Self-Review
- The fast path still clears clean status-context-only runs when there is no current-head rate-limit or in-progress PR-level CodeRabbit comment.
- Existing inline `Potential issue` scanning remains unchanged.
- The new hard-stop only applies when CodeRabbit itself says the current review is rate-limited and cannot complete inside the wait budget.

Authoring-Agent: codex