### PR TITLE
fix(merge-gate): HEAD-pin gate (b) for the merge-clearance delegation (#435)

### DIFF
--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -223,13 +223,15 @@ run_filter() {
   #   $1 = jq filter (gate-b form or gate-c form)
   #   $2 = author login
   #   $3 = same_agent_reviewer login (may be empty)
-  #   $4 = sha (only used by gate-c form; harmless for gate-b)
+  #   $4 = sha (gate-c form, and gate-b HEAD-pin)
   #   $5 = reviews_json
+  #   $6 = require_head ("1" to HEAD-pin gate-b branch 1; default "0")
   echo "$5" | jq -r \
     --argjson reviewers "$REVIEWERS_JSON" \
     --arg author "$2" \
     --arg same_agent_reviewer "$3" \
     --arg sha "$4" \
+    --arg require_head "${6:-0}" \
     "$1"
 }
 
@@ -239,6 +241,7 @@ GATE_B_FILTER='
     | select(.user.login as $u | $reviewers | index($u))
     | select(.user.login != $author)
     | select($same_agent_reviewer == "" or .user.login != $same_agent_reviewer)
+    | select($require_head != "1" or .commit_id == $sha)
   ]
   | group_by(.user.login)
   | map(max_by(.submitted_at))
@@ -364,6 +367,47 @@ if [ -z "$got" ]; then
 else
   fail=$((fail + 1))
   echo "  FAIL: gate (b) used stale APPROVED instead of latest CHANGES_REQUESTED — got '$got'" >&2
+fi
+
+# Case F (#435): cross-agent APPROVED on a STALE commit (not HEAD).
+#   require_head=1 (merge-clearance-gate delegation) → gate (b) rejects it,
+#   so a stale approval can't ride a later push to clearance.
+#   require_head=0 (default / auto-clear path) → accepted, preserving the
+#   existing non-HEAD-pinned behavior.
+REVIEWS_F='[
+  {"user":{"login":"nathanpayne-codex"},"state":"APPROVED","commit_id":"OLDsha999","submitted_at":"2026-05-15T10:00:00Z"}
+]'
+
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_F" 1)
+if [ -z "$got" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) HEAD-pin rejects stale-commit APPROVED when require_head=1 (#435)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) HEAD-pin accepted stale-commit APPROVED — got '$got'" >&2
+fi
+
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_F" 0)
+if [ "$got" = "nathanpayne-codex" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) default (require_head=0) still accepts stale-commit APPROVED (no regression)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) default path changed behavior — got '$got'" >&2
+fi
+
+# Case G (#435): cross-agent APPROVED ON the current HEAD with require_head=1
+#   → accepted. Confirms HEAD-pin only blocks stale approvals, not fresh ones.
+REVIEWS_G='[
+  {"user":{"login":"nathanpayne-codex"},"state":"APPROVED","commit_id":"abc123","submitted_at":"2026-05-15T10:00:00Z"}
+]'
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_G" 1)
+if [ "$got" = "nathanpayne-codex" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) HEAD-pin accepts APPROVED on current HEAD when require_head=1 (#435)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) HEAD-pin rejected fresh on-HEAD APPROVED — got '$got'" >&2
 fi
 
 echo

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -241,11 +241,10 @@ GATE_B_FILTER='
     | select(.user.login as $u | $reviewers | index($u))
     | select(.user.login != $author)
     | select($same_agent_reviewer == "" or .user.login != $same_agent_reviewer)
-    | select($require_head != "1" or .commit_id == $sha)
   ]
   | group_by(.user.login)
   | map(max_by(.submitted_at))
-  | map(select(.state == "APPROVED"))
+  | map(select(.state == "APPROVED" and ($require_head != "1" or .commit_id == $sha)))
   | first
   | if . == null then empty else .user.login end
 '
@@ -408,6 +407,25 @@ if [ "$got" = "nathanpayne-codex" ]; then
 else
   fail=$((fail + 1))
   echo "  FAIL: gate (b) HEAD-pin rejected fresh on-HEAD APPROVED — got '$got'" >&2
+fi
+
+# Case H (#436 Codex P1): reviewer APPROVED on HEAD, then later
+# CHANGES_REQUESTED on a stale/pending non-HEAD commit. Their LATEST
+# opinionated state is CHANGES_REQUESTED, so gate (b) must REJECT — even with
+# require_head=1. Filtering non-HEAD reviews BEFORE the latest-state collapse
+# (the original buggy fix) would discard the blocking CHANGES_REQUESTED and
+# wrongly clear via the stale on-HEAD APPROVED.
+REVIEWS_H='[
+  {"user":{"login":"nathanpayne-codex"},"state":"APPROVED","commit_id":"abc123","submitted_at":"2026-05-15T10:00:00Z"},
+  {"user":{"login":"nathanpayne-codex"},"state":"CHANGES_REQUESTED","commit_id":"OLDsha999","submitted_at":"2026-05-15T12:00:00Z"}
+]'
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_H" 1)
+if [ -z "$got" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) HEAD-pin honors a LATER non-HEAD CHANGES_REQUESTED over a stale on-HEAD APPROVED (#436)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) discarded the later CHANGES_REQUESTED and cleared via stale APPROVED — got '$got'" >&2
 fi
 
 echo

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -268,6 +268,22 @@ if [ "${CODEX_REVIEW_CHECK_SKIP_CI:-}" = "1" ]; then
   REQUIRE_CI_GREEN=false
 fi
 
+# Per-invocation gate-(b) HEAD-pin override (#435, the #427/#428 class one
+# layer deeper). By default gate (b) branch 1 accepts each reviewer's
+# latest-state APPROVED on ANY commit — so a reviewer's approval of an
+# earlier head can survive a later push and clear gate (b) while gate (c)
+# clears via a fresh on-HEAD Codex signal, merging a HEAD the reviewer never
+# approved. When this is "1", gate (b) branch 1 additionally requires the
+# APPROVED to be on the current HEAD (commit_id == HEAD_SHA), matching the
+# gate-(c) Phase-4b-substitute's HEAD pinning. scripts/merge-clearance-gate.sh
+# sets it so its REQUIRED check is fully HEAD-pinned (reviewer + Codex/Phase-4b
+# both on HEAD). Unset (default) preserves the auto-clear path's behavior,
+# where branch-protection dismiss_stale_reviews is the intended control.
+REQUIRE_APPROVAL_ON_HEAD=0
+if [ "${CODEX_REVIEW_CHECK_REQUIRE_APPROVAL_ON_HEAD:-}" = "1" ]; then
+  REQUIRE_APPROVAL_ON_HEAD=1
+fi
+
 # Honor codex.allow_phase_4b_substitute. When true (default), gate (c)
 # also accepts an APPROVED review on the current HEAD from an
 # available_reviewers identity != the PR author as a Codex-equivalent
@@ -743,12 +759,17 @@ REVIEWERS_JSON=$(echo "$REVIEWERS" | jq -R . | jq -s .)
 APPROVING_REVIEWER=$(echo "$REVIEWS_JSON" | jq -r \
   --argjson reviewers "$REVIEWERS_JSON" \
   --arg author "$PR_AUTHOR" \
-  --arg same_agent_reviewer "$SAME_AGENT_REVIEWER" '
+  --arg same_agent_reviewer "$SAME_AGENT_REVIEWER" \
+  --arg sha "$HEAD_SHA" \
+  --arg require_head "$REQUIRE_APPROVAL_ON_HEAD" '
     [ .[]
       | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
       | select(.user.login as $u | $reviewers | index($u))
       | select(.user.login != $author)
       | select($same_agent_reviewer == "" or .user.login != $same_agent_reviewer)
+      # HEAD-pin (#435): when required, only reviews ON the current HEAD count,
+      # so a stale earlier-head APPROVED cannot ride a later push to clearance.
+      | select($require_head != "1" or .commit_id == $sha)
     ]
     | group_by(.user.login)
     | map(max_by(.submitted_at))

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -767,13 +767,16 @@ APPROVING_REVIEWER=$(echo "$REVIEWS_JSON" | jq -r \
       | select(.user.login as $u | $reviewers | index($u))
       | select(.user.login != $author)
       | select($same_agent_reviewer == "" or .user.login != $same_agent_reviewer)
-      # HEAD-pin (#435): when required, only reviews ON the current HEAD count,
-      # so a stale earlier-head APPROVED cannot ride a later push to clearance.
-      | select($require_head != "1" or .commit_id == $sha)
     ]
     | group_by(.user.login)
     | map(max_by(.submitted_at))
-    | map(select(.state == "APPROVED"))
+    # Collapse to each reviewer'\''s LATEST opinionated state FIRST, then require
+    # that latest state to be APPROVED — and, when HEAD-pinned (#435), to be on
+    # the current HEAD. Filtering non-HEAD reviews BEFORE this collapse would
+    # discard a later blocking CHANGES_REQUESTED/DISMISSED on an outdated/pending
+    # commit and let a stale earlier APPROVED still clear gate (b). (Codex P1 on
+    # PR #436.)
+    | map(select(.state == "APPROVED" and ($require_head != "1" or .commit_id == $sha)))
     | first
     | if . == null then empty else .user.login end
 ')

--- a/scripts/merge-clearance-gate.sh
+++ b/scripts/merge-clearance-gate.sh
@@ -475,11 +475,14 @@ if [ "$EXTERNAL_GATE_ENABLED" = "true" ]; then
 
     # Delegate to the shared predicate. CODEX_REVIEW_CHECK_SKIP_CI=1 skips
     # gate (a) for THIS invocation only (avoids the required-check
-    # self-deadlock); gate (b) reviewer-APPROVED + gate (c) Codex/Phase-4b
-    # on HEAD still run. codex-review-check.sh exits: 0 clear, 1 gate fail,
-    # 3 infra. Map 3 → 2 (config/infra error).
+    # self-deadlock). CODEX_REVIEW_CHECK_REQUIRE_APPROVAL_ON_HEAD=1 HEAD-pins
+    # gate (b) so a stale earlier-head reviewer APPROVED can't ride a later
+    # push to clearance (#435) — making this REQUIRED check fully HEAD-pinned
+    # (reviewer + Codex/Phase-4b both on HEAD). codex-review-check.sh exits:
+    # 0 clear, 1 gate fail, 3 infra. Map 3 → 2 (config/infra error).
     set +e
-    CODEX_REVIEW_CHECK_SKIP_CI=1 bash "$CODEX_CHECK_BIN" "$PR_NUMBER" "$REPO"
+    CODEX_REVIEW_CHECK_SKIP_CI=1 CODEX_REVIEW_CHECK_REQUIRE_APPROVAL_ON_HEAD=1 \
+      bash "$CODEX_CHECK_BIN" "$PR_NUMBER" "$REPO"
     crc=$?
     set -e
     case "$crc" in


### PR DESCRIPTION
Closes #435.

## Summary

`scripts/codex-review-check.sh` gate (b) branch 1 accepted each reviewer's latest-state `APPROVED` on **any** commit — not HEAD-pinned. So a stale earlier-head approval could ride a later push to clearance while gate (c) cleared via a fresh on-HEAD Codex signal, merging a HEAD the reviewer never approved. This is the #427/#428 "clearance must be pinned to the merge HEAD" class, inside the shared predicate that `merge-clearance-gate.sh` (#429) delegates to.

Surfaced by Codex's live review on overridebroadway#85 + device-platform-reporting#107 during the `8eddd1e` propagation wave (`nathanpayne-codex` CHANGES_REQUESTED on both).

## Fix

- `codex-review-check.sh`: new per-invocation `CODEX_REVIEW_CHECK_REQUIRE_APPROVAL_ON_HEAD` (default `0`). When `1`, gate (b) branch 1 additionally requires `commit_id == HEAD_SHA` (matching gate (c)'s Phase-4b-substitute pinning).
- `merge-clearance-gate.sh`: sets it alongside `CODEX_REVIEW_CHECK_SKIP_CI=1` when delegating, so its **required** check is fully HEAD-pinned (reviewer **and** Codex/Phase-4b both on HEAD).
- Default unset preserves the auto-clear/label-UX path's behavior (branch-protection `dismiss_stale_reviews` is the intended control there).

## Self-Review
- **Correctness:** The HEAD-pin is a single added `select($require_head != "1" or .commit_id == $sha)` in gate (b) branch 1, gated on the env flag. The test's standalone `GATE_B_FILTER` copy in `check_canonical_bugs_263caf3` is updated in lockstep (it deliberately re-implements the filter to lock the logic).
- **Regression risk:** Default (`require_head` unset → `0`) is behavior-identical; the new Case F explicitly asserts the default path still accepts a stale-commit APPROVED. All existing suites green (`check_codex_scripts`, `check_canonical_bugs_263caf3` 50 tests, `check_merge_clearance_gate`).
- **Style/conventions:** Mirrors the existing `CODEX_REVIEW_CHECK_SKIP_CI` per-invocation override pattern (honored only on literal `"1"`), with inline rationale citing #435/#427/#428.
- **Test coverage:** +3 cases — stale-commit APPROVED rejected when `require_head=1`; default still accepts (no regression); on-HEAD APPROVED accepted when `require_head=1`.
- **Security/dependency hygiene:** Tightens (never loosens) clearance; no new deps. Scoped to the required-check path to avoid broad re-approval friction.

Once merged, the two CHANGES_REQUESTED consumer PRs (overridebroadway#85, device-platform-reporting#107) get the fix on re-propagation and a fresh cross-agent review.

Authoring-Agent: claude
