### PR TITLE
fix(rollup): paginate dedupe comment reads beyond the ~100 inline cap (#403)

### DIFF
--- a/scripts/daily-feedback-rollup.sh
+++ b/scripts/daily-feedback-rollup.sh
@@ -614,16 +614,32 @@ collect_triaged_ids_for_label() {
   n=$(printf '%s' "$merged" | jq 'length')
   local x=0
   while [ "$x" -lt "$n" ]; do
-    local issue_state issue_text
+    local issue_state issue_num issue_body inline_comment_count comment_text issue_text
     issue_state=$(printf '%s' "$merged" | jq -r ".[$x].state")
+    issue_num=$(printf '%s' "$merged" | jq -r ".[$x].number")
+    issue_body=$(printf '%s' "$merged" | jq -r ".[$x].body // \"\"")
+    inline_comment_count=$(printf '%s' "$merged" | jq -r ".[$x].comments // [] | length")
     # Parse the BODY *and* all comment bodies (#402). The throttle path
     # appends today's findings as a COMMENT (append-only, atomic — we keep
     # that rather than a read-modify-write body edit that could clobber a
-    # concurrent run). So mp-ids and triage signals can live in comments;
-    # folding them in here makes the comment-append path dedupe-visible.
-    issue_text=$(printf '%s' "$merged" | jq -r "
-      .[$x] | ((.body // \"\") + \"\n\" + ((.comments // []) | map(.body // \"\") | join(\"\n\")))
-    ")
+    # concurrent run). The inline `comments` list field is page-capped
+    # (~100, #403), so when an issue has any comments we paginate the REST
+    # endpoint to read EVERY one — otherwise a rollup with >100 appended
+    # comments would lose dedupe visibility for the later mp-ids. The
+    # inline count is only a cheap "are there comments?" gate so the
+    # common (0-comment) rollup skips the extra call.
+    comment_text=""
+    if [ "$inline_comment_count" -gt 0 ]; then
+      if ! comment_text=$(gh api --paginate \
+           "repos/$OWNER/$NAME/issues/$issue_num/comments" \
+           --jq '.[].body // empty' 2>/dev/null); then
+        echo "daily-feedback-rollup: WARN dedupe: could not paginate comments for #$issue_num (best-effort, continuing)" >&2
+        DEDUP_FETCH_FAILURES=$((DEDUP_FETCH_FAILURES + 1))
+        comment_text=""
+      fi
+    fi
+    issue_text="${issue_body}
+${comment_text}"
     if [ "$issue_state" = "CLOSED" ] || [ "$issue_state" = "closed" ]; then
       # Closed host → ALL mp-ids on this rollup (body + comments) are
       # implicitly triaged.

--- a/tests/test_daily_feedback_rollup.sh
+++ b/tests/test_daily_feedback_rollup.sh
@@ -397,7 +397,7 @@ gen_findings 200 > "$BIG_RB"
 # --- 1) Rich mode (default budget): no loss + within cap ---
 render_rollup_body "$BIG_RB" "substantive" > "$RB_OUT"
 RB_BYTES=$(wc -c < "$RB_OUT" | tr -d ' ')
-RB_MPIDS=$(grep -oE '<!-- *mp-id:[a-f0-9]+ *-->' "$RB_OUT" | sort -u | wc -l | tr -d ' ')
+RB_MPIDS=$(grep -oE '<!-- *mp-id:[a-f0-9]+ *-->' "$RB_OUT" | sort -u | wc -l | tr -d ' ' || true)
 
 if [ "$RB_BYTES" -le 65536 ] && [ "$RB_BYTES" -gt 0 ]; then
   pass "render_rollup_body: 200-finding body within 65536-byte cap ($RB_BYTES B)"
@@ -441,7 +441,7 @@ fi
 STUB_OUT="$(mktemp "${TMPDIR:-/tmp}/rb-stub-XXXXXX.md")"
 ROLLUP_BODY_BUDGET=30000 render_rollup_body "$BIG_RB" "substantive" > "$STUB_OUT"
 STUB_BYTES=$(wc -c < "$STUB_OUT" | tr -d ' ')
-STUB_MPIDS=$(grep -oE '<!-- *mp-id:[a-f0-9]+ *-->' "$STUB_OUT" | sort -u | wc -l | tr -d ' ')
+STUB_MPIDS=$(grep -oE '<!-- *mp-id:[a-f0-9]+ *-->' "$STUB_OUT" | sort -u | wc -l | tr -d ' ' || true)
 if [ "$STUB_BYTES" -le 30000 ] && [ "$STUB_MPIDS" -eq 200 ] && grep -qE '^- \[ \] <!-- mp-id:' "$STUB_OUT"; then
   pass "render_rollup_body: stub-mode keeps all 200 mp-ids under a 30000B budget ($STUB_BYTES B)"
 else
@@ -486,6 +486,22 @@ if [ "$all402" = "aaaaaaaaaaaa bbbbbbbbbbbb cccccccccccc " ]; then
   pass "#402 dedupe: closed-host parse_all reads all body+comment mp-ids"
 else
   fail "#402 dedupe: all set = [$all402] (want all three)"
+fi
+
+# ---------------------------------------------------------------------
+# #403: the dedupe must read EVERY comment via pagination (the inline
+# `gh issue list --json comments` field is page-capped at ~100), else a
+# rollup with >100 appended comments loses dedupe visibility for the
+# later mp-ids. The fetch is gh-integration (the body+comments PARSE
+# contract is covered by the #402 test above); this guards the source
+# is the paginated REST endpoint, not the capped inline field.
+# ---------------------------------------------------------------------
+SCRIPT_SRC="$ROOT/scripts/daily-feedback-rollup.sh"
+if grep -q 'gh api --paginate' "$SCRIPT_SRC" \
+   && grep -qE '/issues/\$issue_num/comments' "$SCRIPT_SRC"; then
+  pass "#403 dedupe: comments read via 'gh api --paginate …/comments' (beyond the ~100 inline cap)"
+else
+  fail "#403 dedupe: paginated comment fetch missing — >100-comment rollups would lose dedupe visibility"
 fi
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Follow-up to #401/#402, closes **#403**. The #402 fix made the throttle/append **comment** path dedupe-visible by folding comment bodies into `collect_triaged_ids_for_label` via the inline `gh issue list --json comments` field — but that nested field is GitHub **page-capped at ~100**. A rollup issue with >100 appended comments (heavy throttle use over time) would lose dedupe visibility for the later mp-ids — a narrower re-occurrence of #402. Codex flagged it (P2) on the #401 propagation canary, matchline#250.

## Change

`collect_triaged_ids_for_label` now uses the inline `comments` length only as a cheap **"are there any comments?"** gate; when an issue has comments it fetches **every** one via `gh api --paginate repos/{owner}/{repo}/issues/{n}/comments` (best-effort — warn + body-only on failure, consistent with the existing dedupe fail-soft), then parses body + all comments. The common **0-comment rollup skips the extra call**. The append mechanism is unchanged (still an append-only comment — no read-modify-write concurrency risk).

Also folded in the CodeRabbit nits from the same review:
- `|| true` on two test `grep | … | wc -l` pipelines for `set -euo pipefail` parity (clean assertion failure instead of a `set -e` abort).
- The mktemp-suffix Minor is a **non-issue** — `check_mktemp_portability` passes and CI runs GNU mktemp; left as-is.

## Verification (73 tests pass)

- #402 parse contract (unchanged): body + comments concatenation surfaces comment-resident triaged mp-ids (open host) and the full set (closed host).
- #403 regression guard: asserts the comment source is the **paginated** REST endpoint, not the capped inline field. (The fetch itself is best-effort gh-integration; the parse contract is the unit-tested part.)
- `check_daily_feedback_rollup` green (unit + dry-run smoke that runs `collect_triaged_ids` + #304 dedupe); `check_mktemp_portability` green.

## Post-merge

Script-only change to the synced `daily-feedback-rollup.sh` → propagates to the 8 consumers via canary-first per-commit propagation after merge.

Closes #403.

Authoring-Agent: claude

## Self-Review

- **Correctness**: Paginated REST fetch reads all comments regardless of the inline field's cap (verified `gh api --paginate` returns full comment sets). Best-effort: a per-issue fetch failure warns + degrades to body-only for that issue (doesn't abort — matches the dedupe's existing fail-soft posture; the all-or-nothing gate protects the post path, not the read-only dedupe). 0-comment rollups skip the call.
- **Regression risk**: Low. 48-line change, isolated to the dedupe read loop; the parse path is unchanged. Append mechanism unchanged (no concurrency exposure). Adds N best-effort API calls only for issues that actually have comments.
- **Style**: Matches the function's existing jq + fail-soft idioms; bash 3.2-safe.
- **Test coverage**: parse contract + paginated-source structural guard; test pipefail parity fixed.
- **Security/deps**: no new deps; read-only `gh api` GET; one extra paginated read per commented issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
