### PR TITLE
fix(sync): propagate op-preflight token-mode tests

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -377,9 +377,12 @@ paths:
     consumers: all
   # Pairs with scripts/op-preflight.sh + scripts/lib/preflight-helpers.sh
   # + scripts/ci/check_op_preflight_contract. The check wrapper requires
-  # both test files; same coupling pattern as the gh-as-author and
-  # codex-p1-gate suites above. See #282.
+  # all three test files; same coupling pattern as the gh-as-author and
+  # codex-p1-gate suites above. See #282/#374.
   - path: tests/test_op_preflight_check.sh
+    type: canonical
+    consumers: all
+  - path: tests/test_op_preflight_token_mode.sh
     type: canonical
     consumers: all
   - path: tests/test_helper_autosource.sh

--- a/scripts/ci/check_op_firebase_deploy_integration
+++ b/scripts/ci/check_op_firebase_deploy_integration
@@ -475,7 +475,7 @@ run_case \
 provision_preflight_cached_project_sa() {
   local case_dir="$1" bin_dir="$2" tmp_dir="$3" home_dir="$4" project="$5"
 
-  local preflight_sa_path="$tmp_dir/preflight-firebase-sa.json"
+  local preflight_sa_path="$tmp_dir/preflight-cached-project-sa.json"
   write_fake_sa_key "$preflight_sa_path" \
     "firebase-deployer@${project}.iam.gserviceaccount.com"
 


### PR DESCRIPTION
Fixes the closure gap caught by the downstream sync canary on nathanjohnpayne/device-source-of-truth#95.

## Changes

- Add `tests/test_op_preflight_token_mode.sh` to `.mergepath-sync.yml` so `scripts/ci/check_op_preflight_contract` does not propagate without all required tests.
- Rename the pre-provisioned Firebase deploy integration fixture from `preflight-firebase-sa.json` to `preflight-cached-project-sa.json` so the test harness-owned file does not match the tempfile leak detector pattern.

Authoring-Agent: codex

## Self-Review
- Correctness: closes the missing-test propagation gap and preserves the same preflight/deploy test behavior.
- Regression risk: low; manifest-only propagation addition plus a fixture filename that is internal to one integration test.
- Style: matches existing manifest comments and shell test naming.
- Test coverage: ran `scripts/ci/check_sync_manifest`, `scripts/ci/check_op_preflight_contract`, `MERGEPATH_RUN_INTEGRATION=1 scripts/ci/check_op_firebase_deploy_integration`, `scripts/ci/check_ci_scripts_wired`, and `git diff --check`.
- Security: no secrets or new credential paths; improves propagation of token-mode test coverage.
