### PR TITLE
fix(sync): propagate gh wrapper parallel test

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -340,6 +340,9 @@ paths:
   - path: tests/test_gh_as_reviewer.sh
     type: canonical
     consumers: all
+  - path: tests/test_gh_wrapper_parallel.sh
+    type: canonical
+    consumers: all
   # Pairs with scripts/identity-check.sh (#284). The helper is called
   # from the top of every WRITE-path helper script; the test exercises
   # all four assert modes against `gh config get` shims plus an
@@ -530,6 +533,7 @@ paths:
       - "tests/test_gh_pr_guard.sh"            # check_gh_as_author
       - "tests/test_gh_as_author.sh"           # check_gh_as_author
       - "tests/test_gh_as_reviewer.sh"         # check_gh_as_author
+      - "tests/test_gh_wrapper_parallel.sh"    # check_gh_as_author
       - "tests/test_codex_p1_gate.sh"          # check_codex_p1_gate
       - "tests/test_disagreement_detector.sh"  # check_disagreement_detector
       - "tests/test_verify_propagation_pr.sh"  # check_verify_propagation_pr


### PR DESCRIPTION
## Summary

- add `tests/test_gh_wrapper_parallel.sh` to the propagation manifest as a canonical test
- add the same file to the `scripts/ci/` requires closure for `check_gh_as_author`

## Why

The #413 matchline canary PR exposed a manifest closure gap: downstream `check_gh_as_author` now requires `tests/test_gh_wrapper_parallel.sh`, but the test did not propagate with the wrapper/check kit. That made the canary fail repo-lint before any remaining consumer fan-out.

Consumer fan-out is intentionally parked while additional queued feature requests are resolved; this PR only fixes the upstream manifest gap found by the canary.

## Self-Review

- Correctness: `.mergepath-sync.yml` now propagates the test file that `scripts/ci/check_gh_as_author` hard-requires, and the `scripts/ci/` kit closure names that dependency explicitly.
- Regression risk: low; manifest-only addition, no runtime behavior changes.
- Style/conventions: follows the existing canonical test entries and `requires:` comment style.
- Test coverage: verified with `scripts/ci/check_sync_manifest`, `scripts/ci/check_gh_as_author`, and `git diff --check`.
- Security/dependency hygiene: no new dependencies or secrets; this tightens propagation completeness for the token-wrapper test surface.

## Verification

- `scripts/ci/check_sync_manifest`
- `scripts/ci/check_gh_as_author`
- `git diff --check`

Refs: #413, #408
