### PR TITLE
fix(workflows): make js-yaml install peer-safe

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -259,7 +259,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install js-yaml
-        run: npm install js-yaml
+        run: npm install --no-save --ignore-scripts --legacy-peer-deps js-yaml
 
       - name: Check for conflicting reviews
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -366,7 +366,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install js-yaml
-        run: npm install js-yaml
+        run: npm install --no-save --ignore-scripts --legacy-peer-deps js-yaml
 
       - name: Check and dismiss
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install js-yaml
-        run: npm install js-yaml
+        run: npm install --no-save --ignore-scripts --legacy-peer-deps js-yaml
 
       - name: Audit merged PRs for review policy compliance
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -630,6 +630,19 @@ else
   echo "  FAIL: Dependabot auto-merge must check human-hold before queued work, --auto, and fallback squash (got $hold_recheck_count checks)" >&2
 fi
 
+echo "Workflow js-yaml install tests"
+for workflow in .github/workflows/agent-review.yml .github/workflows/pr-audit.yml; do
+  install_count=$(grep -Ec 'run: npm install .*js-yaml' "$workflow" || true)
+  safe_install_count=$(grep -Ec 'run: npm install .*--no-save .*--ignore-scripts .*--legacy-peer-deps .*js-yaml' "$workflow" || true)
+  if [ "$install_count" -gt 0 ] && [ "$install_count" = "$safe_install_count" ]; then
+    pass=$((pass + 1))
+    echo "  PASS: $workflow installs js-yaml without mutating package metadata or resolving peer deps"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: $workflow must install js-yaml with --no-save --ignore-scripts --legacy-peer-deps (safe=$safe_install_count total=$install_count)" >&2
+  fi
+done
+
 echo
 if [ "$fail" -gt 0 ]; then
   echo "check_workflow_parsers: $fail FAIL / $pass PASS" >&2


### PR DESCRIPTION
## Summary
- install js-yaml in workflow jobs with --no-save --ignore-scripts --legacy-peer-deps
- cover agent-review.yml and pr-audit.yml so downstream repos with peer-dependency conflicts do not fail before policy logic runs
- add workflow parser regression coverage for the safe js-yaml install shape

## Self-Review
- Correctness: The workflows still install js-yaml for their Node policy parsing, but no longer mutate package metadata or invoke npm peer resolution against consumer app dependencies.
- Regression risk: Low. The change is limited to install flags and a grep-based regression check.
- Style/conventions: Extends the existing scripts/ci/check_workflow_parsers workflow-shape assertions.
- Test coverage: Ran scripts/ci/check_workflow_parsers and git diff --check.
- Security/dependency hygiene: --ignore-scripts avoids lifecycle script execution; --no-save avoids package metadata churn.

## Validation
- scripts/ci/check_workflow_parsers
- git diff --check