### PR TITLE
fix(ci): fleet tooling hardening — dependabot dev-groups (#374), firebase mergepath-gate (#398), author-attributed Codex trigger

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -38,10 +38,20 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
-      - name: Approve and merge patch/minor updates
+      - name: Approve and merge patch/minor + dev-dependency-group updates
+        # Single patch/minor updates, plus the `dev-dependencies` GROUP
+        # (whatever its highest bump — dev tooling major bumps are
+        # low-risk and still gated by CI-green + the reviewer-identity
+        # approval + the available_reviewers allowlist below). Grouped
+        # dev updates whose highest member is major were previously
+        # skipped here (update-type=major), fell through to a manual
+        # merge with no reviewer approval, and tripped the weekly audit
+        # (#374 Pattern A — matchline#245). Production groups + non-group
+        # major bumps still require manual review.
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.dependency-group == 'dev-dependencies'
         run: |
           set -euo pipefail
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -182,7 +182,26 @@ jobs:
               echo "::notice::PR carries human-hold immediately before fallback squash; skipping Dependabot auto-merge until the human removes the label."
               exit 0
             fi
-            gh pr merge --squash "$PR_URL"
+            # The immediate (no --auto) squash does NOT wait for CI. That's
+            # acceptable for single patch/minor bumps (the long-standing
+            # behavior), but the broadened dev-dependencies-group gate
+            # (#374) can route a semver-MAJOR group here — and the safety
+            # case for auto-merging dev groups is explicitly "CI is green".
+            # Merging a major group before CI in a no-branch-protection
+            # repo would break that (Codex P2 on #405). So only
+            # immediate-squash patch/minor; for anything else (a major dev
+            # group) leave the PR APPROVED but unmerged — --auto will merge
+            # it once branch protection/required checks are configured, or a
+            # human merges after CI. The approval is already recorded, so
+            # the weekly audit's "no reviewer approval" gate is satisfied
+            # either way.
+            if [ "$UPDATE_TYPE" = "version-update:semver-patch" ] || \
+               [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
+              gh pr merge --squash "$PR_URL"
+            else
+              echo "::notice::update-type='$UPDATE_TYPE' (dependency-group='$DEPENDENCY_GROUP') is not patch/minor and --auto is unavailable; leaving the PR approved-but-unmerged to preserve the CI-green safety case. Configure branch protection/auto-merge or merge manually after CI."
+              exit 0
+            fi
           else
             echo "::error::gh pr merge --auto failed for a non-auto-merge-unavailable reason. See stderr above. Not falling back to immediate squash; surface to audit."
             exit "$AUTO_RC"
@@ -195,4 +214,8 @@ jobs:
           # Dependabot PR is never `nathanjohnpayne`). (CodeRabbit
           # Major, #271.)
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          # Dependabot metadata — used by the immediate-squash fallback to
+          # keep major dev-group bumps behind CI (#374 / Codex P2 on #405).
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_GROUP: ${{ steps.metadata.outputs.dependency-group }}
           GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -344,14 +344,20 @@ Notes on auth-split nuance:
   that closes this drift window (#284).
 
 - **Pre-action identity check.** Every helper that posts a write
-  (`coderabbit-wait.sh`, `codex-review-request.sh`,
-  `resolve-pr-threads.sh`, `request-label-removal.sh`, `gh-as-*.sh`)
-  calls `scripts/identity-check.sh` BEFORE the write. The check is
+  (`coderabbit-wait.sh`, `resolve-pr-threads.sh`,
+  `request-label-removal.sh`, `gh-as-*.sh`) calls
+  `scripts/identity-check.sh` BEFORE the write. The check is
   fail-closed: if the keyring's active account (or `GH_TOKEN`'s
   resolved login, depending on the auth path) doesn't match the
   expected identity, the helper exits with a diagnostic rather than
   landing a misattributed write. See #283 for the in-session
   incidents that motivated the check, and #284 for the implementation.
+  `codex-review-request.sh` is the one exception: its `@codex review`
+  trigger must be authored by `nathanjohnpayne` (not a reviewer
+  identity — #405), so instead of a direct `identity-check.sh` call it
+  posts through `scripts/gh-as-author.sh`, which switches to and
+  verifies the author identity (its own fail-closed gate) before the
+  write.
 
 ## Workflow
 
@@ -1006,10 +1012,16 @@ GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq '.login'
 # Read-only helper:
 GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-check.sh <PR#>
 
-# Helpers that may also POST a trigger comment — GH_TOKEN authenticates
-# the API call, but the comment byline is the active keyring account.
-# Set active = nathanpayne-<agent> once per machine; then byline is correct.
+# coderabbit-wait.sh may POST a retry nudge: GH_TOKEN authenticates the
+# read calls; the nudge byline is the active keyring account and is
+# identity-agnostic (set active = nathanpayne-<agent> for audit tidiness).
 GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/coderabbit-wait.sh <PR#>
+
+# codex-review-request.sh uses the reviewer PAT in GH_TOKEN for its READS
+# (polling), but posts the '@codex review' TRIGGER through gh-as-author.sh
+# so the byline is nathanjohnpayne — the Codex App only monitors
+# author-authored triggers (#405). Do NOT set the active account to a
+# reviewer identity for it; the script handles the author switch itself.
 GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-request.sh <PR#>
 
 # ── Write-path: active keyring is the byline; GH_TOKEN is ignored ──

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -478,6 +478,8 @@ An agent proceeds to 4a first. If 4a escalates, times out, or is disabled, the a
 
 11a. The authoring agent runs `scripts/codex-review-request.sh <PR#>` to trigger or await a Codex review. If the Codex App's "Automatic reviews" setting has already caused Codex to review the PR on open (typical latency ~2 minutes for small PRs), the script skips posting `@codex review` and goes straight to polling.
 
+> **The `@codex review` trigger MUST be authored by `nathanjohnpayne`.** The Codex GitHub App only monitors trigger comments from the repo's author/human identity; a trigger posted by a reviewer/bot identity (`nathanpayne-claude`/`-codex`/`-cursor`) is silently ignored and the poll runs to timeout (observed empirically on #405: a reviewer-authored trigger drew no response in 600s, an author-authored one drew a review in ~20s). `codex-review-request.sh` posts the trigger through `gh-as-author.sh` for exactly this reason — do not "fix" a keyring-drift block by switching the active account to a reviewer identity before running it.
+
 12a. `codex-review-request.sh` polls the PR until one of the following:
 
      - **Codex posts a review.** Always in `COMMENTED` state — the Codex GitHub App never uses `APPROVED` or `CHANGES_REQUESTED`. Findings appear as **inline comments on the diff** (`/pulls/{pr}/comments` endpoint), not in the top-level review body. Inline findings carry priority markers: `![P0 Badge]`, `![P1 Badge]`, `![P2 Badge]`, or `![P3 Badge]`.

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -62,12 +62,25 @@ read-path; `coderabbit-wait.sh` and `codex-review-request.sh` BOTH
 post comments on the PR (a retry trigger and an `@codex review`
 trigger respectively, via `gh pr comment` or `gh api`). The PAT in
 `GH_TOKEN` authenticates the API call, but the **byline of the
-posted comment** is the keyring's active account — so the
-active-account convention applies to these helpers too. Set the
-active account once per machine (`gh auth switch -u nathanpayne-<agent>`)
-and the comments attribute correctly. The trigger-comment bodies are
-identity-agnostic, so a wrong byline isn't load-bearing — but
-matters for audit-trail consistency.
+posted comment** is the keyring's active account. The two triggers
+differ in whether that byline is load-bearing:
+
+- **`coderabbit-wait.sh` retry trigger — identity-agnostic.** CodeRabbit
+  re-reviews regardless of who posts the nudge, so the reviewer
+  active-account convention applies (set `gh auth switch -u
+  nathanpayne-<agent>` once per machine; a wrong byline is cosmetic and
+  matters only for audit-trail consistency).
+- **`codex-review-request.sh` `@codex review` trigger — the byline IS
+  load-bearing.** The Codex GitHub App ONLY monitors `@codex review`
+  comments authored by `nathanjohnpayne` (the author/human identity); a
+  trigger posted by a reviewer/bot identity (`nathanpayne-claude`/
+  `-codex`/`-cursor`) is silently ignored and the poll runs to timeout
+  (#405: reviewer-authored drew no response in 600s, author-authored drew
+  a review in ~20s). So `codex-review-request.sh` does **not** follow the
+  reviewer active-account convention for this write — it posts the
+  trigger through `scripts/gh-as-author.sh` (byline = `nathanjohnpayne`).
+  Do **not** "fix" a keyring-drift block by switching the active account
+  to a reviewer identity before running it.
 
 #### PAT lookup table
 
@@ -292,6 +305,7 @@ affect the byline for that row; the byline follows `GH_TOKEN`.
 | `gh pr edit` (general — title/body) | `nathanjohnpayne` (use `scripts/gh-as-author.sh`) | any author-readable PAT |
 | `gh pr edit --remove-label <protected>` | **BLOCKED** by `scripts/hooks/label-removal-guard.sh` for `needs-external-review` / `needs-human-review` / `policy-violation` / `human-hold`; use `scripts/request-label-removal.sh` | n/a |
 | `gh pr comment` | `nathanpayne-<agent>` (agent identity); blocked unless active exactly matches the reviewer resolved from `GH_PR_GUARD_EXPECTED_REVIEWER` or `MERGEPATH_AGENT` per `scripts/hooks/gh-pr-guard.sh` (#284/#363) | reviewer PAT (`$OP_PREFLIGHT_REVIEWER_PAT`) |
+| `gh pr comment "@codex review"` (Codex trigger) | **`nathanjohnpayne`** (use `scripts/gh-as-author.sh`) — EXCEPTION to the reviewer-byline rule above: the Codex App only monitors author-authored triggers (#405), so `codex-review-request.sh` posts it via `gh-as-author.sh` | author or reviewer PAT for auth |
 | `gh pr review --comment` | `nathanpayne-<agent>`; blocked unless active exactly matches the reviewer resolved from `GH_PR_GUARD_EXPECTED_REVIEWER` or `MERGEPATH_AGENT` (#284/#363) | reviewer PAT |
 | `gh pr review --approve` (under-threshold) | `nathanpayne-<agent>`; allowed when PR's `Authoring-Agent:` matches the agent (the intended path) | reviewer PAT |
 | `gh pr review --approve` (over-threshold, same agent) | **BLOCKED** by `scripts/hooks/gh-pr-guard.sh` per § No-self-approve scoping (#284) | n/a |

--- a/scripts/ci/check_op_firebase_deploy_integration
+++ b/scripts/ci/check_op_firebase_deploy_integration
@@ -99,8 +99,12 @@ fi
 # default for a mergepath-only check we can't confirm we're running in.
 REPO_SLUG="${GITHUB_REPOSITORY:-}"
 if [ -z "$REPO_SLUG" ]; then
+  # `|| true`: in a worktree with no `origin` remote, `git config --get`
+  # exits 1; under `set -euo pipefail` that would ABORT the assignment
+  # instead of falling through to the empty-slug skip below (Codex P2 on
+  # #405). Swallow it so REPO_SLUG ends up empty → SKIP (the safe default).
   REPO_SLUG=$(git -C "$REPO_ROOT" config --get remote.origin.url 2>/dev/null \
-    | sed -E 's#(\.git)?$##; s#.*[:/]##')
+    | sed -E 's#(\.git)?$##; s#.*[:/]##' || true)
 fi
 case "$REPO_SLUG" in
   mergepath | */mergepath) ;;  # canonical mergepath (or a fork of it) — run

--- a/scripts/ci/check_op_firebase_deploy_integration
+++ b/scripts/ci/check_op_firebase_deploy_integration
@@ -84,6 +84,21 @@ if [ "${MERGEPATH_RUN_INTEGRATION:-0}" != "1" ]; then
   exit 0
 fi
 
+# mergepath-specific gate (#398). This is an integration test for
+# mergepath's OWN scripts/firebase/op-firebase-deploy, which is NOT in
+# .mergepath-sync.yml (mergepath-canonical, never propagated). The
+# scripts/ci/ KIT does propagate, so this check ships to consumers — but
+# downstream it would FAIL under MERGEPATH_RUN_INTEGRATION=1 against a
+# consumer's own/stale deploy script (the #398 / Codex P2 on
+# tadlockpsychiatry#68). Gate on the propagation manifest, which exists
+# ONLY in the canonical mergepath repo (consumers are propagation
+# targets and never carry it), so the check SKIPs cleanly downstream
+# while still running — and catching a real regression — in mergepath.
+if [ ! -f "$REPO_ROOT/.mergepath-sync.yml" ]; then
+  echo "check_op_firebase_deploy_integration: SKIPPED — not the canonical mergepath repo (.mergepath-sync.yml absent); this integration check exercises mergepath-only scripts/firebase/op-firebase-deploy."
+  exit 0
+fi
+
 DEPLOY_SCRIPT="$REPO_ROOT/scripts/firebase/op-firebase-deploy"
 if [ ! -x "$DEPLOY_SCRIPT" ]; then
   echo "check_op_firebase_deploy_integration: FAIL — $DEPLOY_SCRIPT not found or not executable" >&2

--- a/scripts/ci/check_op_firebase_deploy_integration
+++ b/scripts/ci/check_op_firebase_deploy_integration
@@ -90,13 +90,15 @@ fi
 # so this check ships to consumers — but downstream it would FAIL under
 # MERGEPATH_RUN_INTEGRATION=1 against a consumer's own/stale deploy
 # script (the #398 / Codex P2 on tadlockpsychiatry#68). Identify the
-# canonical repo by its SLUG, not a file marker: a bootstrap-mirrored
-# consumer can transiently carry copied files (Codex P2 on #405), but a
-# consumer/bootstrapped repo is always named after the consumer, never
-# 'mergepath', so the slug can't be spoofed by a copied file. In CI
-# GITHUB_REPOSITORY is authoritative; locally fall back to the origin
-# remote. If neither resolves (no remote / no env) we SKIP — the safe
-# default for a mergepath-only check we can't confirm we're running in.
+# canonical repo by its FULL owner/repo SLUG, not a file marker (a
+# bootstrap-mirrored consumer can transiently carry copied files — Codex
+# P2 on #405) and not a bare repo name (a different owner's fork named
+# `*/mergepath` must NOT run this check against its own deploy script —
+# Codex r2 on #405). In CI GITHUB_REPOSITORY is authoritative; locally
+# fall back to the origin remote. If neither resolves (no remote / no
+# env) the slug is empty → SKIP, the safe default for a mergepath-only
+# check we can't confirm we're running in.
+CANONICAL_REPO="${MERGEPATH_CANONICAL_REPO:-nathanjohnpayne/mergepath}"
 REPO_SLUG="${GITHUB_REPOSITORY:-}"
 if [ -z "$REPO_SLUG" ]; then
   # `|| true`: in a worktree with no `origin` remote, `git config --get`
@@ -104,15 +106,12 @@ if [ -z "$REPO_SLUG" ]; then
   # instead of falling through to the empty-slug skip below (Codex P2 on
   # #405). Swallow it so REPO_SLUG ends up empty → SKIP (the safe default).
   REPO_SLUG=$(git -C "$REPO_ROOT" config --get remote.origin.url 2>/dev/null \
-    | sed -E 's#(\.git)?$##; s#.*[:/]##' || true)
+    | sed -E 's#\.git$##; s#^.*[:/]([^/]+/[^/]+)$#\1#' || true)
 fi
-case "$REPO_SLUG" in
-  mergepath | */mergepath) ;;  # canonical mergepath (or a fork of it) — run
-  *)
-    echo "check_op_firebase_deploy_integration: SKIPPED — repo '${REPO_SLUG:-unknown}' is not canonical mergepath; this integration check exercises mergepath-only scripts/firebase/op-firebase-deploy."
-    exit 0
-    ;;
-esac
+if [ "$REPO_SLUG" != "$CANONICAL_REPO" ]; then
+  echo "check_op_firebase_deploy_integration: SKIPPED — repo '${REPO_SLUG:-unknown}' is not the canonical $CANONICAL_REPO; this integration check exercises mergepath-only scripts/firebase/op-firebase-deploy."
+  exit 0
+fi
 
 DEPLOY_SCRIPT="$REPO_ROOT/scripts/firebase/op-firebase-deploy"
 if [ ! -x "$DEPLOY_SCRIPT" ]; then

--- a/scripts/ci/check_op_firebase_deploy_integration
+++ b/scripts/ci/check_op_firebase_deploy_integration
@@ -85,19 +85,30 @@ if [ "${MERGEPATH_RUN_INTEGRATION:-0}" != "1" ]; then
 fi
 
 # mergepath-specific gate (#398). This is an integration test for
-# mergepath's OWN scripts/firebase/op-firebase-deploy, which is NOT in
-# .mergepath-sync.yml (mergepath-canonical, never propagated). The
-# scripts/ci/ KIT does propagate, so this check ships to consumers — but
-# downstream it would FAIL under MERGEPATH_RUN_INTEGRATION=1 against a
-# consumer's own/stale deploy script (the #398 / Codex P2 on
-# tadlockpsychiatry#68). Gate on the propagation manifest, which exists
-# ONLY in the canonical mergepath repo (consumers are propagation
-# targets and never carry it), so the check SKIPs cleanly downstream
-# while still running — and catching a real regression — in mergepath.
-if [ ! -f "$REPO_ROOT/.mergepath-sync.yml" ]; then
-  echo "check_op_firebase_deploy_integration: SKIPPED — not the canonical mergepath repo (.mergepath-sync.yml absent); this integration check exercises mergepath-only scripts/firebase/op-firebase-deploy."
-  exit 0
+# mergepath's OWN scripts/firebase/op-firebase-deploy, which is NOT
+# propagated (mergepath-canonical). The scripts/ci/ KIT does propagate,
+# so this check ships to consumers — but downstream it would FAIL under
+# MERGEPATH_RUN_INTEGRATION=1 against a consumer's own/stale deploy
+# script (the #398 / Codex P2 on tadlockpsychiatry#68). Identify the
+# canonical repo by its SLUG, not a file marker: a bootstrap-mirrored
+# consumer can transiently carry copied files (Codex P2 on #405), but a
+# consumer/bootstrapped repo is always named after the consumer, never
+# 'mergepath', so the slug can't be spoofed by a copied file. In CI
+# GITHUB_REPOSITORY is authoritative; locally fall back to the origin
+# remote. If neither resolves (no remote / no env) we SKIP — the safe
+# default for a mergepath-only check we can't confirm we're running in.
+REPO_SLUG="${GITHUB_REPOSITORY:-}"
+if [ -z "$REPO_SLUG" ]; then
+  REPO_SLUG=$(git -C "$REPO_ROOT" config --get remote.origin.url 2>/dev/null \
+    | sed -E 's#(\.git)?$##; s#.*[:/]##')
 fi
+case "$REPO_SLUG" in
+  mergepath | */mergepath) ;;  # canonical mergepath (or a fork of it) — run
+  *)
+    echo "check_op_firebase_deploy_integration: SKIPPED — repo '${REPO_SLUG:-unknown}' is not canonical mergepath; this integration check exercises mergepath-only scripts/firebase/op-firebase-deploy."
+    exit 0
+    ;;
+esac
 
 DEPLOY_SCRIPT="$REPO_ROOT/scripts/firebase/op-firebase-deploy"
 if [ ! -x "$DEPLOY_SCRIPT" ]; then

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -447,35 +447,39 @@ TRIGGER_POST_TIME=""
 if has_cleared_signal "$INITIAL_SCAN"; then
   log "Codex has already cleared on HEAD (reaction or no-P0/P1 review) — skipping trigger comment"
 else
-  # Identity check (#284): `gh pr comment` is a keyring-byline write
-  # — fail closed BEFORE posting if the keyring drifted from the
-  # agent's reviewer identity. Opt-out via
-  # CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK=1 for test harnesses.
-  #
-  # r3 (#284): fail CLOSED if the helper is missing or non-executable.
-  # The previous shape ANDed the opt-out and `[ -x "$CHECKER" ]` so a
-  # rename / delete / chmod -x silently skipped the gate. Helper
-  # presence is now a hard error inside the opt-out branch.
-  if [ "${CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK:-0}" != "1" ]; then
-    CHECKER="$(dirname "${BASH_SOURCE[0]}")/identity-check.sh"
-    if [ ! -x "$CHECKER" ]; then
-      echo "ERROR: identity-check helper missing or non-executable: $CHECKER" >&2
-      echo "       Refusing to post '@codex review' without identity verification." >&2
+  # The Codex GitHub App ONLY monitors '@codex review' comments authored
+  # by the repo's AUTHOR/human identity (nathanjohnpayne). A trigger
+  # posted by a reviewer/bot identity (nathanpayne-claude/-codex/-cursor)
+  # is silently ignored: empirically a reviewer-posted trigger sat
+  # unanswered to the full 600s timeout while an author-posted one drew a
+  # Codex review in ~20s (PR #405). `gh pr comment` is a keyring-byline
+  # write, so post it through gh-as-author.sh, which switches the keyring
+  # to nathanjohnpayne for the write (verifying the switch landed) and
+  # restores the prior active account on exit. This SUPERSEDES the #284
+  # `identity-check --expect-reviewer` guard, which fail-closed on the
+  # WRONG identity for this particular write. Opt out via
+  # CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK=1 for test harnesses that
+  # PATH-shim gh (the stub records argv; no real keyring switch).
+  log "posting '@codex review' trigger comment (as author identity nathanjohnpayne)"
+  if [ "${CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK:-0}" = "1" ]; then
+    POST_OUTPUT=$(gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
+      || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
+  else
+    AS_AUTHOR="$(dirname "${BASH_SOURCE[0]}")/gh-as-author.sh"
+    if [ ! -x "$AS_AUTHOR" ]; then
+      echo "ERROR: gh-as-author.sh helper missing or non-executable: $AS_AUTHOR" >&2
+      echo "       Refusing to post '@codex review' without author-identity attribution" >&2
+      echo "       (Codex ignores reviewer/bot-authored triggers — see comment above)." >&2
       echo "       Restore the helper, or opt out via" >&2
       echo "       CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK=1 (dev only)." >&2
-      die 3 "identity-check helper unavailable"
+      die 3 "gh-as-author.sh helper unavailable"
     fi
-    "$CHECKER" --expect-reviewer \
-      || die 3 "identity-check failed before posting '@codex review'; see stderr above."
+    # Capture stdout+stderr so a failure surfaces the real gh error
+    # (404 / 403 / 422) rather than a bare "failed to post". The comment
+    # URL gh prints on success is still extractable downstream.
+    POST_OUTPUT=$("$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
+      || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
   fi
-  log "posting '@codex review' trigger comment"
-  # Capture stderr (and stdout) into a diagnostic variable so a failure
-  # here surfaces the actual gh error — e.g. "404" from a nonexistent
-  # PR, "403" from a token without comment scope, or "422" from a closed
-  # PR — rather than a bare "failed to post". CodeRabbit non-blocking
-  # note on PR #64.
-  POST_OUTPUT=$(gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
-    || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
   TRIGGER_POSTED=true
   # Capture the post time so the poll loop can ignore stale signals
   # that were already on HEAD before the trigger fired. Without this,

--- a/tests/test_identity_check_fail_closed.sh
+++ b/tests/test_identity_check_fail_closed.sh
@@ -117,9 +117,20 @@ check_script_shape "scripts/coderabbit-wait.sh"        "coderabbit-wait"
 CRR="$ROOT/scripts/codex-review-request.sh"
 if grep -q '\[ ! -x "\$AS_AUTHOR" \]' "$CRR" \
    && grep -q 'gh-as-author.sh helper missing or non-executable' "$CRR"; then
-  pass "codex-review-request: '@codex review' trigger posts via gh-as-author, fail-closed on missing helper"
+  pass "codex-review-request: gh-as-author helper presence is fail-closed"
 else
   fail "codex-review-request: missing gh-as-author fail-closed guard for the @codex review trigger"
+fi
+
+# The actual trigger write MUST be wrapped by gh-as-author so the
+# '@codex review' byline is nathanjohnpayne — the load-bearing property
+# the Codex App requires (#405). Assert the real wrapped invocation, not
+# just the guard around it (Codex r2 on #405: a guard can be present
+# while the post still goes out unwrapped).
+if grep -qE '"\$AS_AUTHOR" -- gh pr comment .* --body "@codex review"' "$CRR"; then
+  pass "codex-review-request: '@codex review' trigger posted via \"\$AS_AUTHOR\" -- gh pr comment (author byline)"
+else
+  fail "codex-review-request: '@codex review' trigger is NOT wrapped by gh-as-author — the byline would not be nathanjohnpayne"
 fi
 
 # -----------------------------------------------------------------------

--- a/tests/test_identity_check_fail_closed.sh
+++ b/tests/test_identity_check_fail_closed.sh
@@ -105,9 +105,22 @@ check_script_shape() {
 }
 
 check_script_shape "scripts/resolve-pr-threads.sh"     "resolve-pr-threads"
-check_script_shape "scripts/codex-review-request.sh"   "codex-review-request"
 check_script_shape "scripts/request-label-removal.sh"  "request-label-removal"
 check_script_shape "scripts/coderabbit-wait.sh"        "coderabbit-wait"
+
+# codex-review-request.sh moved its '@codex review' trigger-post guard
+# from identity-check (--expect-reviewer) to gh-as-author.sh, so the
+# trigger is authored by nathanjohnpayne — the Codex App only monitors
+# author-authored triggers (#405). It is no longer an identity-check site,
+# but it must still FAIL-CLOSED if its helper is missing, now against
+# gh-as-author.
+CRR="$ROOT/scripts/codex-review-request.sh"
+if grep -q '\[ ! -x "\$AS_AUTHOR" \]' "$CRR" \
+   && grep -q 'gh-as-author.sh helper missing or non-executable' "$CRR"; then
+  pass "codex-review-request: '@codex review' trigger posts via gh-as-author, fail-closed on missing helper"
+else
+  fail "codex-review-request: missing gh-as-author fail-closed guard for the @codex review trigger"
+fi
 
 # -----------------------------------------------------------------------
 # Part B — Behavioral: the gate idiom rejects helper absence.


### PR DESCRIPTION
## What & why

Fleet CI-tooling hardening surfaced by the **2026-06-01 weekly audit**, the **#401 propagation review**, and a **Codex-trigger bug found in chat**. Closes **#374** and **#398**.

### 1. Auto-merge `dev-dependencies` groups (closes #374, Pattern A)
matchline#245 — a `dev-dependencies` group Dependabot PR — merged with no reviewer approval because the approve step only fired for single `semver-patch`/`semver-minor` updates; a grouped update whose highest member is **major** skipped it and fell through to a manual merge. Extend the gate to also fire when `dependency-group == 'dev-dependencies'` (any bump — still gated by CI-green + reviewer-identity approval + the `available_reviewers` allowlist). **Production groups + non-group majors stay manual.**

### 2. Gate the firebase integration check to mergepath (closes #398)
`check_op_firebase_deploy_integration` tests mergepath's own `scripts/firebase/op-firebase-deploy` (not propagated) but rides the `scripts/ci/` kit into consumers, where `MERGEPATH_RUN_INTEGRATION=1` would FAIL. Gate it to the canonical repo by **repo slug** (`GITHUB_REPOSITORY` / origin remote) — robust against a bootstrap mirror that transiently copies a file sentinel (Codex P2 on this PR). Runs+passes in mergepath, SKIPs for a consumer slug.

### 3. Author-attribute the `@codex review` trigger
The Codex App **only monitors trigger comments authored by `nathanjohnpayne`**; `codex-review-request.sh` posted it as a *reviewer* identity (`--expect-reviewer` + keyring-byline write), which Codex silently ignores — it only ever worked when the auto-review-on-open masked it. On this PR a reviewer-authored trigger **timed out at 600s** while an author-authored one drew a review in **~20s**. Fix: post the trigger through `gh-as-author.sh` (author = `nathanjohnpayne`); document the requirement in REVIEW_POLICY.md. Test opt-out (`CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK=1`) preserved.

## Verification

- `check_op_firebase_deploy_integration`: **PASS (7 cases)** in mergepath (local + CI slug); **SKIPs** for a consumer slug and by default.
- `check_codex_scripts`, `check_workflow_parsers` green.
- The Codex trigger fix is dogfooded on this PR's own re-review (posted as `nathanjohnpayne`).

## Notes

- **Above-threshold** via `.github/**` — routes through Phase 4. The auto-merge broadening (expands what merges without a human) is exactly what external review should scrutinize.
- 3 of 4 files are synced (`dependabot-auto-merge.yml`, `check_op_firebase_deploy_integration`, `codex-review-request.sh`) → one canary-first propagation after merge. REVIEW_POLICY.md is mergepath-only.

Closes #374, closes #398.

Authoring-Agent: claude

## Self-Review

- **Correctness**: Auto-merge change is additive + scoped to dev groups; production/major stay manual. Firebase slug gate is immune to copied files (a consumer is never named `mergepath`); mergepath path unchanged (runs all 7 cases). Codex trigger now guaranteed author-attributed via `gh-as-author.sh` (which verifies the keyring switch).
- **Regression risk**: Low–medium. The auto-merge broadening is the most sensitive — bounded to development dependency groups behind CI + reviewer approval + allowlist. The codex-review-request change is exercised by this PR's re-review; the test opt-out keeps the stubbed-gh harness working.
- **Style**: Matches existing workflow/check/script idioms; bash 3.2-safe.
- **Test coverage**: firebase check verified in 4 contexts; guards green. Trigger-post is gh-integration (validated live on this PR).
- **Security/dependency hygiene**: auto-merge expansion limited to **development** groups; no new secrets/scopes. The trigger fix removes a silent-failure path, not a guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
