### PR TITLE
fix(sync): propagate test_codex_review_request_ack.sh (#421 manifest gap)

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -387,6 +387,15 @@ paths:
   - path: tests/test_codex_p1_gate.sh
     type: canonical
     consumers: all
+  # Pairs with scripts/codex-review-request.sh + scripts/ci/check_codex_scripts
+  # (kit-propagated). check_codex_scripts hard-requires this test file (the
+  # #419/#421 eyes-ack suite); without it propagated, every consumer's
+  # check_codex_scripts fails pre-flight with `No such file` (exit 127).
+  # Same #264/#266 closure class as test_codex_p1_gate.sh above — the gap
+  # was introduced by #421 and surfaced by the 314947f propagation wave.
+  - path: tests/test_codex_review_request_ack.sh
+    type: canonical
+    consumers: all
   # Pairs with scripts/merge-clearance-gate.sh +
   # scripts/ci/check_merge_clearance_gate (kit-propagated). The check
   # wrapper hard-requires this test file; same #264/#266 coupling class
@@ -581,6 +590,7 @@ paths:
       - "tests/test_resolve_pr_threads_rationale_tag.sh"  # check_resolve_pr_threads (delegated test)
       - "tests/test_template_substitution.sh"  # check_template_substitution
       - "tests/test_export_consumer_facts.sh"  # check_export_consumer_facts
+      - "tests/test_codex_review_request_ack.sh"  # check_codex_scripts
       - "scripts/codex-p1-gate.sh"             # check_codex_p1_gate
       - "scripts/merge-clearance-gate.sh"      # check_merge_clearance_gate
       - "scripts/codex-review-request.sh"      # check_codex_scripts


### PR DESCRIPTION
## Summary

`scripts/ci/check_codex_scripts` (shipped via the `scripts/ci/` kit and invoked by consumer `repo_lint.yml`) hard-requires `tests/test_codex_review_request_ack.sh`, but #421 added the test + the check reference **without** adding the test to `.mergepath-sync.yml`. The file never propagated, so every consumer's `check_codex_scripts` fails pre-flight with `exit 127` (No such file).

Surfaced by the `314947f` propagation wave on [matchline#268](https://github.com/nathanjohnpayne/matchline/pull/268) — the canary's `lint` failed exactly there.

Fix: add the test as a canonical synced path **and** to the `scripts/ci/` kit `requires:` closure list (so the #264 closure invariant tracks it going forward). No other consumer-invoked check has an un-propagated test dep (audited: the 13 other un-synced check-referenced tests are mergepath-internal — bootstrap/sync/sweep/eslint-policy meta-checks consumers don't run).

## Self-Review
- **Correctness:** One-line propagation addition; `check_sync_manifest` passes (52 path entries, was 51). Dry-run confirms the test now syncs to consumers.
- **Regression risk:** Additive only — propagates one already-existing, already-reviewed test file. No behavior change to mergepath itself.
- **Style/conventions:** Mirrors the existing `test_codex_p1_gate.sh` / `test_merge_clearance_gate.sh` canonical-path + kit-requires pattern, with a comment citing the #264 closure class and the #421 origin.
- **Test coverage:** `check_sync_manifest` (its own suite, 25 cases) green; the fix is itself about test propagation.
- **Security/dependency hygiene:** No new deps; `.mergepath-sync.yml` does not propagate (mergepath-internal).

Authoring-Agent: claude
