### PR TITLE
feat(templates): add synced issue-template kit and sync PR template (#418)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report broken behavior with enough context to reproduce and fix it
+title: ""
+labels: bug
+assignees: ""
+---
+
+## What broke
+
+Describe the broken behavior and who or what it affects.
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+Describe what should have happened instead.
+
+## Actual behavior
+
+Describe what happened, including relevant logs, screenshots, or links.
+
+## Acceptance criteria
+
+- [ ] The bug is reproduced or the failure mode is otherwise confirmed.
+- [ ] The fix covers the reported behavior.
+- [ ] A regression test or equivalent verification is added when practical.
+
+## Notes / risks
+
+Add related context, suspected cause, rollout concerns, or follow-up risks.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,25 @@
+---
+name: Documentation
+about: Request a documentation addition, correction, or canonical-source update
+title: ""
+labels: documentation
+assignees: ""
+---
+
+## What to document
+
+Describe the missing, stale, or confusing documentation.
+
+## Source of truth
+
+Link the code, policy, issue, PR, or decision the documentation should match.
+
+## Acceptance criteria
+
+- [ ] The canonical document is updated.
+- [ ] Related quick-start, example, or policy references are checked for drift.
+- [ ] The updated text names any remaining assumptions or follow-up work.
+
+## Notes / risks
+
+Add migration concerns, affected consumers, or places likely to contain duplicate wording.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Propose a buildable change or workflow improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## What to build
+
+Describe the feature, workflow change, or improvement.
+
+## Acceptance criteria
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Open decisions
+
+- [ ] 
+
+## Notes / risks
+
+Add constraints, rollout concerns, affected consumers, or follow-up work.

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -498,6 +498,9 @@ paths:
 
   # Canonical workflows — review policy + automation surfaces that
   # should be lockstep across all consumers.
+  - path: .github/pull_request_template.md
+    type: canonical
+    consumers: all
   - path: .github/workflows/agent-review.yml
     type: canonical
     consumers: all
@@ -592,6 +595,14 @@ paths:
 
   # Kit directories — Mergepath-canonical files are required;
   # consumer-only additions in the same directory are allowed.
+  - path: .github/ISSUE_TEMPLATE/
+    type: kit
+    consumers: all
+    # Synced issue templates establish the shared Mergepath issue
+    # shape while preserving allow-extras semantics for product-
+    # specific consumer templates. Keep labels to GitHub default
+    # labels (`bug`, `documentation`, `enhancement`) so consumer
+    # repos do not silently drop non-existent front-matter labels.
   - path: scripts/ci/
     type: kit
     consumers: all

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ fallback (Phase 4b).
 | `BRAND.md` | Mergepath umbrella vocabulary (surfaces, reserved names, naming history) |
 | `mergepath/playground/index.html` | Mergepath Playground — tune the review policy and replay recent PRs against the draft |
 | `scripts/policy-sim.sh` | Bakes real `gh` PR data into a temp copy of the Mergepath Playground for local replay |
+| `.mergepath-sync.yml` | Propagation manifest for synced canonical, kit, and templated surfaces |
+| `.github/ISSUE_TEMPLATE/` | Synced issue-template kit; consumers may add product-specific templates |
+| `.github/pull_request_template.md` | Synced canonical pull-request template |
 | `ai_agent_tooling_standard.md` | Full repository standard (reference) |
 
 ## Firebase Auth Template


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Add `.github/ISSUE_TEMPLATE/` with four Markdown templates (bug report, feature request, documentation, `config.yml`) encoding the Mergepath house issue format (`## What to build` / `## Acceptance criteria` checklists).
- Register `.github/ISSUE_TEMPLATE/` in `.mergepath-sync.yml` as a **kit** directory (`consumers: all`) — Mergepath templates are enforced while consumers keep allow-extras room for product-specific templates.
- Fold in the identical gap for `.github/pull_request_template.md`: registered as **canonical**, `consumers: all`.
- Front-matter labels restricted to GitHub default labels (`bug`, `enhancement`, `documentation`) so no label is silently dropped in consumers that lack Mergepath's label set.
- Document both new synced surfaces in `README.md`.

Design decisions from #418 resolved as recommended there: kit (not per-file canonical), legacy Markdown format (matches the freeform house style), default-only labels, PR template folded in.

Closes #418

## Testing
- [x] `scripts/ci/check_sync_manifest` passes (8 consumers, 56 path entries; new kit + canonical entries validate)
- [x] Build succeeds (no build surface affected)
- [x] Manual verification: front-matter parses, labels are GitHub defaults

## Self-Review
- [x] Correctness: changes match stated requirements
- [x] Regression risk: no unintended impact on existing behavior
- [x] Style and conventions: follows repository standards
- [x] Test coverage: covered by check_sync_manifest regression suite
- [x] Security and dependency hygiene: no new vulnerabilities or unnecessary deps