### PR TITLE
fix(merge-gate): HEAD-pinned merge-clearance gate (#427, #428)

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -388,6 +388,57 @@ codex:
   p1_gate:
     enabled: true
 
+  # External-review merge-clearance gate (nathanjohnpayne/mergepath#428).
+  #
+  # When enabled, scripts/merge-clearance-gate.sh runs as the required CI
+  # check `Merge Clearance Gate / Merge clearance gate` and BLOCKS a PR
+  # carrying `needs-external-review` from merging unless clearance holds
+  # ON THE CURRENT HEAD — re-using scripts/codex-review-check.sh's
+  # gate (b) reviewer-APPROVED + gate (c) Codex/Phase-4b predicate (CI
+  # checking skipped, since this gate is itself a required check).
+  #
+  # This closes the #428 escape: nathanpaynedotcom#405 merged on a HEAD
+  # with no APPROVED CLI review and no Codex review because clearance was
+  # enforced only through the removable `needs-external-review` label
+  # (Label Gate), which went stale on a new push. The label and
+  # auto-clear-blocking-labels.yml remain the UX layer; the merge-blocking
+  # truth moves to this HEAD-pinned required check, which re-evaluates on
+  # every push and cannot be satisfied by a stale earlier-HEAD clearance.
+  #
+  # Default everywhere except mergepath: false. Same narrow-start posture
+  # as p1_gate above — enabled here first, then propagated.
+  external_review_gate:
+    enabled: true
+
+# ---------------------------------------------------------------------------
+# Dependabot reviewer-approval merge gate (#427)
+# ---------------------------------------------------------------------------
+# When reviewer_gate.enabled is true, scripts/merge-clearance-gate.sh runs
+# as the required CI check `Merge Clearance Gate / Merge clearance gate`
+# and BLOCKS a Dependabot PR from merging unless a reviewer identity in
+# `available_reviewers` (≠ the PR author) has a latest-state APPROVED
+# review whose commit_id == the current HEAD.
+#
+# This closes the #427 escape: matchline#245 (a dev-dependencies group
+# bump) merged with NO reviewer-identity approval on the merge HEAD. The
+# dependabot-auto-merge.yml approval is transient — GitHub dismisses it on
+# a rebase push (Dependabot rebases grouped PRs often), so by the final
+# HEAD there was no approval on record, and a human merged the
+# approved-but-unmerged PR with nothing failing closed. This gate is the
+# HEAD-pinned, merge-time form of pr-audit.yml Check 2's Dependabot path
+# (which previously caught this only a week later, retroactively).
+#
+# Note: an admin "merge without waiting for requirements" can still bypass
+# a required check. Pair this with branch protection `enforce_admins:
+# true` (or audit admin-overridden merges) to close the human-merge path
+# fully. See #427.
+#
+# Default everywhere except mergepath: false. Same narrow-start posture as
+# codex.p1_gate / codex.external_review_gate.
+dependabot:
+  reviewer_gate:
+    enabled: true
+
 # ---------------------------------------------------------------------------
 # Phase 4b proactive triggers (#158)
 # ---------------------------------------------------------------------------

--- a/.github/workflows/merge-clearance-gate.yml
+++ b/.github/workflows/merge-clearance-gate.yml
@@ -1,0 +1,239 @@
+name: Merge Clearance Gate
+
+# Enforces nathanjohnpayne/mergepath#427 + #428: a PR's clearance
+# condition must hold ON THE CURRENT HEAD before it can merge. This is
+# the merge-TIME, fail-closed counterpart to the WEEKLY retroactive
+# pr-audit.yml — the two escapes that motivated it (matchline#245 dev-deps
+# bump with no reviewer approval on HEAD; nathanpaynedotcom#405 external
+# PR merged on a HEAD with no APPROVED CLI review and no Codex review)
+# were caught a week late by the audit because no required status check
+# represented clearance on the merge HEAD.
+#
+# Reports the required check `Merge clearance gate` via
+# scripts/merge-clearance-gate.sh. The script exits 1 (gate fails) when:
+#   - a Dependabot PR has no reviewer-identity APPROVED review on HEAD
+#     (dependabot.reviewer_gate.enabled=true), OR
+#   - a needs-external-review PR is not cleared on HEAD by
+#     codex-review-check.sh (codex.external_review_gate.enabled=true).
+# Otherwise it exits 0 (clean pass) — including for normal under-threshold
+# PRs and when the relevant knob is off — so it is safe as a required
+# check on every PR.
+#
+# Gate ON/OFF is controlled per-class in .github/review-policy.yml
+# (dependabot.reviewer_gate.enabled, codex.external_review_gate.enabled).
+# Mergepath sets both true (canonical source). Downstream consumers
+# default to false until the pattern is shaken out here (#235's
+# "start narrow" recommendation, same posture as codex-p1-gate.yml).
+#
+# Re-runs on every push to a PR AND on review-related events, so a
+# dismissed approval (rebase push), a fresh reviewer approval, or a Codex
+# clearance flips the check without manual intervention.
+#
+# Trigger shape note: identical to codex-p1-gate.yml. GitHub Actions does
+# NOT support pull_request_review_thread as a workflow trigger, so we
+# combine event-driven triggers with a scheduled sweep that re-posts a
+# check_run per open PR head SHA — covering the no-event transitions
+# (a 👍 reaction, a UI label resolve, the bot-relabel-doesn't-retrigger
+# case that produced #428). See scripts/ci/check_merge_clearance_gate.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  # Catches a Codex P0/P1 posted mid-review without a fresh
+  # review-submission event (external-review path).
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  # Periodic sweep — the only backstop for transitions that fire no
+  # Actions event (👍 reaction, UI label resolve, GITHUB_TOKEN relabel).
+  # 15-min cadence mirrors codex-p1-gate.yml.
+  schedule:
+    - cron: "*/15 * * * *"
+
+permissions:
+  contents: read
+  pull-requests: read
+  # `checks: write` is required for the scheduled sweep job: it posts a
+  # check_run on each open PR's head SHA so a no-event clearance flips the
+  # stuck required check without a push. The event-driven job produces its
+  # check natively and would not need this on its own.
+  checks: write
+
+jobs:
+  merge-clearance-gate:
+    name: Merge clearance gate
+    runs-on: ubuntu-latest
+    # Event-driven path. The scheduled sweep below runs the same gate but
+    # on every open PR via the Checks API; gating this job to non-schedule
+    # events avoids paying for an empty no-op run.
+    if: github.event_name != 'schedule'
+    steps:
+      - name: Checkout repo (default branch — trusted gate scripts)
+        # Pin to the default branch, NOT the PR HEAD. This is a REQUIRED
+        # status check: if it ran scripts/merge-clearance-gate.sh (and the
+        # codex-review-check.sh it delegates to) from the PR's own
+        # checkout, a PR could edit those scripts to `exit 0`, satisfy the
+        # required check, and merge past the gate. "Read-only" does NOT
+        # mean "can't be weaponized" — satisfying a required check IS the
+        # weaponization. Same trusted-checkout posture as codex-p1-gate.yml.
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Resolve PR number
+        id: pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_JSON: ${{ toJSON(github.event) }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request|pull_request_review|pull_request_review_comment)
+              pr=$(jq -r '.pull_request.number' <<<"$EVENT_JSON")
+              ;;
+            *)
+              echo "Unsupported event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+            echo "Could not resolve PR number from event payload." >&2
+            exit 1
+          fi
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+
+      - name: Run scripts/merge-clearance-gate.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # The script is the source of truth for what blocks merge.
+          # Exit codes:
+          #   0 = clearance satisfied (or gate not applicable / disabled)
+          #   1 = clearance NOT satisfied on HEAD (gate blocks)
+          #   2 = config / usage / infra error (CI failure, not a gate block)
+          set +e
+          scripts/merge-clearance-gate.sh "$PR_NUMBER" "$REPO"
+          rc=$?
+          set -e
+          if [ "$rc" -eq 2 ]; then
+            echo "::error::merge-clearance-gate.sh exited 2 (config/usage/infra error)"
+            exit 1
+          fi
+          exit "$rc"
+
+  scheduled-sweep:
+    name: Merge clearance scheduled sweep
+    # Periodic re-evaluation across every open PR. Required because no
+    # Actions event fires for some clearance transitions (a Codex 👍
+    # reaction, a UI label resolve, a GITHUB_TOKEN-authored relabel —
+    # the exact #428 case). This sweep walks every open PR, runs the same
+    # gate script, and posts a fresh check_run on each PR's head SHA via
+    # the Checks API. Required-check resolution keys on (head_sha, name),
+    # so the new check supersedes the stale one. Idempotent.
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo (default branch — trusted scripts)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Find open PRs
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # List ALL open PRs. The gate script itself short-circuits to a
+          # clean pass when both per-class knobs are off, so we don't
+          # filter by label/author here. `--limit 500` mirrors
+          # codex-p1-gate.yml's bound.
+          if ! prs_raw=$(gh pr list --repo "$REPO" --state open \
+            --limit 500 --json number --jq '.[].number'); then
+            echo "::error::Failed to list open PRs on $REPO"
+            exit 1
+          fi
+          if [ -z "$prs_raw" ]; then
+            echo "No open PRs on $REPO; sweep is a no-op."
+            echo "prs=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo 'prs<<EOF'
+            printf '%s\n' "$prs_raw"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Re-evaluate gate per PR and post check_run
+        if: steps.find.outputs.prs != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRS: ${{ steps.find.outputs.prs }}
+          REPO: ${{ github.repository }}
+          # Check name MUST match the event-driven job name above so
+          # branch protection's required-check entry resolves either
+          # source as the same gate. GitHub keys required checks on
+          # (head_sha, name); a fresh check_run with the same name
+          # supersedes the stale one.
+          CHECK_NAME: "Merge clearance gate"
+        run: |
+          set -euo pipefail
+          had_infra_error=0
+          while IFS= read -r PR; do
+            [ -z "$PR" ] && continue
+            echo "::group::Sweep PR #$PR"
+
+            head_sha=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')
+            if [ -z "$head_sha" ] || [ "$head_sha" = "null" ]; then
+              echo "::warning::Could not resolve head SHA for PR #$PR; skipping"
+              echo "::endgroup::"
+              continue
+            fi
+
+            set +e
+            output=$(scripts/merge-clearance-gate.sh "$PR" "$REPO" 2>&1)
+            rc=$?
+            set -e
+            echo "$output"
+
+            case "$rc" in
+              0) conclusion="success" ;;
+              1) conclusion="failure" ;;
+              *)
+                echo "::error::merge-clearance-gate.sh rc=$rc on PR #$PR (config/usage/infra error)"
+                had_infra_error=1
+                echo "::endgroup::"
+                continue
+                ;;
+            esac
+
+            summary=$(printf '%s\n' "$output" | head -c 60000)
+
+            # Posting the check_run IS the sweep's whole purpose — it's
+            # what supersedes the stale required-check after a no-event
+            # clearance transition. A failed POST means the sweep did not
+            # do its job; that's an infra error.
+            if ! gh api -X POST "repos/$REPO/check-runs" \
+              -f name="$CHECK_NAME" \
+              -f head_sha="$head_sha" \
+              -f status="completed" \
+              -f conclusion="$conclusion" \
+              -f "output[title]=Merge clearance gate (scheduled re-evaluation)" \
+              -f "output[summary]=$summary" \
+              >/dev/null; then
+              echo "::error::Failed to post check_run for PR #$PR — stale required check not refreshed."
+              had_infra_error=1
+            fi
+            echo "::endgroup::"
+          done <<<"$PRS"
+          if [ "$had_infra_error" -ne 0 ]; then
+            echo "::error::Sweep finished with one or more infra errors"
+            exit 1
+          fi

--- a/.github/workflows/merge-clearance-gate.yml
+++ b/.github/workflows/merge-clearance-gate.yml
@@ -51,14 +51,13 @@ on:
   schedule:
     - cron: "*/15 * * * *"
 
+# Least-privilege default for the whole workflow: read-only. `checks: write`
+# is granted ONLY to the scheduled-sweep job below (it POSTs check_runs);
+# the event-driven job produces its check natively and needs no write scope
+# (CodeRabbit ⚠️ on PR #429).
 permissions:
   contents: read
   pull-requests: read
-  # `checks: write` is required for the scheduled sweep job: it posts a
-  # check_run on each open PR's head SHA so a no-event clearance flips the
-  # stuck required check without a push. The event-driven job produces its
-  # check natively and would not need this on its own.
-  checks: write
 
 jobs:
   merge-clearance-gate:
@@ -81,6 +80,10 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
+          # The gate only reads via GH_TOKEN; it never does git-authenticated
+          # writes. Don't leave the checkout token in local git config
+          # (CodeRabbit ⚠️ on PR #429).
+          persist-credentials: false
 
       - name: Resolve PR number
         id: pr
@@ -137,12 +140,18 @@ jobs:
     # so the new check supersedes the stale one. Idempotent.
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    # Only this job needs checks:write — it POSTs a check_run per open PR.
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
     steps:
       - name: Checkout repo (default branch — trusted scripts)
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Find open PRs
         id: find

--- a/.github/workflows/merge-clearance-gate.yml
+++ b/.github/workflows/merge-clearance-gate.yml
@@ -38,7 +38,12 @@ name: Merge Clearance Gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    # labeled/unlabeled included so adding/removing needs-external-review
+    # re-runs the gate immediately, instead of a stale green check riding
+    # until the scheduled sweep (Codex P2 on PR #429). The script treats a
+    # present label as a force-on signal, so the gate must observe label
+    # transitions.
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
   pull_request_review:
     types: [submitted, edited, dismissed]
   # Catches a Codex P0/P1 posted mid-review without a fresh

--- a/.github/workflows/merge-clearance-gate.yml
+++ b/.github/workflows/merge-clearance-gate.yml
@@ -217,14 +217,24 @@ jobs:
             set -e
             echo "$output"
 
+            # head_sha is resolved here (the guard above `continue`d
+            # otherwise), so EVERY exit — including infra/config (rc 2 or
+            # any non-0/1) — posts a check_run. On an infra error we post a
+            # FAILURE: the sweep runs on the DEFAULT branch, so if we merely
+            # failed the workflow run and `continue`d, branch protection
+            # would still see the PR head's PREVIOUS green `Merge clearance
+            # gate` and the gate would fail OPEN on exactly the no-event
+            # refresh path this sweep exists to cover (Codex P2 on PR #429).
+            # Fail closed: red check on the PR head + a non-zero workflow run.
+            check_title="Merge clearance gate (scheduled re-evaluation)"
             case "$rc" in
               0) conclusion="success" ;;
               1) conclusion="failure" ;;
               *)
                 echo "::error::merge-clearance-gate.sh rc=$rc on PR #$PR (config/usage/infra error)"
                 had_infra_error=1
-                echo "::endgroup::"
-                continue
+                conclusion="failure"
+                check_title="Merge clearance gate — infra/config error (rc=$rc)"
                 ;;
             esac
 
@@ -232,14 +242,15 @@ jobs:
 
             # Posting the check_run IS the sweep's whole purpose — it's
             # what supersedes the stale required-check after a no-event
-            # clearance transition. A failed POST means the sweep did not
-            # do its job; that's an infra error.
+            # clearance transition (or pins a fail-closed red on infra
+            # error). A failed POST means the sweep did not do its job;
+            # that's an infra error.
             if ! gh api -X POST "repos/$REPO/check-runs" \
               -f name="$CHECK_NAME" \
               -f head_sha="$head_sha" \
               -f status="completed" \
               -f conclusion="$conclusion" \
-              -f "output[title]=Merge clearance gate (scheduled re-evaluation)" \
+              -f "output[title]=$check_title" \
               -f "output[summary]=$summary" \
               >/dev/null; then
               echo "::error::Failed to post check_run for PR #$PR — stale required check not refreshed."

--- a/.github/workflows/merge-clearance-gate.yml
+++ b/.github/workflows/merge-clearance-gate.yml
@@ -60,9 +60,18 @@ on:
 # is granted ONLY to the scheduled-sweep job below (it POSTs check_runs);
 # the event-driven job produces its check natively and needs no write scope
 # (CodeRabbit ⚠️ on PR #429).
+#
+# `issues: read` is required (Codex P2 on PR #429): the gate reads
+# /issues/{pr}/comments for the propagation-lane marker, and the delegated
+# codex-review-check.sh reads /issues/{pr}/reactions for the Codex 👍
+# signal — both are ISSUES-scoped endpoints. On a restricted-default
+# GITHUB_TOKEN (private repos) an omitted scope defaults to `none`, so
+# without this the required check would fail with an infra error (or miss
+# the propagation exemption) even when clearance exists.
 permissions:
   contents: read
   pull-requests: read
+  issues: read
 
 jobs:
   merge-clearance-gate:
@@ -146,9 +155,12 @@ jobs:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     # Only this job needs checks:write — it POSTs a check_run per open PR.
+    # issues:read for the same /issues/{pr}/comments + /issues/{pr}/reactions
+    # reads the event-driven job needs (Codex P2 on PR #429).
     permissions:
       contents: read
       pull-requests: read
+      issues: read
       checks: write
     steps:
       - name: Checkout repo (default branch — trusted scripts)

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -276,6 +276,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Embedded in the lane marker so the signal is HEAD-PINNED — a
+          # consumer (merge-clearance-gate.sh's propagation exemption, #429)
+          # can confirm THIS head was verified, not merely that the PR was
+          # once a faithful mirror at an earlier head.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Recognized propagation PR (see REVIEW_POLICY.md § Propagation
           # PR review lane): the check step VERIFIED it is a byte-for-byte
@@ -302,16 +307,27 @@ jobs:
             echo "Removed needs-external-review — PR qualifies for the propagation review lane."
           fi
 
-          # Post the lane note once. The HTML marker keeps re-runs
-          # (synchronize events) from re-commenting.
-          MARKER="<!-- propagation-review-lane -->"
+          # Post a HEAD-PINNED, machine-readable lane marker. The marker
+          # embeds the verified head SHA, so a consumer of this signal
+          # (scripts/merge-clearance-gate.sh's propagation exemption, #429)
+          # exempts a head ONLY if the lane verified THAT head — not merely
+          # that the PR was once a faithful mirror at some earlier head.
+          # Posted only by this workflow (github-actions[bot]); a PR author
+          # cannot forge that identity. One marker per distinct verified
+          # head: grep includes the head SHA, so re-runs on the same head
+          # don't re-comment; a faithful re-push to a NEW head posts a fresh
+          # marker; a DIVERGED push never reaches this step (propagation_lane
+          # is false), so no marker is ever posted for an unverified head.
+          # Marker contract is shared with merge-clearance-gate.sh — keep the
+          # `mergepath-propagation-lane verified-head=<sha>` form in sync.
+          MARKER="<!-- mergepath-propagation-lane verified-head=$HEAD_SHA -->"
           ALREADY=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json comments --jq '.comments[].body' | grep -F "$MARKER" || true)
           if [ -z "$ALREADY" ]; then
             gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$(cat <<EOF
           $MARKER
-          **Propagation PR review lane** — verified faithful mirror ✅
+          **Propagation PR review lane** — verified faithful mirror ✅ (head \`$HEAD_SHA\`)
 
-          This PR was checked out against \`mergepath\` at the source commit named in its branch and **verified byte-for-byte**: every changed file is under a \`.mergepath-sync.yml\` path AND matches \`mergepath@<sha>\`'s content (\`scripts/workflow/verify-propagation-pr.sh\`). Its content was already reviewed in the upstream mergepath PR(s). Per REVIEW_POLICY.md § Propagation PR review lane it is **exempt from the Phase 4 external-review requirement**.
+          This PR was checked out against \`mergepath\` at the source commit named in its branch and **verified byte-for-byte at this head**: every changed file is under a \`.mergepath-sync.yml\` path AND matches \`mergepath@<sha>\`'s content (\`scripts/workflow/verify-propagation-pr.sh\`). Its content was already reviewed in the upstream mergepath PR(s). Per REVIEW_POLICY.md § Propagation PR review lane it is **exempt from the Phase 4 external-review requirement**.
 
           It is still subject to: CI green, CodeRabbit advisory review, and an internal reviewer-identity \`APPROVED\` — the standard under-threshold path. Merge as the author once those clear.
 

--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -154,6 +154,9 @@ jobs:
       - name: check_codex_p1_gate
         run: ./scripts/ci/check_codex_p1_gate
 
+      - name: check_merge_clearance_gate
+        run: ./scripts/ci/check_merge_clearance_gate
+
       - name: check_resolve_pr_threads
         run: ./scripts/ci/check_resolve_pr_threads
 

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -273,6 +273,17 @@ paths:
   - path: scripts/codex-p1-gate.sh
     type: canonical
     consumers: all
+  - path: scripts/merge-clearance-gate.sh
+    # HEAD-pinned merge-clearance gate (#427/#428). The external-review
+    # path delegates to scripts/codex-review-check.sh (with CI checking
+    # skipped via CODEX_REVIEW_CHECK_SKIP_CI=1); without that script in
+    # the consumer the gate fails-closed on `command not found` for every
+    # external-review PR. Same coupling class as codex-p1-gate.yml +
+    # codex-p1-gate.sh.
+    type: canonical
+    consumers: all
+    requires:
+      - "scripts/codex-review-check.sh"
   - path: scripts/daily-feedback-rollup.sh
     # Cron workhorse invoked by .github/workflows/daily-feedback-rollup.yml.
     # Sources scripts/lib/daily-feedback-rollup-helpers.sh. The
@@ -371,6 +382,13 @@ paths:
   # in pre-flight with `Missing required file`. Same #264/#266 coupling
   # class — surfaced again by the 024e0da propagation wave (#273).
   - path: tests/test_codex_p1_gate.sh
+    type: canonical
+    consumers: all
+  # Pairs with scripts/merge-clearance-gate.sh +
+  # scripts/ci/check_merge_clearance_gate (kit-propagated). The check
+  # wrapper hard-requires this test file; same #264/#266 coupling class
+  # as test_codex_p1_gate.sh above (#427/#428).
+  - path: tests/test_merge_clearance_gate.sh
     type: canonical
     consumers: all
   # Pairs with scripts/disagreement-detector.cjs +
@@ -491,6 +509,17 @@ paths:
     # `command not found` for every PR in the consumer.
     requires:
       - "scripts/codex-p1-gate.sh"
+  - path: .github/workflows/merge-clearance-gate.yml
+    type: canonical
+    consumers: all
+    # Both jobs run `scripts/merge-clearance-gate.sh` directly, which in
+    # turn delegates the external-review path to
+    # scripts/codex-review-check.sh. Propagating the workflow without
+    # those scripts fails-closed on `command not found`. Same coupling
+    # class as codex-p1-gate.yml above (#427/#428).
+    requires:
+      - "scripts/merge-clearance-gate.sh"
+      - "scripts/codex-review-check.sh"
   - path: .github/workflows/daily-feedback-rollup.yml
     type: canonical
     consumers: all
@@ -543,12 +572,14 @@ paths:
       - "tests/test_gh_wrapper_parallel.sh"    # check_gh_as_author
       - "tests/test_coderabbit_wait_status_probe.sh"  # check_coderabbit_wait
       - "tests/test_codex_p1_gate.sh"          # check_codex_p1_gate
+      - "tests/test_merge_clearance_gate.sh"   # check_merge_clearance_gate
       - "tests/test_disagreement_detector.sh"  # check_disagreement_detector
       - "tests/test_verify_propagation_pr.sh"  # check_verify_propagation_pr
       - "tests/test_resolve_pr_threads_rationale_tag.sh"  # check_resolve_pr_threads (delegated test)
       - "tests/test_template_substitution.sh"  # check_template_substitution
       - "tests/test_export_consumer_facts.sh"  # check_export_consumer_facts
       - "scripts/codex-p1-gate.sh"             # check_codex_p1_gate
+      - "scripts/merge-clearance-gate.sh"      # check_merge_clearance_gate
       - "scripts/codex-review-request.sh"      # check_codex_scripts
       - "scripts/codex-review-check.sh"        # check_codex_scripts, check_canonical_bugs_263caf3
       - "scripts/phase-4b-classifier.sh"       # check_phase_4b_classifier
@@ -561,6 +592,7 @@ paths:
       - "scripts/workflow/"                    # check_workflow_parsers
       - ".github/workflows/agent-review.yml"   # check_disagreement_detector structural assertion
       - ".github/workflows/codex-p1-gate.yml"  # check_codex_p1_gate workflow shape
+      - ".github/workflows/merge-clearance-gate.yml"  # check_merge_clearance_gate workflow shape
       - ".github/workflows/pr-audit.yml"       # check_pr_audit_codex_clearance
   - path: scripts/gh-projects/
     type: kit

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -276,7 +276,9 @@ paths:
   - path: scripts/merge-clearance-gate.sh
     # HEAD-pinned merge-clearance gate (#427/#428). The external-review
     # path delegates to scripts/codex-review-check.sh (with CI checking
-    # skipped via CODEX_REVIEW_CHECK_SKIP_CI=1); without that script in
+    # skipped via CODEX_REVIEW_CHECK_SKIP_CI=1) and DERIVES applicability
+    # from the threshold/protected-paths via scripts/workflow/
+    # {parse_policy_list,match_protected_paths}.sh (#429); without those in
     # the consumer the gate fails-closed on `command not found` for every
     # external-review PR. Same coupling class as codex-p1-gate.yml +
     # codex-p1-gate.sh.
@@ -284,6 +286,7 @@ paths:
     consumers: all
     requires:
       - "scripts/codex-review-check.sh"
+      - "scripts/workflow/"
   - path: scripts/daily-feedback-rollup.sh
     # Cron workhorse invoked by .github/workflows/daily-feedback-rollup.yml.
     # Sources scripts/lib/daily-feedback-rollup-helpers.sh. The

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -773,6 +773,8 @@ Each repo using this template must mark these as required on `main` (Settings �
 
 - **`Label Gate`** — fails when any of `needs-external-review`, `needs-human-review`, `policy-violation`, or `human-hold` is on the PR. The hard gate behind the doctrine in [Agent prohibitions](#agent-prohibitions).
 - **`Self-Review Required`** — fails when the PR body lacks a `## Self-Review` section (Dependabot-exempt).
+- **`Codex P1 unresolved threads`** — fails when any Codex P1 inline-finding thread on the current HEAD is unresolved (`codex.p1_gate.enabled`, #235). A no-op (always green) when the knob is off, so it is safe to require everywhere.
+- **`Merge clearance gate`** — the HEAD-pinned, merge-time enforcement of clearance (#427/#428). Fails when a Dependabot PR has no reviewer-identity `APPROVED` review on the current HEAD (`dependabot.reviewer_gate.enabled`), or when a `needs-external-review` PR is not cleared on the current HEAD by `scripts/codex-review-check.sh` (`codex.external_review_gate.enabled`). It re-evaluates on every push (and via a scheduled sweep for no-event transitions), so a clearance recorded on an earlier HEAD — or an approval dismissed by a rebase push — cannot ride a new HEAD to merge. This closes the two escapes that previously surfaced only in the weekly retroactive audit: a Dependabot dev-deps bump merged with no approval on HEAD (matchline#245), and an external-review PR merged on a HEAD with no `APPROVED` CLI review and no Codex review (nathanpaynedotcom#405). A no-op (always green) when both knobs are off. **Caveat:** a required check is bypassable by an admin "merge without waiting for requirements"; both escapes were admin merges, so pair this with branch-protection `enforce_admins: true` to fully close the human-merge path.
 
 Audit a repo's branch protection with `scripts/audit-branch-protection.sh` (read-only; exits 3 if any canonical check is not required, with a fix recipe). Re-run after every protection change.
 
@@ -850,6 +852,19 @@ codex:
   review_timeout_seconds: 600                 # per-round poll timeout
   require_ci_green: true                      # merge gate
   allow_phase_4b_substitute: true             # accept Phase 4b APPROVED on HEAD as gate (c) clearance (#218)
+  p1_gate:
+    enabled: true                             # required check `Codex P1 unresolved threads` (#235)
+  external_review_gate:
+    enabled: true                             # required check `Merge clearance gate`, external-review arm (#428)
+
+# Dependabot HEAD-pinned reviewer-approval merge gate (#427).
+# When reviewer_gate.enabled is true, the required check `Merge clearance
+# gate` blocks a Dependabot PR unless a reviewer identity (≠ author) has a
+# latest-state APPROVED review whose commit_id == the current HEAD.
+# Default false everywhere except mergepath (narrow-start, then propagate).
+dependabot:
+  reviewer_gate:
+    enabled: true
 ```
 
 > **Note on `enabled` flags (both `coderabbit` and `codex`).** These flags govern **agent behavior only** — whether the authoring agent waits for the corresponding review in its phase. They do NOT control whether the underlying GitHub App runs. Both apps run based on their own install state on GitHub, independent of what this YAML says. Setting `coderabbit.enabled: false` alone will cause the agent to skip the CodeRabbit phase while the app continues to post reviews silently in the background. Setting `codex.enabled: false` routes the agent to Phase 4b and makes `scripts/codex-review-check.sh` ignore Codex bot reviews/reactions for the merge gate, but the Codex App may still post comments unless it is disabled in ChatGPT/GitHub. To fully disable an integration, uninstall or disable the GitHub App AND set the flag to false.

--- a/scripts/audit-branch-protection.sh
+++ b/scripts/audit-branch-protection.sh
@@ -46,6 +46,15 @@ set -eo pipefail
 CANONICAL_REQUIRED_CHECKS=(
   "Label Gate"
   "Self-Review Required"
+  # HEAD-pinned merge gates. Each is a required check whose workflow
+  # ships from mergepath. They are no-ops (always green) when their
+  # per-repo knob in .github/review-policy.yml is off, so requiring them
+  # in branch protection is safe even on consumers that haven't enabled
+  # the gate yet — and it flags consumers whose branch protection doesn't
+  # require them, which is the gap #427/#428 exploited (the gate ran but
+  # was advisory, so escapes were caught only by the weekly audit).
+  "Codex P1 unresolved threads"   # .github/workflows/codex-p1-gate.yml (#235)
+  "Merge clearance gate"          # .github/workflows/merge-clearance-gate.yml (#427/#428)
 )
 
 REPO=""

--- a/scripts/ci/check_merge_clearance_gate
+++ b/scripts/ci/check_merge_clearance_gate
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# check_merge_clearance_gate
+#
+# CI wrapper for scripts/merge-clearance-gate.sh — the HEAD-pinned
+# merge-clearance gate (nathanjohnpayne/mergepath#427 + #428).
+#
+# Two concerns:
+#   1. The script and its workflow must exist on disk and be executable
+#      (consistent with check_codex_p1_gate for the P1 gate).
+#   2. The script's class-dispatch + clearance logic must work against
+#      fixture payloads. Delegated to tests/test_merge_clearance_gate.sh,
+#      which PATH-shims `gh` and stubs the codex-review-check.sh delegate.
+#
+# Invoked by .github/workflows/repo_lint.yml alongside the other
+# scripts/ci/check_* scripts.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+SCRIPT="scripts/merge-clearance-gate.sh"
+WORKFLOW=".github/workflows/merge-clearance-gate.yml"
+TEST="tests/test_merge_clearance_gate.sh"
+
+FAILED=0
+
+# Existence + executability checks.
+for rel in "$SCRIPT" "$TEST"; do
+  if [ ! -f "$rel" ]; then
+    echo "FAIL: Missing required file: $rel"
+    FAILED=1
+    continue
+  fi
+  if [ ! -x "$rel" ]; then
+    echo "FAIL: File is not executable: $rel"
+    echo "      Fix with: chmod +x $rel"
+    FAILED=1
+  fi
+done
+
+# Workflow file exists (not executable; YAML is not a shell script).
+if [ ! -f "$WORKFLOW" ]; then
+  echo "FAIL: Missing required workflow: $WORKFLOW"
+  FAILED=1
+fi
+
+# Workflow trigger shape — same posture as check_codex_p1_gate. GitHub
+# Actions does NOT document pull_request_review_thread as a workflow
+# trigger, so the gate combines event-driven triggers with a scheduled
+# sweep that re-posts a check_run per open PR head SHA (the only backstop
+# for the no-event transitions that produced #428: 👍 reaction, UI label
+# resolve, GITHUB_TOKEN-authored relabel).
+if [ -f "$WORKFLOW" ]; then
+  for trigger in pull_request pull_request_review pull_request_review_comment schedule; do
+    if ! grep -qE "^[[:space:]]*${trigger}:" "$WORKFLOW"; then
+      echo "FAIL: $WORKFLOW missing required trigger: $trigger"
+      echo "      The gate must fire on push, review submission, inline-comment, AND on a periodic schedule (no-event safety net)."
+      FAILED=1
+    fi
+  done
+
+  # Forbid the misleading pull_request_review_thread trigger.
+  if grep -qE "^[[:space:]]*pull_request_review_thread:" "$WORKFLOW"; then
+    echo "FAIL: $WORKFLOW lists pull_request_review_thread as a workflow trigger."
+    echo "      That event is a webhook payload for GitHub Apps, NOT a documented Actions workflow trigger."
+    echo "      Use schedule (cron) for the no-event safety net instead. See codex-p1-gate.yml / PR #257."
+    FAILED=1
+  fi
+
+  # Schedule cron must be present in the on: block.
+  if ! awk '
+    /^on:/ {in_on=1; next}
+    in_on && /^[^[:space:]#]/ {in_on=0}
+    in_on && /^[[:space:]]+schedule:/ {in_sched=1; next}
+    in_sched && /^[[:space:]]+- cron:/ {found=1; exit}
+    in_sched && /^[[:space:]]+[a-z]/ {in_sched=0}
+    END {exit (found ? 0 : 1)}
+  ' "$WORKFLOW"; then
+    echo "FAIL: $WORKFLOW schedule: block missing a 'cron:' entry."
+    echo "      The schedule trigger needs a cron expression (e.g. '*/15 * * * *')."
+    FAILED=1
+  fi
+
+  # The required-check display name (job name) must match the name the
+  # scheduled-sweep posts AND the entry in audit-branch-protection.sh's
+  # CANONICAL_REQUIRED_CHECKS. Branch protection keys on the job name, so
+  # a drift here would silently de-wire the gate.
+  if ! grep -qE '^[[:space:]]+name:[[:space:]]*Merge clearance gate[[:space:]]*$' "$WORKFLOW"; then
+    echo "FAIL: $WORKFLOW must define a job named exactly 'Merge clearance gate'"
+    echo "      (the required-check context; must match the sweep CHECK_NAME and audit-branch-protection.sh)."
+    FAILED=1
+  fi
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "check_merge_clearance_gate: FAIL (pre-flight)"
+  exit 1
+fi
+
+# Run the fixture-driven test suite.
+if ! bash "$TEST"; then
+  echo "check_merge_clearance_gate: FAIL (test suite)"
+  exit 1
+fi
+
+echo "check_merge_clearance_gate: PASS"
+exit 0

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -243,6 +243,21 @@ fi
 REQUIRE_CI_GREEN=$(codex_field require_ci_green)
 REQUIRE_CI_GREEN=${REQUIRE_CI_GREEN:-true}
 
+# Per-invocation CI-skip override (#427/#428). scripts/merge-clearance-gate.sh
+# delegates the external-review clearance check to THIS script, but it is
+# itself a REQUIRED status check (`Merge clearance gate`). Having gate (a)
+# wait on the full required-check rollup — which now INCLUDES the
+# merge-clearance gate — would deadlock: the gate can never go green
+# because it would be blocking on itself. This override forces gate (a) to
+# skip for the current invocation ONLY; it does not change config or the
+# auto-clear path's behavior, and CI green is still enforced independently
+# by the other required checks in branch protection. Honored only when set
+# to the literal "1" so a stray empty/other value can't silently weaken CI
+# enforcement on the normal path.
+if [ "${CODEX_REVIEW_CHECK_SKIP_CI:-}" = "1" ]; then
+  REQUIRE_CI_GREEN=false
+fi
+
 # Honor codex.allow_phase_4b_substitute. When true (default), gate (c)
 # also accepts an APPROVED review on the current HEAD from an
 # available_reviewers identity != the PR author as a Codex-equivalent

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -242,6 +242,16 @@ fi
 # actually consulted by this script).
 REQUIRE_CI_GREEN=$(codex_field require_ci_green)
 REQUIRE_CI_GREEN=${REQUIRE_CI_GREEN:-true}
+# Validate strictly (consistent with codex.enabled /
+# allow_phase_4b_substitute above) so a config typo can't silently skip
+# gate (a) by being treated as "not true" (CodeRabbit ⚠️ Major on PR #429).
+case "$REQUIRE_CI_GREEN" in
+  true|false) ;;
+  *)
+    echo "ERROR: codex.require_ci_green must be true|false; got '$REQUIRE_CI_GREEN'" >&2
+    exit 3
+    ;;
+esac
 
 # Per-invocation CI-skip override (#427/#428). scripts/merge-clearance-gate.sh
 # delegates the external-review clearance check to THIS script, but it is

--- a/scripts/merge-clearance-gate.sh
+++ b/scripts/merge-clearance-gate.sh
@@ -75,9 +75,10 @@
 #     (gate (a)) is skipped for this invocation because this gate is ITSELF
 #     a required check; waiting on the full required-check rollup (which
 #     includes this gate) would deadlock. CI green is enforced
-#     independently by the other required checks. Propagation PRs are not
-#     special-cased: they clear via codex-review-check.sh's
-#     internal-reviewer-APPROVED-on-HEAD (Phase-4b-substitute) path.
+#     independently by the other required checks. Verified propagation PRs
+#     (trusted github-actions[bot] lane marker, label absent) are EXEMPT —
+#     the pr-review-policy.yml lane already cleared them; re-deriving would
+#     force them into Phase 4 and break the lane (#429 Codex round-2 P1).
 #
 #   Any other PR (under-threshold, non-Dependabot, or relevant knob off):
 #     CLEAN PASS (exit 0). The gate is a no-op so it can be a required
@@ -240,6 +241,33 @@ fetch_api_array() {  # <endpoint> <label>
     || die 2 "failed to flatten $label pagination output"
 }
 
+# Propagation-lane exemption (#429 Codex round-2 P1). Returns 0 (true) iff a
+# PR comment authored by github-actions[bot] carries the propagation-lane
+# marker that .github/workflows/pr-review-policy.yml posts ONLY after
+# mergepath@<sha>'s verify-propagation-pr.sh byte-confirms a faithful mirror.
+# A PR author cannot post as github-actions[bot], so this is a TRUSTED
+# positive signal that the lane already exempted this PR from external
+# review (REVIEW_POLICY.md § Propagation PR review lane). Without this,
+# deriving applicability from threshold/protected-paths would force verified
+# propagation PRs — which are large by design, touch .github/**, AND carry an
+# `Authoring-Agent` stamp (so codex-review-check.sh's same-agent guard
+# disqualifies their normal internal approval) — into Phase 4/Codex
+# clearance, breaking the documented under-threshold/internal-approval lane.
+#
+# Per-HEAD safety: the lane re-evaluates on every push. If a propagation PR
+# diverges from its mirror, the lane RE-ADDS needs-external-review, which the
+# label-present branch catches first — so a stale marker cannot exempt a
+# diverged PR outside the same ~20s post-push window pr-review-policy.yml
+# itself races in.
+lane_verified() {
+  local comments
+  comments=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" 2>/dev/null | jq -s 'add // []' 2>/dev/null) || return 1
+  echo "$comments" | jq -e '
+    any(.[]; (.user.login == "github-actions[bot]")
+             and ((.body // "") | test("<!-- propagation-review-lane -->")))
+  ' >/dev/null 2>&1
+}
+
 # --- fetch PR metadata ------------------------------------------------------
 
 log "PR $REPO#$PR_NUMBER — fetching metadata"
@@ -335,8 +363,17 @@ if [ "$EXTERNAL_GATE_ENABLED" = "true" ]; then
   REQUIRES_REASON=""
 
   if [ "$HAS_EXTERNAL_LABEL" = "true" ]; then
+    # Label present forces the arm on (a human may add it to a small PR;
+    # or the propagation lane RE-ADDED it after a divergence). Not subject
+    # to the propagation exemption below — a present label means the lane's
+    # latest per-HEAD verdict is "needs review."
     REQUIRES_EXTERNAL=true
     REQUIRES_REASON="needs-external-review label present"
+  elif lane_verified; then
+    # Verified propagation PR (trusted github-actions[bot] lane marker, label
+    # absent). The lane already exempted it from external review; defer to it
+    # and do NOT re-derive from threshold/paths (#429 Codex round-2 P1).
+    log "verified propagation lane (trusted marker present, label absent) — exempt from external-review derivation; deferring to pr-review-policy.yml lane"
   else
     # `|| true` so a missing key (grep no-match → pipeline non-zero under
     # pipefail) does NOT abort the script before the `:-300` fallback runs

--- a/scripts/merge-clearance-gate.sh
+++ b/scripts/merge-clearance-gate.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# scripts/merge-clearance-gate.sh — HEAD-pinned merge-clearance gate
+#
+# Read-only required-status-check gate that fails CLOSED at merge time
+# when a PR's clearance condition is not satisfied ON THE CURRENT HEAD.
+# Never merges, labels, or comments.
+#
+# Context — nathanjohnpayne/mergepath#427 + #428. Two merge-gate escapes
+# slipped past the enforcement layer and were caught only by the WEEKLY
+# retroactive audit (pr-audit.yml), a week after merge:
+#
+#   #427 (matchline#245): a Dependabot dev-dependencies group bump merged
+#        with NO reviewer-identity APPROVED review on the merge HEAD. The
+#        dependabot-auto-merge.yml approval is transient — a rebase push
+#        dismisses it (or it was never re-posted on the final SHA) — and a
+#        human then merged the approved-but-unmerged PR. Nothing failed
+#        closed.
+#   #428 (nathanpaynedotcom#405): an over-threshold (needs-external-review)
+#        PR merged with no APPROVED CLI review and no Codex review on the
+#        merge HEAD. Clearance was evaluated on an EARLIER HEAD, the
+#        removable-label proxy went stale, and the only required checks
+#        (Label Gate green-but-stale, Codex P1 vacuously green) did not
+#        represent clearance on the merge HEAD.
+#
+# Shared root cause: clearance was enforced via a MUTABLE proxy (a
+# dismissable review, a removable label) plus a weekly audit — never as a
+# HEAD-pinned required status check that re-evaluates on every push and
+# fails closed. This script is that check. Modeled on the proven
+# codex-p1-gate.sh / codex-p1-gate.yml pattern (required check +
+# scheduled sweep + trusted default-branch checkout).
+#
+# Usage:
+#   scripts/merge-clearance-gate.sh [PR_NUMBER] [REPO]
+#   scripts/merge-clearance-gate.sh                  # env-only mode
+#
+# Arguments (positional take precedence; env fallbacks support the
+# scheduled-sweep / workflow_dispatch invocation shape):
+#   PR_NUMBER  Required (positional or $PR_NUMBER env). Integer.
+#   REPO       Optional. "owner/repo". Falls back to $REPO env, then to
+#              the current repo via `gh repo view`.
+#
+# Environment:
+#   GH_TOKEN   Required. Needs pull_requests:read (+ the read scopes
+#              codex-review-check.sh needs for the external-review path).
+#   MERGE_CLEARANCE_CODEX_CHECK_BIN
+#              Optional. Path to codex-review-check.sh. Defaults to the
+#              sibling script next to this one. Tests override it to a
+#              stub so the external-review dispatch + exit-code mapping
+#              can be exercised without re-deriving codex-review-check's
+#              full behavior.
+#
+# What it enforces, by PR class (evaluated on pr.head.sha):
+#
+#   Dependabot PR (author == 'dependabot[bot]'):
+#     Gated by `dependabot.reviewer_gate.enabled` (default false; true in
+#     mergepath). When enabled, BLOCKS unless a reviewer identity in
+#     `available_reviewers` (≠ PR author) has a latest-state APPROVED
+#     review whose commit_id == HEAD. This is the HEAD-pinned form of
+#     pr-audit.yml Check 2's Dependabot path — a transient approval
+#     dismissed on a rebase push re-blocks on the new HEAD.
+#
+#   External-review PR (carries `needs-external-review`):
+#     Gated by `codex.external_review_gate.enabled` (default false; true
+#     in mergepath). When enabled, delegates to codex-review-check.sh —
+#     the SAME clearance predicate (gate (b) reviewer APPROVED + gate (c)
+#     Codex / Phase-4b-substitute on HEAD) the auto-clear workflow uses —
+#     so the merge-time gate and the label-clear logic cannot drift. CI
+#     checking (gate (a)) is skipped for this invocation because this
+#     gate is ITSELF a required check; waiting on the full required-check
+#     rollup (which includes this gate) would deadlock. CI green is
+#     enforced independently by the other required checks.
+#
+#   Any other PR (under-threshold, non-Dependabot, or relevant knob off):
+#     CLEAN PASS (exit 0). The gate is a no-op so it can be a required
+#     check on every PR without blocking normal under-threshold merges.
+#
+# Exit codes (same contract as scripts/codex-p1-gate.sh):
+#   0   Clearance satisfied (or gate not applicable / disabled).
+#   1   Clearance NOT satisfied on the current HEAD — gate BLOCKS.
+#   2   Usage / config / infrastructure error. Message on stderr.
+#
+# Design notes:
+#   - Read-only. Only GETs against the GitHub API (plus a read-only
+#     delegate to codex-review-check.sh on the external-review path).
+#   - bash 3.2 portable; PATH-shimmable `gh` for tests (see
+#     tests/test_merge_clearance_gate.sh).
+#
+# References:
+#   - nathanjohnpayne/mergepath#427, #428 — this script
+#   - scripts/codex-review-check.sh — the shared external-review predicate
+#   - .github/workflows/pr-audit.yml Check 2 — the retroactive backstop
+#   - scripts/codex-p1-gate.sh — the required-check pattern this mirrors
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- argument parsing -------------------------------------------------------
+
+if [ $# -gt 2 ]; then
+  echo "Usage: $0 [PR_NUMBER] [REPO]" >&2
+  echo "       PR_NUMBER and REPO may also be set via env." >&2
+  exit 2
+fi
+
+PR_NUMBER=${1:-${PR_NUMBER:-}}
+if [ -z "$PR_NUMBER" ]; then
+  echo "ERROR: PR_NUMBER required (positional arg or \$PR_NUMBER env)" >&2
+  exit 2
+fi
+if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+  echo "ERROR: PR_NUMBER must be an integer; got '$PR_NUMBER'" >&2
+  exit 2
+fi
+
+REPO=${2:-${REPO:-}}
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+  if [ -z "$REPO" ]; then
+    echo "ERROR: could not detect current repo via 'gh repo view'. Pass REPO explicitly." >&2
+    exit 2
+  fi
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  exit 2
+fi
+
+# --- config readers ---------------------------------------------------------
+
+CONFIG=".github/review-policy.yml"
+
+# Read a scalar field nested two levels deep: `<block>:` `<sub>:` `<field>:`.
+# Same state-machine awk pattern as codex-p1-gate.sh's
+# codex_p1_gate_field, generalized over the top block + sub-block names so
+# it serves both `dependabot.reviewer_gate.enabled` and
+# `codex.external_review_gate.enabled`.
+nested_field() {  # <top_block> <sub_block> <field>
+  # NOTE: do not name an awk -v variable `sub` — it shadows awk's
+  # built-in sub() used in the body. Use topkey/subkey/fldkey.
+  local topkey=$1 subkey=$2 fldkey=$3
+  [ -f "$CONFIG" ] || return 0
+  awk -v topkey="$topkey" -v subkey="$subkey" -v fldkey="$fldkey" '
+    $0 ~ "^" topkey ":" { in_top=1; in_sub=0; next }
+    in_top && /^[^[:space:]#]/ { in_top=0; in_sub=0 }
+    in_top && $1 == subkey":" { in_sub=1; next }
+    in_sub && /^[[:space:]]{0,3}[^[:space:]#]/ { in_sub=0 }
+    in_sub && $1 == fldkey":" {
+      sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+      gsub(/^"/, "", $0)
+      gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      gsub(/[[:space:]]*#.*$/, "", $0)
+      sub(/[[:space:]]+$/, "", $0)
+      print
+      exit
+    }
+  ' "$CONFIG"
+}
+
+# Read the available_reviewers list (one login per line). Identical parser
+# to scripts/codex-review-check.sh read_available_reviewers.
+read_available_reviewers() {
+  [ -f "$CONFIG" ] || return 0
+  awk '
+    /^available_reviewers:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block && /^ *-/ {print}
+  ' "$CONFIG" | sed -E 's/^[[:space:]]*-[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/'
+}
+
+DEPENDABOT_GATE_ENABLED=$(nested_field dependabot reviewer_gate enabled)
+DEPENDABOT_GATE_ENABLED=${DEPENDABOT_GATE_ENABLED:-false}
+case "$DEPENDABOT_GATE_ENABLED" in
+  true|false) ;;
+  *)
+    echo "ERROR: dependabot.reviewer_gate.enabled must be true|false; got '$DEPENDABOT_GATE_ENABLED'" >&2
+    exit 2
+    ;;
+esac
+
+EXTERNAL_GATE_ENABLED=$(nested_field codex external_review_gate enabled)
+EXTERNAL_GATE_ENABLED=${EXTERNAL_GATE_ENABLED:-false}
+case "$EXTERNAL_GATE_ENABLED" in
+  true|false) ;;
+  *)
+    echo "ERROR: codex.external_review_gate.enabled must be true|false; got '$EXTERNAL_GATE_ENABLED'" >&2
+    exit 2
+    ;;
+esac
+
+# --- logging helpers --------------------------------------------------------
+
+log() {
+  echo "[merge-clearance-gate] $*" >&2
+}
+
+die() {  # <code> <msg>
+  local code=$1; shift
+  echo "[merge-clearance-gate] ERROR: $*" >&2
+  exit "$code"
+}
+
+block() {  # <reason>
+  echo ""
+  echo "Merge clearance: BLOCKED — $*"
+  echo ""
+  exit 1
+}
+
+clear_pass() {  # <reason>
+  echo "Merge clearance: PASS — $*"
+  exit 0
+}
+
+fetch_api_array() {  # <endpoint> <label>
+  local endpoint=$1 label=$2 raw
+  raw=$(gh api --paginate "$endpoint" 2>&1) || die 2 "failed to fetch $label: $raw"
+  echo "$raw" | jq -s 'add // []' 2>/dev/null \
+    || die 2 "failed to flatten $label pagination output"
+}
+
+# --- fetch PR metadata ------------------------------------------------------
+
+log "PR $REPO#$PR_NUMBER — fetching metadata"
+
+PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>&1) \
+  || die 2 "failed to fetch PR metadata: $PR_JSON"
+
+HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login')
+if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+  die 2 "could not determine HEAD sha for PR #$PR_NUMBER"
+fi
+
+HAS_EXTERNAL_LABEL=$(echo "$PR_JSON" \
+  | jq -r 'if any(.labels[]?.name; . == "needs-external-review") then "true" else "false" end')
+
+log "HEAD = $HEAD_SHA    author = $PR_AUTHOR    needs-external-review = $HAS_EXTERNAL_LABEL"
+
+# --- class dispatch ---------------------------------------------------------
+#
+# Dependabot is checked FIRST and uses the narrower rule (CLI reviewer
+# APPROVED on HEAD only — Codex does not review Dependabot PRs). This
+# mirrors pr-audit.yml Check 2's precedence: a Dependabot PR that also
+# carries needs-external-review is still judged by the Dependabot rule.
+
+if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+  if [ "$DEPENDABOT_GATE_ENABLED" != "true" ]; then
+    clear_pass "Dependabot PR and dependabot.reviewer_gate.enabled=false (gate disabled)"
+  fi
+
+  log "Dependabot path: requiring a reviewer-identity APPROVED review on HEAD"
+
+  REVIEWERS=$(read_available_reviewers)
+  if [ -z "$REVIEWERS" ]; then
+    die 2 "no available_reviewers found in $CONFIG"
+  fi
+  REVIEWERS_JSON=$(echo "$REVIEWERS" | jq -R . | jq -s .)
+
+  REVIEWS_JSON=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/reviews" "reviews")
+
+  # Latest-state-per-reviewer APPROVED on the current HEAD, from a
+  # reviewer identity that is not the PR author. Mirrors the proven
+  # filter shape in codex-review-check.sh gate (c) Phase-4b-substitute:
+  # collapse each reviewer's review history on HEAD to their most-recent
+  # opinionated state, then accept only if that latest state is APPROVED.
+  # A reviewer who APPROVED then later submitted CHANGES_REQUESTED on the
+  # same HEAD does NOT clear (stale APPROVED rejected). commit_id == HEAD
+  # is the HEAD pinning that closes the #427 escape.
+  APPROVER=$(echo "$REVIEWS_JSON" | jq -r \
+    --argjson reviewers "$REVIEWERS_JSON" \
+    --arg author "$PR_AUTHOR" \
+    --arg sha "$HEAD_SHA" '
+      [ .[]
+        | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+        | select(.commit_id == $sha)
+        | select(.user.login as $u | $reviewers | index($u))
+        | select(.user.login != $author)
+      ]
+      | group_by(.user.login)
+      | map(max_by(.submitted_at))
+      | map(select(.state == "APPROVED"))
+      | first
+      | if . == null then "" else .user.login end
+  ')
+
+  if [ -n "$APPROVER" ]; then
+    clear_pass "Dependabot PR has a latest-state APPROVED review on HEAD $HEAD_SHA from $APPROVER"
+  fi
+  block "Dependabot PR has no reviewer-identity APPROVED review on the merge HEAD $HEAD_SHA. The dependabot-auto-merge approval is missing or was dismissed on a push; a fresh reviewer-identity approval on this HEAD is required (mergepath#427)."
+fi
+
+if [ "$HAS_EXTERNAL_LABEL" = "true" ]; then
+  if [ "$EXTERNAL_GATE_ENABLED" != "true" ]; then
+    clear_pass "needs-external-review present but codex.external_review_gate.enabled=false (gate disabled)"
+  fi
+
+  CODEX_CHECK_BIN="${MERGE_CLEARANCE_CODEX_CHECK_BIN:-$SCRIPT_DIR/codex-review-check.sh}"
+  if [ ! -f "$CODEX_CHECK_BIN" ]; then
+    die 2 "codex-review-check.sh not found at $CODEX_CHECK_BIN (required for the external-review path)"
+  fi
+
+  log "External-review path: delegating to codex-review-check.sh (CI gate skipped — this gate is itself a required check)"
+
+  # Delegate to the shared predicate. CODEX_REVIEW_CHECK_SKIP_CI=1 skips
+  # gate (a) for THIS invocation only (avoids the required-check
+  # self-deadlock); gate (b) reviewer-APPROVED + gate (c) Codex/Phase-4b
+  # on HEAD still run. codex-review-check.sh exits: 0 clear, 1 gate fail,
+  # 3 infra. Map 3 → 2 (config/infra error).
+  set +e
+  CODEX_REVIEW_CHECK_SKIP_CI=1 bash "$CODEX_CHECK_BIN" "$PR_NUMBER" "$REPO"
+  crc=$?
+  set -e
+  case "$crc" in
+    0) clear_pass "codex-review-check.sh cleared external-review on HEAD $HEAD_SHA (reviewer APPROVED + Codex/Phase-4b on HEAD)" ;;
+    1) block "codex-review-check.sh reports external review is NOT cleared on the merge HEAD $HEAD_SHA (no APPROVED CLI review and/or no Codex clearance on this HEAD). See its stderr above (mergepath#428)." ;;
+    *) die 2 "codex-review-check.sh returned rc=$crc (config/infrastructure error) on PR #$PR_NUMBER" ;;
+  esac
+fi
+
+# Not a Dependabot PR and not external-review-labeled → gate not
+# applicable. Clean pass so the required check is green on normal
+# under-threshold PRs.
+clear_pass "not a Dependabot or needs-external-review PR — merge-clearance gate not applicable"

--- a/scripts/merge-clearance-gate.sh
+++ b/scripts/merge-clearance-gate.sh
@@ -241,30 +241,43 @@ fetch_api_array() {  # <endpoint> <label>
     || die 2 "failed to flatten $label pagination output"
 }
 
-# Propagation-lane exemption (#429 Codex round-2 P1). Returns 0 (true) iff a
-# PR comment authored by github-actions[bot] carries the propagation-lane
-# marker that .github/workflows/pr-review-policy.yml posts ONLY after
-# mergepath@<sha>'s verify-propagation-pr.sh byte-confirms a faithful mirror.
-# A PR author cannot post as github-actions[bot], so this is a TRUSTED
-# positive signal that the lane already exempted this PR from external
-# review (REVIEW_POLICY.md § Propagation PR review lane). Without this,
-# deriving applicability from threshold/protected-paths would force verified
-# propagation PRs — which are large by design, touch .github/**, AND carry an
-# `Authoring-Agent` stamp (so codex-review-check.sh's same-agent guard
-# disqualifies their normal internal approval) — into Phase 4/Codex
-# clearance, breaking the documented under-threshold/internal-approval lane.
+# Propagation-lane exemption (#429), HEAD-PINNED. Returns 0 (true) iff a PR
+# comment authored by github-actions[bot] carries the propagation-lane marker
+# scoped to the CURRENT head SHA — i.e. `mergepath-propagation-lane
+# verified-head=<HEAD_SHA>`. .github/workflows/pr-review-policy.yml posts that
+# marker ONLY after mergepath@<sha>'s verify-propagation-pr.sh byte-confirms a
+# faithful mirror AT THAT HEAD, and a PR author cannot post as
+# github-actions[bot] — so it is a TRUSTED, head-scoped signal that the lane
+# already exempted THIS head from external review (REVIEW_POLICY.md §
+# Propagation PR review lane).
 #
-# Per-HEAD safety: the lane re-evaluates on every push. If a propagation PR
-# diverges from its mirror, the lane RE-ADDS needs-external-review, which the
-# label-present branch catches first — so a stale marker cannot exempt a
-# diverged PR outside the same ~20s post-push window pr-review-policy.yml
-# itself races in.
+# Why head-pinned (Codex round-3 P1 + nathanpayne-codex CHANGES_REQUESTED on
+# #429): an unscoped "was-ever-a-mirror" marker is posted once and survives a
+# later divergent push. On the synchronize where this gate finishes before
+# pr-review-policy.yml re-adds needs-external-review, an unscoped check would
+# go GREEN on an unverified large/.github PR. Pinning the exemption to the
+# current head SHA closes that race independently of label timing: a diverged
+# (or merely newer-but-not-yet-verified) head has no matching marker, so the
+# gate does NOT exempt it and falls through to threshold/paths derivation.
+# A DIVERGED push never gets a marker at all (the lane's propagation_lane is
+# false → it posts nothing for that head). A faithful re-push is briefly
+# not-yet-exempt (fail-closed) until the lane posts the new head's marker and
+# the next event / scheduled sweep re-evaluates.
+#
+# Without this exemption, deriving applicability from threshold/protected-paths
+# would force verified propagation PRs — large by design, touching .github/**,
+# AND carrying an `Authoring-Agent` stamp (so codex-review-check.sh's
+# same-agent guard disqualifies their normal internal approval) — into Phase
+# 4/Codex clearance, breaking the documented under-threshold lane.
+#
+# Marker contract is shared with pr-review-policy.yml — keep the
+# `mergepath-propagation-lane verified-head=<sha>` form in sync.
 lane_verified() {
   local comments
   comments=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" 2>/dev/null | jq -s 'add // []' 2>/dev/null) || return 1
-  echo "$comments" | jq -e '
+  echo "$comments" | jq -e --arg head "$HEAD_SHA" '
     any(.[]; (.user.login == "github-actions[bot]")
-             and ((.body // "") | test("<!-- propagation-review-lane -->")))
+             and ((.body // "") | contains("mergepath-propagation-lane verified-head=" + $head)))
   ' >/dev/null 2>&1
 }
 
@@ -370,10 +383,11 @@ if [ "$EXTERNAL_GATE_ENABLED" = "true" ]; then
     REQUIRES_EXTERNAL=true
     REQUIRES_REASON="needs-external-review label present"
   elif lane_verified; then
-    # Verified propagation PR (trusted github-actions[bot] lane marker, label
-    # absent). The lane already exempted it from external review; defer to it
-    # and do NOT re-derive from threshold/paths (#429 Codex round-2 P1).
-    log "verified propagation lane (trusted marker present, label absent) — exempt from external-review derivation; deferring to pr-review-policy.yml lane"
+    # Verified propagation PR: a trusted github-actions[bot] lane marker
+    # scoped to THIS head SHA is present (label absent). The lane already
+    # byte-verified this exact head and exempted it from external review;
+    # defer to it and do NOT re-derive from threshold/paths (#429).
+    log "verified propagation lane (trusted head-pinned marker for $HEAD_SHA, label absent) — exempt from external-review derivation; deferring to pr-review-policy.yml lane"
   else
     # `|| true` so a missing key (grep no-match → pipeline non-zero under
     # pipefail) does NOT abort the script before the `:-300` fallback runs

--- a/scripts/merge-clearance-gate.sh
+++ b/scripts/merge-clearance-gate.sh
@@ -59,16 +59,25 @@
 #     pr-audit.yml Check 2's Dependabot path — a transient approval
 #     dismissed on a rebase push re-blocks on the new HEAD.
 #
-#   External-review PR (carries `needs-external-review`):
+#   External-review PR:
 #     Gated by `codex.external_review_gate.enabled` (default false; true
-#     in mergepath). When enabled, delegates to codex-review-check.sh —
-#     the SAME clearance predicate (gate (b) reviewer APPROVED + gate (c)
-#     Codex / Phase-4b-substitute on HEAD) the auto-clear workflow uses —
-#     so the merge-time gate and the label-clear logic cannot drift. CI
-#     checking (gate (a)) is skipped for this invocation because this
-#     gate is ITSELF a required check; waiting on the full required-check
-#     rollup (which includes this gate) would deadlock. CI green is
-#     enforced independently by the other required checks.
+#     in mergepath). Applicability is DERIVED from the PR's intrinsic
+#     properties — over `external_review_threshold` lines, OR a changed
+#     file matching `external_review_paths`, OR the `needs-external-review`
+#     label present — NOT from the label alone. (Trusting the label would
+#     reopen the #428 stale-label race: after a push, this gate can run
+#     before pr-review-policy.yml re-adds the label, and a label-only check
+#     would false-clear on an uncleared HEAD. #429 Codex P1.) When it
+#     applies, delegates to codex-review-check.sh — the SAME clearance
+#     predicate (gate (b) reviewer APPROVED + gate (c) Codex /
+#     Phase-4b-substitute on HEAD) the auto-clear workflow uses — so the
+#     merge-time gate and the label-clear logic cannot drift. CI checking
+#     (gate (a)) is skipped for this invocation because this gate is ITSELF
+#     a required check; waiting on the full required-check rollup (which
+#     includes this gate) would deadlock. CI green is enforced
+#     independently by the other required checks. Propagation PRs are not
+#     special-cased: they clear via codex-review-check.sh's
+#     internal-reviewer-APPROVED-on-HEAD (Phase-4b-substitute) path.
 #
 #   Any other PR (under-threshold, non-Dependabot, or relevant knob off):
 #     CLEAN PASS (exit 0). The gate is a no-op so it can be a required
@@ -291,35 +300,107 @@ if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
   block "Dependabot PR has no reviewer-identity APPROVED review on the merge HEAD $HEAD_SHA. The dependabot-auto-merge approval is missing or was dismissed on a push; a fresh reviewer-identity approval on this HEAD is required (mergepath#427)."
 fi
 
-if [ "$HAS_EXTERNAL_LABEL" = "true" ]; then
-  if [ "$EXTERNAL_GATE_ENABLED" != "true" ]; then
-    clear_pass "needs-external-review present but codex.external_review_gate.enabled=false (gate disabled)"
+# --- external-review applicability (DERIVED, not label-trusting) -----------
+#
+# #429 Codex P1: keying the external arm on the CURRENT label state would
+# reintroduce the exact stale-label race this gate exists to close. After a
+# push, this gate can run on `synchronize` BEFORE pr-review-policy.yml
+# re-adds `needs-external-review` for the new HEAD; a label-only check would
+# then fall through to "not applicable" and go GREEN on an uncleared HEAD
+# (the #428 escape, reopened). So derive applicability from the PR's
+# INTRINSIC properties — the same line-threshold + protected-paths
+# computation pr-review-policy.yml's External Review Check uses — and treat
+# the label, when present, as an additional force-on signal (a human may
+# add it to a small PR). Config (threshold + paths) is read from the
+# TRUSTED default-branch review-policy.yml; the changed-file set comes from
+# the API (this gate runs on a default-branch checkout with no local PR
+# diff). Propagation PRs are NOT special-cased: they reach clearance via
+# codex-review-check.sh's internal-reviewer-APPROVED-on-HEAD (Phase-4b
+# substitute) path, consistent with the lane's standard "internal
+# reviewer-identity APPROVED required" rule.
+
+if [ "$EXTERNAL_GATE_ENABLED" = "true" ]; then
+  REQUIRES_EXTERNAL=false
+  REQUIRES_REASON=""
+
+  if [ "$HAS_EXTERNAL_LABEL" = "true" ]; then
+    REQUIRES_EXTERNAL=true
+    REQUIRES_REASON="needs-external-review label present"
+  else
+    THRESHOLD=$(grep -E '^external_review_threshold:' "$CONFIG" 2>/dev/null | awk '{print $2}')
+    THRESHOLD=${THRESHOLD:-300}
+    if ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]]; then THRESHOLD=300; fi
+
+    FILES_JSON=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/files" "PR files")
+
+    # Sum additions+deletions, excluding the same generated/lockfile
+    # patterns pr-review-policy.yml's git-diff pathspec excludes.
+    LINES_CHANGED=$(echo "$FILES_JSON" | jq '
+      [ .[]
+        | select((.filename
+            | test("(\\.lock$)|(lock\\.json$)|(\\.min\\.js$)|(\\.min\\.css$)|(\\.generated\\.)|(\\.g\\.dart$)|(\\.freezed\\.dart$)")) | not)
+        | ((.additions // 0) + (.deletions // 0)) ]
+      | add // 0')
+    LINES_CHANGED=${LINES_CHANGED:-0}
+
+    if [ "$LINES_CHANGED" -ge "$THRESHOLD" ]; then
+      REQUIRES_EXTERNAL=true
+      REQUIRES_REASON="$LINES_CHANGED lines changed >= threshold $THRESHOLD"
+    else
+      # Protected-paths match, reusing the SAME helpers pr-review-policy.yml
+      # uses (no drift). Resolved relative to this script so they work from a
+      # trusted default-branch checkout; they take the config path + read
+      # candidate filenames on stdin (no filesystem access to PR content).
+      PARSE="$SCRIPT_DIR/workflow/parse_policy_list.sh"
+      MATCH="$SCRIPT_DIR/workflow/match_protected_paths.sh"
+      if [ -f "$PARSE" ] && [ -f "$MATCH" ]; then
+        PATHS=$(bash "$PARSE" "$CONFIG" external_review_paths 2>/dev/null || true)
+        if [ -n "$PATHS" ]; then
+          PATTERNS=()
+          while IFS= read -r pline; do
+            [ -n "$pline" ] && PATTERNS+=("$pline")
+          done <<<"$PATHS"
+          if [ "${#PATTERNS[@]}" -gt 0 ]; then
+            CHANGED_FILES=$(echo "$FILES_JSON" | jq -r '.[].filename')
+            MATCHED=$(printf '%s\n' "$CHANGED_FILES" | bash "$MATCH" "${PATTERNS[@]}" 2>/dev/null || true)
+            if [ -n "$MATCHED" ]; then
+              REQUIRES_EXTERNAL=true
+              REQUIRES_REASON="protected paths modified: $(printf '%s' "$MATCHED" | tr '\n' ' ')"
+            fi
+          fi
+        fi
+      else
+        log "WARNING: $PARSE / $MATCH not found — protected-paths derivation skipped (threshold-only)."
+      fi
+    fi
   fi
 
-  CODEX_CHECK_BIN="${MERGE_CLEARANCE_CODEX_CHECK_BIN:-$SCRIPT_DIR/codex-review-check.sh}"
-  if [ ! -f "$CODEX_CHECK_BIN" ]; then
-    die 2 "codex-review-check.sh not found at $CODEX_CHECK_BIN (required for the external-review path)"
+  if [ "$REQUIRES_EXTERNAL" = "true" ]; then
+    log "external review applies ($REQUIRES_REASON); delegating to codex-review-check.sh (CI gate skipped — this gate is itself a required check)"
+
+    CODEX_CHECK_BIN="${MERGE_CLEARANCE_CODEX_CHECK_BIN:-$SCRIPT_DIR/codex-review-check.sh}"
+    if [ ! -f "$CODEX_CHECK_BIN" ]; then
+      die 2 "codex-review-check.sh not found at $CODEX_CHECK_BIN (required for the external-review path)"
+    fi
+
+    # Delegate to the shared predicate. CODEX_REVIEW_CHECK_SKIP_CI=1 skips
+    # gate (a) for THIS invocation only (avoids the required-check
+    # self-deadlock); gate (b) reviewer-APPROVED + gate (c) Codex/Phase-4b
+    # on HEAD still run. codex-review-check.sh exits: 0 clear, 1 gate fail,
+    # 3 infra. Map 3 → 2 (config/infra error).
+    set +e
+    CODEX_REVIEW_CHECK_SKIP_CI=1 bash "$CODEX_CHECK_BIN" "$PR_NUMBER" "$REPO"
+    crc=$?
+    set -e
+    case "$crc" in
+      0) clear_pass "external review cleared on HEAD $HEAD_SHA ($REQUIRES_REASON; reviewer APPROVED + Codex/Phase-4b on HEAD)" ;;
+      1) block "external review is NOT cleared on the merge HEAD $HEAD_SHA ($REQUIRES_REASON; no APPROVED CLI review and/or no Codex clearance on this HEAD). See codex-review-check.sh stderr above (mergepath#428)." ;;
+      *) die 2 "codex-review-check.sh returned rc=$crc (config/infrastructure error) on PR #$PR_NUMBER" ;;
+    esac
   fi
-
-  log "External-review path: delegating to codex-review-check.sh (CI gate skipped — this gate is itself a required check)"
-
-  # Delegate to the shared predicate. CODEX_REVIEW_CHECK_SKIP_CI=1 skips
-  # gate (a) for THIS invocation only (avoids the required-check
-  # self-deadlock); gate (b) reviewer-APPROVED + gate (c) Codex/Phase-4b
-  # on HEAD still run. codex-review-check.sh exits: 0 clear, 1 gate fail,
-  # 3 infra. Map 3 → 2 (config/infra error).
-  set +e
-  CODEX_REVIEW_CHECK_SKIP_CI=1 bash "$CODEX_CHECK_BIN" "$PR_NUMBER" "$REPO"
-  crc=$?
-  set -e
-  case "$crc" in
-    0) clear_pass "codex-review-check.sh cleared external-review on HEAD $HEAD_SHA (reviewer APPROVED + Codex/Phase-4b on HEAD)" ;;
-    1) block "codex-review-check.sh reports external review is NOT cleared on the merge HEAD $HEAD_SHA (no APPROVED CLI review and/or no Codex clearance on this HEAD). See its stderr above (mergepath#428)." ;;
-    *) die 2 "codex-review-check.sh returned rc=$crc (config/infrastructure error) on PR #$PR_NUMBER" ;;
-  esac
 fi
 
-# Not a Dependabot PR and not external-review-labeled → gate not
-# applicable. Clean pass so the required check is green on normal
-# under-threshold PRs.
-clear_pass "not a Dependabot or needs-external-review PR — merge-clearance gate not applicable"
+# Not a Dependabot PR, and external review does not apply (under threshold,
+# no protected paths, no label — or the external gate is disabled). Clean
+# pass so the required check is green on normal under-threshold PRs.
+clear_pass "merge-clearance gate not applicable (under threshold, no protected paths, no external-review label; or external gate disabled)"

--- a/scripts/merge-clearance-gate.sh
+++ b/scripts/merge-clearance-gate.sh
@@ -104,6 +104,17 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# --- tool preflight ---------------------------------------------------------
+# Fail with the documented config/usage code (2) if a hard dependency is
+# missing, rather than dying mid-run with an opaque 127 that the workflow
+# would map to a generic CI error (CodeRabbit ⚠️ on PR #429).
+for _tool in gh jq awk; do
+  if ! command -v "$_tool" >/dev/null 2>&1; then
+    echo "ERROR: required tool '$_tool' not found on PATH" >&2
+    exit 2
+  fi
+done
+
 # --- argument parsing -------------------------------------------------------
 
 if [ $# -gt 2 ]; then
@@ -327,7 +338,10 @@ if [ "$EXTERNAL_GATE_ENABLED" = "true" ]; then
     REQUIRES_EXTERNAL=true
     REQUIRES_REASON="needs-external-review label present"
   else
-    THRESHOLD=$(grep -E '^external_review_threshold:' "$CONFIG" 2>/dev/null | awk '{print $2}')
+    # `|| true` so a missing key (grep no-match → pipeline non-zero under
+    # pipefail) does NOT abort the script before the `:-300` fallback runs
+    # (CodeRabbit ⚠️ on PR #429).
+    THRESHOLD=$(grep -E '^external_review_threshold:' "$CONFIG" 2>/dev/null | awk '{print $2}' || true)
     THRESHOLD=${THRESHOLD:-300}
     if ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]]; then THRESHOLD=300; fi
 
@@ -351,26 +365,51 @@ if [ "$EXTERNAL_GATE_ENABLED" = "true" ]; then
       # uses (no drift). Resolved relative to this script so they work from a
       # trusted default-branch checkout; they take the config path + read
       # candidate filenames on stdin (no filesystem access to PR content).
-      PARSE="$SCRIPT_DIR/workflow/parse_policy_list.sh"
-      MATCH="$SCRIPT_DIR/workflow/match_protected_paths.sh"
-      if [ -f "$PARSE" ] && [ -f "$MATCH" ]; then
-        PATHS=$(bash "$PARSE" "$CONFIG" external_review_paths 2>/dev/null || true)
-        if [ -n "$PATHS" ]; then
+      # MERGE_CLEARANCE_WORKFLOW_DIR overrides the helper dir (tests only).
+      #
+      # Fail CLOSED on any failure to RUN the matcher (missing helper, parse
+      # error, match error): a protected-path PR must never slip through as
+      # "threshold-only" just because the matcher couldn't run. The helpers
+      # ship with this gate via .mergepath-sync.yml, so their absence means a
+      # broken install — require external review rather than skip it.
+      # (CodeRabbit ⚠️ Major on PR #429.) Note: a SUCCESSFUL parse that
+      # yields no entries (external_review_paths absent/empty) is NOT a
+      # failure — it legitimately means "no protected paths," so the gate
+      # does not fail closed in that case.
+      WF_DIR="${MERGE_CLEARANCE_WORKFLOW_DIR:-$SCRIPT_DIR/workflow}"
+      PARSE="$WF_DIR/parse_policy_list.sh"
+      MATCH="$WF_DIR/match_protected_paths.sh"
+      if [ ! -f "$PARSE" ] || [ ! -f "$MATCH" ]; then
+        REQUIRES_EXTERNAL=true
+        REQUIRES_REASON="protected-paths check unavailable (parser/matcher missing under $WF_DIR) — failing closed"
+      else
+        set +e
+        PATHS=$(bash "$PARSE" "$CONFIG" external_review_paths)
+        parse_rc=$?
+        set -e
+        if [ "$parse_rc" -ne 0 ]; then
+          REQUIRES_EXTERNAL=true
+          REQUIRES_REASON="protected-paths parse failed (rc=$parse_rc) — failing closed"
+        elif [ -n "$PATHS" ]; then
           PATTERNS=()
           while IFS= read -r pline; do
             [ -n "$pline" ] && PATTERNS+=("$pline")
           done <<<"$PATHS"
           if [ "${#PATTERNS[@]}" -gt 0 ]; then
             CHANGED_FILES=$(echo "$FILES_JSON" | jq -r '.[].filename')
-            MATCHED=$(printf '%s\n' "$CHANGED_FILES" | bash "$MATCH" "${PATTERNS[@]}" 2>/dev/null || true)
-            if [ -n "$MATCHED" ]; then
+            set +e
+            MATCHED=$(printf '%s\n' "$CHANGED_FILES" | bash "$MATCH" "${PATTERNS[@]}")
+            match_rc=$?
+            set -e
+            if [ "$match_rc" -ne 0 ]; then
+              REQUIRES_EXTERNAL=true
+              REQUIRES_REASON="protected-paths match failed (rc=$match_rc) — failing closed"
+            elif [ -n "$MATCHED" ]; then
               REQUIRES_EXTERNAL=true
               REQUIRES_REASON="protected paths modified: $(printf '%s' "$MATCHED" | tr '\n' ' ')"
             fi
           fi
         fi
-      else
-        log "WARNING: $PARSE / $MATCH not found — protected-paths derivation skipped (threshold-only)."
       fi
     fi
   fi

--- a/tests/test_audit_branch_protection.sh
+++ b/tests/test_audit_branch_protection.sh
@@ -105,8 +105,15 @@ case "$path" in
         ;;
       classic_protected)
         # Classic protection present; required_status_checks includes
-        # both canonical checks plus an extra one.
-        emit_status_and_body 200 '{"required_status_checks":{"contexts":["Label Gate","Self-Review Required","lint"]}}'
+        # all canonical checks plus an extra one.
+        emit_status_and_body 200 '{"required_status_checks":{"contexts":["Label Gate","Self-Review Required","Codex P1 unresolved threads","Merge clearance gate","lint"]}}'
+        exit $?
+        ;;
+      classic_missing_clearance_gate)
+        # Classic protection present but MISSING "Merge clearance gate".
+        # Regression net for #427/#428: the auditor must FAIL when the
+        # HEAD-pinned merge-clearance check is not a required check.
+        emit_status_and_body 200 '{"required_status_checks":{"contexts":["Label Gate","Self-Review Required","Codex P1 unresolved threads","lint"]}}'
         exit $?
         ;;
       no_protection|ruleset_*|ruleset_all_but_main_excluded)
@@ -161,12 +168,12 @@ case "$path" in
     ;;
   */rulesets/101)
     # ~ALL include, canonical checks
-    printf '%s\n' '{"id":101,"target":"branch","conditions":{"ref_name":{"include":["~ALL"],"exclude":[]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"Label Gate"},{"context":"Self-Review Required"}]}}]}'
+    printf '%s\n' '{"id":101,"target":"branch","conditions":{"ref_name":{"include":["~ALL"],"exclude":[]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"Label Gate"},{"context":"Self-Review Required"},{"context":"Codex P1 unresolved threads"},{"context":"Merge clearance gate"}]}}]}'
     exit 0
     ;;
   */rulesets/102)
     # refs/heads/* glob include, canonical checks
-    printf '%s\n' '{"id":102,"target":"branch","conditions":{"ref_name":{"include":["refs/heads/*"],"exclude":[]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"Label Gate"},{"context":"Self-Review Required"}]}}]}'
+    printf '%s\n' '{"id":102,"target":"branch","conditions":{"ref_name":{"include":["refs/heads/*"],"exclude":[]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"Label Gate"},{"context":"Self-Review Required"},{"context":"Codex P1 unresolved threads"},{"context":"Merge clearance gate"}]}}]}'
     exit 0
     ;;
   */rulesets/201)
@@ -179,7 +186,7 @@ case "$path" in
     ;;
   */rulesets/202)
     # ~DEFAULT_BRANCH with canonical checks — should match audit of main.
-    printf '%s\n' '{"id":202,"target":"branch","conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"Label Gate"},{"context":"Self-Review Required"}]}}]}'
+    printf '%s\n' '{"id":202,"target":"branch","conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"Label Gate"},{"context":"Self-Review Required"},{"context":"Codex P1 unresolved threads"},{"context":"Merge clearance gate"}]}}]}'
     exit 0
     ;;
   */rulesets/301)
@@ -359,6 +366,24 @@ elif ! echo "$out" | grep -q "no rulesets target main"; then
   fail "ruleset all-but-main-excluded: missing 'no rulesets target main' verdict; output: $out"
 else
   pass "ruleset all-but-main-excluded: exclude correctly disqualifies the ~ALL include"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 10 (#427/#428): classic protection present but MISSING the
+#         "Merge clearance gate" required check → exit 3. Regression net
+#         that the HEAD-pinned merge-clearance gate is wired into the
+#         canonical required-checks list.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_audit classic_missing_clearance_gate 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 3 ]; then
+  fail "missing clearance gate: exit $rc, expected 3; output: $out"
+elif ! echo "$out" | grep -q "Merge clearance gate"; then
+  fail "missing clearance gate: diagnostic must name 'Merge clearance gate'; output: $out"
+else
+  pass "missing 'Merge clearance gate' required check: exits 3 (canonical gap flagged)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_merge_clearance_gate.sh
+++ b/tests/test_merge_clearance_gate.sh
@@ -582,15 +582,16 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 17 (#429 Codex round-2 P1): verified propagation PR — over-threshold,
-# NO needs-external-review label, but a github-actions[bot] lane marker
-# comment is present → EXEMPT (not applicable), must NOT delegate.
+# Test 17 (#429): verified propagation PR — over-threshold, NO
+# needs-external-review label, with a github-actions[bot] lane marker scoped
+# to the CURRENT head → EXEMPT (not applicable), must NOT delegate.
 # ---------------------------------------------------------------------------
-echo; echo "--- Test 17: verified propagation lane → exempt"
+echo; echo "--- Test 17: verified propagation lane (head-pinned) → exempt"
 SCRATCH=$(make_scratch false true)
 FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" '[]')
 FIXTURE_FILES=$(make_files_fixture '[{"filename":".github/workflows/x.yml","additions":400,"deletions":50}]')
-FIXTURE_COMMENTS=$(make_comments_fixture '[{"user":{"login":"github-actions[bot]"},"body":"<!-- propagation-review-lane -->\nVerified faithful mirror ✅"}]')
+FIXTURE_COMMENTS=$(make_comments_fixture "$(jq -n --arg h "$HEAD_SHA" '
+  [{user:{login:"github-actions[bot]"}, body:("<!-- mergepath-propagation-lane verified-head=" + $h + " -->\nverified faithful mirror ✅")}]')")
 set +e
 OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_FILES="$FIXTURE_FILES" FIXTURE_COMMENTS="$FIXTURE_COMMENTS" \
       MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \
@@ -599,13 +600,39 @@ OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_FILES="$FIXTURE_FILES" FIXTURE_COMMENTS="
 RC=$?
 set -e
 if [ "$RC" = 0 ] && echo "$OUT" | grep -qi "not applicable"; then
-  pass "verified propagation lane → exempt (exit 0, no delegate)"
+  pass "verified propagation lane (current-head marker) → exempt (exit 0, no delegate)"
 else
   fail "expected rc=0 not-applicable (exempt); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
 fi
 
 # ---------------------------------------------------------------------------
-# Test 18: SPOOFED lane marker — same marker text but authored by a NON-bot
+# Test 17b (#429 Codex round-3 P1 / nathanpayne-codex CHANGES_REQUESTED): a
+# STALE lane marker — bot-authored but scoped to an OLD head — must NOT exempt
+# a diverged current head. This is the head-pinning regression: an unscoped
+# "was-ever-a-mirror" marker would have false-exempted here. Over-threshold +
+# stale marker → still requires external → delegate blocks.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 17b: STALE bot marker (old head) + diverged head → NOT exempt"
+SCRATCH=$(make_scratch false true)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" '[]')
+FIXTURE_FILES=$(make_files_fixture '[{"filename":".github/workflows/x.yml","additions":400,"deletions":50}]')
+FIXTURE_COMMENTS=$(make_comments_fixture "$(jq -n --arg old "$OLD_SHA" '
+  [{user:{login:"github-actions[bot]"}, body:("<!-- mergepath-propagation-lane verified-head=" + $old + " -->\nverified faithful mirror ✅")}]')")
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_FILES="$FIXTURE_FILES" FIXTURE_COMMENTS="$FIXTURE_COMMENTS" \
+      MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \
+      CODEX_STUB_RC=1 \
+      run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 1 ] && echo "$OUT" | grep -q "BLOCKED"; then
+  pass "stale marker (old head) → NOT exempt → delegate blocks → exit 1 (head-pinned)"
+else
+  fail "expected rc=1 BLOCKED (stale marker ignored); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 18: SPOOFED lane marker — current-head marker but authored by a NON-bot
 # login → must NOT exempt (a PR author can't forge github-actions[bot]).
 # Over-threshold + spoofed marker → still requires external → delegate blocks.
 # ---------------------------------------------------------------------------
@@ -613,7 +640,8 @@ echo; echo "--- Test 18: spoofed (non-bot) lane marker → NOT exempt"
 SCRATCH=$(make_scratch false true)
 FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" '[]')
 FIXTURE_FILES=$(make_files_fixture '[{"filename":"src/big.ts","additions":250,"deletions":120}]')
-FIXTURE_COMMENTS=$(make_comments_fixture '[{"user":{"login":"nathanjohnpayne"},"body":"<!-- propagation-review-lane --> nice try"}]')
+FIXTURE_COMMENTS=$(make_comments_fixture "$(jq -n --arg h "$HEAD_SHA" '
+  [{user:{login:"nathanjohnpayne"}, body:("<!-- mergepath-propagation-lane verified-head=" + $h + " --> nice try")}]')")
 set +e
 OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_FILES="$FIXTURE_FILES" FIXTURE_COMMENTS="$FIXTURE_COMMENTS" \
       MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \

--- a/tests/test_merge_clearance_gate.sh
+++ b/tests/test_merge_clearance_gate.sh
@@ -86,9 +86,18 @@ if [ "$1" = "api" ]; then
       cat "${FIXTURE_PR:-/dev/null}"
       exit 0
       ;;
+    *)
+      # Fail (don't silently succeed) on an unhandled endpoint so a future
+      # gate change that calls a new endpoint surfaces as a test failure
+      # rather than a false green (CodeRabbit ⚠️ on PR #429).
+      echo "STUB gh: unhandled api endpoint: $endpoint" >&2
+      exit 1
+      ;;
   esac
 fi
-exit 0
+# Any non-`gh api` invocation is unexpected for this gate.
+echo "STUB gh: unhandled invocation: $*" >&2
+exit 1
 STUB
 chmod +x "$STUB_DIR/gh"
 
@@ -503,6 +512,62 @@ if [ "$RC" = 0 ] && echo "$OUT" | grep -q "PASS"; then
   pass "env-only PR_NUMBER + REPO → exit 0"
 else
   fail "expected rc=0 PASS; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 15 (CodeRabbit ⚠️ #429): external_review_threshold ABSENT from config
+# → defaults to 300 without crashing under set -euo pipefail. A small PR
+# stays "not applicable" (exit 0); the grep|awk no-match must not abort.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 15: threshold key absent → default 300, no crash"
+SCRATCH=$(mktemp -d "$WORKDIR/scratch.XXXXXX"); mkdir -p "$SCRATCH/.github"
+cat >"$SCRATCH/.github/review-policy.yml" <<EOF
+external_review_paths:
+  - ".github/**"
+available_reviewers:
+  - nathanpayne-claude
+codex:
+  external_review_gate:
+    enabled: true
+dependabot:
+  reviewer_gate:
+    enabled: false
+EOF
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" '[]')
+FIXTURE_FILES=$(make_files_fixture '[{"filename":"README.md","additions":10,"deletions":2}]')
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_FILES="$FIXTURE_FILES" run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 0 ] && echo "$OUT" | grep -qi "not applicable"; then
+  pass "threshold absent → default 300 applied, small PR not applicable (no crash)"
+else
+  fail "expected rc=0 not-applicable; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 16 (CodeRabbit ⚠️ Major #429): protected-paths matcher UNAVAILABLE →
+# the gate must FAIL CLOSED (require external review), not skip to
+# threshold-only. Point the helper dir at an empty location; an
+# under-threshold PR must then still delegate (→ delegate blocks → exit 1).
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 16: missing protected-paths helpers → fail closed"
+SCRATCH=$(make_scratch false true)
+EMPTY_WF=$(mktemp -d "$WORKDIR/emptywf.XXXXXX")
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" '[]')
+FIXTURE_FILES=$(make_files_fixture '[{"filename":"README.md","additions":5,"deletions":1}]')
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_FILES="$FIXTURE_FILES" \
+      MERGE_CLEARANCE_WORKFLOW_DIR="$EMPTY_WF" \
+      MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \
+      CODEX_STUB_RC=1 \
+      run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 1 ] && echo "$OUT" | grep -q "BLOCKED" && echo "$OUT" | grep -qi "failing closed"; then
+  pass "missing matcher → fail closed → external arm applies → delegate blocks → exit 1"
+else
+  fail "expected rc=1 BLOCKED via fail-closed; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_merge_clearance_gate.sh
+++ b/tests/test_merge_clearance_gate.sh
@@ -78,6 +78,10 @@ if [ "$1" = "api" ]; then
       cat "${FIXTURE_REVIEWS:-/dev/null}"
       exit 0
       ;;
+    repos/*/pulls/*/files)
+      cat "${FIXTURE_FILES:-/dev/null}"
+      exit 0
+      ;;
     repos/*/pulls/*)
       cat "${FIXTURE_PR:-/dev/null}"
       exit 0
@@ -106,6 +110,11 @@ make_scratch() {
   dir=$(mktemp -d "$WORKDIR/scratch.XXXXXX")
   mkdir -p "$dir/.github"
   cat >"$dir/.github/review-policy.yml" <<EOF
+external_review_threshold: 300
+external_review_paths:
+  - ".github/**"
+  - "src/auth/**"
+
 available_reviewers:
   - nathanpayne-claude
   - nathanpayne-cursor
@@ -121,6 +130,13 @@ dependabot:
     enabled: $dependabot_enabled
 EOF
   echo "$dir"
+}
+
+make_files_fixture() {  # <json_array_literal>   e.g. '[{"filename":"x","additions":5,"deletions":0}]'
+  local content=$1
+  local file="$WORKDIR/files.$$.$RANDOM.json"
+  echo "$content" >"$file"
+  echo "$file"
 }
 
 make_pr_fixture() {  # <sha> <author> <labels_json_array>
@@ -356,12 +372,79 @@ fi
 echo; echo "--- Test 11: normal under-threshold PR → not applicable"
 SCRATCH=$(make_scratch true true)
 FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" '[]')
+FIXTURE_FILES=$(make_files_fixture '[{"filename":"README.md","additions":3,"deletions":1}]')
 set +e
-OUT=$(FIXTURE_PR="$FIXTURE_PR" run_gate "$SCRATCH" 99 owner/repo 2>&1)
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_FILES="$FIXTURE_FILES" run_gate "$SCRATCH" 99 owner/repo 2>&1)
 RC=$?
 set -e
 if [ "$RC" = 0 ] && echo "$OUT" | grep -qi "not applicable"; then
   pass "normal PR → exit 0 (not applicable)"
+else
+  fail "expected rc=0 not-applicable; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11b (#429 Codex P1): NO needs-external-review label, but the PR is
+# intrinsically OVER THRESHOLD. The gate must DERIVE applicability (not
+# trust the label) and delegate — so a delegate that blocks → exit 1. This
+# is the stale-label race regression net: a label-only check would have
+# fallen through to "not applicable" green here.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 11b: no label + over-threshold → derives applicability (#429)"
+SCRATCH=$(make_scratch false true)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" '[]')
+FIXTURE_FILES=$(make_files_fixture '[{"filename":"src/big.ts","additions":250,"deletions":120}]')
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_FILES="$FIXTURE_FILES" \
+      MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \
+      CODEX_STUB_RC=1 \
+      run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 1 ] && echo "$OUT" | grep -q "BLOCKED" && echo "$OUT" | grep -qi "lines changed"; then
+  pass "no label + over-threshold → external arm derived → delegate blocks → exit 1"
+else
+  fail "expected rc=1 BLOCKED via derived threshold; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11c: NO label, UNDER threshold, but touches a protected path
+# (.github/**) → external arm applies via paths → delegate blocks → exit 1.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 11c: no label + protected path → derives applicability"
+SCRATCH=$(make_scratch false true)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" '[]')
+FIXTURE_FILES=$(make_files_fixture '[{"filename":".github/workflows/x.yml","additions":4,"deletions":0}]')
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_FILES="$FIXTURE_FILES" \
+      MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \
+      CODEX_STUB_RC=1 \
+      run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 1 ] && echo "$OUT" | grep -q "BLOCKED" && echo "$OUT" | grep -qi "protected paths"; then
+  pass "no label + protected path → external arm derived → delegate blocks → exit 1"
+else
+  fail "expected rc=1 BLOCKED via protected paths; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11d: external gate DISABLED + over-threshold no-label → exit 0
+# (knob off short-circuits the whole arm; never reaches the delegate).
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 11d: external gate disabled + over-threshold → not applicable"
+SCRATCH=$(make_scratch false false)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" '[]')
+FIXTURE_FILES=$(make_files_fixture '[{"filename":"src/big.ts","additions":250,"deletions":120}]')
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_FILES="$FIXTURE_FILES" \
+      MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \
+      CODEX_STUB_RC=1 \
+      run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 0 ] && echo "$OUT" | grep -qi "not applicable"; then
+  pass "external gate disabled → over-threshold no-label still exit 0"
 else
   fail "expected rc=0 not-applicable; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
 fi

--- a/tests/test_merge_clearance_gate.sh
+++ b/tests/test_merge_clearance_gate.sh
@@ -82,6 +82,10 @@ if [ "$1" = "api" ]; then
       cat "${FIXTURE_FILES:-/dev/null}"
       exit 0
       ;;
+    repos/*/issues/*/comments)
+      cat "${FIXTURE_COMMENTS:-/dev/null}"
+      exit 0
+      ;;
     repos/*/pulls/*)
       cat "${FIXTURE_PR:-/dev/null}"
       exit 0
@@ -144,6 +148,13 @@ EOF
 make_files_fixture() {  # <json_array_literal>   e.g. '[{"filename":"x","additions":5,"deletions":0}]'
   local content=$1
   local file="$WORKDIR/files.$$.$RANDOM.json"
+  echo "$content" >"$file"
+  echo "$file"
+}
+
+make_comments_fixture() {  # <json_array_literal>  issue comments
+  local content=$1
+  local file="$WORKDIR/comments.$$.$RANDOM.json"
   echo "$content" >"$file"
   echo "$file"
 }
@@ -568,6 +579,52 @@ if [ "$RC" = 1 ] && echo "$OUT" | grep -q "BLOCKED" && echo "$OUT" | grep -qi "f
   pass "missing matcher → fail closed → external arm applies → delegate blocks → exit 1"
 else
   fail "expected rc=1 BLOCKED via fail-closed; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 17 (#429 Codex round-2 P1): verified propagation PR — over-threshold,
+# NO needs-external-review label, but a github-actions[bot] lane marker
+# comment is present → EXEMPT (not applicable), must NOT delegate.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 17: verified propagation lane → exempt"
+SCRATCH=$(make_scratch false true)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" '[]')
+FIXTURE_FILES=$(make_files_fixture '[{"filename":".github/workflows/x.yml","additions":400,"deletions":50}]')
+FIXTURE_COMMENTS=$(make_comments_fixture '[{"user":{"login":"github-actions[bot]"},"body":"<!-- propagation-review-lane -->\nVerified faithful mirror ✅"}]')
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_FILES="$FIXTURE_FILES" FIXTURE_COMMENTS="$FIXTURE_COMMENTS" \
+      MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \
+      CODEX_STUB_RC=1 \
+      run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 0 ] && echo "$OUT" | grep -qi "not applicable"; then
+  pass "verified propagation lane → exempt (exit 0, no delegate)"
+else
+  fail "expected rc=0 not-applicable (exempt); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 18: SPOOFED lane marker — same marker text but authored by a NON-bot
+# login → must NOT exempt (a PR author can't forge github-actions[bot]).
+# Over-threshold + spoofed marker → still requires external → delegate blocks.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 18: spoofed (non-bot) lane marker → NOT exempt"
+SCRATCH=$(make_scratch false true)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" '[]')
+FIXTURE_FILES=$(make_files_fixture '[{"filename":"src/big.ts","additions":250,"deletions":120}]')
+FIXTURE_COMMENTS=$(make_comments_fixture '[{"user":{"login":"nathanjohnpayne"},"body":"<!-- propagation-review-lane --> nice try"}]')
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_FILES="$FIXTURE_FILES" FIXTURE_COMMENTS="$FIXTURE_COMMENTS" \
+      MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \
+      CODEX_STUB_RC=1 \
+      run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 1 ] && echo "$OUT" | grep -q "BLOCKED"; then
+  pass "spoofed non-bot marker → NOT exempt → delegate blocks → exit 1"
+else
+  fail "expected rc=1 BLOCKED (spoof ignored); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_merge_clearance_gate.sh
+++ b/tests/test_merge_clearance_gate.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+# tests/test_merge_clearance_gate.sh
+#
+# Unit tests for scripts/merge-clearance-gate.sh — the HEAD-pinned
+# merge-clearance gate (nathanjohnpayne/mergepath#427 + #428).
+#
+# Strategy: PATH-shim `gh` so the script's REST calls return canned
+# fixtures, and stub the codex-review-check.sh delegate via
+# MERGE_CLEARANCE_CODEX_CHECK_BIN so the external-review dispatch +
+# exit-code mapping can be exercised without re-deriving that script's
+# behavior. Same shape as tests/test_codex_p1_gate.sh.
+#
+# Cases:
+#   Dependabot path
+#     1.  reviewer_gate disabled → exit 0, no API calls.
+#     2.  enabled + latest-state APPROVED on HEAD by a reviewer → exit 0.
+#     3.  enabled + APPROVED only on a STALE sha (not HEAD) → exit 1.
+#         [#427 repro: matchline#245 — approval dismissed/absent on HEAD]
+#     4.  enabled + APPROVED then later CHANGES_REQUESTED on HEAD → exit 1.
+#     5.  enabled + APPROVED on HEAD by a non-reviewer login → exit 1.
+#   External-review path
+#     6.  external_review_gate disabled → exit 0.
+#     7.  enabled + delegate returns 0 → exit 0.
+#     8.  enabled + delegate returns 1 → exit 1.
+#         [#428 repro: nathanpaynedotcom#405 — not cleared on merge HEAD]
+#     9.  enabled + delegate returns 3 (infra) → exit 2.
+#   Dispatch / misc
+#     10. Dependabot precedence: dependabot author + needs-external-review
+#         label → judged by the Dependabot rule (not the external path).
+#     11. neither Dependabot nor external-review → exit 0 (not applicable).
+#     12. malformed PR_NUMBER → exit 2.
+#     13. missing GH_TOKEN → exit 2.
+#     14. env-only PR_NUMBER + REPO → same behavior as positional.
+#
+# Bash 3.2 portable.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/merge-clearance-gate.sh"
+
+[[ -x "$SCRIPT" ]] || { echo "missing or non-executable $SCRIPT" >&2; exit 1; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not available (merge-clearance-gate.sh requires jq)" >&2
+  exit 0
+fi
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/merge-clearance-gate-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# PATH-shim gh: log calls, route pulls/N/reviews and pulls/N to fixtures.
+# ---------------------------------------------------------------------------
+STUB_DIR="$WORKDIR/stub-bin"
+mkdir -p "$STUB_DIR"
+
+cat >"$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+LOG="${GH_CALLS_LOG:-/dev/null}"
+{
+  printf 'gh'
+  for a in "$@"; do printf '\t%s' "$a"; done
+  printf '\n'
+} >> "$LOG"
+
+if [ "$1" = "api" ]; then
+  shift
+  if [ "${1:-}" = "--paginate" ]; then shift; fi
+  endpoint="${1:-}"
+  case "$endpoint" in
+    repos/*/pulls/*/reviews)
+      cat "${FIXTURE_REVIEWS:-/dev/null}"
+      exit 0
+      ;;
+    repos/*/pulls/*)
+      cat "${FIXTURE_PR:-/dev/null}"
+      exit 0
+      ;;
+  esac
+fi
+exit 0
+STUB
+chmod +x "$STUB_DIR/gh"
+
+# A stub codex-review-check.sh that exits with $CODEX_STUB_RC (inherited
+# from the gate's environment). Default 0.
+cat >"$STUB_DIR/codex-check-stub" <<'STUB'
+#!/usr/bin/env bash
+exit "${CODEX_STUB_RC:-0}"
+STUB
+chmod +x "$STUB_DIR/codex-check-stub"
+
+# ---------------------------------------------------------------------------
+# Scratch repo dir with a review-policy.yml controlling both knobs +
+# the available_reviewers list.
+# ---------------------------------------------------------------------------
+make_scratch() {
+  local dependabot_enabled=$1 external_enabled=$2
+  local dir
+  dir=$(mktemp -d "$WORKDIR/scratch.XXXXXX")
+  mkdir -p "$dir/.github"
+  cat >"$dir/.github/review-policy.yml" <<EOF
+available_reviewers:
+  - nathanpayne-claude
+  - nathanpayne-cursor
+  - nathanpayne-codex
+
+codex:
+  bot_login: "chatgpt-codex-connector[bot]"
+  external_review_gate:
+    enabled: $external_enabled
+
+dependabot:
+  reviewer_gate:
+    enabled: $dependabot_enabled
+EOF
+  echo "$dir"
+}
+
+make_pr_fixture() {  # <sha> <author> <labels_json_array>
+  local sha=$1 author=$2 labels=${3:-'[]'}
+  local file="$WORKDIR/pr.$$.$RANDOM.json"
+  jq -n --arg sha "$sha" --arg author "$author" --argjson labels "$labels" '
+    { number: 99, head: { sha: $sha }, user: { login: $author }, labels: $labels }
+  ' >"$file"
+  echo "$file"
+}
+
+make_reviews_fixture() {  # <json_array_literal>
+  local content=$1
+  local file="$WORKDIR/reviews.$$.$RANDOM.json"
+  echo "$content" >"$file"
+  echo "$file"
+}
+
+run_gate() {  # <scratch> [args...]   (env: FIXTURE_PR, FIXTURE_REVIEWS, CODEX_STUB_RC, MERGE_CLEARANCE_CODEX_CHECK_BIN)
+  local scratch=$1; shift
+  (
+    cd "$scratch"
+    PATH="$STUB_DIR:$PATH" \
+      GH_TOKEN="dummy-token" \
+      GH_CALLS_LOG="$WORKDIR/gh-calls.log" \
+      "$SCRIPT" "$@"
+  )
+}
+
+HEAD_SHA="head000aaa"
+OLD_SHA="old111bbb"
+DEPENDABOT='dependabot[bot]'
+EXT_LABEL='[{"name":"needs-external-review"}]'
+
+# ---------------------------------------------------------------------------
+# Test 1: Dependabot, reviewer_gate disabled → exit 0, no reviews API call.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 1: Dependabot, gate disabled"
+SCRATCH=$(make_scratch false false)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "$DEPENDABOT")
+: > "$WORKDIR/gh-calls.log"
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 0 ] && echo "$OUT" | grep -q "PASS" \
+    && ! grep -q "reviews" "$WORKDIR/gh-calls.log"; then
+  pass "Dependabot + gate disabled → exit 0, no reviews fetch"
+else
+  fail "expected rc=0 + no reviews fetch; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: Dependabot, enabled, latest-state APPROVED on HEAD → exit 0.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 2: Dependabot, APPROVED on HEAD"
+SCRATCH=$(make_scratch true false)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "$DEPENDABOT")
+FIXTURE_REVIEWS=$(make_reviews_fixture "$(jq -n --arg sha "$HEAD_SHA" '
+  [{ user:{login:"nathanpayne-claude"}, state:"APPROVED", commit_id:$sha, submitted_at:"2026-06-01T10:00:00Z" }]
+')")
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_REVIEWS="$FIXTURE_REVIEWS" run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 0 ] && echo "$OUT" | grep -q "PASS" && echo "$OUT" | grep -q "nathanpayne-claude"; then
+  pass "Dependabot + APPROVED on HEAD → exit 0"
+else
+  fail "expected rc=0 PASS with approver; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3 (#427 repro): APPROVED only on a STALE sha (not HEAD) → exit 1.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 3: Dependabot, APPROVED only on stale sha (#427)"
+SCRATCH=$(make_scratch true false)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "$DEPENDABOT")
+FIXTURE_REVIEWS=$(make_reviews_fixture "$(jq -n --arg old "$OLD_SHA" '
+  [{ user:{login:"nathanpayne-claude"}, state:"APPROVED", commit_id:$old, submitted_at:"2026-06-01T09:00:00Z" }]
+')")
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_REVIEWS="$FIXTURE_REVIEWS" run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 1 ] && echo "$OUT" | grep -q "BLOCKED"; then
+  pass "Dependabot + stale-sha approval → exit 1 (HEAD-pinned)"
+else
+  fail "expected rc=1 BLOCKED; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: APPROVED then later CHANGES_REQUESTED on HEAD → exit 1.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 4: Dependabot, latest-state CHANGES_REQUESTED on HEAD"
+SCRATCH=$(make_scratch true false)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "$DEPENDABOT")
+FIXTURE_REVIEWS=$(make_reviews_fixture "$(jq -n --arg sha "$HEAD_SHA" '
+  [
+    { user:{login:"nathanpayne-claude"}, state:"APPROVED", commit_id:$sha, submitted_at:"2026-06-01T10:00:00Z" },
+    { user:{login:"nathanpayne-claude"}, state:"CHANGES_REQUESTED", commit_id:$sha, submitted_at:"2026-06-01T11:00:00Z" }
+  ]
+')")
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_REVIEWS="$FIXTURE_REVIEWS" run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 1 ] && echo "$OUT" | grep -q "BLOCKED"; then
+  pass "Dependabot + stale APPROVED behind CHANGES_REQUESTED → exit 1"
+else
+  fail "expected rc=1 BLOCKED; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: APPROVED on HEAD by a login NOT in available_reviewers → exit 1.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 5: Dependabot, APPROVED by non-reviewer login"
+SCRATCH=$(make_scratch true false)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "$DEPENDABOT")
+FIXTURE_REVIEWS=$(make_reviews_fixture "$(jq -n --arg sha "$HEAD_SHA" '
+  [{ user:{login:"some-random-collaborator"}, state:"APPROVED", commit_id:$sha, submitted_at:"2026-06-01T10:00:00Z" }]
+')")
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_REVIEWS="$FIXTURE_REVIEWS" run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 1 ] && echo "$OUT" | grep -q "BLOCKED"; then
+  pass "Dependabot + non-reviewer approval → exit 1"
+else
+  fail "expected rc=1 BLOCKED; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: External-review, gate disabled → exit 0.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 6: external-review, gate disabled"
+SCRATCH=$(make_scratch false false)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" "$EXT_LABEL")
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 0 ] && echo "$OUT" | grep -q "PASS"; then
+  pass "external-review + gate disabled → exit 0"
+else
+  fail "expected rc=0 PASS; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: External-review, enabled, delegate returns 0 → exit 0.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 7: external-review, delegate clears"
+SCRATCH=$(make_scratch false true)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" "$EXT_LABEL")
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" \
+      MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \
+      CODEX_STUB_RC=0 \
+      run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 0 ] && echo "$OUT" | grep -q "PASS"; then
+  pass "external-review + delegate rc=0 → exit 0"
+else
+  fail "expected rc=0 PASS; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8 (#428 repro): delegate returns 1 (not cleared on HEAD) → exit 1.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 8: external-review, delegate blocks (#428)"
+SCRATCH=$(make_scratch false true)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" "$EXT_LABEL")
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" \
+      MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \
+      CODEX_STUB_RC=1 \
+      run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 1 ] && echo "$OUT" | grep -q "BLOCKED"; then
+  pass "external-review + delegate rc=1 → exit 1"
+else
+  fail "expected rc=1 BLOCKED; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 9: delegate returns 3 (infra) → mapped to exit 2.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 9: external-review, delegate infra error"
+SCRATCH=$(make_scratch false true)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" "$EXT_LABEL")
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" \
+      MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \
+      CODEX_STUB_RC=3 \
+      run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 2 ] && echo "$OUT" | grep -qi "rc=3"; then
+  pass "external-review + delegate rc=3 → exit 2 (infra)"
+else
+  fail "expected rc=2; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 10: Dependabot precedence — dependabot author + needs-external-review
+#          → judged by the Dependabot rule (no APPROVED on HEAD → exit 1),
+#          NOT routed to the external delegate.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 10: Dependabot precedence over external label"
+SCRATCH=$(make_scratch true true)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "$DEPENDABOT" "$EXT_LABEL")
+FIXTURE_REVIEWS=$(make_reviews_fixture '[]')
+set +e
+# If it wrongly took the external path, the delegate stub (rc=0) would
+# clear it. Point the delegate at a stub that would PASS so a precedence
+# bug surfaces as a wrong exit 0.
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_REVIEWS="$FIXTURE_REVIEWS" \
+      MERGE_CLEARANCE_CODEX_CHECK_BIN="$STUB_DIR/codex-check-stub" \
+      CODEX_STUB_RC=0 \
+      run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 1 ] && echo "$OUT" | grep -q "BLOCKED" && echo "$OUT" | grep -qi "Dependabot"; then
+  pass "Dependabot + external label → judged by Dependabot rule → exit 1"
+else
+  fail "expected rc=1 via Dependabot rule; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11: neither Dependabot nor external-review → exit 0 (not applicable).
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 11: normal under-threshold PR → not applicable"
+SCRATCH=$(make_scratch true true)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "nathanjohnpayne" '[]')
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 0 ] && echo "$OUT" | grep -qi "not applicable"; then
+  pass "normal PR → exit 0 (not applicable)"
+else
+  fail "expected rc=0 not-applicable; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 12: malformed PR_NUMBER → exit 2.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 12: malformed PR_NUMBER"
+SCRATCH=$(make_scratch true true)
+set +e
+OUT=$(run_gate "$SCRATCH" "not-a-number" owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 2 ] && echo "$OUT" | grep -qi "PR_NUMBER must be an integer"; then
+  pass "malformed PR_NUMBER → exit 2"
+else
+  fail "expected rc=2; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 13: missing GH_TOKEN → exit 2.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 13: missing GH_TOKEN"
+SCRATCH=$(make_scratch true true)
+set +e
+OUT=$(cd "$SCRATCH" && PATH="$STUB_DIR:$PATH" "$SCRIPT" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 2 ] && echo "$OUT" | grep -q "GH_TOKEN is required"; then
+  pass "missing GH_TOKEN → exit 2"
+else
+  fail "expected rc=2; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 14: env-only PR_NUMBER + REPO → same behavior as positional.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 14: env-only PR_NUMBER + REPO"
+SCRATCH=$(make_scratch true false)
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "$DEPENDABOT")
+FIXTURE_REVIEWS=$(make_reviews_fixture "$(jq -n --arg sha "$HEAD_SHA" '
+  [{ user:{login:"nathanpayne-codex"}, state:"APPROVED", commit_id:$sha, submitted_at:"2026-06-01T10:00:00Z" }]
+')")
+set +e
+OUT=$(
+  cd "$SCRATCH" && \
+    PATH="$STUB_DIR:$PATH" \
+    GH_TOKEN="dummy-token" \
+    PR_NUMBER=99 REPO=owner/repo \
+    FIXTURE_PR="$FIXTURE_PR" FIXTURE_REVIEWS="$FIXTURE_REVIEWS" \
+    "$SCRIPT" 2>&1
+)
+RC=$?
+set -e
+if [ "$RC" = 0 ] && echo "$OUT" | grep -q "PASS"; then
+  pass "env-only PR_NUMBER + REPO → exit 0"
+else
+  fail "expected rc=0 PASS; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "============================================"
+echo "test_merge_clearance_gate.sh: $PASS passed, $FAIL failed"
+echo "============================================"
+if [ "$FAIL" -gt 0 ]; then exit 1; fi
+exit 0


### PR DESCRIPTION
Closes #427. Closes #428.

## Problem

Both issues are **merge-gate escapes caught only by the weekly retroactive `pr-audit.yml`** — a week after merge. They share one root cause:

> Clearance was enforced via a **mutable proxy** (a dismissable review, a removable label) plus a weekly audit — never as a **HEAD-pinned required status check** that re-evaluates on every push and fails closed.

- **#427 (matchline#245):** a `dev-dependencies` group bump merged with **no reviewer-identity APPROVED review on the merge HEAD** (`reviews: []`, `mergedBy: nathanjohnpayne`). The dependabot-auto-merge approval is transient — GitHub dismisses it on a rebase push, and a human merged the approved-but-unmerged PR. The consumer already ran the #406-hardened workflow, so #406 did **not** close the class.
- **#428 (nathanpaynedotcom#405):** an over-threshold PR merged on HEAD `0d14bfd` with **no APPROVED CLI review and no Codex review on that HEAD**. Clearance was evaluated on an earlier HEAD (`12df03a`); `Label Gate` went stale-green (a `GITHUB_TOKEN` relabel doesn't re-trigger it — the #315/#324 gap) and `Codex P1` was vacuously green (zero Codex reviews).

`pr-audit.yml` Check 2 already detects both — but retroactively. There was no **merge-time** required check representing clearance on the merge HEAD.

## Fix

One shared HEAD-pinned required check, modeled on the proven `codex-p1-gate.yml` pattern (required check + scheduled sweep + trusted default-branch checkout):

- **`scripts/merge-clearance-gate.sh`** — read-only, exit `0`/`1`/`2`.
  - **Dependabot PR:** blocks unless a reviewer identity (≠ author) has a latest-state `APPROVED` review with `commit_id == HEAD` (`dependabot.reviewer_gate.enabled`). A rebase push that dismisses the approval re-blocks on the new HEAD.
  - **`needs-external-review` PR:** delegates to **`scripts/codex-review-check.sh`** — the *same* gate (b)+(c) predicate `auto-clear-blocking-labels.yml` uses, so the merge gate and label-clear logic **cannot drift** — with CI checking skipped (`CODEX_REVIEW_CHECK_SKIP_CI=1`) to avoid the required-check self-deadlock.
  - Any other PR (or knob off): clean pass, so it's safe to require on every PR.
- **`.github/workflows/merge-clearance-gate.yml`** — `pull_request`/`pull_request_review`/`pull_request_review_comment` + `*/15` scheduled sweep that posts a `check_run` per open PR head SHA (covers the no-event transitions — 👍 reaction, UI label resolve, the bot-relabel-doesn't-retrigger case). Trusted default-branch checkout (never PR HEAD).
- **`.github/review-policy.yml`** — per-class knobs `dependabot.reviewer_gate.enabled` + `codex.external_review_gate.enabled` (`true` here; default `false` downstream — narrow-start, then propagate).
- **`scripts/audit-branch-protection.sh`** — adds `Merge clearance gate` **and** the pre-existing-but-unwired `Codex P1 unresolved threads` to `CANONICAL_REQUIRED_CHECKS`, so consumers are flagged when these aren't required in branch protection.
- **Tests + wiring + propagation + docs:** `tests/test_merge_clearance_gate.sh` (14 cases incl. the #427 stale-approval and #428 not-cleared-on-HEAD repros), `scripts/ci/check_merge_clearance_gate`, `repo_lint.yml` step, `.mergepath-sync.yml` entries, `REVIEW_POLICY.md` § Required status checks + config example, and a new `test_audit_branch_protection.sh` case.

`pr-audit.yml` stays as the retroactive backstop. **Admin caveat:** a required check is bypassable by an admin "merge without waiting for requirements" — both escapes were admin merges — so this is paired with a documented recommendation to set branch-protection `enforce_admins: true` to fully close the human-merge path.

## The shared assumption (two-strike audit, per operating-rules.md)

#427 recurs #406/#359; #428 recurs #359/#258/#249. Every prior fix patched the approval-recording side (#406) or the audit side (#258/#249) while preserving the belief that clearance can live in a mutable proxy + a weekly audit. This PR breaks that assumption directly with a HEAD-pinned required check.

## Self-Review

- **Correctness:** Gate dispatches Dependabot-first (mirrors `pr-audit.yml` Check 2 precedence), then external-review, else clean pass. Dependabot predicate reuses the proven latest-state-per-reviewer + `commit_id == HEAD` jq shape from `codex-review-check.sh` gate (c). External path reuses `codex-review-check.sh` verbatim (no drift). `CODEX_REVIEW_CHECK_SKIP_CI=1` only flips `REQUIRE_CI_GREEN` when set to literal `"1"`; the normal path is unchanged (`check_codex_scripts` + `check_canonical_bugs_263caf3` green).
- **Regression risk:** New required check is a **no-op (always exit 0)** for under-threshold PRs and when both knobs are off, so it cannot block normal merges downstream where it ships disabled. Avoided the required-check self-deadlock via the CI-skip override (documented inline). `actions/checkout` pinned to the current `v6.0.3` SHA.
- **Style/conventions:** Mirrors `codex-p1-gate.sh`/`.yml` exit-code contract, logging, trusted-checkout posture, and scheduled-sweep check_run mechanics. `awk` interval `{0,3}` matches the existing proven construct (a `-v sub=` shadow of awk's `sub()` builtin was caught in test and renamed).
- **Test coverage:** `test_merge_clearance_gate.sh` 14/14 (incl. #427 stale-sha-approval → block and #428 delegate-blocks → block, plus Dependabot-precedence, non-reviewer approval, env-only invocation, malformed input). `test_audit_branch_protection.sh` 10/10 (new case: missing `Merge clearance gate` → exit 3). All affected CI guards pass locally: `check_merge_clearance_gate`, `check_ci_scripts_wired`, `check_sync_manifest`, `check_codex_scripts`, `check_codex_p1_gate`, `check_spec_test_alignment`, `check_workflow_parsers`.
- **Security/dependency hygiene:** Read-only (GETs only + a read-only delegate). Trusted default-branch checkout so a PR can't weaponize the gate scripts to satisfy their own required check. No new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Authoring-Agent: claude
