### PR TITLE
Fix Firebase deploy stale configstore auth

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -603,8 +603,10 @@ op-firebase-deploy --only functions
 2. Reads source credentials per [Deploy credential precedence (canonical)](#deploy-credential-precedence-canonical) above. Logs the selected source on stderr (`[op-firebase-deploy] source credential: ...`) so deploy auth debugging is no longer opaque.
 3. If the source credential is a `service_account` key matching the target `firebase-deployer@{project-id}.iam.gserviceaccount.com`, uses it directly (no impersonation wrapper needed — faster, no `serviceAccountTokenCreator` required).
 4. Otherwise, unwraps nested impersonated credentials if needed, stamps the target project into `quota_project_id`, and writes a temporary `impersonated_service_account` credential file.
-5. Runs `firebase deploy --non-interactive`.
-6. Cleans up the temp credentials on exit.
+5. Runs `firebase deploy --non-interactive` with an isolated Firebase CLI
+   configstore, so stale `firebase login` user tokens cannot override the
+   selected Application Default Credential.
+6. Cleans up the temp credentials and Firebase CLI configstore on exit.
 
 No browser prompt is needed for routine use once a valid credential exists in the resolution chain and the 1Password CLI is unlocked.
 
@@ -958,28 +960,27 @@ op-firebase-setup {project-id}
 
 ### Firebase CLI "Authentication Error: credentials are no longer valid" (daily reauth)
 
-`op-firebase-deploy` (and `scripts/deploy.sh` by extension) occasionally fails
-mid-deploy with:
+Current `op-firebase-deploy` isolates Firebase CLI's configstore for the
+deploy subprocess, so stale `firebase login` user tokens should no longer
+override the selected 1Password-backed Application Default Credential. This
+keeps routine deploys on the project Firebase-vault SA key and avoids the
+daily `firebase login --reauth` loop.
+
+If an older helper is still installed, deploys can fail mid-deploy with:
 
 ```
 Authentication Error: Your credentials are no longer valid. Please run firebase login --reauth
 ```
 
-The 1Password source-credential chain is still healthy when this fires —
-`gcloud auth application-default print-access-token` against the materialized
-ADC still mints a valid token. The failure is inside firebase CLI, which
-ignores `GOOGLE_APPLICATION_CREDENTIALS` in some hosting-deploy code paths
-and falls back to the user-login cache at
-`~/.config/configstore/firebase-tools.json`. That cache's access token
-expires roughly daily and is not refreshed by the 1Password flow.
+The 1Password source-credential chain may still be healthy when this fires.
+The failure is inside Firebase CLI, which checks cached user-login state at
+`~/.config/configstore/firebase-tools.json` before using ADC. That cache's
+access token expires roughly daily and is not refreshed by the 1Password flow.
 
-**Workaround:** run `firebase login --reauth` once, then re-run the exact
-same `scripts/deploy.sh` (or `op-firebase-deploy`) command. It will succeed
-on the next attempt. See nathanjohnpayne/mergepath#137 for the open
-investigation and the longer-term fix under consideration
-(detect stale configstore in `op-firebase-deploy` and print a clear message
-instead of the current cryptic "Assertion failed: resolving hosting target"
-trailer).
+**Fix:** install the current `op-firebase-deploy` helper and re-run the same
+`scripts/deploy.sh` (or `op-firebase-deploy`) command. The expected source log
+is the project Firebase-vault SA key, and the command should complete without
+prompting for `firebase login --reauth`.
 
 ### 1Password ADC item refresh token expired (#137 failure mode B)
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -968,7 +968,7 @@ daily `firebase login --reauth` loop.
 
 If an older helper is still installed, deploys can fail mid-deploy with:
 
-```
+```text
 Authentication Error: Your credentials are no longer valid. Please run firebase login --reauth
 ```
 

--- a/scripts/ci/check_op_firebase_deploy_integration
+++ b/scripts/ci/check_op_firebase_deploy_integration
@@ -62,6 +62,8 @@
 #   (b) every tempfile the script wrote under our scratch TMPDIR is
 #       cleaned up after the process exits (no leaked SA key / ADC
 #       material on disk)
+#   (c) the Firebase CLI subprocess receives an isolated configstore
+#       so stale `firebase login` state cannot override ADC
 #
 # NOTE on resolver coverage: The brief for #211 named a fourth case
 # "firebase-login-state" as the last-resort fallback. The script as
@@ -158,6 +160,7 @@ JSON
   cat >"$bin_dir/firebase" <<'STUB'
 #!/usr/bin/env bash
 echo "[stub-firebase] called with: $*" >&2
+echo "[stub-firebase] XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-}" >&2
 exit 0
 STUB
   chmod +x "$bin_dir/firebase"
@@ -194,6 +197,7 @@ STUB
     env -i \
       PATH="$bin_dir:$PYTHON3_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
       HOME="$home_dir" \
+      XDG_CONFIG_HOME="$home_dir/.config" \
       TMPDIR="$tmp_dir" \
       "$DEPLOY_SCRIPT" \
       >"$stdout_log" 2>"$stderr_log"
@@ -216,6 +220,13 @@ STUB
     check_passed=false
   fi
 
+  if ! grep -qE '^\[stub-firebase\] XDG_CONFIG_HOME=.*/firebase-configstore-[^[:space:]]+$' "$stderr_log"; then
+    echo "  FAIL: $case_name — firebase subprocess did not receive isolated XDG_CONFIG_HOME"
+    echo "    actual stderr:"
+    sed 's/^/      /' "$stderr_log" >&2 || true
+    check_passed=false
+  fi
+
   # Tempfile cleanup verification: every file we expected the script
   # to create under $tmp_dir must be gone after exit.
   local lingering
@@ -223,6 +234,13 @@ STUB
   if [ -n "$lingering" ]; then
     echo "  FAIL: $case_name — tempfiles leaked under $tmp_dir:"
     echo "$lingering" | sed 's/^/      /' >&2
+    check_passed=false
+  fi
+  local lingering_config
+  lingering_config="$(find "$tmp_dir" -type d -name 'firebase-configstore-*' 2>/dev/null | sort || true)"
+  if [ -n "$lingering_config" ]; then
+    echo "  FAIL: $case_name — firebase configstore tempdir leaked under $tmp_dir:"
+    echo "$lingering_config" | sed 's/^/      /' >&2
     check_passed=false
   fi
 
@@ -256,6 +274,7 @@ JSON
   cat >"$bin_dir/firebase" <<'STUB'
 #!/usr/bin/env bash
 echo "[stub-firebase] called with: $*" >&2
+echo "[stub-firebase] XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-}" >&2
 exit 0
 STUB
   chmod +x "$bin_dir/firebase"
@@ -291,6 +310,7 @@ RUNNER
     env -i \
       PATH="$bin_dir:$PYTHON3_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
       HOME="$home_dir" \
+      XDG_CONFIG_HOME="$home_dir/.config" \
       TMPDIR="$tmp_dir" \
       "$case_dir/runner.sh" \
       >"$stdout_log" 2>"$stderr_log"
@@ -313,6 +333,13 @@ RUNNER
     check_passed=false
   fi
 
+  if ! grep -qE '^\[stub-firebase\] XDG_CONFIG_HOME=.*/firebase-configstore-[^[:space:]]+$' "$stderr_log"; then
+    echo "  FAIL: $case_name — firebase subprocess did not receive isolated XDG_CONFIG_HOME"
+    echo "    actual stderr:"
+    sed 's/^/      /' "$stderr_log" >&2 || true
+    check_passed=false
+  fi
+
   # Tempfile cleanup: the script-written tempfiles (gcp-impersonated-*,
   # firebase-sa-*, gcp-adc-*) must be gone. Note that for cases that
   # pre-provision their own credentials (preflight ADC, explicit GAC),
@@ -323,6 +350,13 @@ RUNNER
   if [ -n "$lingering" ]; then
     echo "  FAIL: $case_name — tempfiles leaked under $tmp_dir:"
     echo "$lingering" | sed 's/^/      /' >&2
+    check_passed=false
+  fi
+  local lingering_config
+  lingering_config="$(find "$tmp_dir" -type d -name 'firebase-configstore-*' 2>/dev/null | sort || true)"
+  if [ -n "$lingering_config" ]; then
+    echo "  FAIL: $case_name — firebase configstore tempdir leaked under $tmp_dir:"
+    echo "$lingering_config" | sed 's/^/      /' >&2
     check_passed=false
   fi
 

--- a/scripts/firebase/op-firebase-deploy
+++ b/scripts/firebase/op-firebase-deploy
@@ -22,6 +22,7 @@ DEFAULT_ADC_FILE="${HOME}/.config/gcloud/application_default_credentials.json"
 DEFAULT_ADC_OP_URI="${FIREBASE_SOURCE_CREDENTIAL_OP_URI:-${GCP_ADC_OP_URI:-op://Private/GCP ADC/credential}}"
 SOURCE_CRED_FILE=""
 SOURCE_CRED_TMPFILE=""
+FIREBASE_CONFIG_TMPDIR=""
 
 PROJECT=""
 EXTRA_ARGS=()
@@ -56,6 +57,12 @@ fi
 cleanup_source_cred() {
   if [[ -n "${SOURCE_CRED_TMPFILE}" && -f "${SOURCE_CRED_TMPFILE}" ]]; then
     rm -f "${SOURCE_CRED_TMPFILE}"
+  fi
+}
+
+cleanup_firebase_config() {
+  if [[ -n "${FIREBASE_CONFIG_TMPDIR}" && -d "${FIREBASE_CONFIG_TMPDIR}" ]]; then
+    rm -rf "${FIREBASE_CONFIG_TMPDIR}"
   fi
 }
 
@@ -283,7 +290,8 @@ PY
 
 umask 077
 ADC_TMPFILE="$(mktemp "${TMPDIR:-/tmp}/gcp-impersonated-XXXXXX")"
-trap 'cleanup_source_cred; rm -f "$ADC_TMPFILE"' EXIT
+FIREBASE_CONFIG_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/firebase-configstore-XXXXXX")"
+trap 'cleanup_source_cred; rm -f "$ADC_TMPFILE"; cleanup_firebase_config' EXIT
 
 SA_EMAIL="${FIREBASE_DEPLOY_SA_EMAIL:-${SA_NAME}@${PROJECT}.iam.gserviceaccount.com}"
 
@@ -411,4 +419,8 @@ export CLOUDSDK_BILLING_QUOTA_PROJECT="$PROJECT"
 export CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
 export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 
-firebase deploy --project "$PROJECT" --non-interactive ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
+# Firebase CLI checks its configstore user token before Application Default
+# Credentials. Run with an isolated configstore so stale `firebase login`
+# state cannot override the service account key we just materialized.
+XDG_CONFIG_HOME="$FIREBASE_CONFIG_TMPDIR" \
+  firebase deploy --project "$PROJECT" --non-interactive ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}


### PR DESCRIPTION
## Summary

Closes #211.

- isolate Firebase CLI's configstore inside `op-firebase-deploy` so stale `firebase login` user tokens cannot override the selected ADC / project Firebase-vault SA key
- extend the opt-in deploy integration check to assert the Firebase subprocess receives an isolated `XDG_CONFIG_HOME` and that the temp configstore is cleaned up
- update deploy docs to replace the old `firebase login --reauth` workaround with the current helper behavior

## Live #211 Proof

Consumer repo: `nathanjohnpayne/nathanpaynedotcom`.

- First canonical deploy attempt reproduced the bug: wrapper selected `project Firebase-vault SA key (nathanpaynedotcom — Firebase Deployer SA Key)`, then Firebase CLI failed on stale cached user auth with `firebase login --reauth`.
- Control run with only `XDG_CONFIG_HOME` isolated succeeded, confirming Firebase CLI configstore precedence was the cause.
- After this patch, canonical `op-firebase-deploy --only hosting` with no manual `XDG_CONFIG_HOME` succeeded:
  - source credential log: `project Firebase-vault SA key (nathanpaynedotcom — Firebase Deployer SA Key)`
  - deploy output: `Deploy complete!`, Hosting URL `https://nathanpaynedotcom.web.app`
  - `https://nathanpayne.com/` returned `HTTP/2 200`, `last-modified: Sat, 23 May 2026 20:45:26 GMT`
  - local ADC hash stayed unchanged: `d9508be0112bfa4e9bddca80f8d8230cbcf30460172b3ef31ef1bc91b727af07`
  - temp credential/configstore scan under `$TMPDIR` found no residue

## Validation

- `bash -n scripts/firebase/op-firebase-deploy scripts/ci/check_op_firebase_deploy_integration`
- `MERGEPATH_RUN_INTEGRATION=1 bash scripts/ci/check_op_firebase_deploy_integration`
- `bash scripts/ci/check_ci_scripts_wired`
- `bash scripts/ci/check_required_root_files && bash scripts/ci/check_no_tool_folder_instructions && bash scripts/ci/check_no_forbidden_top_level_dirs && bash scripts/ci/check_dist_not_modified`
- `bash scripts/ci/check_duplicate_docs`
- `bash scripts/ci/check_mktemp_portability`
- `bash scripts/ci/check_op_preflight_contract`
- `bash scripts/ci/check_export_consumer_facts`
- `bash scripts/ci/check_bootstrap_firebase_and_codereview`
- live `nathanjohnpayne/nathanpaynedotcom`: `op-firebase-deploy --only hosting`

## Self-Review

- Correctness: Firebase CLI reads cached user auth before ADC; isolating configstore for the deploy subprocess makes the wrapper's selected credential authoritative.
- Regression risk: low to moderate. The wrapper already passes `--project`, so it does not rely on Firebase CLI's global active-project config. The change affects only the Firebase subprocess environment and cleans up after itself.
- Style: follows existing temp-file cleanup and deploy-wrapper patterns.
- Test coverage: opt-in integration suite now covers isolation across all resolver ranks, plus live nathanpaynedotcom deploy proof.
- Security/dependency hygiene: no new dependencies; no secrets logged or committed; temp configstore and credentials are removed on exit.

Authoring-Agent: codex
