### PR TITLE
fix(sync): propagate gh-token-resolver.sh + manifest-fact-helpers.sh (manifest gaps)

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -242,6 +242,24 @@ paths:
   - path: scripts/lib/gh-retry-helpers.sh
     type: canonical
     consumers: all
+  # Sourced by scripts/gh-as-author.sh + scripts/gh-as-reviewer.sh (and the
+  # other write-path helpers) to resolve a verified token for an identity —
+  # prefers the OP_PREFLIGHT_*_PAT cache, falls back to `gh auth token
+  # --user`. Added by #415/#416 but never propagated; without it every
+  # consumer's gh-as-author/reviewer wrapper aborts at `source ... : No such
+  # file` and check_gh_as_author fails. Surfaced by the b10671e propagation
+  # wave on matchline#269. Same #264 closure class.
+  - path: scripts/lib/gh-token-resolver.sh
+    type: canonical
+    consumers: all
+  # Sourced by scripts/workflow/verify-propagation-pr.sh (propagated kit) and
+  # the sync tooling to read consumer facts from the manifest. Travels with
+  # verify-propagation-pr.sh so a consumer running check_verify_propagation_pr
+  # doesn't abort at `source ... : No such file`. Same #264 closure class as
+  # gh-token-resolver.sh above; both gaps from recent (#415/#416) refactors.
+  - path: scripts/lib/manifest-fact-helpers.sh
+    type: canonical
+    consumers: all
   - path: scripts/coderabbit-wait.sh
     type: canonical
     consumers: all
@@ -315,9 +333,15 @@ paths:
   - path: scripts/gh-as-author.sh
     type: canonical
     consumers: all
+    # Sources scripts/lib/gh-token-resolver.sh at startup; without it the
+    # wrapper aborts under `set -euo pipefail`. Closure-tracked (#264).
+    requires:
+      - "scripts/lib/gh-token-resolver.sh"
   - path: scripts/gh-as-reviewer.sh
     type: canonical
     consumers: all
+    requires:
+      - "scripts/lib/gh-token-resolver.sh"
   # Pre-action identity check (#284) — the assertion helper that every
   # WRITE-path helper script calls at the top to fail-close on
   # active-account drift. Travels with the helper scripts that depend


### PR DESCRIPTION
## Summary

Two `scripts/lib/*.sh` helpers are sourced by propagated scripts but were never added to `.mergepath-sync.yml`, so they don't reach consumers and the sourcing scripts abort with `No such file` under `set -euo pipefail`:

- **`scripts/lib/gh-token-resolver.sh`** — sourced by `scripts/gh-as-author.sh` + `scripts/gh-as-reviewer.sh` (added by the #415/#416 token-wrapper refactor). Without it, every consumer's gh wrappers fail and `check_gh_as_author` fails. Surfaced by the `b10671e` propagation wave on [matchline#269](https://github.com/nathanjohnpayne/matchline/pull/269).
- **`scripts/lib/manifest-fact-helpers.sh`** — sourced by the propagated `scripts/workflow/verify-propagation-pr.sh`; travels with it so a consumer running `check_verify_propagation_pr` doesn't abort.

Both are `#264`-closure-class gaps from recent refactors that added a lib without a manifest entry. Fix: add both as canonical synced paths + declare `gh-token-resolver.sh` in the `gh-as-author`/`gh-as-reviewer` `requires:` closure lists.

I ran an **exhaustive dependency audit** (every `scripts/lib` sourced by any propagated script + every test referenced by consumer-run `check_*`): after this fix, **zero gaps remain**.

## Self-Review
- **Correctness:** Two canonical path additions + two `requires:` entries; `check_sync_manifest` green (54 entries, was 52). Dry-run confirms both libs now sync.
- **Regression risk:** Additive only — propagates two existing, already-reviewed lib files. No mergepath behavior change.
- **Style/conventions:** Mirrors the existing `scripts/lib/gh-retry-helpers.sh` / `preflight-helpers.sh` canonical-path pattern with closure comments citing #264 and the #415/#416 origin.
- **Test coverage:** `check_sync_manifest` (25-case suite) green; this PR is itself about closing the propagation dependency closure.
- **Security/dependency hygiene:** No new deps; `.mergepath-sync.yml` is mergepath-internal (not propagated). Follow-up worth filing: a `check_sync_manifest` extension that parses each propagated script's `source` directives and fails if a sourced file isn't propagated — would have caught both of these mechanically.

Authoring-Agent: claude
