### PR TITLE
fix(sweep): bound rollup render body under GitHub 65536-char cap (#397)

### DIFF
--- a/scripts/sweep-unresolved-feedback/render.sh
+++ b/scripts/sweep-unresolved-feedback/render.sh
@@ -104,6 +104,21 @@ _hash() {
 TARGET_REPO="${SWEEP_TARGET_REPO:-nathanjohnpayne/mergepath}"
 TITLE_PREFIX="${SWEEP_ROLLUP_TITLE:-Unresolved reviewer feedback backlog}"
 
+# Body-size bounding knobs (#397). GitHub caps issue/comment bodies at
+# 65536 bytes; a large unresolved-feedback backlog (693 findings on the
+# 2026-06-01 run) blew past it because the old render emitted every
+# finding inline. We now bound the VISIBLE findings to a hard global
+# budget and keep the full set in the workflow's NDJSON artifact + the
+# hidden thread-id marker block (which is itself compacted, below).
+#   MAX_VISIBLE      hard cap on visible finding lines across the whole
+#                    Findings section (and across the delta comment).
+#   EXCERPT_LEN      max chars of body_excerpt per visible line.
+#   PER_REPO_VISIBLE soft per-(severity,repo) cap so one noisy bucket
+#                    cannot consume the whole global budget.
+MAX_VISIBLE="${SWEEP_MAX_VISIBLE:-60}"
+EXCERPT_LEN="${SWEEP_EXCERPT_LEN:-120}"
+PER_REPO_VISIBLE="${SWEEP_PER_REPO_VISIBLE:-8}"
+
 if [ -n "${SWEEP_TODAY:-}" ]; then
   TODAY="$SWEEP_TODAY"
 else
@@ -152,11 +167,89 @@ fi
 CONTENT_HASH=$(_hash < "$SORTED_IDS")
 echo "render: content hash = $CONTENT_HASH" >&2
 
-# Render the body. Sections grouped by repo, ordered by repo name; per
-# repo, items grouped by severity (P0, P1, P2, P3, Unknown).
+# ---------------------------------------------------------------------------
+# Build the bounded "## Findings" section into a file (#397). Ordered
+# severity-major (P0,P1,P2,P3,Unknown) so the most important findings are
+# emitted first and are never the ones truncated; within a severity,
+# repos by descending count. A global visible-line budget (MAX_VISIBLE)
+# bounds the rendered bytes regardless of total finding count N — the
+# complete set always lives in the NDJSON workflow artifact and the
+# hidden thread-id marker block. Built in a file (not a pipe) so the
+# REMAINING/SHOWN_TOTAL counters survive (a piped `while` subshells them
+# away under bash 3.2).
+# ---------------------------------------------------------------------------
+FINDINGS_MD="$WORKDIR/findings.md"
+: > "$FINDINGS_MD"
+if [ "$LINE_COUNT" -gt 0 ]; then
+  # Ordered bucket list: "<sev>\t<count>\t<repo>".
+  BUCKETS="$WORKDIR/buckets.txt"
+  : > "$BUCKETS"
+  for sev in P0 P1 P2 P3 Unknown; do
+    jq -r --arg s "$sev" 'select(.severity == $s) | .repo' "$NDJSON" \
+      | sort | uniq -c | sort -k1,1nr -k2,2 \
+      | while read -r c r; do
+          [ -n "$r" ] && printf '%s\t%s\t%s\n' "$sev" "$c" "$r"
+        done >> "$BUCKETS"
+  done
+
+  {
+    echo "## Findings"
+    echo ""
+    # Headline per-severity totals so the reader sees the full shape even
+    # when individual buckets are truncated.
+    printf 'Severity totals — '
+    sev_first=1
+    for sev in P0 P1 P2 P3 Unknown; do
+      sc=$(jq -r --arg s "$sev" 'select(.severity == $s) | .thread_id' "$NDJSON" | wc -l | tr -d ' ')
+      [ "$sev_first" -eq 1 ] || printf ' · '
+      printf '%s: %s' "$sev" "$sc"
+      sev_first=0
+    done
+    printf '  (showing at most %s items inline; full list in the workflow artifact)\n' "$MAX_VISIBLE"
+    echo ""
+
+    REMAINING="$MAX_VISIBLE"
+    SHOWN_TOTAL=0
+    while IFS="$(printf '\t')" read -r sev bucket_count repo; do
+      [ -z "$repo" ] && continue
+      [ "$REMAINING" -le 0 ] && break
+      show="$bucket_count"
+      [ "$show" -gt "$PER_REPO_VISIBLE" ] && show="$PER_REPO_VISIBLE"
+      [ "$show" -gt "$REMAINING" ] && show="$REMAINING"
+      echo "<details>"
+      echo "<summary>$sev — $repo ($bucket_count, showing $show)</summary>"
+      echo ""
+      # Write to a file then `head` the file — piping `jq | head` would
+      # SIGPIPE jq when head closes early, and `set -o pipefail` + `set -e`
+      # would abort the whole render (the #397-adjacent footgun).
+      jq -r --arg r "$repo" --arg s "$sev" --argjson len "$EXCERPT_LEN" '
+        select(.repo == $r and .severity == $s)
+        | "- [#\(.pr_number) · \((.pr_title // "(no title)")[0:80])](\(.thread_url)) — `\(.author_login)`: \((.body_excerpt // "")[0:$len])"
+      ' "$NDJSON" > "$WORKDIR/bucket-lines.txt"
+      head -n "$show" "$WORKDIR/bucket-lines.txt"
+      if [ "$bucket_count" -gt "$show" ]; then
+        printf -- '- _+%s more in this group — full list in the workflow artifact._\n' "$((bucket_count - show))"
+      fi
+      echo ""
+      echo "</details>"
+      echo ""
+      REMAINING=$((REMAINING - show))
+      SHOWN_TOTAL=$((SHOWN_TOTAL + show))
+    done < "$BUCKETS"
+
+    if [ "$SHOWN_TOTAL" -lt "$LINE_COUNT" ]; then
+      printf '> **+%s more findings not shown above.** Full enumeration (all %s threads, every severity) is in the workflow artifact **sweep-findings-%s** (NDJSON, see #236).\n' \
+        "$((LINE_COUNT - SHOWN_TOTAL))" "$LINE_COUNT" "${GITHUB_RUN_ID:-<run>}"
+      echo ""
+    fi
+  } > "$FINDINGS_MD"
+fi
+
+# Render the body. Per-repo aggregate counts, then the bounded Findings
+# section assembled above.
 BODY="$WORKDIR/body.md"
 {
-  echo "<!-- sweep-unresolved-feedback v1 -->"
+  echo "<!-- sweep-unresolved-feedback v2 -->"
   echo "<!-- content-hash: $CONTENT_HASH -->"
   echo "<!-- last-run: $TODAY -->"
   echo ""
@@ -184,30 +277,7 @@ BODY="$WORKDIR/body.md"
     done
     echo ""
 
-    echo "## Findings"
-    echo ""
-    jq -r '.repo' "$NDJSON" | sort -u | while IFS= read -r repo; do
-      [ -z "$repo" ] && continue
-      echo "### $repo"
-      echo ""
-      for sev in P0 P1 P2 P3 Unknown; do
-        count=$(jq -r --arg r "$repo" --arg s "$sev" '
-          select(.repo == $r and .severity == $s) | .thread_id
-        ' "$NDJSON" | wc -l | tr -d ' ')
-        if [ "$count" -gt 0 ]; then
-          echo "<details>"
-          echo "<summary>$sev ($count)</summary>"
-          echo ""
-          jq -r --arg r "$repo" --arg s "$sev" '
-            select(.repo == $r and .severity == $s)
-            | "- [#\(.pr_number) · \(.pr_title // "(no title)")](\(.thread_url)) — `\(.author_login)`: \(.body_excerpt)"
-          ' "$NDJSON"
-          echo ""
-          echo "</details>"
-          echo ""
-        fi
-      done
-    done
+    cat "$FINDINGS_MD"
   fi
 } > "$BODY"
 
@@ -223,15 +293,33 @@ BODY="$WORKDIR/body.md"
   cat "$BODY"
   echo ""
   echo "<!-- thread-ids-begin -->"
+  # Compact, chunked encoding (#397): ids are space-joined, ~40 per
+  # comment line, instead of one comment per id. This block is the
+  # load-bearing delta/idempotency state and MUST carry the COMPLETE id
+  # set (dropping any reintroduces the #254 regression where every
+  # dropped thread reappears as "new"), but at ~38 B/id the old per-line
+  # form became a second body-size ceiling. The compact form is ~13 B/id
+  # (~3x headroom). The reader below accepts BOTH this and the legacy v1
+  # per-line form, so a body written by the old script stays
+  # delta-diffable on the first v2 run.
   if [ -s "$SORTED_IDS" ]; then
-    while IFS= read -r tid; do
-      [ -z "$tid" ] && continue
-      printf '<!-- %s -->\n' "$tid"
-    done < "$SORTED_IDS"
+    awk 'NF {
+      buf = (buf == "" ? $0 : buf " " $0); c++
+      if (c == 40) { print "<!-- thread-ids-chunk: " buf " -->"; buf = ""; c = 0 }
+    } END { if (buf != "") print "<!-- thread-ids-chunk: " buf " -->" }' "$SORTED_IDS"
   fi
   echo "<!-- thread-ids-end -->"
 } > "$BODY.with-marker"
 mv "$BODY.with-marker" "$BODY"
+
+# Body-size safety net (#397). Bounded Findings + compact marker keep the
+# body well under GitHub's 65536-byte cap for any realistic backlog; warn
+# loudly if a pathological N still approaches it rather than failing
+# opaquely at gh create/edit time.
+BODY_BYTES=$(wc -c < "$BODY" | tr -d ' ')
+if [ "$BODY_BYTES" -gt 65000 ]; then
+  echo "render: WARNING body is ${BODY_BYTES} bytes, approaching GitHub's 65536-byte cap (findings=$LINE_COUNT). Lower SWEEP_MAX_VISIBLE or investigate the marker block." >&2
+fi
 
 # ---------------------------------------------------------------------------
 # Dry-run short-circuit. Print the body and exit. Tests use this.
@@ -286,14 +374,29 @@ if [ -n "$PRIOR_HASH" ] && [ "$PRIOR_HASH" = "$CONTENT_HASH" ]; then
   exit 0
 fi
 
-# Delta detection: extract the prior sorted thread-id list from a
-# hidden marker block in the body (we write it on every update).
+# Delta detection: extract the prior sorted thread-id list from the
+# hidden marker block. Accepts BOTH the v2 compact chunk form
+# (`<!-- thread-ids-chunk: id1 id2 ... -->`) and the legacy v1 per-line
+# form (`<!-- <id> -->`), so a body written by the old script is still
+# delta-diffable on the first v2 run (#397).
 PRIOR_IDS="$WORKDIR/prior-ids.txt"
 printf '%s' "$PRIOR_BODY" | awk '
   /<!-- thread-ids-begin -->/ { capture=1; next }
   /<!-- thread-ids-end -->/   { capture=0 }
-  capture==1                  { print }
-' | sed -E 's/^<!-- //; s/ -->$//' | sort -u > "$PRIOR_IDS" || true
+  capture==1 {
+    line = $0
+    if (line ~ /thread-ids-chunk:/) {
+      sub(/.*thread-ids-chunk:[[:space:]]*/, "", line)
+      sub(/[[:space:]]*-->.*/, "", line)
+      n = split(line, ids, /[[:space:]]+/)
+      for (i = 1; i <= n; i++) if (ids[i] != "") print ids[i]
+    } else {
+      sub(/^<!--[[:space:]]*/, "", line)
+      sub(/[[:space:]]*-->.*/, "", line)
+      if (line != "") print line
+    }
+  }
+' | sort -u > "$PRIOR_IDS" || true
 
 NEW_IDS="$WORKDIR/new-ids.txt"
 comm -23 "$SORTED_IDS" "$PRIOR_IDS" > "$NEW_IDS" 2>/dev/null || true
@@ -328,13 +431,23 @@ if [ "$NEW_COUNT" -gt 0 ]; then
     echo ""
     echo "### New items"
     echo ""
+    # Bound the comment to MAX_VISIBLE lines with truncated excerpts so a
+    # large new-item batch can't exceed GitHub's 65536-byte comment cap
+    # (#397). The full set is always in the workflow artifact.
+    shown=0
     while IFS= read -r tid; do
       [ -z "$tid" ] && continue
-      jq -r --arg t "$tid" '
+      [ "$shown" -ge "$MAX_VISIBLE" ] && break
+      jq -r --arg t "$tid" --argjson len "$EXCERPT_LEN" '
         select(.thread_id == $t)
-        | "- **\(.repo) #\(.pr_number)** · `\(.severity)` · [\(.pr_title // "(no title)")](\(.thread_url)) — `\(.author_login)`: \(.body_excerpt)"
+        | "- **\(.repo) #\(.pr_number)** · `\(.severity)` · [\((.pr_title // "(no title)")[0:80])](\(.thread_url)) — `\(.author_login)`: \((.body_excerpt // "")[0:$len])"
       ' "$NDJSON"
+      shown=$((shown + 1))
     done < "$NEW_IDS"
+    if [ "$NEW_COUNT" -gt "$MAX_VISIBLE" ]; then
+      printf '\n> **+%s more new items not shown above.** Full enumeration is in the workflow artifact **sweep-findings-%s** (NDJSON, see #236).\n' \
+        "$((NEW_COUNT - MAX_VISIBLE))" "${GITHUB_RUN_ID:-<run>}"
+    fi
   } > "$COMMENT"
 
   if ! gh issue comment "$EXISTING_NUMBER" \

--- a/scripts/sweep-unresolved-feedback/render.sh
+++ b/scripts/sweep-unresolved-feedback/render.sh
@@ -289,36 +289,59 @@ BODY="$WORKDIR/body.md"
 # thread as "new" because PRIOR_IDS would parse as empty (see #254
 # Codex P2 finding).
 # ---------------------------------------------------------------------------
+# Marker budget (#397, Codex P2 on #399). The marker is the load-bearing
+# delta state and MUST carry the COMPLETE id set (dropping any reintroduces
+# the #254 regression). It is also the only body term that grows with N
+# once Findings are capped. Rather than merely WARN and still post an
+# over-limit body (which would deterministically fail at gh create/edit —
+# the exact bug this PR fixes), we HARD-bound the marker to the bytes left
+# under the cap after the rendered body, and on the (only at >~4500-id)
+# overflow drop the tail with a `thread-ids-truncated` sentinel. That is a
+# self-healing soft degradation (next run re-reports the dropped ids as
+# "new") instead of a hard crash. SWEEP_MARKER_MAX_BYTES overrides the
+# computed budget (used by tests to exercise the truncation path).
+PRE_MARKER_BYTES=$(wc -c < "$BODY" | tr -d ' ')
+MARKER_MAX_BYTES="${SWEEP_MARKER_MAX_BYTES:-$(( 65000 - PRE_MARKER_BYTES - 200 ))}"
+[ "$MARKER_MAX_BYTES" -lt 0 ] && MARKER_MAX_BYTES=0
+
 {
   cat "$BODY"
   echo ""
   echo "<!-- thread-ids-begin -->"
-  # Compact, chunked encoding (#397): ids are space-joined, ~40 per
-  # comment line, instead of one comment per id. This block is the
-  # load-bearing delta/idempotency state and MUST carry the COMPLETE id
-  # set (dropping any reintroduces the #254 regression where every
-  # dropped thread reappears as "new"), but at ~38 B/id the old per-line
-  # form became a second body-size ceiling. The compact form is ~13 B/id
-  # (~3x headroom). The reader below accepts BOTH this and the legacy v1
-  # per-line form, so a body written by the old script stays
-  # delta-diffable on the first v2 run.
+  # Compact, chunked encoding: ids are space-joined, ~40 per comment line,
+  # instead of one comment per id (~13 B/id vs ~38, ~3x headroom). Emission
+  # stops once MARKER_MAX_BYTES is reached, appending a truncated sentinel.
+  # The reader below accepts this chunk form, the truncated sentinel, AND
+  # the legacy v1 per-line form, so an old body stays delta-diffable.
   if [ -s "$SORTED_IDS" ]; then
-    awk 'NF {
-      buf = (buf == "" ? $0 : buf " " $0); c++
-      if (c == 40) { print "<!-- thread-ids-chunk: " buf " -->"; buf = ""; c = 0 }
-    } END { if (buf != "") print "<!-- thread-ids-chunk: " buf " -->" }' "$SORTED_IDS"
+    awk -v budget="$MARKER_MAX_BYTES" '
+      BEGIN { used = 0; c = 0; buf = ""; trunc = 0 }
+      NF {
+        if (trunc) next
+        cost = length($0) + 1
+        # +45 amortizes the "<!-- thread-ids-chunk:  -->\n" framing per line.
+        if (used + cost + 45 > budget) { trunc = 1; next }
+        buf = (buf == "" ? $0 : buf " " $0); c++; used += cost
+        if (c == 40) { print "<!-- thread-ids-chunk: " buf " -->"; used += 45; buf = ""; c = 0 }
+      }
+      END {
+        if (buf != "") print "<!-- thread-ids-chunk: " buf " -->"
+        if (trunc) print "<!-- thread-ids-truncated -->"
+      }
+    ' "$SORTED_IDS"
   fi
   echo "<!-- thread-ids-end -->"
 } > "$BODY.with-marker"
 mv "$BODY.with-marker" "$BODY"
 
-# Body-size safety net (#397). Bounded Findings + compact marker keep the
-# body well under GitHub's 65536-byte cap for any realistic backlog; warn
-# loudly if a pathological N still approaches it rather than failing
-# opaquely at gh create/edit time.
+# Belt-and-suspenders: the budget guard above keeps the body under the cap
+# for any N, so this should never fire — if it does, it is a real alarm.
 BODY_BYTES=$(wc -c < "$BODY" | tr -d ' ')
-if [ "$BODY_BYTES" -gt 65000 ]; then
-  echo "render: WARNING body is ${BODY_BYTES} bytes, approaching GitHub's 65536-byte cap (findings=$LINE_COUNT). Lower SWEEP_MAX_VISIBLE or investigate the marker block." >&2
+if [ "$BODY_BYTES" -gt 65536 ]; then
+  echo "render: WARNING body is ${BODY_BYTES} bytes, still over GitHub's 65536-byte cap (findings=$LINE_COUNT) despite bounding — investigate before relying on this run." >&2
+fi
+if grep -q '<!-- thread-ids-truncated -->' "$BODY" 2>/dev/null; then
+  echo "render: NOTE thread-id marker truncated to fit the 65536-byte cap (findings=$LINE_COUNT); delta state is partial this run and self-heals next run." >&2
 fi
 
 # ---------------------------------------------------------------------------
@@ -385,6 +408,7 @@ printf '%s' "$PRIOR_BODY" | awk '
   /<!-- thread-ids-end -->/   { capture=0 }
   capture==1 {
     line = $0
+    if (line ~ /thread-ids-truncated/) { next }
     if (line ~ /thread-ids-chunk:/) {
       sub(/.*thread-ids-chunk:[[:space:]]*/, "", line)
       sub(/[[:space:]]*-->.*/, "", line)

--- a/tests/test_sweep_unresolved_feedback.sh
+++ b/tests/test_sweep_unresolved_feedback.sh
@@ -362,7 +362,7 @@ if [ "$rc" -ne 0 ]; then
   cat "$WORKDIR/render.stderr" >&2
 fi
 
-grep -q '<!-- sweep-unresolved-feedback v1 -->' "$BODY_OUT" \
+grep -q '<!-- sweep-unresolved-feedback v2 -->' "$BODY_OUT" \
   && pass "render: emitted marker comment" \
   || fail "render: missing marker comment"
 
@@ -386,17 +386,24 @@ grep -q '\*\*owner/alpha\*\* — 3 items' "$BODY_OUT" \
   && pass "render: per-repo count rendered" \
   || fail "render: per-repo count missing"
 
-grep -q '<summary>P1 (1)</summary>' "$BODY_OUT" \
+# Severity-major bounded render (#397): summaries are now
+# "<sev> — <repo> (<bucket_count>, showing <shown>)".
+grep -q '<summary>P1 — owner/alpha (1, showing 1)</summary>' "$BODY_OUT" \
   && pass "render: P1 severity group rendered with count" \
   || fail "render: P1 group missing"
 
-grep -q '<summary>P3 (1)</summary>' "$BODY_OUT" \
+grep -q '<summary>P3 — owner/alpha (1, showing 1)</summary>' "$BODY_OUT" \
   && pass "render: P3 severity group rendered" \
   || fail "render: P3 group missing"
 
-grep -q '<summary>Unknown (1)</summary>' "$BODY_OUT" \
+grep -q '<summary>Unknown — owner/alpha (1, showing 1)</summary>' "$BODY_OUT" \
   && pass "render: Unknown severity group rendered" \
   || fail "render: Unknown group missing"
+
+# Headline per-severity totals line (#397).
+grep -q 'Severity totals — P0: 0 · P1: 1 · P2: 0 · P3: 1 · Unknown: 1' "$BODY_OUT" \
+  && pass "render: severity totals headline rendered" \
+  || fail "render: severity totals headline missing"
 
 # Codex #254 P2: the body must include the thread-ids marker block on
 # BOTH the create path and the edit path, otherwise the first sweep
@@ -411,11 +418,24 @@ grep -q '<!-- thread-ids-end -->' "$BODY_OUT" \
   && pass "render: dry-run body includes thread-ids-end marker" \
   || fail "render: dry-run body missing thread-ids-end marker"
 
+# Marker is now the v2 compact chunk form; parse both forms (#397).
 MARKER_IDS=$(awk '
   /<!-- thread-ids-begin -->/ { capture=1; next }
   /<!-- thread-ids-end -->/   { capture=0 }
-  capture==1                  { print }
-' "$BODY_OUT" | sed -E 's/^<!-- //; s/ -->$//' | sort -u | tr '\n' ' ')
+  capture==1 {
+    line = $0
+    if (line ~ /thread-ids-chunk:/) {
+      sub(/.*thread-ids-chunk:[[:space:]]*/, "", line)
+      sub(/[[:space:]]*-->.*/, "", line)
+      n = split(line, a, /[[:space:]]+/)
+      for (i = 1; i <= n; i++) if (a[i] != "") print a[i]
+    } else {
+      sub(/^<!--[[:space:]]*/, "", line)
+      sub(/[[:space:]]*-->.*/, "", line)
+      if (line != "") print line
+    }
+  }
+' "$BODY_OUT" | sort -u | tr '\n' ' ')
 WANT_MARKER_IDS="PRT_alpha_1_a PRT_alpha_2_a PRT_alpha_2_b "
 if [ "$MARKER_IDS" = "$WANT_MARKER_IDS" ]; then
   pass "render: thread-id marker block contains all current thread_ids"
@@ -588,6 +608,110 @@ else
     || fail "workflow: does not run enumerate.sh"
   grep -q "render.sh" "$WF" && pass "workflow: runs render.sh" \
     || fail "workflow: does not run render.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 9: body-size cap regression (#397). A large backlog must render a
+# body within GitHub's 65536-byte issue cap; the full id set must still
+# survive in the marker block (delta correctness), and the truncation
+# footer must point at the artifact. This is the regression that broke
+# the 2026-05-25 / 2026-06-01 weekly sweeps (693 findings → body too long).
+# ---------------------------------------------------------------------------
+BIG="$WORKDIR/big.ndjson"
+: > "$BIG"
+bi=0
+while [ "$bi" -lt 750 ]; do
+  bsev=$(printf 'P0 P1 P2 P3 Unknown' | tr ' ' '\n' | sed -n "$(((bi % 5) + 1))p")
+  brepo="owner/repo$((bi % 5))"
+  jq -nc --arg tid "PRT_big_$bi" --arg repo "$brepo" --arg sev "$bsev" --argjson pr "$bi" \
+    '{repo:$repo,pr_number:$pr,pr_title:("Finding "+($pr|tostring)),
+      pr_url:("https://github.com/"+$repo+"/pull/"+($pr|tostring)),thread_id:$tid,
+      author_login:"coderabbitai[bot]",
+      body_excerpt:"Potential issue: a representative ~150 char excerpt mirroring what enumerate.sh emits so the rendered per-finding line reflects realistic bloat here ok done now",
+      severity:$sev,
+      thread_url:("https://github.com/"+$repo+"/pull/"+($pr|tostring)+"#discussion_r"+($pr|tostring))}' >> "$BIG"
+  bi=$((bi + 1))
+done
+
+BODY_BIG="$WORKDIR/body-big.md"
+set +e
+SWEEP_DRY_RUN=1 SWEEP_TODAY="2026-05-13" GH_TOKEN="dummy" \
+  "$RENDER" "$BIG" > "$BODY_BIG" 2>/dev/null
+rc=$?
+set -e
+BIG_BYTES=$(wc -c < "$BODY_BIG" | tr -d ' ')
+if [ "$rc" -eq 0 ] && [ "$BIG_BYTES" -gt 0 ] && [ "$BIG_BYTES" -le 65536 ]; then
+  pass "render: 750-finding dry-run body within 65536-byte cap ($BIG_BYTES B)"
+else
+  fail "render: 750-finding body is $BIG_BYTES B (rc=$rc), expected 1..65536 — bounded-render regression"
+fi
+
+# Marker block must still carry the COMPLETE id set (parse both forms).
+BIG_MARKER_IDS=$(awk '
+  /<!-- thread-ids-begin -->/ { capture=1; next }
+  /<!-- thread-ids-end -->/   { capture=0 }
+  capture==1 {
+    line = $0
+    if (line ~ /thread-ids-chunk:/) {
+      sub(/.*thread-ids-chunk:[[:space:]]*/, "", line); sub(/[[:space:]]*-->.*/, "", line)
+      n = split(line, a, /[[:space:]]+/); for (i = 1; i <= n; i++) if (a[i] != "") print a[i]
+    } else {
+      sub(/^<!--[[:space:]]*/, "", line); sub(/[[:space:]]*-->.*/, "", line)
+      if (line != "") print line
+    }
+  }
+' "$BODY_BIG" | sort -u | wc -l | tr -d ' ')
+if [ "$BIG_MARKER_IDS" -eq 750 ]; then
+  pass "render: marker block carries all 750 ids despite bounded findings"
+else
+  fail "render: marker block has $BIG_MARKER_IDS ids, expected 750 — delta state would be lossy"
+fi
+
+# Truncation footer must be present and name the artifact.
+if grep -q 'more findings not shown above' "$BODY_BIG" \
+   && grep -q 'workflow artifact' "$BODY_BIG"; then
+  pass "render: truncation footer present and references the workflow artifact"
+else
+  fail "render: truncation footer missing on a bounded render"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 10: v1 → v2 marker migration (#397). A rollup body written by the
+# OLD per-line (v1) script must stay delta-diffable on the first v2 run —
+# the reader accepts both the legacy per-line and the new chunk form.
+# Drive the edit path with a v1 prior body whose ids differ from current
+# and assert the new/resolved counts are computed from the legacy ids
+# (if the legacy reader failed, PRIOR_IDS would be empty → new=3).
+# ---------------------------------------------------------------------------
+cat >"$STUB_FIXTURES/issue-list.json" <<'JSON'
+[
+  {
+    "number": 4243,
+    "title": "Unresolved reviewer feedback backlog — 2026-05-06",
+    "body": "<!-- sweep-unresolved-feedback v1 -->\n<!-- content-hash: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef -->\n<!-- last-run: 2026-05-06 -->\n\n# Unresolved reviewer feedback backlog\n\nstale body\n\n<!-- thread-ids-begin -->\n<!-- PRT_alpha_1_a -->\n<!-- PRT_alpha_2_a -->\n<!-- PRT_old_stale -->\n<!-- thread-ids-end -->"
+  }
+]
+JSON
+
+: > "$GH_CALLS_LOG"
+set +e
+PATH="$STUB_DIR:$PATH" \
+GH_TOKEN="dummy-pat" \
+STUB_FIXTURES="$STUB_FIXTURES" \
+GH_CALLS_LOG="$GH_CALLS_LOG" \
+SWEEP_TODAY="2026-05-13" \
+  "$RENDER" "$OUT_NDJSON" >/dev/null 2>"$WORKDIR/render-migrate.stderr"
+rc=$?
+set -e
+
+if [ "$rc" -ne 0 ]; then
+  fail "v1→v2 migration: render exited $rc, expected 0"
+  cat "$WORKDIR/render-migrate.stderr" >&2
+elif grep -q 'new=1, resolved=1' "$WORKDIR/render-migrate.stderr"; then
+  pass "v1→v2 migration: legacy per-line marker parsed (new=1, resolved=1)"
+else
+  fail "v1→v2 migration: wrong delta counts (legacy reader likely broke)"
+  grep 'updating issue' "$WORKDIR/render-migrate.stderr" >&2 || true
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sweep_unresolved_feedback.sh
+++ b/tests/test_sweep_unresolved_feedback.sh
@@ -424,6 +424,7 @@ MARKER_IDS=$(awk '
   /<!-- thread-ids-end -->/   { capture=0 }
   capture==1 {
     line = $0
+    if (line ~ /thread-ids-truncated/) { next }
     if (line ~ /thread-ids-chunk:/) {
       sub(/.*thread-ids-chunk:[[:space:]]*/, "", line)
       sub(/[[:space:]]*-->.*/, "", line)
@@ -652,6 +653,7 @@ BIG_MARKER_IDS=$(awk '
   /<!-- thread-ids-end -->/   { capture=0 }
   capture==1 {
     line = $0
+    if (line ~ /thread-ids-truncated/) { next }
     if (line ~ /thread-ids-chunk:/) {
       sub(/.*thread-ids-chunk:[[:space:]]*/, "", line); sub(/[[:space:]]*-->.*/, "", line)
       n = split(line, a, /[[:space:]]+/); for (i = 1; i <= n; i++) if (a[i] != "") print a[i]
@@ -712,6 +714,30 @@ elif grep -q 'new=1, resolved=1' "$WORKDIR/render-migrate.stderr"; then
 else
   fail "v1→v2 migration: wrong delta counts (legacy reader likely broke)"
   grep 'updating issue' "$WORKDIR/render-migrate.stderr" >&2 || true
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11: marker truncation hard-guard (#399 Codex P2). When the complete
+# marker can't fit under the byte budget, emission stops with a truncated
+# sentinel and the body is still well-formed — the render NEVER posts an
+# over-limit body. Force a tiny SWEEP_MARKER_MAX_BYTES so the path is
+# exercised deterministically (the real budget only truncates at ~4500+ ids).
+# ---------------------------------------------------------------------------
+BODY_TRUNC="$WORKDIR/body-trunc.md"
+set +e
+SWEEP_DRY_RUN=1 SWEEP_TODAY="2026-05-13" GH_TOKEN="dummy" SWEEP_MARKER_MAX_BYTES=80 \
+  "$RENDER" "$OUT_NDJSON" > "$BODY_TRUNC" 2>/dev/null
+rc=$?
+set -e
+TRUNC_BYTES=$(wc -c < "$BODY_TRUNC" | tr -d ' ')
+if [ "$rc" -eq 0 ] \
+   && grep -q '<!-- thread-ids-truncated -->' "$BODY_TRUNC" \
+   && grep -q '<!-- thread-ids-begin -->' "$BODY_TRUNC" \
+   && grep -q '<!-- thread-ids-end -->' "$BODY_TRUNC" \
+   && [ "$TRUNC_BYTES" -le 65536 ]; then
+  pass "render: marker truncation guard fires under a tiny budget, body stays well-formed"
+else
+  fail "render: marker truncation guard did not fire / body malformed (rc=$rc, bytes=$TRUNC_BYTES)"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

The scheduled `weekly-feedback-sweep` workflow failed deterministically twice — 2026-05-25 (#396) and 2026-06-01 (#397). Root cause (full RCA on #397): `scripts/sweep-unresolved-feedback/render.sh` rendered **every** finding inline, so the unresolved-feedback backlog (693 findings) produced an issue body past GitHub's hard **65536-character** limit:

```
render: 693 findings ingested
render: no existing rollup issue found — creating new one
GraphQL: Body is too long, Body is too long (maximum is 65536 characters) (createIssue)
render: gh issue create failed   → exit 2
```

It is the workflow, not the input — render.sh had no body-size guard, so it fails every Monday once the backlog crosses ~65 KB of rendered Markdown.

## Change

Bound the rendered body while keeping full fidelity for correctness state:

- **Findings section** — now severity-major (P0/P1 first, so the most important findings are never the ones truncated), with a hard global `MAX_VISIBLE` cap (default 60), truncated excerpts (`SWEEP_EXCERPT_LEN`, 120) and titles (80), per-bucket and section `+N more` footers pointing at the existing NDJSON workflow artifact. The byte ceiling is independent of total finding count N.
- **Thread-id marker block** — the load-bearing delta/idempotency state. Switched from one HTML comment per id (~38 B/id, a second independent ceiling at ~1500 findings) to a compact chunked encoding (~13 B/id, ~3× headroom) that still carries the **complete** id set, so delta detection stays correct. The reader accepts both the new chunk form and the legacy v1 per-line form, so a body written by the old script stays delta-diffable on the first v2 run.
- **Delta comment** — same `MAX_VISIBLE` bound, closing the equivalent 65536 cap on comments.
- **Safety net** — a stderr warning if a pathological N still nears the cap (instead of an opaque `gh` failure).

`content-hash` is unchanged (still hashed over the full sorted id set), so no-op idempotency is preserved.

## Verification

- New `tests/test_sweep_unresolved_feedback.sh` cases: a synthetic **750-finding** payload renders a **20239-byte** body (was >65536), with **all 750 ids preserved** in the marker, the truncation footer present, and the **v1→v2 migration** delta path (`new=1, resolved=1`) confirmed.
- Full suite green: **45 passed, 0 failed** (was 41). `check_sweep_unresolved_feedback` (already wired in `repo_lint.yml`) runs these, so the size cap is now CI-guarded — folded into the existing check rather than a new `scripts/ci/check_*`, because `scripts/ci/` is a propagated kit and a new check there would fan out to all consumers.
- `bash -n` clean; adjacent guards (`check_mktemp_portability`, `check_spec_test_alignment`) pass; `test_daily_feedback_rollup` (untouched) still 61/61.

## Scope notes

- `render.sh` and its test are **mergepath-canonical** (not in `.mergepath-sync.yml`) — this fix touches **zero propagated files**, so no consumer fan-out.
- `scripts/daily-feedback-rollup.sh` carries the **same latent class of bug** (two `gh issue create`/`comment` write sites, plus `--body` arg fragility). It is **in** the sync manifest, so fixing it triggers a consumer propagation wave — deliberately **deferred** to a separate follow-up rather than bundled here. It has not failed (latent).

Closes #397. (#396 closed as a duplicate.)

Authoring-Agent: claude

## Self-Review

- **Correctness**: `content-hash` still computed over the full sorted id set, so no-op detection is byte-identical. The complete id set survives in the marker (verified: 750/750), so `#254`-correct delta detection is preserved despite visible truncation. Severity-major ordering guarantees P0/P1 are emitted before the budget is consumed. The `jq | head` SIGPIPE-under-`pipefail` footgun is avoided by writing to a file then `head`-ing it.
- **Regression risk**: Low. Output format changes only above the visible cap; small inputs render the same shape (plus the new severity-totals headline and reworded `<summary>`). v1→v2 reader is backward-compatible (tested). No propagated files touched.
- **Style**: Matches the existing render.sh idioms (jq + awk, bash 3.2, `$WORKDIR` temp files, stderr logging).
- **Test coverage**: Added size-cap, marker-completeness, footer, and v1→v2 migration cases; existing assertions updated for the new format. 45/45 green.
- **Security/deps**: No new dependencies, no new network or auth surface. Dry-run path unchanged (still short-circuits before any `gh` call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
