### PR TITLE
fix(gates): pipefail-safe scheduled-sweep summary truncation (Codex P2)

### DIFF
--- a/.github/workflows/codex-p1-gate.yml
+++ b/.github/workflows/codex-p1-gate.yml
@@ -233,9 +233,15 @@ jobs:
                 ;;
             esac
 
-            # Truncate the summary to ~60KB to stay well under
-            # GitHub's 65535-char limit on check_run.output.summary.
-            summary=$(printf '%s\n' "$output" | head -c 60000)
+            # Truncate to stay under GitHub's 65535-char summary limit.
+            # Bash slice, NOT `printf | head -c`: under `set -euo pipefail`
+            # a >60KB output makes head close the pipe early, printf takes
+            # SIGPIPE (141), pipefail propagates it, and `summary=$(...)`
+            # aborts the sweep BEFORE the check_run POST — fail-open on the
+            # UI-resolve path this sweep exists to close. Slicing is
+            # pipefail-safe + char-based (same fix as merge-clearance-gate.yml;
+            # Codex P2 on the b10671e propagation wave).
+            summary="${output:0:60000}"
 
             # Posting the check_run IS the sweep's whole purpose —
             # it's what supersedes the stale red required-check after

--- a/.github/workflows/merge-clearance-gate.yml
+++ b/.github/workflows/merge-clearance-gate.yml
@@ -250,7 +250,15 @@ jobs:
                 ;;
             esac
 
-            summary=$(printf '%s\n' "$output" | head -c 60000)
+            # Truncate to stay under GitHub's 65535-char summary limit.
+            # Bash slice, NOT `printf | head -c`: under `set -euo pipefail`
+            # a >60KB output makes head close the pipe early, printf takes
+            # SIGPIPE (141), pipefail propagates it, and `summary=$(...)`
+            # aborts the sweep BEFORE the check_run POST — fail-open on the
+            # very no-event path this sweep exists to close (Codex P2 on the
+            # b10671e propagation wave). Slicing is pipefail-safe + char-based
+            # (correct for the char-limit).
+            summary="${output:0:60000}"
 
             # Posting the check_run IS the sweep's whole purpose — it's
             # what supersedes the stale required-check after a no-event


### PR DESCRIPTION
## Summary

`merge-clearance-gate.yml` and `codex-p1-gate.yml` truncate their scheduled-sweep `check_run` summary with:

```bash
summary=$(printf '%s\n' "$output" | head -c 60000)
```

Under `set -euo pipefail`, an `$output` over 60 KB makes `head -c` close the pipe after 60000 bytes; `printf` then takes SIGPIPE (141), `pipefail` propagates it, and the `summary=$(...)` command substitution exits non-zero → `set -e` **aborts the sweep before the `check_run` POST**. That leaves the PR head with the *previous* `Merge clearance gate` / `Codex P1` result instead of the fail-closed refresh — the exact fail-open these sweeps exist to close on the no-event path.

Fix: drop the pipe, use a bash slice — `summary="${output:0:60000}"`. No subprocess, no SIGPIPE, pipefail-safe; char-based truncation is also more correct for GitHub's 65535-**char** summary limit. Applied to both gate workflows (same copied pattern).

Surfaced by Codex on the `b10671e` propagation wave (nathanpaynedotcom#451, friends-and-family-billing#300, as P2).

## Self-Review
- **Correctness:** `${output:0:60000}` yields the first 60000 chars with no pipeline → no SIGPIPE. Verified: a 70 KB input slices to 60000 with `rc=0` under `set -euo pipefail` (the old form aborts).
- **Regression risk:** Behavior-identical for normal (<60 KB) output; only the >60 KB edge changes — from "abort the sweep" to "post a truncated summary." Both gate workflows' structural guards (`check_merge_clearance_gate`, `check_codex_p1_gate`) pass.
- **Style/conventions:** Inline comment explains the pipefail/SIGPIPE hazard so the pipe isn't reintroduced.
- **Test coverage:** Structural guards green; the fix is a one-line shell-robustness change with an inline verification note.
- **Security/dependency hygiene:** Tightens the fail-closed sweep (removes a fail-open); no new deps.

Authoring-Agent: claude
