### PR TITLE
fix(sync): skip mergepath-only CI checks in consumers

### DIFF
--- a/scripts/ci/check_bootstrap_sh
+++ b/scripts/ci/check_bootstrap_sh
@@ -10,6 +10,10 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEST_SCRIPT="$REPO_ROOT/tests/test_bootstrap_sh.sh"
 
 if [ ! -f "$TEST_SCRIPT" ]; then
+  if [ ! -f "$REPO_ROOT/.mergepath-sync.yml" ]; then
+    echo "check_bootstrap_sh: SKIP (consumer checkout: tests/test_bootstrap_sh.sh + .mergepath-sync.yml both absent)"
+    exit 0
+  fi
   echo "check_bootstrap_sh: ERROR (missing $TEST_SCRIPT)" >&2
   exit 1
 fi

--- a/scripts/ci/check_onepassword_headless_proof_workflow
+++ b/scripts/ci/check_onepassword_headless_proof_workflow
@@ -12,6 +12,10 @@ fail() {
   exit 1
 }
 
+if [[ ! -f "$WORKFLOW" && ! -f "$SETUP_SCRIPT" && ! -f "$ROOT/.mergepath-sync.yml" ]]; then
+  echo "check_onepassword_headless_proof_workflow: SKIP (consumer checkout: headless proof workflow/setup + .mergepath-sync.yml all absent)"
+  exit 0
+fi
 [[ -f "$WORKFLOW" ]] || fail "missing $WORKFLOW"
 [[ -f "$SETUP_SCRIPT" ]] || fail "missing $SETUP_SCRIPT"
 


### PR DESCRIPTION
## Summary
- make check_bootstrap_sh skip only in consumer checkouts where the mergepath-only test suite is absent
- make check_onepassword_headless_proof_workflow skip only in non-adopter consumer checkouts while still failing on partial adoption or Mergepath misconfig

## Self-Review
- Correctness: The checks now distinguish Mergepath from consumers with the non-propagated .mergepath-sync.yml marker, matching the existing consumer-safe CI-check pattern.
- Regression risk: Low. Mergepath behavior remains fail-closed when paired artifacts are missing; consumer skip only applies when the marker and paired artifacts are absent.
- Style/conventions: Uses the existing shell guard style from nearby scripts/ci checks.
- Test coverage: Ran both checks in Mergepath, smoke-tested consumer skip behavior, partial-adoption failure, Mergepath-marker failure, check_sync_manifest, check_ci_scripts_wired, and git diff --check.
- Security/dependency hygiene: No new dependencies or secret-handling changes.

## Validation
- scripts/ci/check_bootstrap_sh
- scripts/ci/check_onepassword_headless_proof_workflow
- consumer-checkout smoke: both checks skip when .mergepath-sync.yml and their paired artifacts are absent
- partial-adoption smoke: headless proof check fails when only the workflow exists
- mergepath-marker smoke: bootstrap check fails when .mergepath-sync.yml exists but the test is absent
- scripts/ci/check_sync_manifest
- scripts/ci/check_ci_scripts_wired
- git diff --check