### PR TITLE
Prefer Firebase SA key during deploy preflight

### DIFF
--- a/.ai_context.md
+++ b/.ai_context.md
@@ -44,6 +44,7 @@ chmod +x ~/.local/bin/gcloud ~/.local/bin/op-firebase-deploy ~/.local/bin/op-fir
 
 - Each project has a dedicated GCP service account: `firebase-deployer@{project-id}.iam.gserviceaccount.com`
 - The default source credential is the per-project Firebase-vault SA key in 1Password — see `DEPLOYMENT.md` § [Deploy credential precedence (canonical)](DEPLOYMENT.md#deploy-credential-precedence-canonical) for the full 5-step resolution order and the impersonation-vs-direct trade-off
+- Deploy preflight (`scripts/op-preflight.sh --mode deploy|all`) follows that same deploy order in Firebase repos: it caches the project SA key identified by `.firebaserc` before trying the shared human ADC, avoiding the recurring RAPT/reauth probe when the durable key is provisioned
 - The 1Password-first deploy-auth model is a deliberate default for repos created from this template and should not be reversed without explicit human approval
 - The local `gcloud` wrapper resolves source credentials through a narrower 3-step chain (`GOOGLE_APPLICATION_CREDENTIALS` → shared 1Password ADC → local ADC file) so normal `gcloud` commands work without routine browser login prompts. The wrapper does NOT consult per-project Firebase-vault SA keys; that step is specific to `op-firebase-deploy`
 - No deploy service-account key is committed to a repo (the SA key lives in 1Password and is materialized only as a tempfile during a single deploy invocation)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -181,9 +181,9 @@ from generated local files.
 
 For `scripts/deploy.sh` and the underlying `op-firebase-deploy`, the source-credential resolution order is:
 
-1. **Genuine human-supplied override** — `GOOGLE_APPLICATION_CREDENTIALS` set by the human OUTSIDE preflight (no `OP_PREFLIGHT_ADC_TMPFILE` marker, or its value differs from the marker). Wins. Used for one-off debugging, alternate-account deploys, or CI runners that materialize their own credential.
-2. **Project Firebase-vault SA key** — `op://Firebase/{project-id} — Firebase Deployer SA Key`, when present. **The standard day-to-day credential, both interactive and CI.** Stable (no `firebase login --reauth` churn from RAPT/refresh-token expiry on the shared ADC; see [#137](https://github.com/nathanjohnpayne/mergepath/issues/137)), parity between local and CI flows, no dependence on Firebase CLI local-login state.
-3. **Preflight-injected `GOOGLE_APPLICATION_CREDENTIALS`** — when no project SA key is provisioned, `scripts/op-preflight.sh --mode deploy` (or `--mode all`) materializes the shared 1Password ADC into a tempfile and exports its path. Subject to the same RAPT-expiry surface as the shared ADC.
+1. **Genuine human-supplied override** — `GOOGLE_APPLICATION_CREDENTIALS` set by the human OUTSIDE preflight (no `OP_PREFLIGHT_FIREBASE_SA_TMPFILE` or `OP_PREFLIGHT_ADC_TMPFILE` marker matching the same path). Wins. Used for one-off debugging, alternate-account deploys, or CI runners that materialize their own credential.
+2. **Project Firebase-vault SA key** — `op://Firebase/{project-id} — Firebase Deployer SA Key`, when present. **The standard day-to-day credential, both interactive and CI.** Stable (no `firebase login --reauth` churn from RAPT/refresh-token expiry on the shared ADC; see [#137](https://github.com/nathanjohnpayne/mergepath/issues/137)), parity between local and CI flows, no dependence on Firebase CLI local-login state. In a repo with a `.firebaserc` default project, `scripts/op-preflight.sh --mode deploy` (or `--mode all`) now caches this key first and exports `OP_PREFLIGHT_FIREBASE_SA_TMPFILE` / `OP_PREFLIGHT_FIREBASE_PROJECT`, so the deploy wrapper does not spend time probing the stale shared ADC before using the durable project key.
+3. **Preflight-injected shared ADC** — when no project SA key is provisioned or detectable, `scripts/op-preflight.sh --mode deploy` (or `--mode all`) materializes the shared 1Password ADC into a tempfile and exports its path as `OP_PREFLIGHT_ADC_TMPFILE`. Subject to the same RAPT-expiry surface as the shared ADC.
 4. **Shared 1Password ADC read directly** — `op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential`, read by the script when neither preflight nor an SA key are available. Same RAPT-expiry surface.
 5. **Local ADC file** — `~/.config/gcloud/application_default_credentials.json` from a prior `gcloud auth application-default login`. Last resort.
 
@@ -582,6 +582,10 @@ DEPLOY_ALLOW_DIRTY=1 scripts/deploy.sh
 When the override is used, the script logs the dirty paths to stderr under a `⚠️  DEPLOY_ALLOW_DIRTY=1` banner so the deviation is visible in the deploy transcript. Never use `--force` or `DEPLOY_ALLOW_DIRTY=1` during routine deploys.
 
 Cloudflare cache purge runs when `CF_API_TOKEN` and `CF_ZONE_ID` are set in the environment. `CF_API_TOKEN` is sourced automatically by `scripts/op-preflight.sh --mode deploy` (or `--mode all`) from the shared "All Domains — Cache Purge API token" 1Password item — no `op read` needed in your shell. `CF_ZONE_ID` is per-repo; each downstream consumer sets its own zone ID (e.g., in the repo's bootstrap or as a hardcoded value in its `scripts/deploy.sh` wrapper) since one CF token covers all domains but each domain has its own zone. Without both variables the purge step no-ops with a clear log line.
+
+Deploy preflight in a Firebase repo reads credentials in the same stable order as `op-firebase-deploy`: first the project Firebase-vault SA key identified by `.firebaserc`, then the shared GCP ADC only if the project key is absent or invalid. This keeps attended deploy sessions from repeatedly hitting the human authorized-user ADC path that expires under Google Workspace reauth/RAPT policy.
+
+Because deploy preflight exports the selected credential through `GOOGLE_APPLICATION_CREDENTIALS`, ordinary `gcloud` commands in that same shell may also see the project SA key. For broad, non-deploy `gcloud` work, use review preflight only or unset `GOOGLE_APPLICATION_CREDENTIALS` and let the `scripts/gcloud/gcloud` wrapper resolve its normal ADC chain.
 
 **Do not run `op-firebase-deploy` or `firebase deploy` directly for routine deploys.** They skip the branch + freshness guards and the cache purge. Direct invocation is reserved for debugging or one-off flows where the deploy surface is known.
 
@@ -988,12 +992,15 @@ Google, `op-firebase-deploy` will refuse the credential with:
 Error: GOOGLE_APPLICATION_CREDENTIALS points to an unusable credential file: /var/folders/.../op-preflight-adc-*
 ```
 
-Starting with the #137 fix, `op-preflight.sh` now validates the
-materialized ADC against the OAuth2 `/token` endpoint before exporting
-`GOOGLE_APPLICATION_CREDENTIALS`. When the credential is stale,
-preflight prints an actionable warning and skips the export — downstream
-callers (`op-firebase-deploy`, `gcloud` wrappers) then fall back to the
-local firebase-login / ADC path that the reauth has just refreshed.
+Starting with the #137 fix, `op-preflight.sh` validates the materialized
+ADC against the OAuth2 `/token` endpoint before exporting
+`GOOGLE_APPLICATION_CREDENTIALS`. In Firebase repos, deploy preflight
+tries the project Firebase-vault SA key before this shared ADC path, so
+a provisioned project key avoids the RAPT-prone credential entirely.
+When the shared ADC is still needed and is stale, preflight prints an
+actionable warning and skips the export — downstream callers
+(`op-firebase-deploy`, `gcloud` wrappers) then fall back to the next
+available credential.
 
 **Fix permanently** by refreshing the 1Password item:
 
@@ -1008,11 +1015,22 @@ op document edit 'GCP ADC' --vault=Private \
 After that, the next preflight run will materialize a usable credential
 and the `GOOGLE_APPLICATION_CREDENTIALS` export resumes normally.
 
+For routine Firebase deploys, the preferred permanent fix is to
+provision or rotate the project Firebase-vault SA key instead of
+depending on the shared human ADC. The shared ADC remains a fallback for
+projects that have not provisioned the key and for non-Firebase `gcloud`
+operations.
+
 ## Changelog
 
 **2026-05-15: Deploy credential precedence updated.** Project Firebase-vault SA keys
 are now the default for `op-firebase-deploy`. See #154 / #211 for implementation
 history; live consumer verification on matchline pending (#211 close-out).
+
+**2026-05-22: Deploy preflight caches the project SA key first.** In Firebase repos,
+`op-preflight.sh --mode deploy|all` now materializes the project Firebase-vault SA
+key before trying the shared GCP ADC. This removes the routine stale-ADC/RAPT probe
+from attended deploy sessions when the durable project key exists.
 
 **2026-05-15: `op-firebase-setup --provision-sa-key` flag added.** The setup script
 now optionally mints the deployer SA key and uploads it to

--- a/docs/agents/deployment-process.md
+++ b/docs/agents/deployment-process.md
@@ -13,10 +13,18 @@ If the project uses Firebase or Google Cloud, prefer the canonical
   scripts, or secret stores unless a project explicitly requires them. The Firebase-vault SA key in 1Password is the supported on-account form; on-disk deploy keys are not.
 - If credential preflight was run at session start with deploy creds
   loaded (`scripts/op-preflight.sh --mode deploy` or `--mode all`),
-  deploy credentials are already cached. No additional biometric
-  prompt is needed for deployment. The default `--mode review` does
-  NOT load deploy credentials (#282); pass `--mode deploy` explicitly
-  for a deploy session.
+  deploy credentials are already cached. In a Firebase repo with a
+  `.firebaserc` default project, deploy preflight caches the project
+  Firebase-vault SA key first and only falls back to the shared GCP ADC
+  when that key is absent. No additional biometric prompt is needed for
+  deployment. The default `--mode review` does NOT load deploy
+  credentials (#282); pass `--mode deploy` explicitly for a deploy
+  session.
+- Deploy preflight exports the selected deploy credential through
+  `GOOGLE_APPLICATION_CREDENTIALS`. If the next operation is broad
+  non-deploy `gcloud` work rather than Firebase deploy, use review
+  preflight only or unset `GOOGLE_APPLICATION_CREDENTIALS` so the
+  `scripts/gcloud/gcloud` wrapper can resolve its normal ADC chain.
 - If an `op` command fails with a sign-in or biometric error during deploy, follow the pause-and-prompt procedure in [operating-rules.md](operating-rules.md#1password-cli-authentication-failures). Do not retry or work around the failure without the human present.
 
 ## Runtime 1Password secrets for agents
@@ -68,7 +76,8 @@ If the source is unexpected, the diagnosis order is usually:
 
 1. **Source = `local-adc`** when `project-sa-key` was expected → the 1Password item `op://Firebase/{project-id} — Firebase Deployer SA Key` likely doesn't exist or `op` CLI auth is stale. Verify with `op item get "{project-id} — Firebase Deployer SA Key" --vault Firebase --reveal`. If the item is missing, follow `DEPLOYMENT.md` § Provisioning the Firebase-vault SA key. If `op item get` errors with a sign-in failure, run `op signin` and retry.
 2. **Source = `human-override`** unexpectedly → a `GOOGLE_APPLICATION_CREDENTIALS` env var is set in the shell that wasn't materialized by preflight. Check with `env | grep GOOGLE_APPLICATION_CREDENTIALS` and unset it (`unset GOOGLE_APPLICATION_CREDENTIALS`) for routine deploys.
-3. **Source = `preflight-adc`** when `project-sa-key` was expected → same as case 1 (no SA key item), but preflight has run and provided the shared ADC fallback. The deploy will work but is subject to the shared ADC's RAPT-expiry surface. Provision the per-project SA key for stable deploys.
-4. **Deploy succeeds but logs an `ADC quota project` warning** → expected when the underlying credential was originally stamped for another project. `op-firebase-deploy` overrides `quota_project_id` to the target project for actual deploy commands, so the warning is cosmetic.
+3. **Source = `preflight-cached project Firebase-vault SA key`** → expected when `op-preflight.sh --mode deploy|all` ran in this Firebase repo before the deploy. The cached key is still the project Firebase-vault SA key; preflight just materialized it ahead of time so `op-firebase-deploy` does not need another 1Password read.
+4. **Source = `preflight-adc`** when `project-sa-key` was expected → same as case 1 (no SA key item or preflight could not detect the Firebase project), but preflight has run and provided the shared ADC fallback. The deploy will work only while that ADC is fresh and is subject to the shared ADC's RAPT-expiry surface. Provision the per-project SA key for stable deploys.
+5. **Deploy succeeds but logs an `ADC quota project` warning** → expected when the underlying credential was originally stamped for another project. `op-firebase-deploy` overrides `quota_project_id` to the target project for actual deploy commands, so the warning is cosmetic.
 
 If the rotation procedure is needed, follow `DEPLOYMENT.md` § [Rotating a Firebase deploy SA key](../../DEPLOYMENT.md#rotating-a-firebase-deploy-sa-key). Rotation is human-only and not automated by any agent or workflow.

--- a/scripts/ci/check_op_firebase_deploy_integration
+++ b/scripts/ci/check_op_firebase_deploy_integration
@@ -32,12 +32,18 @@
 #        log: "source credential: explicit GOOGLE_APPLICATION_CREDENTIALS ..."
 #   1. project SA key present → rank 2 wins
 #        log: "source credential: project Firebase-vault SA key ..."
-#   2. project SA absent + preflight ADC present → rank 3 wins
+#   2. preflight-cached project SA key present → rank 2 wins without
+#      re-reading 1Password
+#        log: "source credential: preflight-cached project Firebase-vault SA key ..."
+#   3. preflight-cached project SA key for a different project is
+#      ignored, then current project SA key wins
+#        log: "source credential: project Firebase-vault SA key ..."
+#   4. project SA absent + preflight ADC present → rank 3 wins
 #        log: "source credential: preflight-injected ADC ..."
-#   3. project SA absent + preflight absent + shared op ADC reachable
+#   5. project SA absent + preflight absent + shared op ADC reachable
 #      → rank 4 wins
 #        log: "source credential: shared 1Password ADC ..."
-#   4. all op sources absent + local ADC file present → rank 5 wins
+#   6. all op sources absent + local ADC file present → rank 5 wins
 #        log: "source credential: local ADC file ..."
 #
 # Not covered (deliberate): the usability-fallback walk (rank-N
@@ -463,7 +469,102 @@ run_case \
   provision_project_sa
 
 # ----------------------------------------------------------------------
-# Case 2 — project SA absent, preflight ADC present (rank 3 wins)
+# Case 2 — preflight-cached project SA key present (rank 2 wins
+#          without re-reading 1Password)
+# ----------------------------------------------------------------------
+provision_preflight_cached_project_sa() {
+  local case_dir="$1" bin_dir="$2" tmp_dir="$3" home_dir="$4" project="$5"
+
+  local preflight_sa_path="$tmp_dir/preflight-firebase-sa.json"
+  write_fake_sa_key "$preflight_sa_path" \
+    "firebase-deployer@${project}.iam.gserviceaccount.com"
+
+  # Any op call means the cached preflight SA marker was not honored.
+  cat >"$bin_dir/op" <<'STUB'
+#!/usr/bin/env bash
+echo "FATAL: op should not be called when preflight-cached Firebase SA is valid: $*" >&2
+exit 99
+STUB
+  chmod +x "$bin_dir/op"
+
+  cat >"$case_dir/case-env.sh" <<ENV
+export GOOGLE_APPLICATION_CREDENTIALS="$preflight_sa_path"
+export OP_PREFLIGHT_FIREBASE_SA_TMPFILE="$preflight_sa_path"
+export OP_PREFLIGHT_FIREBASE_PROJECT="$project"
+unset OP_PREFLIGHT_ADC_TMPFILE
+ENV
+}
+
+run_case_with_env \
+  "case2_preflight_cached_project_sa" \
+  "source credential: preflight-cached project Firebase-vault SA key" \
+  "merge-path-test" \
+  provision_preflight_cached_project_sa
+
+# ----------------------------------------------------------------------
+# Case 3 — preflight-cached project SA key for a different project is
+#          ignored, then current project SA key wins
+# ----------------------------------------------------------------------
+provision_mismatched_preflight_cached_project_sa() {
+  local case_dir="$1" bin_dir="$2" tmp_dir="$3" home_dir="$4" project="$5"
+
+  local preflight_sa_path="$tmp_dir/preflight-other-project-sa.json"
+  write_fake_sa_key "$preflight_sa_path" \
+    "firebase-deployer@other-project.iam.gserviceaccount.com"
+
+  local sa_payload_dir="$case_dir/op-payloads"
+  mkdir -p "$sa_payload_dir"
+  write_fake_sa_key "$sa_payload_dir/project-sa.json" \
+    "firebase-deployer@${project}.iam.gserviceaccount.com"
+
+  cat >"$bin_dir/op" <<STUB
+#!/usr/bin/env bash
+case "\$1" in
+  document)
+    shift
+    if [ "\$1" = "get" ]; then
+      shift
+      out_path=""
+      while [ \$# -gt 0 ]; do
+        if [ "\$1" = "--out-file" ]; then
+          shift; out_path="\$1"
+        fi
+        shift || true
+      done
+      if [ -n "\$out_path" ]; then
+        cp "$sa_payload_dir/project-sa.json" "\$out_path"
+        exit 0
+      fi
+      exit 1
+    fi
+    exit 1
+    ;;
+  read)
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$bin_dir/op"
+
+  cat >"$case_dir/case-env.sh" <<ENV
+export GOOGLE_APPLICATION_CREDENTIALS="$preflight_sa_path"
+export OP_PREFLIGHT_FIREBASE_SA_TMPFILE="$preflight_sa_path"
+export OP_PREFLIGHT_FIREBASE_PROJECT="other-project"
+unset OP_PREFLIGHT_ADC_TMPFILE
+ENV
+}
+
+run_case_with_env \
+  "case3_mismatched_preflight_cached_project_sa" \
+  "source credential: project Firebase-vault SA key" \
+  "merge-path-test" \
+  provision_mismatched_preflight_cached_project_sa
+
+# ----------------------------------------------------------------------
+# Case 4 — project SA absent, preflight ADC present (rank 3 wins)
 # ----------------------------------------------------------------------
 provision_preflight_adc() {
   local case_dir="$1" bin_dir="$2" tmp_dir="$3" home_dir="$4" project="$5"
@@ -498,13 +599,13 @@ ENV
 }
 
 run_case_with_env \
-  "case2_preflight_adc_present" \
+  "case4_preflight_adc_present" \
   "source credential: preflight-injected ADC" \
   "merge-path-test" \
   provision_preflight_adc
 
 # ----------------------------------------------------------------------
-# Case 3 — project SA absent, preflight absent, shared 1Password ADC
+# Case 5 — project SA absent, preflight absent, shared 1Password ADC
 # reachable (rank 4 wins)
 # ----------------------------------------------------------------------
 provision_shared_op_adc() {
@@ -539,13 +640,13 @@ STUB
 }
 
 run_case \
-  "case3_shared_op_adc_present" \
+  "case5_shared_op_adc_present" \
   "source credential: shared 1Password ADC" \
   "merge-path-test" \
   provision_shared_op_adc
 
 # ----------------------------------------------------------------------
-# Case 4 — all op sources absent, local ADC file present (rank 5 wins)
+# Case 6 — all op sources absent, local ADC file present (rank 5 wins)
 # ----------------------------------------------------------------------
 provision_local_adc() {
   local case_dir="$1" bin_dir="$2" tmp_dir="$3" home_dir="$4" project="$5"
@@ -564,7 +665,7 @@ STUB
 }
 
 run_case \
-  "case4_local_adc_present" \
+  "case6_local_adc_present" \
   "source credential: local ADC file" \
   "merge-path-test" \
   provision_local_adc

--- a/scripts/firebase/op-firebase-deploy
+++ b/scripts/firebase/op-firebase-deploy
@@ -133,9 +133,10 @@ resolve_source_cred_file() {
   # Precedence (#154 — codified policy decision):
   #
   #   1. Genuinely user-supplied GOOGLE_APPLICATION_CREDENTIALS
-  #   2. Project-specific SA key from 1Password Firebase vault
+  #   2. Project-specific SA key from 1Password Firebase vault,
+  #      including op-preflight.sh's cached Firebase SA tempfile
   #   3. Preflight-injected GOOGLE_APPLICATION_CREDENTIALS
-  #      (op-preflight.sh's ADC tempfile)
+  #      (op-preflight.sh's shared ADC tempfile)
   #   4. Shared ADC from 1Password Private vault
   #   5. Local ADC file on disk
   #
@@ -144,29 +145,39 @@ resolve_source_cred_file() {
   # set GOOGLE_APPLICATION_CREDENTIALS in the shell themselves
   # (debugging, one-off flow, alternate project), they meant it.
   #
-  # Step 3 is a NEW behavior change (was step 1 in the prior
-  # implementation): when GOOGLE_APPLICATION_CREDENTIALS came from
-  # op-preflight.sh's --mode deploy, the ADC is the shared 1Password
-  # ADC item (which suffers from refresh-token RAPT expiry — see
-  # mergepath#137). Falling through to the project SA key first means
-  # routine deploys use the more-stable credential without the
-  # daily-reauth churn.
+  # Step 3 is a behavior change from the original implementation:
+  # when GOOGLE_APPLICATION_CREDENTIALS came from op-preflight.sh's
+  # --mode deploy, the ADC is the shared 1Password ADC item (which
+  # suffers from refresh-token RAPT expiry — see mergepath#137).
+  # Falling through to the project SA key first means routine deploys
+  # use the more-stable credential without the daily-reauth churn.
   #
-  # The marker that distinguishes (1) from (3): the OP_PREFLIGHT_ADC_TMPFILE
-  # env var. Preflight sets it to the same path as
-  # GOOGLE_APPLICATION_CREDENTIALS when it injects an ADC; if the two
-  # match, the GOOGLE_APPLICATION_CREDENTIALS is preflight-injected,
-  # not user-set.
+  # The markers that distinguish (1) from preflight-managed files:
+  # OP_PREFLIGHT_FIREBASE_SA_TMPFILE and OP_PREFLIGHT_ADC_TMPFILE.
+  # Preflight sets one of those to the same path as
+  # GOOGLE_APPLICATION_CREDENTIALS when it injects deploy credentials;
+  # if they match, the GOOGLE_APPLICATION_CREDENTIALS is preflight-
+  # managed, not user-set.
   local explicit_file="${GOOGLE_APPLICATION_CREDENTIALS:-}"
   local preflight_tmpfile="${OP_PREFLIGHT_ADC_TMPFILE:-}"
+  local preflight_firebase_sa_tmpfile="${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}"
+  local preflight_firebase_project="${OP_PREFLIGHT_FIREBASE_PROJECT:-}"
   local resolved=""
   local is_preflight_injected=0
+  local is_preflight_firebase_sa=0
   if [[ -n "$explicit_file" && -n "$preflight_tmpfile" && "$explicit_file" == "$preflight_tmpfile" ]]; then
     is_preflight_injected=1
   fi
+  if [[ -n "$explicit_file" && -n "$preflight_firebase_sa_tmpfile" && "$explicit_file" == "$preflight_firebase_sa_tmpfile" ]]; then
+    if [[ "$preflight_firebase_project" == "$PROJECT" ]]; then
+      is_preflight_firebase_sa=1
+    else
+      echo "[op-firebase-deploy] ignoring preflight-cached Firebase SA for project ${preflight_firebase_project:-unknown}; target project is $PROJECT" >&2
+    fi
+  fi
 
   # 1. Genuinely user-supplied GOOGLE_APPLICATION_CREDENTIALS
-  if [[ -n "$explicit_file" && "$is_preflight_injected" -eq 0 ]]; then
+  if [[ -n "$explicit_file" && "$is_preflight_injected" -eq 0 && "$is_preflight_firebase_sa" -eq 0 && "$explicit_file" != "$preflight_firebase_sa_tmpfile" ]]; then
     if [[ ! -f "$explicit_file" ]]; then
       # User explicitly set GOOGLE_APPLICATION_CREDENTIALS to a path
       # that doesn't exist. Fail fast — silently falling through to
@@ -182,6 +193,12 @@ resolve_source_cred_file() {
   fi
 
   # 2. Project-specific SA key from 1Password Firebase vault
+  if [[ "$is_preflight_firebase_sa" -eq 1 && -f "$explicit_file" ]]; then
+    SOURCE_CRED_FILE="$explicit_file"
+    SOURCE_CRED_DESCRIPTION="preflight-cached project Firebase-vault SA key ($PROJECT — Firebase Deployer SA Key)"
+    return 0
+  fi
+
   resolved="$(materialize_firebase_vault_sa_key "$PROJECT" || true)"
   if [[ -n "$resolved" ]]; then
     SOURCE_CRED_FILE="$resolved"
@@ -289,12 +306,16 @@ if ! source_cred_is_usable "$SOURCE_CRED_FILE"; then
   # one (fall through to lower ranks). Codex P2 on PR #181 caught that
   # the prior unconditional equality check exited 1 even when the env
   # var was preflight's, masking ranks 4-5 fallbacks (shared op ADC,
-  # local ADC) that were specifically designated for this case.
+  # local ADC) that were specifically designated for this case. The
+  # same rule now applies to preflight's cached Firebase SA key: it is
+  # managed by preflight, not a human override.
   if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" && "$SOURCE_CRED_FILE" == "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
     if [[ -n "${OP_PREFLIGHT_ADC_TMPFILE:-}" && "$SOURCE_CRED_FILE" == "${OP_PREFLIGHT_ADC_TMPFILE}" ]]; then
       # Preflight-injected and unusable — log and continue down the
       # fallback chain. Don't treat as explicit override.
       echo "[op-firebase-deploy] preflight-injected ADC ($SOURCE_CRED_FILE) is unusable; falling through to shared op ADC + local ADC" >&2
+    elif [[ -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" && "$SOURCE_CRED_FILE" == "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE}" ]]; then
+      echo "[op-firebase-deploy] preflight-cached Firebase SA key ($SOURCE_CRED_FILE) is unusable; re-reading project SA key before lower fallbacks" >&2
     else
       echo "Error: GOOGLE_APPLICATION_CREDENTIALS points to an unusable credential file: $SOURCE_CRED_FILE" >&2
       exit 1
@@ -305,13 +326,28 @@ if ! source_cred_is_usable "$SOURCE_CRED_FILE"; then
   SOURCE_CRED_FILE=""
   SOURCE_CRED_TMPFILE=""
 
-  # Rank 4 fallback: shared op ADC (in case the preflight tempfile is
-  # stale but a fresh op read of the same item works).
-  resolved="$(materialize_op_source_cred "$DEFAULT_ADC_OP_URI" || true)"
-  if [[ -n "$resolved" ]]; then
+  # Rank 2 retry: if the preflight-cached Firebase SA tempfile was
+  # stale/corrupt, re-read the project item before dropping to the
+  # RAPT-prone shared ADC fallbacks.
+  resolved="$(materialize_firebase_vault_sa_key "$PROJECT" || true)"
+  if [[ -n "$resolved" ]] && source_cred_is_usable "$resolved"; then
     SOURCE_CRED_FILE="$resolved"
     SOURCE_CRED_TMPFILE="$resolved"
-    SOURCE_CRED_DESCRIPTION="shared 1Password ADC ($DEFAULT_ADC_OP_URI; rank 4 fallback after rank-3 unusable)"
+    SOURCE_CRED_DESCRIPTION="project Firebase-vault SA key ($PROJECT — Firebase Deployer SA Key; fallback after cached SA unusable)"
+  fi
+
+  # Rank 4 fallback: shared op ADC (in case the preflight tempfile is
+  # stale but a fresh op read of the same item works).
+  if ! source_cred_is_usable "$SOURCE_CRED_FILE"; then
+    cleanup_source_cred
+    SOURCE_CRED_FILE=""
+    SOURCE_CRED_TMPFILE=""
+    resolved="$(materialize_op_source_cred "$DEFAULT_ADC_OP_URI" || true)"
+    if [[ -n "$resolved" ]]; then
+      SOURCE_CRED_FILE="$resolved"
+      SOURCE_CRED_TMPFILE="$resolved"
+      SOURCE_CRED_DESCRIPTION="shared 1Password ADC ($DEFAULT_ADC_OP_URI; rank 4 fallback after preflight credential unusable)"
+    fi
   fi
 
   # Rank 5 fallback: local ADC file on disk.

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -289,6 +289,31 @@ if not isinstance(project, str) or not project:
 print(project)
 PY
 }
+
+json_string_field_no_python() {
+  local file="${1:-}" field="${2:-}"
+  [[ -n "$file" && -f "$file" && -n "$field" ]] || return 1
+  tr '\n' ' ' < "$file" \
+    | sed -nE "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"([^\"]+)\".*/\\1/p" \
+    | head -n 1
+}
+
+detect_firebase_project_no_python() {
+  if [[ -n "${OP_PREFLIGHT_FIREBASE_PROJECT_ID:-}" ]]; then
+    printf '%s\n' "$OP_PREFLIGHT_FIREBASE_PROJECT_ID"
+    return 0
+  fi
+  json_string_field_no_python ".firebaserc" "default"
+}
+
+firebase_sa_matches_project_no_python() {
+  local file="${1:-}" project="${2:-}" client_email expected
+  [[ -n "$file" && -f "$file" && -s "$file" && -n "$project" ]] || return 1
+  client_email="$(json_string_field_no_python "$file" "client_email" || true)"
+  expected="${SA_NAME}@${project}.iam.gserviceaccount.com"
+  [[ "$client_email" == "$expected" ]]
+}
+
 # Validate the override is a non-negative integer before any arithmetic
 # context (`[[ "$age" -lt "$SSH_WARM_TTL_SECONDS" ]]` later in the
 # script). A non-numeric override (`OP_PREFLIGHT_SSH_WARM_TTL_SECONDS=foo`)
@@ -713,13 +738,23 @@ emit_from_session_file() (
     if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || [[ ! -s "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
       exit 2
     fi
-    if [[ "${OP_PREFLIGHT_CHECK_MODE:-0}" != "1" && -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" && "${GOOGLE_APPLICATION_CREDENTIALS}" == "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE}" ]]; then
-      current_firebase_project="$(detect_firebase_project 2>/dev/null || true)"
+    if [[ -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" && "${GOOGLE_APPLICATION_CREDENTIALS}" == "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE}" ]]; then
+      if [[ "${OP_PREFLIGHT_CHECK_MODE:-0}" == "1" ]]; then
+        current_firebase_project="$(detect_firebase_project_no_python 2>/dev/null || true)"
+        firebase_sa_matches_project_check() {
+          firebase_sa_matches_project_no_python "${GOOGLE_APPLICATION_CREDENTIALS}" "$current_firebase_project"
+        }
+      else
+        current_firebase_project="$(detect_firebase_project 2>/dev/null || true)"
+        firebase_sa_matches_project_check() {
+          firebase_sa_matches_project "${GOOGLE_APPLICATION_CREDENTIALS}" "$current_firebase_project"
+        }
+      fi
       if [[ -z "$current_firebase_project" || "$current_firebase_project" != "${OP_PREFLIGHT_FIREBASE_PROJECT:-}" ]]; then
         echo "# WARNING: cached Firebase project SA key is for '${OP_PREFLIGHT_FIREBASE_PROJECT:-unknown}', but current project is '${current_firebase_project:-none}'; refreshing deploy credentials." >&2
         exit 2
       fi
-      if ! firebase_sa_matches_project "${GOOGLE_APPLICATION_CREDENTIALS}" "$current_firebase_project"; then
+      if ! firebase_sa_matches_project_check; then
         echo "# WARNING: cached Firebase project SA key file does not match current project '$current_firebase_project'; refreshing deploy credentials." >&2
         exit 2
       fi
@@ -1089,6 +1124,7 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
     # prompt. Overwrite in place — chmod 600 before writing secret content.
     touch "$FIREBASE_SA_TMPFILE"
     chmod 600 "$FIREBASE_SA_TMPFILE"
+    : > "$FIREBASE_SA_TMPFILE"
 
     # For --mode deploy (no review credentials loaded), this is the first
     # op call of the run — log it. For --mode all, the Phase 1 op inject

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -730,11 +730,14 @@ emit_from_session_file() (
       # deploy-credential path is degraded.
       if [[ -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" && "${GOOGLE_APPLICATION_CREDENTIALS}" == "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE}" ]]; then
         echo "# WARNING: cached Firebase project SA key is unusable; refreshing deploy credentials." >&2
+        unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+        unset OP_PREFLIGHT_FIREBASE_SA_TMPFILE OP_PREFLIGHT_FIREBASE_PROJECT
+        exit 2
       else
         log_stale_adc_guidance
+        unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+        unset OP_PREFLIGHT_FIREBASE_SA_TMPFILE OP_PREFLIGHT_FIREBASE_PROJECT
       fi
-      unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
-      unset OP_PREFLIGHT_FIREBASE_SA_TMPFILE OP_PREFLIGHT_FIREBASE_PROJECT
     fi
   fi
 

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -713,10 +713,14 @@ emit_from_session_file() (
     if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || [[ ! -s "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
       exit 2
     fi
-    if [[ -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" && "${GOOGLE_APPLICATION_CREDENTIALS}" == "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE}" ]]; then
+    if [[ "${OP_PREFLIGHT_CHECK_MODE:-0}" != "1" && -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" && "${GOOGLE_APPLICATION_CREDENTIALS}" == "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE}" ]]; then
       current_firebase_project="$(detect_firebase_project 2>/dev/null || true)"
       if [[ -z "$current_firebase_project" || "$current_firebase_project" != "${OP_PREFLIGHT_FIREBASE_PROJECT:-}" ]]; then
         echo "# WARNING: cached Firebase project SA key is for '${OP_PREFLIGHT_FIREBASE_PROJECT:-unknown}', but current project is '${current_firebase_project:-none}'; refreshing deploy credentials." >&2
+        exit 2
+      fi
+      if ! firebase_sa_matches_project "${GOOGLE_APPLICATION_CREDENTIALS}" "$current_firebase_project"; then
+        echo "# WARNING: cached Firebase project SA key file does not match current project '$current_firebase_project'; refreshing deploy credentials." >&2
         exit 2
       fi
     fi

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -293,9 +293,41 @@ PY
 json_string_field_no_python() {
   local file="${1:-}" field="${2:-}"
   [[ -n "$file" && -f "$file" && -n "$field" ]] || return 1
-  tr '\n' ' ' < "$file" \
-    | sed -nE "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"([^\"]+)\".*/\\1/p" \
-    | head -n 1
+  awk -v field="$field" '
+    { text = text $0 " " }
+    END {
+      pattern = "\"" field "\"[[:space:]]*:[[:space:]]*\"[^\"]+\""
+      if (!match(text, pattern)) {
+        exit 1
+      }
+      matched = substr(text, RSTART, RLENGTH)
+      if (split(matched, parts, "\"") < 4) {
+        exit 1
+      }
+      print parts[4]
+    }
+  ' "$file"
+}
+
+firebaserc_default_project_no_python() {
+  [[ -f .firebaserc ]] || return 1
+  awk '
+    { text = text $0 " " }
+    END {
+      if (!match(text, /"projects"[[:space:]]*:[[:space:]]*\{[^}]*\}/)) {
+        exit 1
+      }
+      projects = substr(text, RSTART, RLENGTH)
+      if (!match(projects, /"default"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        exit 1
+      }
+      matched = substr(projects, RSTART, RLENGTH)
+      if (split(matched, parts, "\"") < 4) {
+        exit 1
+      }
+      print parts[4]
+    }
+  ' .firebaserc
 }
 
 detect_firebase_project_no_python() {
@@ -303,7 +335,7 @@ detect_firebase_project_no_python() {
     printf '%s\n' "$OP_PREFLIGHT_FIREBASE_PROJECT_ID"
     return 0
   fi
-  json_string_field_no_python ".firebaserc" "default"
+  firebaserc_default_project_no_python
 }
 
 firebase_sa_matches_project_no_python() {

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -713,6 +713,13 @@ emit_from_session_file() (
     if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || [[ ! -s "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
       exit 2
     fi
+    if [[ -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" && "${GOOGLE_APPLICATION_CREDENTIALS}" == "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE}" ]]; then
+      current_firebase_project="$(detect_firebase_project 2>/dev/null || true)"
+      if [[ -z "$current_firebase_project" || "$current_firebase_project" != "${OP_PREFLIGHT_FIREBASE_PROJECT:-}" ]]; then
+        echo "# WARNING: cached Firebase project SA key is for '${OP_PREFLIGHT_FIREBASE_PROJECT:-unknown}', but current project is '${current_firebase_project:-none}'; refreshing deploy credentials." >&2
+        exit 2
+      fi
+    fi
     # --check is the "no external probes" contract — never invoke op,
     # ssh, OR python3. The `adc_is_usable` probe spawns python3 to
     # validate the OAuth2 refresh token, which fires a network call.

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -34,7 +34,8 @@
 #
 # Modes:
 #   review  — reviewer PAT + author PAT + SSH key warming (DEFAULT)
-#   deploy  — GCP ADC credential + Cloudflare cache-purge token
+#   deploy  — Firebase project SA key (when .firebaserc is present),
+#             else GCP ADC credential + Cloudflare cache-purge token
 #   all     — everything
 #
 # Flags:
@@ -170,6 +171,10 @@ TTL_SECONDS="${OP_PREFLIGHT_TTL_SECONDS:-$DEFAULT_TTL_SECONDS}"
 # ── GCP ADC ───────────────────────────────────────────────────────────
 DEFAULT_ADC_OP_URI="${GCP_ADC_OP_URI:-op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential}"
 
+# ── Firebase deploy SA key ────────────────────────────────────────────
+SA_NAME="${FIREBASE_DEPLOY_SA_NAME:-firebase-deployer}"
+FIREBASE_SA_VAULT="${FIREBASE_SA_VAULT:-Firebase}"
+
 # ── Cloudflare Cache Purge token (#167) ───────────────────────────────
 # Shared API token with Purge:Edit permission across all domains. Wired
 # into preflight so scripts/deploy.sh's existing CF purge step
@@ -228,7 +233,7 @@ fi
 if $PURGE_ALL; then
   if [[ -d "$CACHE_DIR" ]]; then
     echo "# Purging all session files under $CACHE_DIR" >&2
-    find "$CACHE_DIR" -maxdepth 1 -type f \( -name 'op-preflight-*.env' -o -name 'op-preflight-*-adc.json' -o -name 'op-preflight-*.ssh-warmed' \) -print -delete >&2
+    find "$CACHE_DIR" -maxdepth 1 -type f \( -name 'op-preflight-*.env' -o -name 'op-preflight-*-adc.json' -o -name 'op-preflight-*-firebase-sa.json' -o -name 'op-preflight-*.ssh-warmed' \) -print -delete >&2
   fi
   exit 0
 fi
@@ -257,10 +262,33 @@ fi
 # ── Cache paths (deterministic per agent) ─────────────────────────────
 SESSION_FILE="$CACHE_DIR/op-preflight-$AGENT.env"
 ADC_TMPFILE="$CACHE_DIR/op-preflight-$AGENT-adc.json"
+FIREBASE_SA_TMPFILE="$CACHE_DIR/op-preflight-$AGENT-firebase-sa.json"
 SSH_WARM_MARKER="$CACHE_DIR/op-preflight-$AGENT.ssh-warmed"
 BIOMETRIC_LOG="$CACHE_DIR/biometric-log"  # #282: append a one-line
                                           # record on each fresh fetch.
 SSH_WARM_TTL_SECONDS="${OP_PREFLIGHT_SSH_WARM_TTL_SECONDS:-1800}"  # 30 min default; #163
+
+detect_firebase_project() {
+  if [[ -n "${OP_PREFLIGHT_FIREBASE_PROJECT_ID:-}" ]]; then
+    printf '%s\n' "$OP_PREFLIGHT_FIREBASE_PROJECT_ID"
+    return 0
+  fi
+  [[ -f .firebaserc ]] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 - <<'PY'
+import json
+import pathlib
+import sys
+
+try:
+    project = json.loads(pathlib.Path(".firebaserc").read_text())["projects"]["default"]
+except Exception:
+    sys.exit(1)
+if not isinstance(project, str) or not project:
+    sys.exit(1)
+print(project)
+PY
+}
 # Validate the override is a non-negative integer before any arithmetic
 # context (`[[ "$age" -lt "$SSH_WARM_TTL_SECONDS" ]]` later in the
 # script). A non-numeric override (`OP_PREFLIGHT_SSH_WARM_TTL_SECONDS=foo`)
@@ -297,8 +325,8 @@ log_biometric_trigger() {
 
 # ── Purge mode ────────────────────────────────────────────────────────
 if $PURGE; then
-  rm -f "$SESSION_FILE" "$ADC_TMPFILE" "$SSH_WARM_MARKER"
-  echo "# Purged session file + ADC tempfile + SSH-warm marker for agent=$AGENT" >&2
+  rm -f "$SESSION_FILE" "$ADC_TMPFILE" "$FIREBASE_SA_TMPFILE" "$SSH_WARM_MARKER"
+  echo "# Purged session file + ADC tempfile + Firebase SA tempfile + SSH-warm marker for agent=$AGENT" >&2
   exit 0
 fi
 
@@ -313,6 +341,7 @@ if $DRY_RUN; then
   echo "#" >&2
   echo "# Session file:   $SESSION_FILE" >&2
   echo "# ADC tempfile:   $ADC_TMPFILE" >&2
+  echo "# Firebase SA tempfile: $FIREBASE_SA_TMPFILE" >&2
   echo "# TTL seconds:    $TTL_SECONDS" >&2
   if [[ -f "$SESSION_FILE" ]]; then
     # `|| true` so a missing epoch key doesn't take down dry-run under
@@ -354,7 +383,12 @@ if $DRY_RUN; then
     fi
   fi
   if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
-    echo "# Would read: GCP ADC ($DEFAULT_ADC_OP_URI)" >&2
+    if firebase_project="$(detect_firebase_project 2>/dev/null || true)" && [[ -n "$firebase_project" ]]; then
+      echo "# Would read: Firebase project SA key (${firebase_project} — Firebase Deployer SA Key in vault ${FIREBASE_SA_VAULT})" >&2
+      echo "# Would fall back to: GCP ADC ($DEFAULT_ADC_OP_URI)" >&2
+    else
+      echo "# Would read: GCP ADC ($DEFAULT_ADC_OP_URI)" >&2
+    fi
     echo "# Would read: Cloudflare cache-purge token ($DEFAULT_CF_TOKEN_OP_URI)" >&2
   fi
   exit 0
@@ -454,6 +488,28 @@ try:
     urllib.request.urlopen(req, timeout=10)
 except Exception:
     sys.exit(1)
+PY
+}
+
+firebase_sa_matches_project() {
+  local file="${1:-}" project="${2:-}"
+  [[ -n "$file" && -f "$file" && -s "$file" && -n "$project" ]] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 - "$file" "$project" "$SA_NAME" <<'PY'
+import json
+import pathlib
+import sys
+
+path, project, sa_name = sys.argv[1:4]
+expected = f"{sa_name}@{project}.iam.gserviceaccount.com"
+try:
+    cred = json.loads(pathlib.Path(path).read_text())
+except Exception:
+    sys.exit(1)
+
+if cred.get("type") == "service_account" and cred.get("client_email") == expected:
+    sys.exit(0)
+sys.exit(1)
 PY
 }
 
@@ -591,6 +647,7 @@ emit_from_session_file() (
   # stdout+exit; parent stays clean.
   unset OP_PREFLIGHT_REVIEWER_PAT OP_PREFLIGHT_AUTHOR_PAT
   unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+  unset OP_PREFLIGHT_FIREBASE_SA_TMPFILE OP_PREFLIGHT_FIREBASE_PROJECT
   unset CF_API_TOKEN
   unset OP_PREFLIGHT_DONE OP_PREFLIGHT_AGENT OP_PREFLIGHT_MODE
   unset OP_PREFLIGHT_TOKEN_MODE OP_PREFLIGHT_REVIEWER_PAT_SOURCE_REF
@@ -638,10 +695,10 @@ emit_from_session_file() (
     fi
   fi
   if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
-    # Both `--mode deploy` and `--mode all` require a usable ADC from
-    # the cache to take the fast path. If the session file's ADC field
-    # is missing or the materialized file is unreadable, return 2 to
-    # trigger a full refresh.
+    # Both `--mode deploy` and `--mode all` require a usable deploy
+    # credential from the cache to take the fast path. If the session
+    # file's credential field is missing or the materialized file is
+    # unreadable, return 2 to trigger a full refresh.
     #
     # An earlier iteration of this code treated missing-ADC on
     # `--mode all` as a partial hit (emit PATs, skip ADC) to spare
@@ -666,14 +723,18 @@ emit_from_session_file() (
     # `--check --mode deploy` still spawned python3.)
     if [[ "${OP_PREFLIGHT_CHECK_MODE:-0}" != "1" ]] && \
        ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
-      # File exists but refresh token is rejected. Warn and skip the
-      # export so downstream deploy callers can fall back to local
-      # firebase-login / ADC. OP_PREFLIGHT_DONE stays 1 and PATs are
-      # still emitted below, because preflight itself succeeded —
-      # only the ADC-specific path is degraded, which matches what
-      # the user will see when they run `gcloud auth ...` manually.
-      log_stale_adc_guidance
+      # File exists but the credential is unusable. Warn and skip the
+      # export so downstream deploy callers can fall back through their
+      # own resolver. OP_PREFLIGHT_DONE stays 1 and PATs are still
+      # emitted below, because preflight itself succeeded — only the
+      # deploy-credential path is degraded.
+      if [[ -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" && "${GOOGLE_APPLICATION_CREDENTIALS}" == "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE}" ]]; then
+        echo "# WARNING: cached Firebase project SA key is unusable; refreshing deploy credentials." >&2
+      else
+        log_stale_adc_guidance
+      fi
       unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+      unset OP_PREFLIGHT_FIREBASE_SA_TMPFILE OP_PREFLIGHT_FIREBASE_PROJECT
     fi
   fi
 
@@ -687,6 +748,10 @@ emit_from_session_file() (
     printf 'export GOOGLE_APPLICATION_CREDENTIALS=%q\n' "$GOOGLE_APPLICATION_CREDENTIALS"
   [[ -n "${OP_PREFLIGHT_ADC_TMPFILE:-}" ]] && \
     printf 'export OP_PREFLIGHT_ADC_TMPFILE=%q\n' "$OP_PREFLIGHT_ADC_TMPFILE"
+  [[ -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" ]] && \
+    printf 'export OP_PREFLIGHT_FIREBASE_SA_TMPFILE=%q\n' "$OP_PREFLIGHT_FIREBASE_SA_TMPFILE"
+  [[ -n "${OP_PREFLIGHT_FIREBASE_PROJECT:-}" ]] && \
+    printf 'export OP_PREFLIGHT_FIREBASE_PROJECT=%q\n' "$OP_PREFLIGHT_FIREBASE_PROJECT"
   [[ -n "${CF_API_TOKEN:-}" ]] && \
     printf 'export CF_API_TOKEN=%q\n' "$CF_API_TOKEN"
   printf 'export OP_PREFLIGHT_DONE=1\n'
@@ -906,6 +971,14 @@ fi
 EXPORTS=()
 SESSION_LINES=()
 SUMMARY=()
+DEPLOY_BIOMETRIC_LOGGED=false
+
+log_deploy_biometric_once() {
+  if [[ "$MODE" == "deploy" && "$DEPLOY_BIOMETRIC_LOGGED" == "false" ]]; then
+    log_biometric_trigger "$BIOMETRIC_REASON"
+    DEPLOY_BIOMETRIC_LOGGED=true
+  fi
+}
 
 # ── Phase 1: CLI credentials (one biometric prompt + session reuse) ───
 if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
@@ -991,36 +1064,70 @@ TPL
 fi
 
 if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
-  echo "# Preflight: reading GCP ADC (reuses session)..." >&2
+  firebase_project="$(detect_firebase_project 2>/dev/null || true)"
+  firebase_sa_loaded=false
 
-  # Deterministic path so subsequent invocations find the same file.
-  # Overwrite in place — chmod 600 before writing secret content.
-  touch "$ADC_TMPFILE"
-  chmod 600 "$ADC_TMPFILE"
+  if [[ -n "$firebase_project" ]]; then
+    echo "# Preflight: reading Firebase project SA key for $firebase_project..." >&2
 
-  # For --mode deploy (no review credentials loaded), this is the first
-  # op call of the run — log it. For --mode all, the Phase 1 op inject
-  # above already logged a single line covering the whole biometric
-  # burst, so no second log entry is needed here.
-  if [[ "$MODE" == "deploy" ]]; then
-    log_biometric_trigger "$BIOMETRIC_REASON"
-  fi
-  if op read "$DEFAULT_ADC_OP_URI" > "$ADC_TMPFILE" 2>/dev/null && [[ -s "$ADC_TMPFILE" ]]; then
-    if adc_is_usable "$ADC_TMPFILE"; then
-      EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
-      EXPORTS+=("export OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
-      SESSION_LINES+=("GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
-      SESSION_LINES+=("OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
-      SUMMARY+=("GCP ADC: loaded -> $ADC_TMPFILE")
+    # Deterministic path so subsequent invocations and op-firebase-deploy
+    # can reuse the same cached project SA key without a second biometric
+    # prompt. Overwrite in place — chmod 600 before writing secret content.
+    touch "$FIREBASE_SA_TMPFILE"
+    chmod 600 "$FIREBASE_SA_TMPFILE"
+
+    # For --mode deploy (no review credentials loaded), this is the first
+    # op call of the run — log it. For --mode all, the Phase 1 op inject
+    # above already logged a single line covering the whole biometric
+    # burst, so no second log entry is needed here.
+    log_deploy_biometric_once
+    if op document get "${firebase_project} — Firebase Deployer SA Key" \
+         --vault "$FIREBASE_SA_VAULT" \
+         --out-file "$FIREBASE_SA_TMPFILE" \
+         --force >/dev/null 2>&1 \
+       && firebase_sa_matches_project "$FIREBASE_SA_TMPFILE" "$firebase_project"; then
+      EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$FIREBASE_SA_TMPFILE")")
+      EXPORTS+=("export OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$(printf '%q' "$FIREBASE_SA_TMPFILE")")
+      EXPORTS+=("export OP_PREFLIGHT_FIREBASE_PROJECT=$(printf '%q' "$firebase_project")")
+      SESSION_LINES+=("GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$FIREBASE_SA_TMPFILE")")
+      SESSION_LINES+=("OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$(printf '%q' "$FIREBASE_SA_TMPFILE")")
+      SESSION_LINES+=("OP_PREFLIGHT_FIREBASE_PROJECT=$(printf '%q' "$firebase_project")")
+      SUMMARY+=("Firebase SA key ($firebase_project): loaded -> $FIREBASE_SA_TMPFILE")
+      firebase_sa_loaded=true
     else
-      rm -f "$ADC_TMPFILE"
-      log_stale_adc_guidance
-      SUMMARY+=("GCP ADC: STALE (refresh_token rejected — see warning above)")
+      rm -f "$FIREBASE_SA_TMPFILE"
+      SUMMARY+=("Firebase SA key ($firebase_project): SKIPPED (not found or did not match ${SA_NAME}@${firebase_project}.iam.gserviceaccount.com)")
     fi
   else
-    rm -f "$ADC_TMPFILE"
-    echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2
-    SUMMARY+=("GCP ADC: SKIPPED (not available)")
+    SUMMARY+=("Firebase SA key: SKIPPED (no .firebaserc default project detected)")
+  fi
+
+  if [[ "$firebase_sa_loaded" != "true" ]]; then
+    echo "# Preflight: reading GCP ADC (reuses session)..." >&2
+
+    # Deterministic path so subsequent invocations find the same file.
+    # Overwrite in place — chmod 600 before writing secret content.
+    touch "$ADC_TMPFILE"
+    chmod 600 "$ADC_TMPFILE"
+
+    log_deploy_biometric_once
+    if op read "$DEFAULT_ADC_OP_URI" > "$ADC_TMPFILE" 2>/dev/null && [[ -s "$ADC_TMPFILE" ]]; then
+      if adc_is_usable "$ADC_TMPFILE"; then
+        EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
+        EXPORTS+=("export OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
+        SESSION_LINES+=("GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
+        SESSION_LINES+=("OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
+        SUMMARY+=("GCP ADC: loaded -> $ADC_TMPFILE")
+      else
+        rm -f "$ADC_TMPFILE"
+        log_stale_adc_guidance
+        SUMMARY+=("GCP ADC: STALE (refresh_token rejected — see warning above)")
+      fi
+    else
+      rm -f "$ADC_TMPFILE"
+      echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2
+      SUMMARY+=("GCP ADC: SKIPPED (not available)")
+    fi
   fi
 
   # Cloudflare cache-purge token (#167). Optional — if 1Password is

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -344,7 +344,10 @@ test_check_deploy_firebase_sa_no_python3_probe() {
   mkdir -p "$case_dir" "$cache_dir" "$py_stub"
 
   cat > "$case_dir/.firebaserc" <<JSON
-{ "projects": { "default": "$project" } }
+{
+  "projects": { "default": "$project" },
+  "hosting": { "default": "wrong-project" }
+}
 JSON
   cat > "$sa_file" <<JSON
 {

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -331,6 +331,78 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# test_check_deploy_firebase_sa_no_python3_probe: --check must stay a
+# no-probe path even when the cached deploy credential is a Firebase SA
+# marker and the checkout has a .firebaserc.
+# ---------------------------------------------------------------------------
+test_check_deploy_firebase_sa_no_python3_probe() {
+  local case_dir="$WORKDIR/deploy-firebase-no-python3"
+  local cache_dir="$case_dir/cache"
+  local py_stub="$case_dir/stub-bin-py"
+  local project="merge-path-test"
+  local sa_file="$case_dir/firebase-sa.json"
+  mkdir -p "$case_dir" "$cache_dir" "$py_stub"
+
+  cat > "$case_dir/.firebaserc" <<JSON
+{ "projects": { "default": "$project" } }
+JSON
+  cat > "$sa_file" <<JSON
+{
+  "type": "service_account",
+  "project_id": "$project",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@${project}.iam.gserviceaccount.com",
+  "client_id": "0"
+}
+JSON
+
+  local epoch
+  epoch=$(date +%s)
+  cat > "$cache_dir/op-preflight-claude.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=claude
+OP_PREFLIGHT_MODE=deploy
+OP_PREFLIGHT_DONE=1
+GOOGLE_APPLICATION_CREDENTIALS=$sa_file
+OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$sa_file
+OP_PREFLIGHT_FIREBASE_PROJECT=$project
+EOF
+  chmod 600 "$cache_dir/op-preflight-claude.env"
+
+  cat > "$py_stub/python3" <<'EOF'
+#!/usr/bin/env bash
+echo "FATAL: --check --mode deploy invoked python3 with args: $*" >&2
+exit 97
+EOF
+  chmod +x "$py_stub/python3"
+
+  local out rc=0
+  (
+    cd "$case_dir"
+    OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      PATH="$py_stub:$STUB_DIR:$PATH" \
+      "$SCRIPT" --agent claude --mode deploy --check 2>&1
+  ) >"$case_dir/out" || rc=$?
+  out="$(cat "$case_dir/out")"
+
+  if [ "$rc" -ne 0 ]; then
+    fail "test_check_deploy_firebase_sa_no_python3_probe: --check returned rc=$rc; out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "invoked python3"; then
+    fail "test_check_deploy_firebase_sa_no_python3_probe: --check invoked python3; out=$out"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_FIREBASE_SA_TMPFILE="; then
+    fail "test_check_deploy_firebase_sa_no_python3_probe: missing Firebase SA marker export; out=$out"
+    return
+  fi
+  pass "test_check_deploy_firebase_sa_no_python3_probe: --check emits Firebase SA without python3 probe"
+}
+
+# ---------------------------------------------------------------------------
 # test_deploy_mode_prefers_firebase_sa_over_gcp_adc (#154/#211): in a
 # Firebase repo, --mode deploy should cache the project Firebase-vault
 # SA key first and must not probe the stale shared GCP ADC item when
@@ -536,7 +608,7 @@ EOF
     fail "test_deploy_mode_refreshes_unusable_cached_firebase_sa: rc=$rc; stderr=$err"
     return
   fi
-  if ! echo "$err" | grep -q "cached Firebase project SA key is unusable; refreshing deploy credentials"; then
+  if ! echo "$err" | grep -q "refreshing deploy credentials"; then
     fail "test_deploy_mode_refreshes_unusable_cached_firebase_sa: missing refresh warning; stderr=$err"
     return
   fi
@@ -684,6 +756,136 @@ EOF
   pass "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: project mismatch forces refresh"
 }
 
+# ---------------------------------------------------------------------------
+# test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch (#154/#211):
+# the session marker may still name the current project even if the
+# deterministic Firebase SA tempfile was overwritten. The fast path must
+# validate the file itself before re-exporting it.
+# ---------------------------------------------------------------------------
+test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch() {
+  local case_dir="$WORKDIR/firebase-sa-file-mismatch"
+  local cache_dir="$case_dir/cache"
+  local bin_dir="$case_dir/bin"
+  local current_project="project-b"
+  local wrong_project="project-a"
+  local shared_adc_uri="op://Private/test-shared-adc-file-mismatch/credential"
+  local op_log="$case_dir/op.log"
+  local cached_sa_file="$case_dir/firebase-sa.json"
+  mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
+
+  cat > "$case_dir/.firebaserc" <<JSON
+{ "projects": { "default": "$current_project" } }
+JSON
+  cat > "$cached_sa_file" <<JSON
+{
+  "type": "service_account",
+  "project_id": "$wrong_project",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@${wrong_project}.iam.gserviceaccount.com",
+  "client_id": "0",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+JSON
+
+  local epoch
+  epoch=$(date +%s)
+  cat > "$cache_dir/op-preflight-.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=''
+OP_PREFLIGHT_MODE=deploy
+OP_PREFLIGHT_DONE=1
+GOOGLE_APPLICATION_CREDENTIALS=$cached_sa_file
+OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$cached_sa_file
+OP_PREFLIGHT_FIREBASE_PROJECT=$current_project
+EOF
+  chmod 600 "$cache_dir/op-preflight-.env"
+
+  cat > "$bin_dir/op" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$op_log"
+case "\${1:-}" in
+  document)
+    shift
+    if [ "\${1:-}" != "get" ]; then
+      exit 1
+    fi
+    shift
+    out_path=""
+    while [ \$# -gt 0 ]; do
+      if [ "\${1:-}" = "--out-file" ]; then
+        shift
+        out_path="\${1:-}"
+      fi
+      shift || true
+    done
+    if [ -z "\$out_path" ]; then
+      exit 1
+    fi
+    cat > "\$out_path" <<'JSON'
+{
+  "type": "service_account",
+  "project_id": "project-b",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@project-b.iam.gserviceaccount.com",
+  "client_id": "0",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+JSON
+    exit 0
+    ;;
+  read)
+    if [ "\${2:-}" = "$shared_adc_uri" ]; then
+      echo "FATAL: file mismatch should re-read current Firebase SA before shared GCP ADC" >&2
+      exit 88
+    fi
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/op"
+
+  local out err rc=0
+  (
+    cd "$case_dir"
+    PATH="$bin_dir:$STUB_DIR:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      GCP_ADC_OP_URI="$shared_adc_uri" \
+      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+  ) || rc=$?
+  out="$(cat "$case_dir/out")"
+  err="$(cat "$case_dir/err")"
+
+  if [ "$rc" -ne 0 ]; then
+    fail "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: rc=$rc; stderr=$err"
+    return
+  fi
+  if ! echo "$err" | grep -q "cached Firebase project SA key file does not match current project '$current_project'"; then
+    fail "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: missing file mismatch warning; stderr=$err"
+    return
+  fi
+  if ! grep -q "document get" "$op_log"; then
+    fail "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: refresh did not re-read current Firebase SA; log=$(cat "$op_log")"
+    return
+  fi
+  if grep -qF "$shared_adc_uri" "$op_log"; then
+    fail "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: refresh touched shared GCP ADC; log=$(cat "$op_log")"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_FIREBASE_PROJECT=$current_project"; then
+    fail "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: missing refreshed current-project export; out=$out"
+    return
+  fi
+  pass "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: file mismatch forces refresh"
+}
+
 test_check_fresh_cache
 test_check_missing_cache
 test_check_stale_cache
@@ -692,9 +894,11 @@ test_status_alias
 test_quiet_mode
 test_default_mode_is_review
 test_check_deploy_no_python3_probe
+test_check_deploy_firebase_sa_no_python3_probe
 test_deploy_mode_prefers_firebase_sa_over_gcp_adc
 test_deploy_mode_refreshes_unusable_cached_firebase_sa
 test_deploy_mode_refreshes_mismatched_cached_firebase_sa
+test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -330,6 +330,111 @@ EOF
   pass "test_check_deploy_no_python3_probe: --check --mode deploy emits ADC without python3 probe"
 }
 
+# ---------------------------------------------------------------------------
+# test_deploy_mode_prefers_firebase_sa_over_gcp_adc (#154/#211): in a
+# Firebase repo, --mode deploy should cache the project Firebase-vault
+# SA key first and must not probe the stale shared GCP ADC item when
+# that key is available.
+# ---------------------------------------------------------------------------
+test_deploy_mode_prefers_firebase_sa_over_gcp_adc() {
+  local case_dir="$WORKDIR/firebase-sa-preflight"
+  local cache_dir="$case_dir/cache"
+  local bin_dir="$case_dir/bin"
+  local project="merge-path-test"
+  local op_log="$case_dir/op.log"
+  mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
+
+  cat > "$case_dir/.firebaserc" <<JSON
+{ "projects": { "default": "$project" } }
+JSON
+
+  cat > "$bin_dir/op" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$op_log"
+case "\${1:-}" in
+  document)
+    shift
+    if [ "\${1:-}" != "get" ]; then
+      exit 1
+    fi
+    shift
+    out_path=""
+    while [ \$# -gt 0 ]; do
+      if [ "\${1:-}" = "--out-file" ]; then
+        shift
+        out_path="\${1:-}"
+      fi
+      shift || true
+    done
+    if [ -z "\$out_path" ]; then
+      exit 1
+    fi
+    cat > "\$out_path" <<'JSON'
+{
+  "type": "service_account",
+  "project_id": "merge-path-test",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@merge-path-test.iam.gserviceaccount.com",
+  "client_id": "0",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+JSON
+    exit 0
+    ;;
+  read)
+    if [ "\${2:-}" = "op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential" ]; then
+      echo "FATAL: deploy preflight read stale shared GCP ADC despite Firebase SA key" >&2
+      exit 88
+    fi
+    # Cloudflare token is optional; return empty/unavailable.
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/op"
+
+  local out err rc=0
+  (
+    cd "$case_dir"
+    PATH="$bin_dir:$STUB_DIR:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+  ) || rc=$?
+  out="$(cat "$case_dir/out")"
+  err="$(cat "$case_dir/err")"
+
+  if [ "$rc" -ne 0 ]; then
+    fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: rc=$rc; stderr=$err"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_FIREBASE_SA_TMPFILE="; then
+    fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: missing Firebase SA marker export; out=$out"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_FIREBASE_PROJECT=$project"; then
+    fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: missing Firebase project export; out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "OP_PREFLIGHT_ADC_TMPFILE"; then
+    fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: should not export shared ADC marker; out=$out"
+    return
+  fi
+  if grep -q "c2v6emkwppjzjjaq2bdqk3wnlm" "$op_log"; then
+    fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: op read touched shared GCP ADC; log=$(cat "$op_log")"
+    return
+  fi
+  if ! echo "$err" | grep -q "Firebase SA key ($project): loaded"; then
+    fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: summary missing Firebase SA loaded line; stderr=$err"
+    return
+  fi
+  pass "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: Firebase SA cached before shared ADC"
+}
+
 test_check_fresh_cache
 test_check_missing_cache
 test_check_stale_cache
@@ -338,6 +443,7 @@ test_status_alias
 test_quiet_mode
 test_default_mode_is_review
 test_check_deploy_no_python3_probe
+test_deploy_mode_prefers_firebase_sa_over_gcp_adc
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -555,6 +555,135 @@ EOF
   pass "test_deploy_mode_refreshes_unusable_cached_firebase_sa: unusable cached SA forces refresh"
 }
 
+# ---------------------------------------------------------------------------
+# test_deploy_mode_refreshes_mismatched_cached_firebase_sa (#154/#211):
+# a project-A Firebase SA cache must not be re-exported in project B
+# within the preflight TTL.
+# ---------------------------------------------------------------------------
+test_deploy_mode_refreshes_mismatched_cached_firebase_sa() {
+  local case_dir="$WORKDIR/firebase-sa-project-mismatch"
+  local cache_dir="$case_dir/cache"
+  local bin_dir="$case_dir/bin"
+  local cached_project="project-a"
+  local current_project="project-b"
+  local shared_adc_uri="op://Private/test-shared-adc-mismatch/credential"
+  local op_log="$case_dir/op.log"
+  local cached_sa_file="$case_dir/project-a-sa.json"
+  mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
+
+  cat > "$case_dir/.firebaserc" <<JSON
+{ "projects": { "default": "$current_project" } }
+JSON
+  cat > "$cached_sa_file" <<JSON
+{
+  "type": "service_account",
+  "project_id": "$cached_project",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@${cached_project}.iam.gserviceaccount.com",
+  "client_id": "0",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+JSON
+
+  local epoch
+  epoch=$(date +%s)
+  cat > "$cache_dir/op-preflight-.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=''
+OP_PREFLIGHT_MODE=deploy
+OP_PREFLIGHT_DONE=1
+GOOGLE_APPLICATION_CREDENTIALS=$cached_sa_file
+OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$cached_sa_file
+OP_PREFLIGHT_FIREBASE_PROJECT=$cached_project
+EOF
+  chmod 600 "$cache_dir/op-preflight-.env"
+
+  cat > "$bin_dir/op" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$op_log"
+case "\${1:-}" in
+  document)
+    shift
+    if [ "\${1:-}" != "get" ]; then
+      exit 1
+    fi
+    shift
+    out_path=""
+    while [ \$# -gt 0 ]; do
+      if [ "\${1:-}" = "--out-file" ]; then
+        shift
+        out_path="\${1:-}"
+      fi
+      shift || true
+    done
+    if [ -z "\$out_path" ]; then
+      exit 1
+    fi
+    cat > "\$out_path" <<'JSON'
+{
+  "type": "service_account",
+  "project_id": "project-b",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@project-b.iam.gserviceaccount.com",
+  "client_id": "0",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+JSON
+    exit 0
+    ;;
+  read)
+    if [ "\${2:-}" = "$shared_adc_uri" ]; then
+      echo "FATAL: project mismatch should re-read current Firebase SA before shared GCP ADC" >&2
+      exit 88
+    fi
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/op"
+
+  local out err rc=0
+  (
+    cd "$case_dir"
+    PATH="$bin_dir:$STUB_DIR:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      GCP_ADC_OP_URI="$shared_adc_uri" \
+      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+  ) || rc=$?
+  out="$(cat "$case_dir/out")"
+  err="$(cat "$case_dir/err")"
+
+  if [ "$rc" -ne 0 ]; then
+    fail "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: rc=$rc; stderr=$err"
+    return
+  fi
+  if ! echo "$err" | grep -q "cached Firebase project SA key is for '$cached_project', but current project is '$current_project'"; then
+    fail "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: missing project mismatch warning; stderr=$err"
+    return
+  fi
+  if ! grep -q "document get" "$op_log"; then
+    fail "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: refresh did not re-read current Firebase SA; log=$(cat "$op_log")"
+    return
+  fi
+  if grep -qF "$shared_adc_uri" "$op_log"; then
+    fail "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: refresh touched shared GCP ADC; log=$(cat "$op_log")"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_FIREBASE_PROJECT=$current_project"; then
+    fail "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: missing refreshed current-project export; out=$out"
+    return
+  fi
+  pass "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: project mismatch forces refresh"
+}
+
 test_check_fresh_cache
 test_check_missing_cache
 test_check_stale_cache
@@ -565,6 +694,7 @@ test_default_mode_is_review
 test_check_deploy_no_python3_probe
 test_deploy_mode_prefers_firebase_sa_over_gcp_adc
 test_deploy_mode_refreshes_unusable_cached_firebase_sa
+test_deploy_mode_refreshes_mismatched_cached_firebase_sa
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -341,6 +341,7 @@ test_deploy_mode_prefers_firebase_sa_over_gcp_adc() {
   local cache_dir="$case_dir/cache"
   local bin_dir="$case_dir/bin"
   local project="merge-path-test"
+  local shared_adc_uri="op://Private/test-shared-adc/credential"
   local op_log="$case_dir/op.log"
   mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
 
@@ -384,7 +385,7 @@ JSON
     exit 0
     ;;
   read)
-    if [ "\${2:-}" = "op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential" ]; then
+    if [ "\${2:-}" = "$shared_adc_uri" ]; then
       echo "FATAL: deploy preflight read stale shared GCP ADC despite Firebase SA key" >&2
       exit 88
     fi
@@ -403,6 +404,7 @@ EOF
     cd "$case_dir"
     PATH="$bin_dir:$STUB_DIR:$PATH" \
       OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      GCP_ADC_OP_URI="$shared_adc_uri" \
       "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
   ) || rc=$?
   out="$(cat "$case_dir/out")"
@@ -424,7 +426,7 @@ EOF
     fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: should not export shared ADC marker; out=$out"
     return
   fi
-  if grep -q "c2v6emkwppjzjjaq2bdqk3wnlm" "$op_log"; then
+  if grep -qF "$shared_adc_uri" "$op_log"; then
     fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: op read touched shared GCP ADC; log=$(cat "$op_log")"
     return
   fi
@@ -433,6 +435,124 @@ EOF
     return
   fi
   pass "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: Firebase SA cached before shared ADC"
+}
+
+# ---------------------------------------------------------------------------
+# test_deploy_mode_refreshes_unusable_cached_firebase_sa (#154/#211):
+# a stale/corrupt preflight-cached Firebase SA file must force the
+# outer fast path into the real refresh flow, not return a cache hit
+# with deploy credentials silently unset.
+# ---------------------------------------------------------------------------
+test_deploy_mode_refreshes_unusable_cached_firebase_sa() {
+  local case_dir="$WORKDIR/firebase-sa-refresh"
+  local cache_dir="$case_dir/cache"
+  local bin_dir="$case_dir/bin"
+  local project="merge-path-test"
+  local shared_adc_uri="op://Private/test-shared-adc-refresh/credential"
+  local op_log="$case_dir/op.log"
+  local bad_sa_file="$case_dir/bad-preflight-sa.json"
+  mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
+
+  cat > "$case_dir/.firebaserc" <<JSON
+{ "projects": { "default": "$project" } }
+JSON
+  printf '{not-json\n' > "$bad_sa_file"
+
+  local epoch
+  epoch=$(date +%s)
+  cat > "$cache_dir/op-preflight-.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=''
+OP_PREFLIGHT_MODE=deploy
+OP_PREFLIGHT_DONE=1
+GOOGLE_APPLICATION_CREDENTIALS=$bad_sa_file
+OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$bad_sa_file
+OP_PREFLIGHT_FIREBASE_PROJECT=$project
+EOF
+  chmod 600 "$cache_dir/op-preflight-.env"
+
+  cat > "$bin_dir/op" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$op_log"
+case "\${1:-}" in
+  document)
+    shift
+    if [ "\${1:-}" != "get" ]; then
+      exit 1
+    fi
+    shift
+    out_path=""
+    while [ \$# -gt 0 ]; do
+      if [ "\${1:-}" = "--out-file" ]; then
+        shift
+        out_path="\${1:-}"
+      fi
+      shift || true
+    done
+    if [ -z "\$out_path" ]; then
+      exit 1
+    fi
+    cat > "\$out_path" <<'JSON'
+{
+  "type": "service_account",
+  "project_id": "merge-path-test",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@merge-path-test.iam.gserviceaccount.com",
+  "client_id": "0",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+JSON
+    exit 0
+    ;;
+  read)
+    if [ "\${2:-}" = "$shared_adc_uri" ]; then
+      echo "FATAL: refresh should re-read Firebase SA before shared GCP ADC" >&2
+      exit 88
+    fi
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/op"
+
+  local out err rc=0
+  (
+    cd "$case_dir"
+    PATH="$bin_dir:$STUB_DIR:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      GCP_ADC_OP_URI="$shared_adc_uri" \
+      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+  ) || rc=$?
+  out="$(cat "$case_dir/out")"
+  err="$(cat "$case_dir/err")"
+
+  if [ "$rc" -ne 0 ]; then
+    fail "test_deploy_mode_refreshes_unusable_cached_firebase_sa: rc=$rc; stderr=$err"
+    return
+  fi
+  if ! echo "$err" | grep -q "cached Firebase project SA key is unusable; refreshing deploy credentials"; then
+    fail "test_deploy_mode_refreshes_unusable_cached_firebase_sa: missing refresh warning; stderr=$err"
+    return
+  fi
+  if ! grep -q "document get" "$op_log"; then
+    fail "test_deploy_mode_refreshes_unusable_cached_firebase_sa: refresh did not re-read Firebase SA; log=$(cat "$op_log")"
+    return
+  fi
+  if grep -qF "$shared_adc_uri" "$op_log"; then
+    fail "test_deploy_mode_refreshes_unusable_cached_firebase_sa: refresh touched shared GCP ADC; log=$(cat "$op_log")"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_FIREBASE_SA_TMPFILE="; then
+    fail "test_deploy_mode_refreshes_unusable_cached_firebase_sa: missing refreshed Firebase SA marker export; out=$out"
+    return
+  fi
+  pass "test_deploy_mode_refreshes_unusable_cached_firebase_sa: unusable cached SA forces refresh"
 }
 
 test_check_fresh_cache
@@ -444,6 +564,7 @@ test_quiet_mode
 test_default_mode_is_review
 test_check_deploy_no_python3_probe
 test_deploy_mode_prefers_firebase_sa_over_gcp_adc
+test_deploy_mode_refreshes_unusable_cached_firebase_sa
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -403,6 +403,76 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# test_check_deploy_firebase_sa_project_mismatch_fails_closed:
+# --check is probe-free, but it must still refuse a Firebase SA cache
+# whose project marker/file no longer match the checkout.
+# ---------------------------------------------------------------------------
+test_check_deploy_firebase_sa_project_mismatch_fails_closed() {
+  local case_dir="$WORKDIR/deploy-firebase-check-mismatch"
+  local cache_dir="$case_dir/cache"
+  local py_stub="$case_dir/stub-bin-py"
+  local cached_project="project-a"
+  local current_project="project-b"
+  local sa_file="$case_dir/firebase-sa.json"
+  mkdir -p "$case_dir" "$cache_dir" "$py_stub"
+
+  cat > "$case_dir/.firebaserc" <<JSON
+{ "projects": { "default": "$current_project" } }
+JSON
+  cat > "$sa_file" <<JSON
+{
+  "type": "service_account",
+  "project_id": "$cached_project",
+  "client_email": "firebase-deployer@${cached_project}.iam.gserviceaccount.com"
+}
+JSON
+
+  local epoch
+  epoch=$(date +%s)
+  cat > "$cache_dir/op-preflight-claude.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=claude
+OP_PREFLIGHT_MODE=deploy
+OP_PREFLIGHT_DONE=1
+GOOGLE_APPLICATION_CREDENTIALS=$sa_file
+OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$sa_file
+OP_PREFLIGHT_FIREBASE_PROJECT=$cached_project
+EOF
+  chmod 600 "$cache_dir/op-preflight-claude.env"
+
+  cat > "$py_stub/python3" <<'EOF'
+#!/usr/bin/env bash
+echo "FATAL: --check --mode deploy invoked python3 with args: $*" >&2
+exit 97
+EOF
+  chmod +x "$py_stub/python3"
+
+  local out rc=0
+  (
+    cd "$case_dir"
+    OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      PATH="$py_stub:$STUB_DIR:$PATH" \
+      "$SCRIPT" --agent claude --mode deploy --check 2>&1
+  ) >"$case_dir/out" || rc=$?
+  out="$(cat "$case_dir/out")"
+
+  if [ "$rc" -eq 0 ]; then
+    fail "test_check_deploy_firebase_sa_project_mismatch_fails_closed: --check should fail closed; out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "invoked python3"; then
+    fail "test_check_deploy_firebase_sa_project_mismatch_fails_closed: --check invoked python3; out=$out"
+    return
+  fi
+  if ! echo "$out" | grep -q "cached Firebase project SA key is for '$cached_project', but current project is '$current_project'"; then
+    fail "test_check_deploy_firebase_sa_project_mismatch_fails_closed: missing mismatch warning; out=$out"
+    return
+  fi
+  pass "test_check_deploy_firebase_sa_project_mismatch_fails_closed: --check fails closed on project drift"
+}
+
+# ---------------------------------------------------------------------------
 # test_deploy_mode_prefers_firebase_sa_over_gcp_adc (#154/#211): in a
 # Firebase repo, --mode deploy should cache the project Firebase-vault
 # SA key first and must not probe the stale shared GCP ADC item when
@@ -770,8 +840,8 @@ test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch() {
   local wrong_project="project-a"
   local shared_adc_uri="op://Private/test-shared-adc-file-mismatch/credential"
   local op_log="$case_dir/op.log"
-  local cached_sa_file="$case_dir/firebase-sa.json"
   mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
+  local cached_sa_file="$cache_dir/op-preflight--firebase-sa.json"
 
   cat > "$case_dir/.firebaserc" <<JSON
 { "projects": { "default": "$current_project" } }
@@ -823,6 +893,10 @@ case "\${1:-}" in
     done
     if [ -z "\$out_path" ]; then
       exit 1
+    fi
+    if [ -s "\$out_path" ]; then
+      echo "FATAL: op document get destination was not truncated before fetch" >&2
+      exit 77
     fi
     cat > "\$out_path" <<'JSON'
 {
@@ -895,6 +969,7 @@ test_quiet_mode
 test_default_mode_is_review
 test_check_deploy_no_python3_probe
 test_check_deploy_firebase_sa_no_python3_probe
+test_check_deploy_firebase_sa_project_mismatch_fails_closed
 test_deploy_mode_prefers_firebase_sa_over_gcp_adc
 test_deploy_mode_refreshes_unusable_cached_firebase_sa
 test_deploy_mode_refreshes_mismatched_cached_firebase_sa


### PR DESCRIPTION
Refs #154 and #211.

## Summary

- Makes deploy preflight follow the same stable credential order as `op-firebase-deploy`: Firebase project SA key first when `.firebaserc` identifies the project, shared GCP ADC only as fallback.
- Adds `OP_PREFLIGHT_FIREBASE_SA_TMPFILE` / `OP_PREFLIGHT_FIREBASE_PROJECT` markers so `op-firebase-deploy` can distinguish a preflight-cached project SA key from a genuine human `GOOGLE_APPLICATION_CREDENTIALS` override.
- Extends the shimmed resolver/preflight tests and updates the deploy docs/debugging notes.

## Audit Of Prior Failed Fixes

- PR #290 added shimmed resolver coverage for `op-firebase-deploy` credential precedence. It proved the deploy wrapper could choose the project SA key, but it did not cover the session preflight path that runs before many attended deploys.
- PR #302 added `op-firebase-setup --provision-sa-key` and rank-1 resolver coverage. It made the project key easier to provision, but still left `op-preflight.sh --mode deploy|all` trying the shared human ADC before the project key.
- Shared assumption: making `op-firebase-deploy` SA-key-first was sufficient. Fresh #154 field evidence showed the remaining daily reauth/RAPT pain was still exposed by deploy preflight itself.
- This PR addresses that assumption directly: deploy preflight now caches the Firebase project SA key before probing the shared ADC, so attended deploy sessions stop paying the stale human-ADC failure path when the durable key exists.

## Tests

- `bash -n scripts/op-preflight.sh scripts/firebase/op-firebase-deploy tests/test_op_preflight_check.sh scripts/ci/check_op_firebase_deploy_integration`
- `bash tests/test_op_preflight_check.sh`
- `MERGEPATH_RUN_INTEGRATION=1 bash scripts/ci/check_op_firebase_deploy_integration`
- `./scripts/ci/check_op_preflight_contract`
- `./scripts/ci/check_duplicate_docs && ./scripts/ci/check_spec_test_alignment && ./scripts/ci/check_mktemp_portability`

Full local repo-lint was attempted, but `check_bootstrap_wizard` hung in an unrelated dry-run path and I terminated that broader sweep. The focused checks above cover this change; GitHub CI should run the full required matrix.

## Self-Review

- Correctness: deploy preflight now only reads shared ADC after the project SA key is unavailable or invalid, and the deploy wrapper handles the new preflight SA marker without mistaking it for a human override.
- Regression risk: moderate; `GOOGLE_APPLICATION_CREDENTIALS` now points to a project SA key after deploy preflight in Firebase repos. Docs call out the non-deploy `gcloud` caveat, and mismatched cached project markers are ignored by `op-firebase-deploy`.
- Style: kept the existing shell patterns, session-file shape, chmod-600 tempfiles, and source-credential log vocabulary.
- Test coverage: added a preflight regression that fails if shared ADC is read when a project SA key is available, plus resolver cases for cached project SA and cross-project marker mismatch.
- Security/dependency hygiene: no new dependencies; no secret values logged; cached SA key stays in the existing 0700/0600 preflight cache and is purged with the session.

Authoring-Agent: codex