### PR TITLE
fix(workflows): grant issues:read in auto-clear-blocking-labels.yml (#431)

### DIFF
--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -66,6 +66,15 @@ permissions:
   # nathanjohnpayne/matchline#233 (#306 propagation canary); see
   # #310 for the full repro + permission scope rationale.
   actions: read
+  # `issues: read` is required because codex-review-check.sh reads
+  # issues-scoped endpoints: /issues/{pr}/reactions (Codex 👍
+  # clearance) and /issues/{pr}/timeline (force-push anchor). On a
+  # restricted-default GITHUB_TOKEN an omitted scope defaults to
+  # `none`, so those reads 403 and the gate aborts with rc=3,
+  # leaving `needs-external-review` stuck even after Codex clears.
+  # Same class as the merge-clearance-gate.yml fix on PR #429; see
+  # #431.
+  issues: read
   # `checks: write` is required so the "Surface infra failure as
   # check-run" step (#324) can POST a failed check-run to the PR's
   # checks tab when this workflow hits an infrastructure error

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -208,7 +208,13 @@ perm_block=$(
 # expected set below now codifies the single-key shape so re-adding
 # `checks: read` fails this check instead of silently breaking the
 # workflow at runtime.
-expected_perms=$'actions: read\nchecks: write\ncontents: read\npull-requests: write'
+# `issues: read` added in #431 — codex-review-check.sh reads
+# /issues/{pr}/reactions (Codex 👍 clearance) and
+# /issues/{pr}/timeline (force-push anchor). On restricted-default
+# GITHUB_TOKEN repos an omitted scope is `none`, those reads 403,
+# and the gate aborts rc=3 with `needs-external-review` stuck. Same
+# class as the merge-clearance-gate.yml `issues: read` fix (#429).
+expected_perms=$'actions: read\nchecks: write\ncontents: read\nissues: read\npull-requests: write'
 if [ "$perm_block" = "$expected_perms" ]; then
   pass=$((pass + 1))
   echo "  PASS: workflow permissions exactly match the least-privilege set"


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Add `issues: read` to `auto-clear-blocking-labels.yml`'s workflow-level `permissions:` block (the only `permissions:` block in the file — no job-level overrides). `codex-review-check.sh`, which both jobs invoke, reads `/issues/{pr}/reactions` (Codex 👍 clearance) and `/issues/{pr}/timeline` (force-push anchor); on restricted-default `GITHUB_TOKEN` repos an omitted scope is `none`, those reads 403, and the gate aborts rc=3 with `needs-external-review` stuck even after Codex clears.
- Update `scripts/ci/check_auto_clear_workflow`'s least-privilege permission contract to include the new scope, with inline rationale.
- Audited the other `codex-review-check.sh` callers per the issue's acceptance criteria: `merge-clearance-gate.yml` already grants `issues: read` at workflow and job level (the #429 fix); `repo_lint.yml` and `dependabot-auto-merge.yml` only reference the script in comments/extracted awk patterns; `pr-audit.yml` grants `issues: write`. No other caller has the gap.
- Propagates to consumers via the existing `.mergepath-sync.yml` entries for both files.

Closes #431

## Testing
- [x] `scripts/ci/check_auto_clear_workflow` passes (26 tests, including the updated least-privilege assertion)
- [x] `scripts/ci/check_workflow_parsers` passes (64 tests)
- [x] Manual verification: single `permissions:` block confirmed, no duplicate keys

## Self-Review
- [x] Correctness: changes match stated requirements
- [x] Regression risk: additive read-only scope; no behavior change on permissive-default repos
- [x] Style and conventions: follows repository standards (rationale comment mirrors the #310/#324 precedent)
- [x] Test coverage: least-privilege contract updated and passing
- [x] Security and dependency hygiene: read-only scope, least-privilege preserved