### PR TITLE
fix(eslint-template): extend TS unused-vars tuning to .astro frontmatter

### DIFF
--- a/examples/eslint.config.cjs.js
+++ b/examples/eslint.config.cjs.js
@@ -191,8 +191,18 @@ module.exports = [
   // Both demotions were hand-added by every TS consumer during the
   // Phase D fanout (#250); folding into the template removes the
   // per-consumer churn.
+  //
+  // `.astro` is in the glob because astro frontmatter (the `---` fence)
+  // is TypeScript, linted by @typescript-eslint via the astro parser —
+  // without it the `^_` convention silently fails on astro consumers
+  // (the rule still fires from the recommended preset, just without
+  // these ignore patterns). Kept in this typescript-gated block, NOT a
+  // separate astro-gated one, so these `@typescript-eslint/*` rule IDs
+  // only render where the plugin is imported — cf. the #327 rule-
+  // without-plugin break. A TS consumer with no `.astro` files matches
+  // none, so the added extension is inert for them.
   {
-    files: ["**/*.{ts,tsx}"],
+    files: ["**/*.{ts,tsx,astro}"],
     rules: {
       "@typescript-eslint/no-unused-vars": ["error", {
         argsIgnorePattern: "^_",

--- a/examples/eslint.config.js
+++ b/examples/eslint.config.js
@@ -185,8 +185,18 @@ export default [
   // Both demotions were hand-added by every TS consumer during the
   // Phase D fanout (#250); folding into the template removes the
   // per-consumer churn.
+  //
+  // `.astro` is in the glob because astro frontmatter (the `---` fence)
+  // is TypeScript, linted by @typescript-eslint via the astro parser —
+  // without it the `^_` convention silently fails on astro consumers
+  // (the rule still fires from the recommended preset, just without
+  // these ignore patterns). Kept in this typescript-gated block, NOT a
+  // separate astro-gated one, so these `@typescript-eslint/*` rule IDs
+  // only render where the plugin is imported — cf. the #327 rule-
+  // without-plugin break. A TS consumer with no `.astro` files matches
+  // none, so the added extension is inert for them.
   {
-    files: ["**/*.{ts,tsx}"],
+    files: ["**/*.{ts,tsx,astro}"],
     rules: {
       "@typescript-eslint/no-unused-vars": ["error", {
         argsIgnorePattern: "^_",

--- a/tests/test_template_substitution.sh
+++ b/tests/test_template_substitution.sh
@@ -765,6 +765,40 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Case 14: the TS unused-vars tuning block extends to `.astro`, and
+# stays co-gated with the `typescript` fact. Renders the REAL templates.
+#   14a — an astro+ts consumer's render carries `.astro` in the glob so
+#         the `^_` convention reaches astro frontmatter.
+#   14b — a consumer WITHOUT the typescript fact never renders the
+#         `@typescript-eslint/*` rule IDs (they would reference a plugin
+#         that is only imported under the typescript fact — the #327
+#         rule-without-plugin break). This is what makes the `.astro`
+#         extension safe to live in the typescript-gated block rather
+#         than a separate astro-gated one.
+# ---------------------------------------------------------------------------
+ASTRO_TS_GLOB='files: ["**/*.{ts,tsx,astro}"]'
+TS_UNUSED_RULE='@typescript-eslint/no-unused-vars'
+for tpl in "$ESM_TEMPLATE" "$CJS_TEMPLATE"; do
+  b=$(basename "$tpl")
+  out_astro=$(reset_facts; export MERGEPATH_FACT_FRAMEWORKS="astro typescript"; source "$LIB"; template_substitution::render "$tpl")
+  if printf '%s' "$out_astro" | grep -qF "$ASTRO_TS_GLOB"; then
+    echo "PASS: 14a $b astro+ts render carries the .astro TS unused-vars glob"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: 14a $b astro+ts render missing $ASTRO_TS_GLOB" >&2
+    FAIL=$((FAIL + 1))
+  fi
+  out_react=$(reset_facts; export MERGEPATH_FACT_FRAMEWORKS="react"; source "$LIB"; template_substitution::render "$tpl")
+  if printf '%s' "$out_react" | grep -qF "$TS_UNUSED_RULE"; then
+    echo "FAIL: 14b $b react-only render leaks $TS_UNUSED_RULE without the typescript fact" >&2
+    FAIL=$((FAIL + 1))
+  else
+    echo "PASS: 14b $b react-only render omits @typescript-eslint rule IDs (co-gated with the plugin)"
+    PASS=$((PASS + 1))
+  fi
+done
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

The ESLint template's `@typescript-eslint/no-unused-vars` (and `no-explicit-any`) tuning block was scoped to `files: ["**/*.{ts,tsx}"]`, so `.astro` frontmatter never received the `^_` ignore-pattern convention — even though astro frontmatter is TypeScript that `@typescript-eslint` lints via the astro parser. The rule still fired (from the recommended preset), just *without* the ignore patterns, so intentionally-unused `_`-prefixed locals errored on a full `eslint .`.

This extends the glob to `["**/*.{ts,tsx,astro}"]` in **both** the ESM (`examples/eslint.config.js`) and CJS (`examples/eslint.config.cjs.js`) template variants, and adds a regression guard.

Authoring-Agent: claude

## Why it lives in the typescript-gated block

The `.astro` extension is added to the **existing `typescript`-gated block**, not a new `astro`-gated one. That keeps the `@typescript-eslint/*` rule IDs co-gated with the `typescript` fact — the only place the `@typescript-eslint` plugin is imported — so they can never render into a config where the plugin is absent (the rule-without-plugin break fixed in #327). For a TS consumer with no `.astro` files (matchline, tadlockpsychiatry) the extra extension matches nothing and is inert: behavior-neutral, the rendered config text gains only the `,astro` token plus the explanatory comment.

(The alternative — an `astro`-gated block referencing `@typescript-eslint/*` — would reintroduce the #327 risk for any future `astro`-without-`typescript` consumer, and v1 templating can't express the `astro && typescript` compound gate.)

## Verification

Rendered both templates with each ESM consumer's real manifest facts via `scripts/lib/manifest-fact-helpers.sh` + `scripts/lib/template-substitution.sh`:

- `render(old, nathanpaynedotcom)` is **byte-identical** to its committed `eslint.config.js` (render harness faithful).
- `render(new, nathanpaynedotcom)` → `npx eslint .` reports **0 errors** (the two latent `_slug` / `_err` errors are gone; only the pre-existing `no-explicit-any` *warnings* in a test remain). This also confirms the `astro/flat-recommended` block (spread later) does not override the setting.
- matchline / tadlockpsychiatry renders differ only by the comment + `,astro` glob token — behavior-neutral (no `.astro` files).
- `tests/test_template_substitution.sh`: **59/59** pass (Case 14 added — below). `tests/test_eslint_policy_check.sh`: **10/10**. Both templates pass `node --check`.

## Self-Review

- **Correctness:** Additive glob change; `.astro` frontmatter is parsed as TS by the astro parser, so the rule applies cleanly — proven by the clean nathanpaynedotcom render-lint. The ESM and CJS edits are identical.
- **Regression risk:** Low. Inert for non-astro TS consumers. New **Case 14** in `test_template_substitution.sh` renders the *real* templates and asserts (a) astro+ts carries `**/*.{ts,tsx,astro}`, and (b) a consumer **without** the `typescript` fact never emits `@typescript-eslint/*` rule IDs — locking in the co-gating safety property. Marker-balance + ESM/CJS symmetry tests still pass.
- **Style:** Matches the file's heavily-commented house style; the comment explains both the `.astro` rationale and the co-gating decision inline.
- **Test coverage:** +4 assertions (Case 14a/14b across ESM + CJS), rendering the real templates.
- **Security/dependency hygiene:** None affected. Comment + one glob token + a shell test; no new dependencies, no credential surface.

## Downstream

After merge this propagates to **nathanpaynedotcom** (the only `astro` consumer) via `scripts/sync-to-downstream.sh`, regenerating its `eslint.config.js` and making `npm run lint` clean there. matchline / tadlockpsychiatry will show a behavior-neutral propagation diff (comment + glob token) on their next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
