### PR TITLE
fix(identity): close three wrapper/token identity-resolution gaps (#438)

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -392,6 +392,9 @@ paths:
   # The test locks the timeout status-probe contract from #417: exit 4
   # stays advisory, the status reply is surfaced in JSON, and the reply
   # never counts as CodeRabbit review clearance.
+  - path: tests/test_coderabbit_wait_identity_derivation.sh
+    type: canonical
+    consumers: all
   - path: tests/test_coderabbit_wait_status_probe.sh
     type: canonical
     consumers: all
@@ -607,6 +610,7 @@ paths:
       - "tests/test_gh_as_reviewer.sh"         # check_gh_as_author
       - "tests/test_gh_wrapper_parallel.sh"    # check_gh_as_author
       - "tests/test_coderabbit_wait_status_probe.sh"  # check_coderabbit_wait
+      - "tests/test_coderabbit_wait_identity_derivation.sh"  # check_coderabbit_wait (#438)
       - "tests/test_codex_p1_gate.sh"          # check_codex_p1_gate
       - "tests/test_merge_clearance_gate.sh"   # check_merge_clearance_gate
       - "tests/test_disagreement_detector.sh"  # check_disagreement_detector

--- a/scripts/ci/check_coderabbit_wait
+++ b/scripts/ci/check_coderabbit_wait
@@ -4,18 +4,25 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-TEST="$REPO_ROOT/tests/test_coderabbit_wait_status_probe.sh"
+TESTS=(
+  "$REPO_ROOT/tests/test_coderabbit_wait_status_probe.sh"
+  "$REPO_ROOT/tests/test_coderabbit_wait_identity_derivation.sh"
+)
 
 if [ ! -x "$REPO_ROOT/scripts/coderabbit-wait.sh" ]; then
   echo "check_coderabbit_wait: ERROR scripts/coderabbit-wait.sh missing or not executable" >&2
   exit 1
 fi
 
-if [ ! -x "$TEST" ]; then
-  echo "check_coderabbit_wait: ERROR $TEST missing or not executable" >&2
-  exit 1
-fi
+for TEST in "${TESTS[@]}"; do
+  if [ ! -x "$TEST" ]; then
+    echo "check_coderabbit_wait: ERROR $TEST missing or not executable" >&2
+    exit 1
+  fi
+done
 
 echo "check_coderabbit_wait: running coderabbit-wait status-probe tests"
-"$TEST"
+"${TESTS[0]}"
+echo "check_coderabbit_wait: running coderabbit-wait identity-derivation tests (#438)"
+"${TESTS[1]}"
 echo "check_coderabbit_wait: PASS"

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -228,7 +228,7 @@ read_available_reviewers() {
     /^available_reviewers:/ {in_block=1; next}
     in_block && /^[^[:space:]#]/ {in_block=0}
     in_block && /^ *-/ {print}
-  ' "$CONFIG" | sed -E 's/^[[:space:]]*-[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/'
+  ' "$CONFIG" | sed -E "s/^[[:space:]]*-[[:space:]]*[\"']?([^\"']*)[\"']?[[:space:]]*\$/\1/"
 }
 
 login_is_available_reviewer() {

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -228,7 +228,7 @@ read_available_reviewers() {
     /^available_reviewers:/ {in_block=1; next}
     in_block && /^[^[:space:]#]/ {in_block=0}
     in_block && /^ *-/ {print}
-  ' "$CONFIG" | sed -E "s/^[[:space:]]*-[[:space:]]*[\"']?([^\"']*)[\"']?[[:space:]]*\$/\1/"
+  ' "$CONFIG" | sed -E "s/^[[:space:]]*-[[:space:]]*//; s/[[:space:]]+#.*\$//; s/^[\"']//; s/[\"']\$//; s/[[:space:]]+\$//"
 }
 
 login_is_available_reviewer() {

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -166,7 +166,23 @@ if [ -z "${GH_TOKEN:-}" ]; then
   exit 3
 fi
 
-EXPECTED_REVIEWER_IDENTITY="$(gh_default_reviewer_identity)"
+# Expected reviewer identity for helper-comment writes. When any of
+# the explicit identity envs is set, honor it via
+# gh_default_reviewer_identity. Otherwise — e.g. agent-review.yml
+# passes only `GH_TOKEN: secrets.REVIEWER_ASSIGNMENT_TOKEN` with no
+# MERGEPATH_AGENT / OP_PREFLIGHT_AGENT / GH_AS_REVIEWER_IDENTITY —
+# leave it empty so verify_reviewer_write_identity derives the
+# expected login from the token itself, constrained to
+# available_reviewers (#438). The old behavior hard-defaulted to
+# nathanpayne-claude, so a repo whose REVIEWER_ASSIGNMENT_TOKEN is a
+# different allowed reviewer failed identity verification before
+# posting a retry/status-probe comment — a rate-limited CodeRabbit
+# run then exited as infra error instead of retrying.
+if [ -n "${GH_AS_REVIEWER_IDENTITY:-}" ] || [ -n "${MERGEPATH_AGENT:-}" ] || [ -n "${OP_PREFLIGHT_AGENT:-}" ]; then
+  EXPECTED_REVIEWER_IDENTITY="$(gh_default_reviewer_identity)"
+else
+  EXPECTED_REVIEWER_IDENTITY=""   # derived lazily from the token at write time
+fi
 
 gh_reviewer() (
   unset GITHUB_TOKEN
@@ -199,6 +215,29 @@ coderabbit_field() {
       }
     }
   ' "$CONFIG"
+}
+
+# Read the available_reviewers list (one login per line). Same
+# state-machine awk pattern as codex-review-check.sh's reader; handles
+# quoted and unquoted list items. Used by the token-derived expected-
+# identity path (#438) to keep the derivation fail-closed: only a
+# login on this allow-list may become the expected reviewer.
+read_available_reviewers() {
+  [ -f "$CONFIG" ] || return 0
+  awk '
+    /^available_reviewers:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block && /^ *-/ {print}
+  ' "$CONFIG" | sed -E 's/^[[:space:]]*-[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/'
+}
+
+login_is_available_reviewer() {
+  local login=$1 reviewer
+  [ -n "$login" ] || return 1
+  while IFS= read -r reviewer; do
+    [ "$reviewer" = "$login" ] && return 0
+  done <<< "$(read_available_reviewers)"
+  return 1
 }
 
 MAX_WAIT_SECONDS=$(coderabbit_field max_wait_seconds)
@@ -724,6 +763,25 @@ verify_reviewer_write_identity() {
       echo "       Restore the helper, or opt out via" >&2
       echo "       CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 (dev only)." >&2
       return 1
+    fi
+    # Lazy token-derived expected identity (#438): no explicit identity
+    # env was set at startup, so derive the expected login from the
+    # token that will sign this write — constrained to
+    # available_reviewers. An unconstrained derivation would make the
+    # check below a tautology; the allow-list keeps it fail-closed: a
+    # non-reviewer token falls back to the static default and fails
+    # verification exactly as before. Derived here (write time) rather
+    # than at startup so read-only runs never pay the extra API call.
+    if [ -z "$EXPECTED_REVIEWER_IDENTITY" ]; then
+      local token_login
+      token_login=$(gh_reviewer api user --jq .login 2>/dev/null || true)
+      if login_is_available_reviewer "$token_login"; then
+        EXPECTED_REVIEWER_IDENTITY="$token_login"
+        log "derived expected reviewer identity '$token_login' from GH_TOKEN (allow-listed in available_reviewers)"
+      else
+        EXPECTED_REVIEWER_IDENTITY="$(gh_default_reviewer_identity)"
+        log "GH_TOKEN login '${token_login:-<unresolvable>}' is not in available_reviewers; falling back to default expected reviewer '$EXPECTED_REVIEWER_IDENTITY'"
+      fi
     fi
     GH_TOKEN="$GH_TOKEN" "$checker" --expect-token-identity "$EXPECTED_REVIEWER_IDENTITY" \
       || return 1

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -547,16 +547,17 @@ post_codex_trigger() {
   # Capture stdout+stderr so a failure surfaces the real gh error
   # (404 / 403 / 422) rather than a bare "failed to post". The comment
   # URL gh prints on success is still extractable downstream.
+  # Pass the configured author identity on BOTH invocation branches:
+  # the wrapper's hard default (nathanjohnpayne) would reject a valid
+  # custom-author token in repos that override author_identity —
+  # bridged-token case (Codex P2 on PR #442 r2) AND warm-preflight /
+  # keyring case (Codex P2 on PR #442 r5). review-policy.yml is the
+  # source of truth this script already reads, so it wins.
   if [ -n "$BRIDGE_AUTHOR_PAT" ]; then
-    # Pass the configured author identity alongside the bridged token:
-    # the token was verified against $AUTHOR_IDENTITY, so the wrapper
-    # must verify the same login — its hard default (nathanjohnpayne)
-    # would reject a valid custom-author token in repos that override
-    # author_identity (Codex P2 on PR #442).
     POST_OUTPUT=$(OP_PREFLIGHT_AUTHOR_PAT="$BRIDGE_AUTHOR_PAT" GH_AS_AUTHOR_IDENTITY="$AUTHOR_IDENTITY" "$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
       || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
   else
-    POST_OUTPUT=$("$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
+    POST_OUTPUT=$(GH_AS_AUTHOR_IDENTITY="$AUTHOR_IDENTITY" "$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
       || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
   fi
   TRIGGER_POSTED=true

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -194,8 +194,10 @@ policy_top_field() {
   awk -v field="$field" '
     /^[^[:space:]#]/ && $1 == field":" {
       sub(/^[^:]+:[[:space:]]*/, "", $0)
-      gsub(/^"/, "", $0)
-      gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      # Both YAML quote styles (Codex P2 on PR #442 r9) — matching the
+      # quote-tolerance of the gh-pr-guard expected-author parser.
+      gsub(/^["\x27]/, "", $0)
+      gsub(/["\x27][[:space:]]*(#.*)?$/, "", $0)
       gsub(/[[:space:]]*#.*$/, "", $0)
       sub(/[[:space:]]+$/, "", $0)
       print

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -185,6 +185,30 @@ codex_field() {
   ' "$CONFIG"
 }
 
+# Extract a top-level scalar (column-0 key, no enclosing block) from
+# review-policy.yml — e.g. author_identity. Same quoting/comment
+# tolerance as codex_field.
+policy_top_field() {
+  local field=$1
+  [ -f "$CONFIG" ] || return 0
+  awk -v field="$field" '
+    /^[^[:space:]#]/ && $1 == field":" {
+      sub(/^[^:]+:[[:space:]]*/, "", $0)
+      gsub(/^"/, "", $0)
+      gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      gsub(/[[:space:]]*#.*$/, "", $0)
+      sub(/[[:space:]]+$/, "", $0)
+      print
+      exit
+    }
+  ' "$CONFIG"
+}
+
+# Author identity for the trigger comment write (#438): used to decide
+# whether an ambient GH_TOKEN may be bridged into gh-as-author.sh.
+AUTHOR_IDENTITY=$(policy_top_field author_identity)
+AUTHOR_IDENTITY=${AUTHOR_IDENTITY:-nathanjohnpayne}
+
 TIMEOUT_SECONDS=$(codex_field review_timeout_seconds)
 TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-600}
 if ! [[ "$TIMEOUT_SECONDS" =~ ^[0-9]+$ ]]; then
@@ -498,11 +522,38 @@ post_codex_trigger() {
     die 3 "gh-as-author.sh helper unavailable"
   fi
 
+  # Inline author-PAT bridging (#438): gh-as-author.sh's resolver
+  # intentionally ignores ambient GH_TOKEN — it reads only
+  # OP_PREFLIGHT_AUTHOR_PAT or a stored `gh auth token --user`. In a
+  # CI/fresh shell with no preflight cache and no keyring, the
+  # still-documented `GH_TOKEN=<author PAT> codex-review-request.sh`
+  # invocation shape passed every read-side check and then failed the
+  # trigger write despite holding a valid author token, forcing an
+  # unnecessary Phase 4b fallback. Bridge the ambient token into the
+  # wrapper's preferred env var ONLY after verifying it actually
+  # resolves to the author identity; any other token (the common
+  # reviewer-PAT session shape) is left alone so the wrapper's own
+  # resolution proceeds unchanged and fails closed as before.
+  BRIDGE_AUTHOR_PAT=""
+  if [ -n "${GH_TOKEN:-}" ] && [ -z "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]; then
+    IDENTITY_CHECKER="$__CODEX_REQUEST_DIR/identity-check.sh"
+    if [ -x "$IDENTITY_CHECKER" ] \
+      && GH_TOKEN="$GH_TOKEN" "$IDENTITY_CHECKER" --expect-token-identity "$AUTHOR_IDENTITY" >/dev/null 2>&1; then
+      log "ambient GH_TOKEN verifies as author identity $AUTHOR_IDENTITY — bridging it into gh-as-author.sh as OP_PREFLIGHT_AUTHOR_PAT"
+      BRIDGE_AUTHOR_PAT="$GH_TOKEN"
+    fi
+  fi
+
   # Capture stdout+stderr so a failure surfaces the real gh error
   # (404 / 403 / 422) rather than a bare "failed to post". The comment
   # URL gh prints on success is still extractable downstream.
-  POST_OUTPUT=$("$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
-    || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
+  if [ -n "$BRIDGE_AUTHOR_PAT" ]; then
+    POST_OUTPUT=$(OP_PREFLIGHT_AUTHOR_PAT="$BRIDGE_AUTHOR_PAT" "$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
+      || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
+  else
+    POST_OUTPUT=$("$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
+      || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
+  fi
   TRIGGER_POSTED=true
 
   # Capture the post time so the poll loop can ignore stale signals

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -548,7 +548,12 @@ post_codex_trigger() {
   # (404 / 403 / 422) rather than a bare "failed to post". The comment
   # URL gh prints on success is still extractable downstream.
   if [ -n "$BRIDGE_AUTHOR_PAT" ]; then
-    POST_OUTPUT=$(OP_PREFLIGHT_AUTHOR_PAT="$BRIDGE_AUTHOR_PAT" "$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
+    # Pass the configured author identity alongside the bridged token:
+    # the token was verified against $AUTHOR_IDENTITY, so the wrapper
+    # must verify the same login — its hard default (nathanjohnpayne)
+    # would reject a valid custom-author token in repos that override
+    # author_identity (Codex P2 on PR #442).
+    POST_OUTPUT=$(OP_PREFLIGHT_AUTHOR_PAT="$BRIDGE_AUTHOR_PAT" GH_AS_AUTHOR_IDENTITY="$AUTHOR_IDENTITY" "$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
       || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
   else
     POST_OUTPUT=$("$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \

--- a/scripts/gh-as-author.sh
+++ b/scripts/gh-as-author.sh
@@ -33,6 +33,24 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 AUTHOR="${GH_AS_AUTHOR_IDENTITY:-nathanjohnpayne}"
 
+# Runtime byline pin (#438): this check runs IN the wrapper process,
+# whose environment is the actual one the write will use — unlike the
+# PreToolUse hook's static command-line analysis, it cannot be evaded
+# by shell environment manipulation (env -u/-i, unset, export forms,
+# eval'd assignments). If the repo declares author_identity in
+# review-policy.yml, the resolved AUTHOR must match it; otherwise the
+# write would land under the wrong byline no matter which token
+# verifies.
+WRAPPER_POLICY_AUTHOR=""
+if [ -f ".github/review-policy.yml" ]; then
+  WRAPPER_POLICY_AUTHOR=$(grep -m1 '^author_identity:' ".github/review-policy.yml" | awk '{print $2}' | sed -E "s/^[\"']//; s/[\"']\$//" || true)
+fi
+if [ -n "$WRAPPER_POLICY_AUTHOR" ] && [ "$AUTHOR" != "$WRAPPER_POLICY_AUTHOR" ]; then
+  echo "gh-as-author: refusing to run as '$AUTHOR' — this repo's review-policy.yml declares author_identity: $WRAPPER_POLICY_AUTHOR (#438 runtime byline pin)." >&2
+  echo "gh-as-author: unset GH_AS_AUTHOR_IDENTITY (or set it to $WRAPPER_POLICY_AUTHOR)." >&2
+  exit 2
+fi
+
 [ "${1:-}" = "--" ] && shift
 
 if [ "$#" -eq 0 ]; then

--- a/scripts/gh-as-author.sh
+++ b/scripts/gh-as-author.sh
@@ -41,9 +41,14 @@ AUTHOR="${GH_AS_AUTHOR_IDENTITY:-nathanjohnpayne}"
 # review-policy.yml, the resolved AUTHOR must match it; otherwise the
 # write would land under the wrong byline no matter which token
 # verifies.
+# Resolve the policy from the wrapper's own repo root, not the
+# caller's cwd — a subdirectory invocation must still load the pin
+# (Codex P2 on PR #442 r20). $ROOT is computed from BASH_SOURCE at
+# the top of this script; in consumers the wrapper is synced into the
+# repo it writes to, so script root == target repo root.
 WRAPPER_POLICY_AUTHOR=""
-if [ -f ".github/review-policy.yml" ]; then
-  WRAPPER_POLICY_AUTHOR=$(grep -m1 '^author_identity:' ".github/review-policy.yml" | awk '{print $2}' | sed -E "s/^[\"']//; s/[\"']\$//" || true)
+if [ -f "$ROOT/.github/review-policy.yml" ]; then
+  WRAPPER_POLICY_AUTHOR=$(grep -m1 '^author_identity:' "$ROOT/.github/review-policy.yml" | awk '{print $2}' | sed -E "s/^[\"']//; s/[\"']\$//" || true)
 fi
 if [ -n "$WRAPPER_POLICY_AUTHOR" ] && [ "$AUTHOR" != "$WRAPPER_POLICY_AUTHOR" ]; then
   echo "gh-as-author: refusing to run as '$AUTHOR' — this repo's review-policy.yml declares author_identity: $WRAPPER_POLICY_AUTHOR (#438 runtime byline pin)." >&2

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -622,6 +622,8 @@ AT_COMMAND_POSITION=1    # 1 = at command position, 0 = walking unrelated-comman
 SEGMENT_HAS_COMMAND=0    # 1 = this segment has seen a non-assignment command (echo, cat, etc.)
 SKIP_PREFIX_VALUE=0      # 1 = next token is the value of a prefix-command flag
 CURRENT_PREFIX=""        # name of the most recently seen prefix command (sudo/time/etc.)
+IN_EXPORT_SEGMENT=0      # 1 = current segment is an `export` command (its
+                         # assignment args reach all later processes)
 for i in "${!TOKENS[@]}"; do
   tok="${TOKENS[$i]}"
   # --- phase 2: walking after gh, looking for pr + subcommand ---
@@ -726,6 +728,7 @@ for i in "${!TOKENS[@]}"; do
       AT_COMMAND_POSITION=1
       CURRENT_PREFIX=""
       WRAPPER_KIND=""
+      IN_EXPORT_SEGMENT=0
       # Clear inline env vars ONLY when the segment that just ended
       # contained a non-assignment command. That means the assignment
       # was a PREFIX scoped to that command, not a standalone
@@ -809,8 +812,36 @@ for i in "${!TOKENS[@]}"; do
   fi
 
   if [ "$AT_COMMAND_POSITION" -eq 0 ]; then
+    # Arguments of an `export` command are DEFINITELY-effective
+    # identity assignments: `export GH_AS_AUTHOR_IDENTITY=x ; wrapper`
+    # puts the value in every later process's environment, while this
+    # walk would otherwise skip the token as an unrelated-command
+    # argument and the byline guard would fall back to the default
+    # candidate (Codex P1 on PR #442 r11 — the wrong-byline class).
+    # Capture them into the standalone (possibly-effective) slots the
+    # candidate model already validates.
+    if [ "$IN_EXPORT_SEGMENT" -eq 1 ]; then
+      case "$tok" in
+        GH_AS_AUTHOR_IDENTITY=*)
+          STANDALONE_GH_AS_AUTHOR_IDENTITY="${tok#GH_AS_AUTHOR_IDENTITY=}"
+          ;;
+        GH_AS_REVIEWER_IDENTITY=*)
+          STANDALONE_GH_AS_REVIEWER_IDENTITY="${tok#GH_AS_REVIEWER_IDENTITY=}"
+          ;;
+      esac
+    fi
     # Skipping arguments of an unrelated command. Stay until a
     # separator resets us above.
+    continue
+  fi
+
+  # `export` at command position: its assignment arguments reach all
+  # later processes. Flag the segment so the skip-path above captures
+  # the identity assignments that follow.
+  if [ "$tok" = "export" ]; then
+    IN_EXPORT_SEGMENT=1
+    SEGMENT_HAS_COMMAND=1
+    AT_COMMAND_POSITION=0
     continue
   fi
 

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -1009,7 +1009,15 @@ fi
 # gh pr merge ...` re-opens the wrong-byline merge/edit path the
 # wrapper migration closed (the #359 class).
 if [ "$WRAPPER_KIND" = "author" ]; then
-  EXPECTED_AUTHOR="${GH_PR_GUARD_EXPECTED_AUTHOR:-nathanjohnpayne}"
+  # Expected-author resolution order: explicit env override, then the
+  # repo's review-policy.yml author_identity (so custom-author repos
+  # need no hook-specific variable — Codex P2 on PR #442 round 2),
+  # then the fleet default.
+  EXPECTED_AUTHOR="${GH_PR_GUARD_EXPECTED_AUTHOR:-}"
+  if [ -z "$EXPECTED_AUTHOR" ] && [ -f ".github/review-policy.yml" ]; then
+    EXPECTED_AUTHOR=$(grep -m1 '^author_identity:' ".github/review-policy.yml" | awk '{print $2}' || true)
+  fi
+  EXPECTED_AUTHOR="${EXPECTED_AUTHOR:-nathanjohnpayne}"
   WRAPPER_AUTHOR_IDENTITY="${INLINE_GH_AS_AUTHOR_IDENTITY:-${GH_AS_AUTHOR_IDENTITY:-}}"
   # Unset means the wrapper will use ITS hard default (nathanjohnpayne)
   # — compare against that, not against EXPECTED_AUTHOR, so a repo

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -635,6 +635,8 @@ IN_EXPORT_SEGMENT=0      # 1 = current segment is an `export` command (its
                          # assignment args reach all later processes)
 SEGMENT_HAS_EVAL=0       # 1 = current segment ran `eval` — an eval'd
                          # assignment persists like a bare standalone
+PENDING_PREFIX_FLAG=""   # "<prefix>:<flag>" whose value the next token is
+                         # (lets the consumer recognize `env -u NAME`)
 for i in "${!TOKENS[@]}"; do
   tok="${TOKENS[$i]}"
   # --- phase 2: walking after gh, looking for pr + subcommand ---
@@ -718,6 +720,24 @@ for i in "${!TOKENS[@]}"; do
   # straight to the actual command.
   if [ "$SKIP_PREFIX_VALUE" -eq 1 ]; then
     SKIP_PREFIX_VALUE=0
+    # `env -u NAME` removes NAME from the wrapped command's
+    # environment: for the identity variables that is exactly the
+    # r15 empty-override semantics — the wrapper falls back to its
+    # hardcoded default, which a custom-author repo must fail closed
+    # on (Codex P2 on PR #442 r17, env --help verified).
+    if [ "$PENDING_PREFIX_FLAG" = "env:-u" ]; then
+      case "$tok" in
+        GH_AS_AUTHOR_IDENTITY)
+          INLINE_GH_AS_AUTHOR_IDENTITY=""
+          INLINE_GH_AS_AUTHOR_IDENTITY_SET=1
+          ;;
+        GH_AS_REVIEWER_IDENTITY)
+          INLINE_GH_AS_REVIEWER_IDENTITY=""
+          INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
+          ;;
+      esac
+    fi
+    PENDING_PREFIX_FLAG=""
     continue
   fi
 
@@ -957,7 +977,33 @@ for i in "${!TOKENS[@]}"; do
       # identically.
       if prefix_flag_takes_value "$CURRENT_PREFIX" "$tok"; then
         SKIP_PREFIX_VALUE=1
+        PENDING_PREFIX_FLAG="$CURRENT_PREFIX:$tok"
         continue
+      fi
+      # env's combined/long forms that drop identity variables from
+      # the wrapped command's environment (same r15 empty-override
+      # semantics as `env -u NAME` above): --unset=NAME, and -i which
+      # clears the whole environment.
+      if [ "$CURRENT_PREFIX" = "env" ]; then
+        case "$tok" in
+          --unset=GH_AS_AUTHOR_IDENTITY|-u=GH_AS_AUTHOR_IDENTITY)
+            INLINE_GH_AS_AUTHOR_IDENTITY=""
+            INLINE_GH_AS_AUTHOR_IDENTITY_SET=1
+            continue
+            ;;
+          --unset=GH_AS_REVIEWER_IDENTITY|-u=GH_AS_REVIEWER_IDENTITY)
+            INLINE_GH_AS_REVIEWER_IDENTITY=""
+            INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
+            continue
+            ;;
+          -i|--ignore-environment)
+            INLINE_GH_AS_AUTHOR_IDENTITY=""
+            INLINE_GH_AS_AUTHOR_IDENTITY_SET=1
+            INLINE_GH_AS_REVIEWER_IDENTITY=""
+            INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
+            continue
+            ;;
+        esac
       fi
       # Otherwise: boolean flag of the current prefix (or a flag
       # of an unknown prefix, which we conservatively assume is

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -737,14 +737,21 @@ for i in "${!TOKENS[@]}"; do
         INLINE_CODEX_CLEARED=""
         INLINE_BREAK_GLASS_ADMIN=""
         INLINE_BREAK_GLASS_MERGE_STATE=""
-        # Identity assignments scope to their segment the same way —
-        # `GH_AS_AUTHOR_IDENTITY=x echo ok ; gh-as-author.sh ...` runs
-        # the wrapper with its DEFAULT identity, so a stale captured
-        # value must not leak into the byline guards below (Codex P2
-        # on PR #442: false block after unrelated prefixed commands).
-        INLINE_GH_AS_AUTHOR_IDENTITY=""
-        INLINE_GH_AS_REVIEWER_IDENTITY=""
       fi
+      # Identity assignments NEVER survive a separator — unlike the
+      # break-glass vars above, their consumer is the WRAPPER process
+      # environment, not this hook. A prefix assignment scopes to its
+      # own command's environment, and a standalone assignment sets an
+      # unexported shell variable the wrapper never receives. Carrying
+      # either across a separator mis-models bash both ways: a stale
+      # prefix value falsely blocks later wrapper writes (Codex P2 on
+      # PR #442 r1), and a standalone value makes the hook believe the
+      # wrapper is configured with an identity it never sees — a
+      # wrong-byline hole in custom-author repos (Codex P2 on PR #442
+      # r3). Exported variables are still caught via the hook's own
+      # environment.
+      INLINE_GH_AS_AUTHOR_IDENTITY=""
+      INLINE_GH_AS_REVIEWER_IDENTITY=""
       SEGMENT_HAS_COMMAND=0
       continue
       ;;

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -624,6 +624,8 @@ SKIP_PREFIX_VALUE=0      # 1 = next token is the value of a prefix-command flag
 CURRENT_PREFIX=""        # name of the most recently seen prefix command (sudo/time/etc.)
 IN_EXPORT_SEGMENT=0      # 1 = current segment is an `export` command (its
                          # assignment args reach all later processes)
+SEGMENT_HAS_EVAL=0       # 1 = current segment ran `eval` — an eval'd
+                         # assignment persists like a bare standalone
 for i in "${!TOKENS[@]}"; do
   tok="${TOKENS[$i]}"
   # --- phase 2: walking after gh, looking for pr + subcommand ---
@@ -768,7 +770,12 @@ for i in "${!TOKENS[@]}"; do
       #     fail closed on the ambiguity (this also covers r3, where
       #     an unexported standalone value would have masked the
       #     wrapper falling back to its stock default).
-      if [ "$SEGMENT_HAS_COMMAND" -eq 0 ]; then
+      if [ "$SEGMENT_HAS_COMMAND" -eq 0 ] || [ "${SEGMENT_HAS_EVAL:-0}" -eq 1 ]; then
+        # Bare standalone segment, or an eval segment — in both, a
+        # captured assignment persists past the separator (eval'd
+        # assignments are standalone-equivalent; assignments that
+        # were prefixes TO the eval are over-captured on purpose,
+        # the fail-closed direction).
         if [ -n "$INLINE_GH_AS_AUTHOR_IDENTITY" ]; then
           STANDALONE_GH_AS_AUTHOR_IDENTITY="$INLINE_GH_AS_AUTHOR_IDENTITY"
         fi
@@ -776,6 +783,7 @@ for i in "${!TOKENS[@]}"; do
           STANDALONE_GH_AS_REVIEWER_IDENTITY="$INLINE_GH_AS_REVIEWER_IDENTITY"
         fi
       fi
+      SEGMENT_HAS_EVAL=0
       INLINE_GH_AS_AUTHOR_IDENTITY=""
       INLINE_GH_AS_REVIEWER_IDENTITY=""
       SEGMENT_HAS_COMMAND=0
@@ -895,6 +903,16 @@ for i in "${!TOKENS[@]}"; do
       # tell value-taking flags from boolean ones — short flags
       # like `-p` mean different things to different commands
       # (boolean for time, value-taking for ionice/sudo).
+      #
+      # eval is special: it executes its arguments as a NEW command
+      # line, so an assignment argument (`eval VAR=x`) becomes a
+      # STANDALONE assignment persisting in the shell — unlike an
+      # ordinary prefix the shell restores. The separator path
+      # promotes captured identities from eval segments to the
+      # possibly-effective slots instead of discarding them.
+      if [ "$tok" = "eval" ]; then
+        SEGMENT_HAS_EVAL=1
+      fi
       CURRENT_PREFIX="$tok"
       continue
       ;;

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -842,6 +842,19 @@ for i in "${!TOKENS[@]}"; do
     IN_EXPORT_SEGMENT=1
     SEGMENT_HAS_COMMAND=1
     AT_COMMAND_POSITION=0
+    # A prefix assignment BEFORE the export command in the same
+    # segment (`VAR=x export VAR`) both persists in the shell and is
+    # exported — bash applies the prefix to the declaration builtin
+    # and the bare-name export then marks the variable. Promote any
+    # already-captured inline identity to the definitely-effective
+    # slots, or the separator path would discard it as an ordinary
+    # command prefix (Codex P1 on PR #442 r12 — wrong-byline class).
+    if [ -n "$INLINE_GH_AS_AUTHOR_IDENTITY" ]; then
+      STANDALONE_GH_AS_AUTHOR_IDENTITY="$INLINE_GH_AS_AUTHOR_IDENTITY"
+    fi
+    if [ -n "$INLINE_GH_AS_REVIEWER_IDENTITY" ]; then
+      STANDALONE_GH_AS_REVIEWER_IDENTITY="$INLINE_GH_AS_REVIEWER_IDENTITY"
+    fi
     continue
   fi
 

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -873,6 +873,21 @@ for i in "${!TOKENS[@]}"; do
           STANDALONE_GH_AS_REVIEWER_IDENTITY="${tok#GH_AS_REVIEWER_IDENTITY=}"
           STANDALONE_GH_AS_REVIEWER_IDENTITY_SET=1
           ;;
+        GH_AS_AUTHOR_IDENTITY)
+          # Bare name as an `unset` argument: the variable is removed
+          # from the shell AND the child environment — the r15
+          # empty-override semantics, persisting past separators.
+          if [ "${DECLARATION_KIND:-}" = "unset" ]; then
+            STANDALONE_GH_AS_AUTHOR_IDENTITY=""
+            STANDALONE_GH_AS_AUTHOR_IDENTITY_SET=1
+          fi
+          ;;
+        GH_AS_REVIEWER_IDENTITY)
+          if [ "${DECLARATION_KIND:-}" = "unset" ]; then
+            STANDALONE_GH_AS_REVIEWER_IDENTITY=""
+            STANDALONE_GH_AS_REVIEWER_IDENTITY_SET=1
+          fi
+          ;;
       esac
     fi
     # Skipping arguments of an unrelated command. Stay until a
@@ -889,8 +904,9 @@ for i in "${!TOKENS[@]}"; do
   # MISMATCHED values, so the cost of the ambiguity is a false block
   # on a non-exported mismatched declaration, which is the fail-closed
   # direction for a byline guard.
-  case "$tok" in export|declare|typeset|readonly|local) IS_DECLARATION_BUILTIN=1 ;; *) IS_DECLARATION_BUILTIN=0 ;; esac
+  case "$tok" in export|declare|typeset|readonly|local|unset) IS_DECLARATION_BUILTIN=1 ;; *) IS_DECLARATION_BUILTIN=0 ;; esac
   if [ "$IS_DECLARATION_BUILTIN" -eq 1 ]; then
+    DECLARATION_KIND="$tok"
     IN_EXPORT_SEGMENT=1
     SEGMENT_HAS_COMMAND=1
     AT_COMMAND_POSITION=0

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -737,6 +737,13 @@ for i in "${!TOKENS[@]}"; do
         INLINE_CODEX_CLEARED=""
         INLINE_BREAK_GLASS_ADMIN=""
         INLINE_BREAK_GLASS_MERGE_STATE=""
+        # Identity assignments scope to their segment the same way —
+        # `GH_AS_AUTHOR_IDENTITY=x echo ok ; gh-as-author.sh ...` runs
+        # the wrapper with its DEFAULT identity, so a stale captured
+        # value must not leak into the byline guards below (Codex P2
+        # on PR #442: false block after unrelated prefixed commands).
+        INLINE_GH_AS_AUTHOR_IDENTITY=""
+        INLINE_GH_AS_REVIEWER_IDENTITY=""
       fi
       SEGMENT_HAS_COMMAND=0
       continue

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -601,6 +601,15 @@ INLINE_BREAK_GLASS_ADMIN=""
 INLINE_BREAK_GLASS_MERGE_STATE=""
 INLINE_GH_AS_AUTHOR_IDENTITY=""
 INLINE_GH_AS_REVIEWER_IDENTITY=""
+# Standalone (own-segment) identity assignments persist as shell
+# variables and — when the name already carries the export attribute in
+# the calling shell — ALSO reach later processes. The hook cannot see
+# the export attribute, so these are tracked separately as
+# possibly-effective candidates that the byline guards must validate
+# alongside the environment value (fail closed on the ambiguity).
+# Codex P1 on PR #442 r4.
+STANDALONE_GH_AS_AUTHOR_IDENTITY=""
+STANDALONE_GH_AS_REVIEWER_IDENTITY=""
 GLOBAL_REPO=""
 PR_SUBCOMMAND=""
 PR_SUBCOMMAND_INDEX=-1    # index in TOKENS where the gh pr subcommand was found
@@ -738,18 +747,32 @@ for i in "${!TOKENS[@]}"; do
         INLINE_BREAK_GLASS_ADMIN=""
         INLINE_BREAK_GLASS_MERGE_STATE=""
       fi
-      # Identity assignments NEVER survive a separator — unlike the
-      # break-glass vars above, their consumer is the WRAPPER process
-      # environment, not this hook. A prefix assignment scopes to its
-      # own command's environment, and a standalone assignment sets an
-      # unexported shell variable the wrapper never receives. Carrying
-      # either across a separator mis-models bash both ways: a stale
-      # prefix value falsely blocks later wrapper writes (Codex P2 on
-      # PR #442 r1), and a standalone value makes the hook believe the
-      # wrapper is configured with an identity it never sees — a
-      # wrong-byline hole in custom-author repos (Codex P2 on PR #442
-      # r3). Exported variables are still caught via the hook's own
-      # environment.
+      # Identity assignments: their consumer is the WRAPPER process
+      # environment, not this hook, and what survives a separator
+      # depends on HOW the assignment appeared (Codex P2s/P1 on PR
+      # #442 r1/r3/r4):
+      #   - PREFIX to an earlier command (`VAR=x echo ok ; wrapper`):
+      #     the shell restores the variable after that command —
+      #     provably ineffective for later segments. Drop it, or a
+      #     stale value falsely blocks later wrapper writes (r1).
+      #   - STANDALONE (`VAR=x ; wrapper` / `VAR=x && wrapper`): the
+      #     value persists as a shell variable, and IF the name
+      #     already carries the export attribute in the calling shell
+      #     it also reaches the wrapper (r4). The hook cannot see the
+      #     export attribute, so the value is stashed as a
+      #     possibly-effective candidate that the byline guards
+      #     validate IN ADDITION to the environment/default value —
+      #     fail closed on the ambiguity (this also covers r3, where
+      #     an unexported standalone value would have masked the
+      #     wrapper falling back to its stock default).
+      if [ "$SEGMENT_HAS_COMMAND" -eq 0 ]; then
+        if [ -n "$INLINE_GH_AS_AUTHOR_IDENTITY" ]; then
+          STANDALONE_GH_AS_AUTHOR_IDENTITY="$INLINE_GH_AS_AUTHOR_IDENTITY"
+        fi
+        if [ -n "$INLINE_GH_AS_REVIEWER_IDENTITY" ]; then
+          STANDALONE_GH_AS_REVIEWER_IDENTITY="$INLINE_GH_AS_REVIEWER_IDENTITY"
+        fi
+      fi
       INLINE_GH_AS_AUTHOR_IDENTITY=""
       INLINE_GH_AS_REVIEWER_IDENTITY=""
       SEGMENT_HAS_COMMAND=0
@@ -1025,18 +1048,31 @@ if [ "$WRAPPER_KIND" = "author" ]; then
     EXPECTED_AUTHOR=$(grep -m1 '^author_identity:' ".github/review-policy.yml" | awk '{print $2}' || true)
   fi
   EXPECTED_AUTHOR="${EXPECTED_AUTHOR:-nathanjohnpayne}"
-  WRAPPER_AUTHOR_IDENTITY="${INLINE_GH_AS_AUTHOR_IDENTITY:-${GH_AS_AUTHOR_IDENTITY:-}}"
-  # Unset means the wrapper will use ITS hard default (nathanjohnpayne)
-  # — compare against that, not against EXPECTED_AUTHOR, so a repo
-  # with a custom GH_PR_GUARD_EXPECTED_AUTHOR fails closed when the
-  # wrapper would actually verify the stock default.
-  WRAPPER_AUTHOR_IDENTITY="${WRAPPER_AUTHOR_IDENTITY:-nathanjohnpayne}"
-  if [ "$WRAPPER_AUTHOR_IDENTITY" != "$EXPECTED_AUTHOR" ]; then
-    echo "BLOCKED: $cmd_label wrapper is configured for author identity '$WRAPPER_AUTHOR_IDENTITY', not expected author '$EXPECTED_AUTHOR'." >&2
-    echo "  gh-as-author.sh verifies whatever login GH_AS_AUTHOR_IDENTITY names; a non-author login here lands the write under the wrong byline (#438)." >&2
-    echo "  Unset GH_AS_AUTHOR_IDENTITY (wrapper default: nathanjohnpayne), or set GH_PR_GUARD_EXPECTED_AUTHOR if this repo's author identity genuinely differs." >&2
-    exit 2
+  # Candidate model (Codex P1 on PR #442 r4): a same-segment prefix on
+  # the wrapper command is DEFINITIVE (it reaches the wrapper's
+  # environment regardless of export attribute). Otherwise the wrapper
+  # may see EITHER the hook's environment value / the wrapper's hard
+  # default (nathanjohnpayne) OR a standalone assignment from an
+  # earlier segment (effective only if the name carries the export
+  # attribute, which the hook cannot observe). Every possibly-effective
+  # candidate must match the expected author — fail closed on the
+  # ambiguity.
+  if [ -n "$INLINE_GH_AS_AUTHOR_IDENTITY" ]; then
+    AUTHOR_IDENTITY_CANDIDATES="$INLINE_GH_AS_AUTHOR_IDENTITY"
+  else
+    AUTHOR_IDENTITY_CANDIDATES="${GH_AS_AUTHOR_IDENTITY:-nathanjohnpayne}"
+    if [ -n "$STANDALONE_GH_AS_AUTHOR_IDENTITY" ]; then
+      AUTHOR_IDENTITY_CANDIDATES="$AUTHOR_IDENTITY_CANDIDATES $STANDALONE_GH_AS_AUTHOR_IDENTITY"
+    fi
   fi
+  for WRAPPER_AUTHOR_IDENTITY in $AUTHOR_IDENTITY_CANDIDATES; do
+    if [ "$WRAPPER_AUTHOR_IDENTITY" != "$EXPECTED_AUTHOR" ]; then
+      echo "BLOCKED: $cmd_label wrapper may run under author identity '$WRAPPER_AUTHOR_IDENTITY', not expected author '$EXPECTED_AUTHOR'." >&2
+      echo "  gh-as-author.sh verifies whatever login GH_AS_AUTHOR_IDENTITY names; a non-author login here lands the write under the wrong byline (#438)." >&2
+      echo "  Unset GH_AS_AUTHOR_IDENTITY (wrapper default: nathanjohnpayne) and drop any standalone GH_AS_AUTHOR_IDENTITY=... assignment from the command, or set GH_PR_GUARD_EXPECTED_AUTHOR if this repo's author identity genuinely differs." >&2
+      exit 2
+    fi
+  done
 fi
 
 # --- byline guard for pr comment / pr review / issue comment ---
@@ -1067,17 +1103,30 @@ else
 fi
 if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS_ISSUE_COMMENT" -eq 1 ]; then
   if [ "$WRAPPER_KIND" = "reviewer" ]; then
-    WRAPPER_REVIEWER_IDENTITY="${INLINE_GH_AS_REVIEWER_IDENTITY:-${GH_AS_REVIEWER_IDENTITY:-}}"
-    if [ -z "$WRAPPER_REVIEWER_IDENTITY" ] && [ -n "${MERGEPATH_AGENT:-}" ]; then
-      WRAPPER_REVIEWER_IDENTITY="nathanpayne-$MERGEPATH_AGENT"
+    # Same candidate model as the author guard above (Codex P1 on PR
+    # #442 r4): a same-segment prefix is definitive; otherwise both
+    # the env/default resolution AND any standalone assignment from an
+    # earlier segment are possibly effective and must ALL match.
+    if [ -n "$INLINE_GH_AS_REVIEWER_IDENTITY" ]; then
+      REVIEWER_IDENTITY_CANDIDATES="$INLINE_GH_AS_REVIEWER_IDENTITY"
+    else
+      REVIEWER_IDENTITY_CANDIDATES="${GH_AS_REVIEWER_IDENTITY:-}"
+      if [ -z "$REVIEWER_IDENTITY_CANDIDATES" ] && [ -n "${MERGEPATH_AGENT:-}" ]; then
+        REVIEWER_IDENTITY_CANDIDATES="nathanpayne-$MERGEPATH_AGENT"
+      fi
+      REVIEWER_IDENTITY_CANDIDATES="${REVIEWER_IDENTITY_CANDIDATES:-nathanpayne-claude}"
+      if [ -n "$STANDALONE_GH_AS_REVIEWER_IDENTITY" ]; then
+        REVIEWER_IDENTITY_CANDIDATES="$REVIEWER_IDENTITY_CANDIDATES $STANDALONE_GH_AS_REVIEWER_IDENTITY"
+      fi
     fi
-    WRAPPER_REVIEWER_IDENTITY="${WRAPPER_REVIEWER_IDENTITY:-nathanpayne-claude}"
-    if [ "$WRAPPER_REVIEWER_IDENTITY" != "$EXPECTED_REVIEWER" ]; then
-      echo "BLOCKED: $cmd_label wrapper is configured for '$WRAPPER_REVIEWER_IDENTITY', not expected reviewer '$EXPECTED_REVIEWER'." >&2
-      echo "  Expected reviewer source: $EXPECTED_REVIEWER_SOURCE" >&2
-      echo "  Set GH_AS_REVIEWER_IDENTITY=$EXPECTED_REVIEWER or MERGEPATH_AGENT=<agent> consistently." >&2
-      exit 2
-    fi
+    for WRAPPER_REVIEWER_IDENTITY in $REVIEWER_IDENTITY_CANDIDATES; do
+      if [ "$WRAPPER_REVIEWER_IDENTITY" != "$EXPECTED_REVIEWER" ]; then
+        echo "BLOCKED: $cmd_label wrapper may run under '$WRAPPER_REVIEWER_IDENTITY', not expected reviewer '$EXPECTED_REVIEWER'." >&2
+        echo "  Expected reviewer source: $EXPECTED_REVIEWER_SOURCE" >&2
+        echo "  Set GH_AS_REVIEWER_IDENTITY=$EXPECTED_REVIEWER or MERGEPATH_AGENT=<agent> consistently, and drop any standalone GH_AS_REVIEWER_IDENTITY=... assignment from the command." >&2
+        exit 2
+      fi
+    done
   fi
 fi
 

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -989,6 +989,34 @@ if [ "$WRAPPER_KIND" = "reviewer" ] && [ "$REVIEWER_WRAPPER_ALLOWED" -ne 1 ]; th
   exit 2
 fi
 
+# --- byline guard for author-wrapper writes (#438) --------------------
+#
+# gh-as-author.sh verifies the token for whatever login
+# GH_AS_AUTHOR_IDENTITY names — its default is nathanjohnpayne, but a
+# shell where the variable is exported (or inline-prefixed) as a
+# different login makes the wrapper verify THAT login's token and run
+# `gh pr merge`/`edit`/`create` under it. Pin the wrapper's effective
+# author identity to the expected author, exactly as the reviewer
+# branch below pins the reviewer identity. Without this,
+# `GH_AS_AUTHOR_IDENTITY=nathanpayne-codex scripts/gh-as-author.sh --
+# gh pr merge ...` re-opens the wrong-byline merge/edit path the
+# wrapper migration closed (the #359 class).
+if [ "$WRAPPER_KIND" = "author" ]; then
+  EXPECTED_AUTHOR="${GH_PR_GUARD_EXPECTED_AUTHOR:-nathanjohnpayne}"
+  WRAPPER_AUTHOR_IDENTITY="${INLINE_GH_AS_AUTHOR_IDENTITY:-${GH_AS_AUTHOR_IDENTITY:-}}"
+  # Unset means the wrapper will use ITS hard default (nathanjohnpayne)
+  # — compare against that, not against EXPECTED_AUTHOR, so a repo
+  # with a custom GH_PR_GUARD_EXPECTED_AUTHOR fails closed when the
+  # wrapper would actually verify the stock default.
+  WRAPPER_AUTHOR_IDENTITY="${WRAPPER_AUTHOR_IDENTITY:-nathanjohnpayne}"
+  if [ "$WRAPPER_AUTHOR_IDENTITY" != "$EXPECTED_AUTHOR" ]; then
+    echo "BLOCKED: $cmd_label wrapper is configured for author identity '$WRAPPER_AUTHOR_IDENTITY', not expected author '$EXPECTED_AUTHOR'." >&2
+    echo "  gh-as-author.sh verifies whatever login GH_AS_AUTHOR_IDENTITY names; a non-author login here lands the write under the wrong byline (#438)." >&2
+    echo "  Unset GH_AS_AUTHOR_IDENTITY (wrapper default: nathanjohnpayne), or set GH_PR_GUARD_EXPECTED_AUTHOR if this repo's author identity genuinely differs." >&2
+    exit 2
+  fi
+fi
+
 # --- byline guard for pr comment / pr review / issue comment ---
 #
 # These three subcommands share a single policy: reviewer writes must be

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -1045,10 +1045,11 @@ if [ "$WRAPPER_KIND" = "author" ]; then
   # then the fleet default.
   EXPECTED_AUTHOR="${GH_PR_GUARD_EXPECTED_AUTHOR:-}"
   if [ -z "$EXPECTED_AUTHOR" ] && [ -f ".github/review-policy.yml" ]; then
-    # Strip surrounding double quotes — `author_identity: "custom-owner"`
-    # is valid YAML and the same quote-tolerance the policy parsers in
-    # codex-review-request.sh / the lane apply (Codex P2 on PR #442 r6).
-    EXPECTED_AUTHOR=$(grep -m1 '^author_identity:' ".github/review-policy.yml" | awk '{print $2}' | sed -E 's/^"//; s/"$//' || true)
+    # Strip surrounding double OR single quotes — both are valid YAML
+    # scalars (`author_identity: "custom-owner"` / `'custom-owner'`),
+    # matching the quote-tolerance of the sibling policy parsers
+    # (Codex P2s on PR #442 r6/r7).
+    EXPECTED_AUTHOR=$(grep -m1 '^author_identity:' ".github/review-policy.yml" | awk '{print $2}' | sed -E "s/^[\"']//; s/[\"']\$//" || true)
   fi
   EXPECTED_AUTHOR="${EXPECTED_AUTHOR:-nathanjohnpayne}"
   # Candidate model (Codex P1 on PR #442 r4): a same-segment prefix on

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -1045,7 +1045,10 @@ if [ "$WRAPPER_KIND" = "author" ]; then
   # then the fleet default.
   EXPECTED_AUTHOR="${GH_PR_GUARD_EXPECTED_AUTHOR:-}"
   if [ -z "$EXPECTED_AUTHOR" ] && [ -f ".github/review-policy.yml" ]; then
-    EXPECTED_AUTHOR=$(grep -m1 '^author_identity:' ".github/review-policy.yml" | awk '{print $2}' || true)
+    # Strip surrounding double quotes — `author_identity: "custom-owner"`
+    # is valid YAML and the same quote-tolerance the policy parsers in
+    # codex-review-request.sh / the lane apply (Codex P2 on PR #442 r6).
+    EXPECTED_AUTHOR=$(grep -m1 '^author_identity:' ".github/review-policy.yml" | awk '{print $2}' | sed -E 's/^"//; s/"$//' || true)
   fi
   EXPECTED_AUTHOR="${EXPECTED_AUTHOR:-nathanjohnpayne}"
   # Candidate model (Codex P1 on PR #442 r4): a same-segment prefix on

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -375,6 +375,29 @@ prefix_flag_takes_value() {
 }
 
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD_REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"
+
+# Locate the governing review-policy.yml without trusting the caller's
+# cwd to BE the repo root (Codex P2 on PR #442 r21): walk upward from
+# the cwd (covers subdirectory invocations and out-of-tree fixture
+# repos), then fall back to the hook's own repo root (the hook is
+# installed at <root>/scripts/hooks/, so script root == project root
+# in production). Echoes the path or nothing.
+guard_policy_file() {
+  local d="$PWD"
+  while [ -n "$d" ] && [ "$d" != "/" ]; do
+    if [ -f "$d/.github/review-policy.yml" ]; then
+      printf '%s\n' "$d/.github/review-policy.yml"
+      return 0
+    fi
+    d="$(dirname "$d")"
+  done
+  if [ -f "$GUARD_REPO_ROOT/.github/review-policy.yml" ]; then
+    printf '%s\n' "$GUARD_REPO_ROOT/.github/review-policy.yml"
+    return 0
+  fi
+  return 1
+}
 REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"
 CANON_AUTHOR_WRAPPER="$REPO_ROOT/scripts/gh-as-author.sh"
 CANON_REVIEWER_WRAPPER="$REPO_ROOT/scripts/gh-as-reviewer.sh"
@@ -1202,12 +1225,14 @@ if [ "$WRAPPER_KIND" = "author" ]; then
   # need no hook-specific variable — Codex P2 on PR #442 round 2),
   # then the fleet default.
   EXPECTED_AUTHOR="${GH_PR_GUARD_EXPECTED_AUTHOR:-}"
-  if [ -z "$EXPECTED_AUTHOR" ] && [ -f ".github/review-policy.yml" ]; then
+  GUARD_POLICY_FILE="$(guard_policy_file || true)"
+  if [ -z "$EXPECTED_AUTHOR" ] && [ -n "$GUARD_POLICY_FILE" ]; then
     # Strip surrounding double OR single quotes — both are valid YAML
     # scalars (`author_identity: "custom-owner"` / `'custom-owner'`),
     # matching the quote-tolerance of the sibling policy parsers
-    # (Codex P2s on PR #442 r6/r7).
-    EXPECTED_AUTHOR=$(grep -m1 '^author_identity:' ".github/review-policy.yml" | awk '{print $2}' | sed -E "s/^[\"']//; s/[\"']\$//" || true)
+    # (Codex P2s on PR #442 r6/r7). Policy located via upward walk +
+    # script-root fallback per r21.
+    EXPECTED_AUTHOR=$(grep -m1 '^author_identity:' "$GUARD_POLICY_FILE" | awk '{print $2}' | sed -E "s/^[\"']//; s/[\"']\$//" || true)
   fi
   EXPECTED_AUTHOR="${EXPECTED_AUTHOR:-nathanjohnpayne}"
   # Candidate model (Codex P1 on PR #442 r4): a same-segment prefix on
@@ -1451,7 +1476,7 @@ if [ "$PR_SUBCOMMAND" = "review" ]; then
         # additions + deletions from the PR JSON; over if sum >= threshold
         # OR threshold can't be determined (fail safe).
         threshold=""
-        policy_path=".github/review-policy.yml"
+        policy_path="$(guard_policy_file || true)"
         if [ -f "$policy_path" ]; then
           threshold=$(grep -oE '^[[:space:]]*external_review_threshold:[[:space:]]*[0-9]+' "$policy_path" | head -1 | grep -oE '[0-9]+$' || true)
         fi

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -367,7 +367,7 @@ prefix_flag_takes_value() {
     ionice:-c|ionice:-n|ionice:-p)
       return 0
       ;;
-    env:-u|env:-S)
+    env:-u|env:-S|env:--unset)
       return 0
       ;;
   esac
@@ -725,7 +725,7 @@ for i in "${!TOKENS[@]}"; do
     # r15 empty-override semantics — the wrapper falls back to its
     # hardcoded default, which a custom-author repo must fail closed
     # on (Codex P2 on PR #442 r17, env --help verified).
-    if [ "$PENDING_PREFIX_FLAG" = "env:-u" ]; then
+    if [ "$PENDING_PREFIX_FLAG" = "env:-u" ] || [ "$PENDING_PREFIX_FLAG" = "env:--unset" ]; then
       case "$tok" in
         GH_AS_AUTHOR_IDENTITY)
           INLINE_GH_AS_AUTHOR_IDENTITY=""

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -610,6 +610,15 @@ INLINE_GH_AS_REVIEWER_IDENTITY=""
 # Codex P1 on PR #442 r4.
 STANDALONE_GH_AS_AUTHOR_IDENTITY=""
 STANDALONE_GH_AS_REVIEWER_IDENTITY=""
+# Set-ness flags: an EMPTY assignment (`GH_AS_AUTHOR_IDENTITY= wrapper`)
+# is NOT absent — it resets the wrapper to its hardcoded default, which
+# in a custom-author repo differs from the expected author (Codex P1 on
+# PR #442 r15). Every capture records both the value and that an
+# assignment happened.
+INLINE_GH_AS_AUTHOR_IDENTITY_SET=0
+INLINE_GH_AS_REVIEWER_IDENTITY_SET=0
+STANDALONE_GH_AS_AUTHOR_IDENTITY_SET=0
+STANDALONE_GH_AS_REVIEWER_IDENTITY_SET=0
 GLOBAL_REPO=""
 PR_SUBCOMMAND=""
 PR_SUBCOMMAND_INDEX=-1    # index in TOKENS where the gh pr subcommand was found
@@ -776,16 +785,20 @@ for i in "${!TOKENS[@]}"; do
         # assignments are standalone-equivalent; assignments that
         # were prefixes TO the eval are over-captured on purpose,
         # the fail-closed direction).
-        if [ -n "$INLINE_GH_AS_AUTHOR_IDENTITY" ]; then
+        if [ "$INLINE_GH_AS_AUTHOR_IDENTITY_SET" -eq 1 ]; then
           STANDALONE_GH_AS_AUTHOR_IDENTITY="$INLINE_GH_AS_AUTHOR_IDENTITY"
+          STANDALONE_GH_AS_AUTHOR_IDENTITY_SET=1
         fi
-        if [ -n "$INLINE_GH_AS_REVIEWER_IDENTITY" ]; then
+        if [ "$INLINE_GH_AS_REVIEWER_IDENTITY_SET" -eq 1 ]; then
           STANDALONE_GH_AS_REVIEWER_IDENTITY="$INLINE_GH_AS_REVIEWER_IDENTITY"
+          STANDALONE_GH_AS_REVIEWER_IDENTITY_SET=1
         fi
       fi
       SEGMENT_HAS_EVAL=0
       INLINE_GH_AS_AUTHOR_IDENTITY=""
       INLINE_GH_AS_REVIEWER_IDENTITY=""
+      INLINE_GH_AS_AUTHOR_IDENTITY_SET=0
+      INLINE_GH_AS_REVIEWER_IDENTITY_SET=0
       SEGMENT_HAS_COMMAND=0
       continue
       ;;
@@ -812,9 +825,11 @@ for i in "${!TOKENS[@]}"; do
         ;;
       GH_AS_AUTHOR_IDENTITY=*)
         INLINE_GH_AS_AUTHOR_IDENTITY="${tok#GH_AS_AUTHOR_IDENTITY=}"
+        INLINE_GH_AS_AUTHOR_IDENTITY_SET=1
         ;;
       GH_AS_REVIEWER_IDENTITY=*)
         INLINE_GH_AS_REVIEWER_IDENTITY="${tok#GH_AS_REVIEWER_IDENTITY=}"
+        INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
         ;;
     esac
   fi
@@ -832,9 +847,11 @@ for i in "${!TOKENS[@]}"; do
       case "$tok" in
         GH_AS_AUTHOR_IDENTITY=*)
           STANDALONE_GH_AS_AUTHOR_IDENTITY="${tok#GH_AS_AUTHOR_IDENTITY=}"
+          STANDALONE_GH_AS_AUTHOR_IDENTITY_SET=1
           ;;
         GH_AS_REVIEWER_IDENTITY=*)
           STANDALONE_GH_AS_REVIEWER_IDENTITY="${tok#GH_AS_REVIEWER_IDENTITY=}"
+          STANDALONE_GH_AS_REVIEWER_IDENTITY_SET=1
           ;;
       esac
     fi
@@ -864,11 +881,13 @@ for i in "${!TOKENS[@]}"; do
     # already-captured inline identity to the definitely-effective
     # slots, or the separator path would discard it as an ordinary
     # command prefix (Codex P1 on PR #442 r12 — wrong-byline class).
-    if [ -n "$INLINE_GH_AS_AUTHOR_IDENTITY" ]; then
+    if [ "$INLINE_GH_AS_AUTHOR_IDENTITY_SET" -eq 1 ]; then
       STANDALONE_GH_AS_AUTHOR_IDENTITY="$INLINE_GH_AS_AUTHOR_IDENTITY"
+      STANDALONE_GH_AS_AUTHOR_IDENTITY_SET=1
     fi
-    if [ -n "$INLINE_GH_AS_REVIEWER_IDENTITY" ]; then
+    if [ "$INLINE_GH_AS_REVIEWER_IDENTITY_SET" -eq 1 ]; then
       STANDALONE_GH_AS_REVIEWER_IDENTITY="$INLINE_GH_AS_REVIEWER_IDENTITY"
+      STANDALONE_GH_AS_REVIEWER_IDENTITY_SET=1
     fi
     continue
   fi
@@ -1130,12 +1149,15 @@ if [ "$WRAPPER_KIND" = "author" ]; then
   # attribute, which the hook cannot observe). Every possibly-effective
   # candidate must match the expected author — fail closed on the
   # ambiguity.
-  if [ -n "$INLINE_GH_AS_AUTHOR_IDENTITY" ]; then
-    AUTHOR_IDENTITY_CANDIDATES="$INLINE_GH_AS_AUTHOR_IDENTITY"
+  if [ "$INLINE_GH_AS_AUTHOR_IDENTITY_SET" -eq 1 ]; then
+    # Same-segment prefix is definitive. An EMPTY override is not
+    # "absent" — it resets the wrapper to its hardcoded default
+    # (Codex P1 on PR #442 r15).
+    AUTHOR_IDENTITY_CANDIDATES="${INLINE_GH_AS_AUTHOR_IDENTITY:-nathanjohnpayne}"
   else
     AUTHOR_IDENTITY_CANDIDATES="${GH_AS_AUTHOR_IDENTITY:-nathanjohnpayne}"
-    if [ -n "$STANDALONE_GH_AS_AUTHOR_IDENTITY" ]; then
-      AUTHOR_IDENTITY_CANDIDATES="$AUTHOR_IDENTITY_CANDIDATES $STANDALONE_GH_AS_AUTHOR_IDENTITY"
+    if [ "$STANDALONE_GH_AS_AUTHOR_IDENTITY_SET" -eq 1 ]; then
+      AUTHOR_IDENTITY_CANDIDATES="$AUTHOR_IDENTITY_CANDIDATES ${STANDALONE_GH_AS_AUTHOR_IDENTITY:-nathanjohnpayne}"
     fi
   fi
   for WRAPPER_AUTHOR_IDENTITY in $AUTHOR_IDENTITY_CANDIDATES; do
@@ -1180,16 +1202,22 @@ if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS
     # #442 r4): a same-segment prefix is definitive; otherwise both
     # the env/default resolution AND any standalone assignment from an
     # earlier segment are possibly effective and must ALL match.
-    if [ -n "$INLINE_GH_AS_REVIEWER_IDENTITY" ]; then
-      REVIEWER_IDENTITY_CANDIDATES="$INLINE_GH_AS_REVIEWER_IDENTITY"
+    # The wrapper resolves an EMPTY GH_AS_REVIEWER_IDENTITY through its
+    # env-free chain (MERGEPATH_AGENT, then nathanpayne-claude) — an
+    # empty-set assignment maps to that, not to "absent" (r15).
+    REVIEWER_EMPTY_FALLBACK="nathanpayne-claude"
+    if [ -n "${MERGEPATH_AGENT:-}" ]; then
+      REVIEWER_EMPTY_FALLBACK="nathanpayne-$MERGEPATH_AGENT"
+    fi
+    if [ "$INLINE_GH_AS_REVIEWER_IDENTITY_SET" -eq 1 ]; then
+      REVIEWER_IDENTITY_CANDIDATES="${INLINE_GH_AS_REVIEWER_IDENTITY:-$REVIEWER_EMPTY_FALLBACK}"
     else
       REVIEWER_IDENTITY_CANDIDATES="${GH_AS_REVIEWER_IDENTITY:-}"
-      if [ -z "$REVIEWER_IDENTITY_CANDIDATES" ] && [ -n "${MERGEPATH_AGENT:-}" ]; then
-        REVIEWER_IDENTITY_CANDIDATES="nathanpayne-$MERGEPATH_AGENT"
+      if [ -z "$REVIEWER_IDENTITY_CANDIDATES" ]; then
+        REVIEWER_IDENTITY_CANDIDATES="$REVIEWER_EMPTY_FALLBACK"
       fi
-      REVIEWER_IDENTITY_CANDIDATES="${REVIEWER_IDENTITY_CANDIDATES:-nathanpayne-claude}"
-      if [ -n "$STANDALONE_GH_AS_REVIEWER_IDENTITY" ]; then
-        REVIEWER_IDENTITY_CANDIDATES="$REVIEWER_IDENTITY_CANDIDATES $STANDALONE_GH_AS_REVIEWER_IDENTITY"
+      if [ "$STANDALONE_GH_AS_REVIEWER_IDENTITY_SET" -eq 1 ]; then
+        REVIEWER_IDENTITY_CANDIDATES="$REVIEWER_IDENTITY_CANDIDATES ${STANDALONE_GH_AS_REVIEWER_IDENTITY:-$REVIEWER_EMPTY_FALLBACK}"
       fi
     fi
     for WRAPPER_REVIEWER_IDENTITY in $REVIEWER_IDENTITY_CANDIDATES; do

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -835,10 +835,15 @@ for i in "${!TOKENS[@]}"; do
     continue
   fi
 
-  # `export` at command position: its assignment arguments reach all
-  # later processes. Flag the segment so the skip-path above captures
-  # the identity assignments that follow.
-  if [ "$tok" = "export" ]; then
+  # `export` (and its declaration-builtin equivalents `declare` /
+  # `typeset`, whose -x flag exports) at command position: assignment
+  # arguments can reach all later processes. Flag the segment so the
+  # skip-path above captures the identity assignments that follow.
+  # declare/typeset without -x are over-captured on purpose — the
+  # candidate model only blocks MISMATCHED values, so the cost of the
+  # ambiguity is a false block on a non-exported mismatched declare,
+  # which is the fail-closed direction for a byline guard.
+  if [ "$tok" = "export" ] || [ "$tok" = "declare" ] || [ "$tok" = "typeset" ]; then
     IN_EXPORT_SEGMENT=1
     SEGMENT_HAS_COMMAND=1
     AT_COMMAND_POSITION=0

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -637,6 +637,8 @@ SEGMENT_HAS_EVAL=0       # 1 = current segment ran `eval` — an eval'd
                          # assignment persists like a bare standalone
 PENDING_PREFIX_FLAG=""   # "<prefix>:<flag>" whose value the next token is
                          # (lets the consumer recognize `env -u NAME`)
+IDENTITY_ENV_CLEARED_FOR_WRAPPER=0  # 1 = env -i seen: the wrapper sees an
+                         # EMPTY environment (no MERGEPATH_AGENT either)
 for i in "${!TOKENS[@]}"; do
   tok="${TOKENS[$i]}"
   # --- phase 2: walking after gh, looking for pr + subcommand ---
@@ -1017,6 +1019,12 @@ for i in "${!TOKENS[@]}"; do
             INLINE_GH_AS_AUTHOR_IDENTITY_SET=1
             INLINE_GH_AS_REVIEWER_IDENTITY=""
             INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
+            # env -i clears EVERYTHING the wrapper would see —
+            # including MERGEPATH_AGENT — so the reviewer fallback
+            # must be the wrapper's bare hardcoded default, not the
+            # hook environment's agent chain (Codex P1 on PR #442
+            # r19).
+            IDENTITY_ENV_CLEARED_FOR_WRAPPER=1
             continue
             ;;
         esac
@@ -1268,7 +1276,10 @@ if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS
     # env-free chain (MERGEPATH_AGENT, then nathanpayne-claude) — an
     # empty-set assignment maps to that, not to "absent" (r15).
     REVIEWER_EMPTY_FALLBACK="nathanpayne-claude"
-    if [ -n "${MERGEPATH_AGENT:-}" ]; then
+    if [ -n "${MERGEPATH_AGENT:-}" ] && [ "$IDENTITY_ENV_CLEARED_FOR_WRAPPER" -eq 0 ]; then
+      # env -i strips MERGEPATH_AGENT from the wrapper too — in that
+      # case the wrapper's chain bottoms out at its hardcoded default
+      # regardless of the hook environment (r19).
       REVIEWER_EMPTY_FALLBACK="nathanpayne-$MERGEPATH_AGENT"
     fi
     if [ "$INLINE_GH_AS_REVIEWER_IDENTITY_SET" -eq 1 ]; then

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -835,15 +835,17 @@ for i in "${!TOKENS[@]}"; do
     continue
   fi
 
-  # `export` (and its declaration-builtin equivalents `declare` /
-  # `typeset`, whose -x flag exports) at command position: assignment
-  # arguments can reach all later processes. Flag the segment so the
-  # skip-path above captures the identity assignments that follow.
-  # declare/typeset without -x are over-captured on purpose — the
-  # candidate model only blocks MISMATCHED values, so the cost of the
-  # ambiguity is a false block on a non-exported mismatched declare,
-  # which is the fail-closed direction for a byline guard.
-  if [ "$tok" = "export" ] || [ "$tok" = "declare" ] || [ "$tok" = "typeset" ]; then
+  # Declaration builtins (`export`, `declare`, `typeset`, `readonly`,
+  # `local`) at command position: their assignment arguments can reach
+  # all later processes (-x exports; readonly -x verified on PR #442
+  # r14). Flag the segment so the skip-path above captures the
+  # identity assignments that follow. Variants without -x are
+  # over-captured on purpose — the candidate model only blocks
+  # MISMATCHED values, so the cost of the ambiguity is a false block
+  # on a non-exported mismatched declaration, which is the fail-closed
+  # direction for a byline guard.
+  case "$tok" in export|declare|typeset|readonly|local) IS_DECLARATION_BUILTIN=1 ;; *) IS_DECLARATION_BUILTIN=0 ;; esac
+  if [ "$IS_DECLARATION_BUILTIN" -eq 1 ]; then
     IN_EXPORT_SEGMENT=1
     SEGMENT_HAS_COMMAND=1
     AT_COMMAND_POSITION=0

--- a/tests/test_coderabbit_wait_identity_derivation.sh
+++ b/tests/test_coderabbit_wait_identity_derivation.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# Regression coverage for coderabbit-wait.sh's token-derived expected
+# reviewer identity (#438).
+#
+# Runs the real helper from a temp repo with stubbed gh/date/sleep and a
+# stubbed identity-check.sh. The write path exercised is the timeout
+# status probe (the first reviewer-token write the helper can reach
+# deterministically). Asserts:
+#   1. With NO identity envs set, the expected identity is derived from
+#      the token's login when that login is in available_reviewers —
+#      not hard-defaulted to nathanpayne-claude.
+#   2. A token login NOT in available_reviewers falls back to the
+#      static default (fail-closed: verification then fails and no
+#      write is posted).
+#   3. An explicit GH_AS_REVIEWER_IDENTITY wins and no derivation
+#      lookup (`gh api user`) is made.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/coderabbit-wait-identity.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+make_case() {
+  local name=$1
+  local dir="$WORKDIR/$name"
+
+  mkdir -p "$dir/scripts/lib" "$dir/.github" "$dir/bin" "$dir/state"
+  cp "$ROOT/scripts/coderabbit-wait.sh" "$dir/scripts/coderabbit-wait.sh"
+  cp "$ROOT/scripts/lib/gh-token-resolver.sh" "$dir/scripts/lib/gh-token-resolver.sh"
+  chmod +x "$dir/scripts/coderabbit-wait.sh"
+
+  cat >"$dir/.github/review-policy.yml" <<'EOF'
+available_reviewers:
+  - nathanpayne-claude
+  - nathanpayne-cursor
+  - nathanpayne-codex
+
+coderabbit:
+  bot_login: "coderabbitai[bot]"
+  max_wait_seconds: 1
+  status_probe_enabled: true
+  status_probe_wait_seconds: 1
+  max_rate_limit_retries: 2
+  wallclock_freshness_window_seconds: 999999999
+  trust_status_context_for_clearance: false
+EOF
+
+  # identity-check stub: records the expected identity it was asked to
+  # verify, succeeds iff that identity matches the stub token's login.
+  cat >"$dir/scripts/identity-check.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state_dir=${CODERABBIT_TEST_STATE_DIR:?}
+[ "${1:-}" = "--expect-token-identity" ] || exit 2
+printf '%s\n' "${2:-}" >>"$state_dir/identity-args"
+[ "${2:-}" = "${CODERABBIT_TEST_TOKEN_LOGIN:?}" ] || exit 1
+exit 0
+EOF
+  chmod +x "$dir/scripts/identity-check.sh"
+
+  cat >"$dir/bin/date" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state_dir=${CODERABBIT_TEST_STATE_DIR:?}
+clock_file="$state_dir/fake-time"
+if [ ! -f "$clock_file" ]; then
+  printf '2000000000\n' >"$clock_file"
+fi
+if [ "$#" -eq 1 ] && [ "$1" = "+%s" ]; then
+  cat "$clock_file"
+  exit 0
+fi
+exec /bin/date "$@"
+EOF
+  chmod +x "$dir/bin/date"
+
+  cat >"$dir/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state_dir=${CODERABBIT_TEST_STATE_DIR:?}
+clock_file="$state_dir/fake-time"
+if [ ! -f "$clock_file" ]; then
+  printf '2000000000\n' >"$clock_file"
+fi
+duration=${1:-0}
+case "$duration" in
+  *.*) duration=${duration%%.*} ;;
+esac
+current=$(cat "$clock_file")
+printf '%s\n' $((current + duration)) >"$clock_file"
+EOF
+  chmod +x "$dir/bin/sleep"
+
+  cat >"$dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state_dir=${CODERABBIT_TEST_STATE_DIR:?}
+head_time='2026-06-04T00:00:00Z'
+
+if [ "${1:-}" != "api" ]; then
+  echo "unexpected gh command: $*" >&2
+  exit 99
+fi
+shift
+
+method="GET"
+if [ "${1:-}" = "--method" ]; then
+  method=${2:-}
+  shift 2
+fi
+if [ "${1:-}" = "--paginate" ]; then
+  shift
+fi
+
+endpoint=${1:-}
+shift || true
+
+if [ "$method" = "POST" ]; then
+  case "$endpoint" in
+    repos/owner/repo/issues/999/comments)
+      count=0
+      if [ -f "$state_dir/post-count" ]; then
+        count=$(cat "$state_dir/post-count")
+      fi
+      count=$((count + 1))
+      printf '%s\n' "$count" >"$state_dir/post-count"
+      printf '{"id":900%s,"created_at":"%s","body":"probe"}\n' "$count" "$head_time"
+      ;;
+    *)
+      echo "unexpected gh api POST endpoint: $endpoint" >&2
+      exit 99
+      ;;
+  esac
+  exit 0
+fi
+
+case "$endpoint" in
+  user)
+    count=0
+    if [ -f "$state_dir/api-user-count" ]; then
+      count=$(cat "$state_dir/api-user-count")
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" >"$state_dir/api-user-count"
+    printf '%s\n' "${CODERABBIT_TEST_TOKEN_LOGIN:?}"
+    ;;
+  repos/owner/repo/pulls/999)
+    printf '{"head":{"sha":"head-sha"}}\n'
+    ;;
+  repos/owner/repo/commits/head-sha)
+    if [ "${1:-}" = "--jq" ]; then
+      printf '%s\n' "$head_time"
+    else
+      printf '{"commit":{"committer":{"date":"%s"}}}\n' "$head_time"
+    fi
+    ;;
+  repos/owner/repo/issues/999/timeline)
+    printf '[]\n'
+    ;;
+  repos/owner/repo/pulls/999/reviews)
+    printf '[]\n'
+    ;;
+  repos/owner/repo/pulls/999/comments)
+    printf '[]\n'
+    ;;
+  repos/owner/repo/issues/999/comments)
+    printf '[]\n'
+    ;;
+  *)
+    echo "unexpected gh api endpoint: $endpoint" >&2
+    exit 99
+    ;;
+esac
+EOF
+  chmod +x "$dir/bin/gh"
+
+  printf '%s\n' "$dir"
+}
+
+run_case() {
+  local dir=$1
+  local token_login=$2
+  local explicit_identity=${3:-}
+  local rc=0
+
+  (
+    cd "$dir"
+    env_args=(
+      PATH="$dir/bin:$PATH"
+      GH_TOKEN=test-token
+      CODERABBIT_TEST_STATE_DIR="$dir/state"
+      CODERABBIT_TEST_TOKEN_LOGIN="$token_login"
+    )
+    if [ -n "$explicit_identity" ]; then
+      env_args+=(GH_AS_REVIEWER_IDENTITY="$explicit_identity")
+    fi
+    env -u MERGEPATH_AGENT -u OP_PREFLIGHT_AGENT -u GH_AS_REVIEWER_IDENTITY \
+      "${env_args[@]}" \
+      ./scripts/coderabbit-wait.sh 999 owner/repo \
+      >"$dir/out.json" 2>"$dir/err.log"
+  ) || rc=$?
+
+  printf '%s\n' "$rc"
+}
+
+state_file() {
+  local dir=$1 name=$2
+  if [ -f "$dir/state/$name" ]; then
+    cat "$dir/state/$name"
+  else
+    printf ''
+  fi
+}
+
+test_derives_identity_from_allow_listed_token() {
+  local dir rc args posts
+  dir=$(make_case "derived-cursor")
+  rc=$(run_case "$dir" nathanpayne-cursor)
+  args=$(state_file "$dir" identity-args)
+  posts=$(state_file "$dir" post-count)
+
+  if [ "$args" != "nathanpayne-cursor" ]; then
+    fail "derived identity: identity-check expected args 'nathanpayne-cursor', got '$args'; stderr=$(cat "$dir/err.log")"
+  elif [ "${posts:-0}" -lt 1 ]; then
+    fail "derived identity: probe write was not posted (post-count='$posts'); stderr=$(cat "$dir/err.log")"
+  elif ! grep -q "derived expected reviewer identity 'nathanpayne-cursor'" "$dir/err.log"; then
+    fail "derived identity: missing derivation log line; stderr=$(cat "$dir/err.log")"
+  else
+    pass "expected identity derived from allow-listed token login (rc=$rc)"
+  fi
+}
+
+test_non_allow_listed_token_fails_closed() {
+  local dir rc args posts
+  dir=$(make_case "mallory")
+  rc=$(run_case "$dir" mallory-user)
+  args=$(state_file "$dir" identity-args)
+  posts=$(state_file "$dir" post-count)
+
+  if [ "$args" != "nathanpayne-claude" ]; then
+    fail "fail-closed: identity-check expected args 'nathanpayne-claude' (static default), got '$args'; stderr=$(cat "$dir/err.log")"
+  elif [ -n "$posts" ]; then
+    fail "fail-closed: a write was posted ($posts) despite identity verification failing"
+  else
+    pass "non-allow-listed token falls back to static default and posts nothing (rc=$rc)"
+  fi
+}
+
+test_explicit_identity_skips_derivation() {
+  local dir rc args user_calls
+  dir=$(make_case "explicit-codex")
+  rc=$(run_case "$dir" nathanpayne-codex nathanpayne-codex)
+  args=$(state_file "$dir" identity-args)
+  user_calls=$(state_file "$dir" api-user-count)
+
+  if [ "$args" != "nathanpayne-codex" ]; then
+    fail "explicit identity: identity-check expected args 'nathanpayne-codex', got '$args'; stderr=$(cat "$dir/err.log")"
+  elif [ -n "$user_calls" ]; then
+    fail "explicit identity: derivation lookup ran ($user_calls api-user calls) despite explicit GH_AS_REVIEWER_IDENTITY"
+  else
+    pass "explicit GH_AS_REVIEWER_IDENTITY wins; no derivation lookup (rc=$rc)"
+  fi
+}
+
+test_derives_identity_from_allow_listed_token
+test_non_allow_listed_token_fails_closed
+test_explicit_identity_skips_derivation
+
+echo ""
+echo "test_coderabbit_wait_identity_derivation: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test_coderabbit_wait_identity_derivation.sh
+++ b/tests/test_coderabbit_wait_identity_derivation.sh
@@ -38,9 +38,9 @@ make_case() {
 
   cat >"$dir/.github/review-policy.yml" <<'EOF'
 available_reviewers:
-  - nathanpayne-claude
+  - nathanpayne-claude  # default agent
   - 'nathanpayne-cursor'
-  - "nathanpayne-codex"
+  - "nathanpayne-codex" # quoted + inline comment
 
 coderabbit:
   bot_login: "coderabbitai[bot]"
@@ -270,7 +270,23 @@ test_explicit_identity_skips_derivation() {
   fi
 }
 
+test_derives_identity_from_quoted_commented_entry() {
+  local dir rc args
+  dir=$(make_case "derived-codex-quoted-commented")
+  rc=$(run_case "$dir" nathanpayne-codex)
+  args=$(state_file "$dir" identity-args)
+
+  if [ "$args" != "nathanpayne-codex" ]; then
+    fail "quoted+commented entry: identity-check expected args 'nathanpayne-codex', got '$args'; stderr=$(cat "$dir/err.log")"
+  elif ! grep -q "derived expected reviewer identity 'nathanpayne-codex'" "$dir/err.log"; then
+    fail "quoted+commented entry: missing derivation log line; stderr=$(cat "$dir/err.log")"
+  else
+    pass "allow-list entry with quotes AND inline comment is normalized for derivation (rc=$rc)"
+  fi
+}
+
 test_derives_identity_from_allow_listed_token
+test_derives_identity_from_quoted_commented_entry
 test_non_allow_listed_token_fails_closed
 test_explicit_identity_skips_derivation
 

--- a/tests/test_coderabbit_wait_identity_derivation.sh
+++ b/tests/test_coderabbit_wait_identity_derivation.sh
@@ -39,8 +39,8 @@ make_case() {
   cat >"$dir/.github/review-policy.yml" <<'EOF'
 available_reviewers:
   - nathanpayne-claude
-  - nathanpayne-cursor
-  - nathanpayne-codex
+  - 'nathanpayne-cursor'
+  - "nathanpayne-codex"
 
 coderabbit:
   bot_login: "coderabbitai[bot]"

--- a/tests/test_codex_review_request_ack.sh
+++ b/tests/test_codex_review_request_ack.sh
@@ -58,6 +58,10 @@ fi
 count=$((count + 1))
 printf '%s\n' "$count" >"$state_dir/trigger-count"
 
+# Record the author-PAT env the wrapper sees, so the #438 inline-token
+# bridging test can assert what (if anything) was bridged in.
+printf '%s\n' "${OP_PREFLIGHT_AUTHOR_PAT:-}" >>"$state_dir/author-pat-env"
+
 comment_id=$((1000 + count))
 printf '%s\n' "$comment_id" >>"$state_dir/trigger-comments"
 if [ "${CODEX_TEST_SCENARIO:-}" = "no_comment_id" ]; then
@@ -212,12 +216,13 @@ run_case() {
   local dir=$1
   local scenario=$2
   local fake_clock=${3:-0}
+  local gh_token=${4:-test-token}
   local rc=0
 
   (
     cd "$dir"
     PATH="$dir/bin:$PATH" \
-      GH_TOKEN=test-token \
+      GH_TOKEN="$gh_token" \
       CODEX_TEST_STATE_DIR="$dir/state" \
       CODEX_TEST_FAKE_CLOCK="$fake_clock" \
       CODEX_TEST_SCENARIO="$scenario" \
@@ -414,6 +419,84 @@ test_ack_wait_window_is_bounded() {
   fi
 }
 
+# --- inline author-PAT bridging (#438) --------------------------------
+
+# identity-check stub used by the bridging tests: succeeds iff the
+# ambient GH_TOKEN is the known author PAT and the expected identity
+# is nathanjohnpayne (the policy default).
+write_identity_check_stub() {
+  local dir=$1
+  cat >"$dir/scripts/identity-check.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = "--expect-token-identity" ] || exit 2
+[ "${2:-}" = "nathanjohnpayne" ] || exit 1
+[ "${GH_TOKEN:-}" = "author-pat-123" ] || exit 1
+exit 0
+EOF
+  chmod +x "$dir/scripts/identity-check.sh"
+}
+
+bridged_pat() {
+  local dir=$1
+  if [ -f "$dir/state/author-pat-env" ]; then
+    head -1 "$dir/state/author-pat-env"
+  else
+    printf ''
+  fi
+}
+
+test_inline_author_pat_bridged_into_wrapper() {
+  local dir rc pat
+  dir=$(make_case "author-pat-bridged" 0 0)
+  write_identity_check_stub "$dir"
+  rc=$(run_case "$dir" absent 0 author-pat-123)
+  pat=$(bridged_pat "$dir")
+
+  if [ "$(trigger_count "$dir")" -lt 1 ]; then
+    fail "author-pat bridge: no trigger was posted; stderr=$(cat "$dir/err.log")"
+  elif [ "$pat" != "author-pat-123" ]; then
+    fail "author-pat bridge: wrapper saw OP_PREFLIGHT_AUTHOR_PAT='$pat', expected the verified inline token; stderr=$(cat "$dir/err.log")"
+  elif ! grep -q "bridging it into gh-as-author.sh" "$dir/err.log"; then
+    fail "author-pat bridge: missing bridging log line; stderr=$(cat "$dir/err.log")"
+  else
+    pass "verified inline author PAT is bridged into gh-as-author.sh (rc=$rc)"
+  fi
+}
+
+test_non_author_token_is_not_bridged() {
+  local dir rc pat
+  dir=$(make_case "reviewer-pat-not-bridged" 0 0)
+  write_identity_check_stub "$dir"
+  rc=$(run_case "$dir" absent 0 reviewer-pat-456)
+  pat=$(bridged_pat "$dir")
+
+  if [ "$(trigger_count "$dir")" -lt 1 ]; then
+    fail "non-author token: no trigger was posted; stderr=$(cat "$dir/err.log")"
+  elif [ -n "$pat" ]; then
+    fail "non-author token: wrapper saw OP_PREFLIGHT_AUTHOR_PAT='$pat', expected empty (no bridge)"
+  elif grep -q "bridging it into gh-as-author.sh" "$dir/err.log"; then
+    fail "non-author token: bridging log line present for a non-author token"
+  else
+    pass "non-author inline token is NOT bridged; wrapper resolution unchanged (rc=$rc)"
+  fi
+}
+
+test_missing_identity_checker_skips_bridge() {
+  local dir rc pat
+  dir=$(make_case "no-checker-no-bridge" 0 0)
+  rc=$(run_case "$dir" absent 0 author-pat-123)
+  pat=$(bridged_pat "$dir")
+
+  if [ "$(trigger_count "$dir")" -lt 1 ]; then
+    fail "missing checker: no trigger was posted; stderr=$(cat "$dir/err.log")"
+  elif [ -n "$pat" ]; then
+    fail "missing checker: wrapper saw OP_PREFLIGHT_AUTHOR_PAT='$pat', expected empty (bridge requires verification)"
+  else
+    pass "without identity-check.sh the bridge is skipped (verification-gated) (rc=$rc)"
+  fi
+}
+
 test_eyes_ack_does_not_retrigger_or_clear
 test_missing_ack_retriggers_once
 test_retry_cap_respected
@@ -423,6 +506,9 @@ test_retry_missing_comment_id_stops_without_extra_retry
 test_retry_resets_review_deadline
 test_retry_preserves_original_trigger_response
 test_ack_wait_window_is_bounded
+test_inline_author_pat_bridged_into_wrapper
+test_non_author_token_is_not_bridged
+test_missing_identity_checker_skips_bridge
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test_codex_review_request_ack.sh
+++ b/tests/test_codex_review_request_ack.sh
@@ -58,9 +58,11 @@ fi
 count=$((count + 1))
 printf '%s\n' "$count" >"$state_dir/trigger-count"
 
-# Record the author-PAT env the wrapper sees, so the #438 inline-token
-# bridging test can assert what (if anything) was bridged in.
+# Record the author-PAT and author-identity env the wrapper sees, so
+# the #438 inline-token bridging tests can assert what (if anything)
+# was bridged in.
 printf '%s\n' "${OP_PREFLIGHT_AUTHOR_PAT:-}" >>"$state_dir/author-pat-env"
+printf '%s\n' "${GH_AS_AUTHOR_IDENTITY:-}" >>"$state_dir/author-identity-env"
 
 comment_id=$((1000 + count))
 printf '%s\n' "$comment_id" >>"$state_dir/trigger-comments"
@@ -464,6 +466,34 @@ test_inline_author_pat_bridged_into_wrapper() {
   fi
 }
 
+test_bridge_passes_configured_author_identity() {
+  local dir rc pat identity
+  dir=$(make_case "custom-author-bridge" 0 0)
+  # Custom author_identity repo (Codex P2 on PR #442): the wrapper must
+  # be told to verify the configured login, not its stock default.
+  printf 'author_identity: custom-owner\n' >>"$dir/.github/review-policy.yml"
+  cat >"$dir/scripts/identity-check.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = "--expect-token-identity" ] || exit 2
+[ "${2:-}" = "custom-owner" ] || exit 1
+[ "${GH_TOKEN:-}" = "author-pat-123" ] || exit 1
+exit 0
+EOF
+  chmod +x "$dir/scripts/identity-check.sh"
+  rc=$(run_case "$dir" absent 0 author-pat-123)
+  pat=$(bridged_pat "$dir")
+  identity=$(head -1 "$dir/state/author-identity-env" 2>/dev/null || printf '')
+
+  if [ "$pat" != "author-pat-123" ]; then
+    fail "custom-author bridge: wrapper saw OP_PREFLIGHT_AUTHOR_PAT='$pat', expected the verified inline token; stderr=$(cat "$dir/err.log")"
+  elif [ "$identity" != "custom-owner" ]; then
+    fail "custom-author bridge: wrapper saw GH_AS_AUTHOR_IDENTITY='$identity', expected 'custom-owner'; stderr=$(cat "$dir/err.log")"
+  else
+    pass "bridge passes the configured author_identity to the wrapper (rc=$rc)"
+  fi
+}
+
 test_non_author_token_is_not_bridged() {
   local dir rc pat
   dir=$(make_case "reviewer-pat-not-bridged" 0 0)
@@ -507,6 +537,7 @@ test_retry_resets_review_deadline
 test_retry_preserves_original_trigger_response
 test_ack_wait_window_is_bounded
 test_inline_author_pat_bridged_into_wrapper
+test_bridge_passes_configured_author_identity
 test_non_author_token_is_not_bridged
 test_missing_identity_checker_skips_bridge
 

--- a/tests/test_codex_review_request_ack.sh
+++ b/tests/test_codex_review_request_ack.sh
@@ -512,6 +512,24 @@ test_non_author_token_is_not_bridged() {
   fi
 }
 
+test_non_bridge_path_passes_configured_identity() {
+  local dir rc identity
+  dir=$(make_case "custom-author-no-bridge" 0 0)
+  # Custom author_identity, NO bridging (token does not verify) — the
+  # wrapper must still be told the configured login (Codex P2 r5).
+  printf 'author_identity: custom-owner\n' >>"$dir/.github/review-policy.yml"
+  rc=$(run_case "$dir" absent 0 reviewer-pat-456)
+  identity=$(head -1 "$dir/state/author-identity-env" 2>/dev/null || printf '')
+
+  if [ "$(trigger_count "$dir")" -lt 1 ]; then
+    fail "non-bridge identity: no trigger was posted; stderr=$(cat "$dir/err.log")"
+  elif [ "$identity" != "custom-owner" ]; then
+    fail "non-bridge identity: wrapper saw GH_AS_AUTHOR_IDENTITY='$identity', expected 'custom-owner'; stderr=$(cat "$dir/err.log")"
+  else
+    pass "non-bridged invocation passes the configured author_identity (rc=$rc)"
+  fi
+}
+
 test_missing_identity_checker_skips_bridge() {
   local dir rc pat
   dir=$(make_case "no-checker-no-bridge" 0 0)
@@ -539,6 +557,7 @@ test_ack_wait_window_is_bounded
 test_inline_author_pat_bridged_into_wrapper
 test_bridge_passes_configured_author_identity
 test_non_author_token_is_not_bridged
+test_non_bridge_path_passes_configured_identity
 test_missing_identity_checker_skips_bridge
 
 echo

--- a/tests/test_codex_review_request_ack.sh
+++ b/tests/test_codex_review_request_ack.sh
@@ -517,7 +517,9 @@ test_non_bridge_path_passes_configured_identity() {
   dir=$(make_case "custom-author-no-bridge" 0 0)
   # Custom author_identity, NO bridging (token does not verify) — the
   # wrapper must still be told the configured login (Codex P2 r5).
-  printf 'author_identity: custom-owner\n' >>"$dir/.github/review-policy.yml"
+  # Single-quoted on purpose: the parser must strip both YAML quote
+  # styles (Codex P2 r9).
+  printf "author_identity: 'custom-owner'\n" >>"$dir/.github/review-policy.yml"
   rc=$(run_case "$dir" absent 0 reviewer-pat-456)
   identity=$(head -1 "$dir/state/author-identity-env" 2>/dev/null || printf '')
 

--- a/tests/test_gh_as_author.sh
+++ b/tests/test_gh_as_author.sh
@@ -169,14 +169,25 @@ fi
 # Runs IN the wrapper process: environment-manipulation-proof, unlike
 # the PreToolUse hook's static analysis.
 
+# The pin resolves the policy from the WRAPPER's repo root (r20), so
+# each fixture repo gets its own copy of the wrapper + its lib deps.
+install_wrapper_copy() {
+  local dir=$1
+  mkdir -p "$dir/scripts/lib" "$dir/.github"
+  cp "$ROOT/scripts/gh-as-author.sh" "$dir/scripts/gh-as-author.sh"
+  cp "$ROOT/scripts/lib/gh-token-resolver.sh" "$dir/scripts/lib/gh-token-resolver.sh"
+  cp "$ROOT/scripts/identity-check.sh" "$dir/scripts/identity-check.sh"
+  chmod +x "$dir/scripts/gh-as-author.sh" "$dir/scripts/identity-check.sh"
+}
+
 PIN_DIR="$WORKDIR/pin-repo"
-mkdir -p "$PIN_DIR/.github"
+install_wrapper_copy "$PIN_DIR"
 printf 'author_identity: nathanjohnpayne\n' >"$PIN_DIR/.github/review-policy.yml"
 
 reset_log
 set +e
 ( cd "$PIN_DIR" && OP_PREFLIGHT_AUTHOR_PAT="author-token" GH_AS_AUTHOR_IDENTITY="nathanpayne-codex" \
-    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" "$WRAPPER" -- gh pr merge 9 --squash ) >/dev/null 2>"$WORKDIR/pin.err"
+    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" "$PIN_DIR/scripts/gh-as-author.sh" -- gh pr merge 9 --squash ) >/dev/null 2>"$WORKDIR/pin.err"
 rc=$?
 set -e
 if [ "$rc" -eq 2 ] && grep -q "runtime byline pin" "$WORKDIR/pin.err"; then
@@ -191,13 +202,13 @@ else
 fi
 
 PIN_DIR2="$WORKDIR/pin-repo-custom"
-mkdir -p "$PIN_DIR2/.github"
+install_wrapper_copy "$PIN_DIR2"
 printf "author_identity: 'custom-author'\n" >"$PIN_DIR2/.github/review-policy.yml"
 
 reset_log
 set +e
 ( cd "$PIN_DIR2" && GH_AS_AUTHOR_IDENTITY="custom-author" \
-    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" "$WRAPPER" -- gh pr merge 9 --squash ) >/dev/null 2>&1
+    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" "$PIN_DIR2/scripts/gh-as-author.sh" -- gh pr merge 9 --squash ) >/dev/null 2>&1
 rc=$?
 set -e
 if [ "$rc" -eq 0 ] && grep -q $'GH_TOKEN=fallback-custom-author-token GITHUB_TOKEN= gh\tpr\tmerge\t9\t--squash' "$WORKDIR/calls.log"; then
@@ -206,12 +217,27 @@ else
   fail "runtime pin: matching custom identity should proceed; rc=$rc calls=$(cat "$WORKDIR/calls.log")"
 fi
 
+# Subdirectory invocation must still load the pin (r20).
+mkdir -p "$PIN_DIR/subdir"
+reset_log
+set +e
+( cd "$PIN_DIR/subdir" && OP_PREFLIGHT_AUTHOR_PAT="author-token" GH_AS_AUTHOR_IDENTITY="nathanpayne-codex" \
+    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" ../scripts/gh-as-author.sh -- gh pr merge 9 --squash ) >/dev/null 2>"$WORKDIR/pin-sub.err"
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && grep -q "runtime byline pin" "$WORKDIR/pin-sub.err"; then
+  pass "runtime pin: subdirectory invocation still loads the repo-root policy"
+else
+  fail "runtime pin: subdirectory invocation should refuse; rc=$rc err=$(cat "$WORKDIR/pin-sub.err")"
+fi
+
 NO_POLICY_DIR="$WORKDIR/pin-repo-none"
-mkdir -p "$NO_POLICY_DIR"
+install_wrapper_copy "$NO_POLICY_DIR"
+rm -rf "$NO_POLICY_DIR/.github"
 reset_log
 set +e
 ( cd "$NO_POLICY_DIR" && OP_PREFLIGHT_AUTHOR_PAT="author-token" \
-    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" "$WRAPPER" -- gh pr merge 9 --squash ) >/dev/null 2>&1
+    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" "$NO_POLICY_DIR/scripts/gh-as-author.sh" -- gh pr merge 9 --squash ) >/dev/null 2>&1
 rc=$?
 set -e
 if [ "$rc" -eq 0 ]; then

--- a/tests/test_gh_as_author.sh
+++ b/tests/test_gh_as_author.sh
@@ -165,6 +165,61 @@ else
   fail "empty command: rc=$rc expected 1"
 fi
 
+# --- runtime byline pin (#438) ----------------------------------------
+# Runs IN the wrapper process: environment-manipulation-proof, unlike
+# the PreToolUse hook's static analysis.
+
+PIN_DIR="$WORKDIR/pin-repo"
+mkdir -p "$PIN_DIR/.github"
+printf 'author_identity: nathanjohnpayne\n' >"$PIN_DIR/.github/review-policy.yml"
+
+reset_log
+set +e
+( cd "$PIN_DIR" && OP_PREFLIGHT_AUTHOR_PAT="author-token" GH_AS_AUTHOR_IDENTITY="nathanpayne-codex" \
+    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" "$WRAPPER" -- gh pr merge 9 --squash ) >/dev/null 2>"$WORKDIR/pin.err"
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && grep -q "runtime byline pin" "$WORKDIR/pin.err"; then
+  pass "runtime pin: non-policy identity refused before any gh call"
+else
+  fail "runtime pin: expected rc=2 with pin message; rc=$rc err=$(cat "$WORKDIR/pin.err")"
+fi
+if grep -q $'gh\tpr\tmerge' "$WORKDIR/calls.log"; then
+  fail "runtime pin: wrapped command ran despite the refusal"
+else
+  pass "runtime pin: no wrapped command executed on refusal"
+fi
+
+PIN_DIR2="$WORKDIR/pin-repo-custom"
+mkdir -p "$PIN_DIR2/.github"
+printf "author_identity: 'custom-author'\n" >"$PIN_DIR2/.github/review-policy.yml"
+
+reset_log
+set +e
+( cd "$PIN_DIR2" && GH_AS_AUTHOR_IDENTITY="custom-author" \
+    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" "$WRAPPER" -- gh pr merge 9 --squash ) >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ] && grep -q $'GH_TOKEN=fallback-custom-author-token GITHUB_TOKEN= gh\tpr\tmerge\t9\t--squash' "$WORKDIR/calls.log"; then
+  pass "runtime pin: matching custom identity (quoted policy) proceeds with its token"
+else
+  fail "runtime pin: matching custom identity should proceed; rc=$rc calls=$(cat "$WORKDIR/calls.log")"
+fi
+
+NO_POLICY_DIR="$WORKDIR/pin-repo-none"
+mkdir -p "$NO_POLICY_DIR"
+reset_log
+set +e
+( cd "$NO_POLICY_DIR" && OP_PREFLIGHT_AUTHOR_PAT="author-token" \
+    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" "$WRAPPER" -- gh pr merge 9 --squash ) >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "runtime pin: absent policy file keeps legacy behavior"
+else
+  fail "runtime pin: absent policy file should not block; rc=$rc"
+fi
+
 echo ""
 echo "test_gh_as_author: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -433,6 +433,13 @@ assert_rc_contains "unset builtin identity removal allowed in default repo" 0 ""
 assert_rc_contains "empty inline author override allowed in default repo" 0 "" \
   'GH_AS_AUTHOR_IDENTITY= scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 
+# Subdirectory invocation: the policy is found by upward walk (r21).
+mkdir -p "$WORKDIR/repo-custom-author/subdir"
+cd "$WORKDIR/repo-custom-author/subdir"
+assert_rc_contains "author identity policy found from a subdirectory" 2 "author identity" \
+  'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+cd "$ORIG_DIR"
+
 # Quoted author_identity is valid YAML — double AND single quotes must
 # be stripped before comparison (Codex P2s on PR #442 r6/r7).
 mkdir -p "$WORKDIR/repo-quoted-author/.github"

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -295,6 +295,13 @@ assert_rc_contains "declare -x non-author identity blocked" 2 "author identity" 
 assert_rc_contains "env-prefixed non-author identity blocked" 2 "author identity" \
   'env GH_AS_AUTHOR_IDENTITY=nathanpayne-codex scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 
+# readonly -x exports too (Codex P1 on PR #442 r14, hook-verified).
+assert_rc_contains "readonly -x non-author identity blocked" 2 "author identity" \
+  'readonly -x GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr create --title "t" --body "Authoring-Agent: claude
+
+## Self-Review
+- ok"' "CLEAN" ""
+
 # The custom-author shape from the r3 finding: standalone assignment of
 # the CUSTOM identity must NOT satisfy the guard — the wrapper would
 # actually verify its stock default.

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -345,6 +345,31 @@ assert_rc_contains "author identity from review-policy.yml blocks the stock defa
   'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 cd "$ORIG_DIR"
 
+# An EMPTY inline override resets the wrapper to its hardcoded default
+# (Codex P1 on PR #442 r15): in a custom-author repo that is a
+# wrong-byline reset and must fail closed, even when the hook's own
+# environment carries the correct custom identity.
+mkdir -p "$WORKDIR/repo-custom-author-empty/.github"
+cat >"$WORKDIR/repo-custom-author-empty/.github/review-policy.yml" <<'YML'
+author_identity: custom-owner
+YML
+cd "$WORKDIR/repo-custom-author-empty"
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=custom-owner run_hook 'GH_AS_AUTHOR_IDENTITY= scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "empty inline author override fails closed in custom-author repo"
+else
+  fail "empty inline author override fails closed in custom-author repo: rc=$rc; output: $out"
+fi
+cd "$ORIG_DIR"
+
+# In a DEFAULT repo an empty override is a no-op (wrapper default ==
+# expected) and must not block.
+assert_rc_contains "empty inline author override allowed in default repo" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY= scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
 # Quoted author_identity is valid YAML — double AND single quotes must
 # be stripped before comparison (Codex P2s on PR #442 r6/r7).
 mkdir -p "$WORKDIR/repo-quoted-author/.github"

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -295,6 +295,11 @@ assert_rc_contains "declare -x non-author identity blocked" 2 "author identity" 
 assert_rc_contains "env-prefixed non-author identity blocked" 2 "author identity" \
   'env GH_AS_AUTHOR_IDENTITY=nathanpayne-codex scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 
+# eval'd assignments persist like bare standalones (preempted, r14
+# family): possibly-effective, so a mismatch fails closed.
+assert_rc_contains "eval'd non-author identity assignment fails closed" 2 "author identity" \
+  'eval GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
 # readonly -x exports too (Codex P1 on PR #442 r14, hook-verified).
 assert_rc_contains "readonly -x non-author identity blocked" 2 "author identity" \
   'readonly -x GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr create --title "t" --body "Authoring-Agent: claude

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -391,6 +391,22 @@ cd "$ORIG_DIR"
 assert_rc_contains "env -u identity unset allowed in default repo" 0 "" \
   'env -u GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 
+# The unset BUILTIN persists past separators (preempted, r17 family).
+cd "$WORKDIR/repo-custom-author-empty"
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=custom-owner run_hook 'unset GH_AS_AUTHOR_IDENTITY ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "unset builtin identity removal fails closed in custom-author repo"
+else
+  fail "unset builtin identity removal fails closed in custom-author repo: rc=$rc; output: $out"
+fi
+cd "$ORIG_DIR"
+
+assert_rc_contains "unset builtin identity removal allowed in default repo" 0 "" \
+  'unset GH_AS_AUTHOR_IDENTITY ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
 # In a DEFAULT repo an empty override is a no-op (wrapper default ==
 # expected) and must not block.
 assert_rc_contains "empty inline author override allowed in default repo" 0 "" \

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -365,6 +365,32 @@ else
 fi
 cd "$ORIG_DIR"
 
+# env -u / --unset / -i remove the identity from the WRAPPER's
+# environment — the r15 empty-override semantics (Codex P2 r17).
+cd "$WORKDIR/repo-custom-author-empty"
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=custom-owner run_hook 'env -u GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "env -u identity unset fails closed in custom-author repo"
+else
+  fail "env -u identity unset fails closed in custom-author repo: rc=$rc; output: $out"
+fi
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=custom-owner run_hook 'env --unset=GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "env --unset= identity fails closed in custom-author repo"
+else
+  fail "env --unset= identity fails closed in custom-author repo: rc=$rc; output: $out"
+fi
+cd "$ORIG_DIR"
+
+assert_rc_contains "env -u identity unset allowed in default repo" 0 "" \
+  'env -u GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
 # In a DEFAULT repo an empty override is a no-op (wrapper default ==
 # expected) and must not block.
 assert_rc_contains "empty inline author override allowed in default repo" 0 "" \

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -279,6 +279,14 @@ assert_rc_contains "exported-via-export-command matching author identity allowed
 assert_rc_contains "exported-via-export-command non-reviewer identity blocked" 2 "expected reviewer" \
   'export GH_AS_REVIEWER_IDENTITY=nathanpayne-codex ; scripts/gh-as-reviewer.sh -- gh pr comment 123 --body "ping"' "CLEAN" ""
 
+# Prefix-assignment BEFORE the export command in the same segment
+# (`VAR=x export VAR`) persists AND exports (Codex P1 on PR #442 r12).
+assert_rc_contains "prefix-then-export non-author identity blocked" 2 "author identity" \
+  'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex export GH_AS_AUTHOR_IDENTITY ; scripts/gh-as-author.sh -- gh pr comment 123 --body "@codex review"' "CLEAN" ""
+
+assert_rc_contains "prefix-then-export matching author identity allowed" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=nathanjohnpayne export GH_AS_AUTHOR_IDENTITY ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
 # The custom-author shape from the r3 finding: standalone assignment of
 # the CUSTOM identity must NOT satisfy the guard — the wrapper would
 # actually verify its stock default.

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -267,6 +267,18 @@ assert_rc_contains "standalone non-author identity assignment fails closed" 2 "a
 assert_rc_contains "standalone matching author identity assignment allowed" 0 "" \
   'GH_AS_AUTHOR_IDENTITY=nathanjohnpayne ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 
+# `export VAR=x ; wrapper` is DEFINITELY effective — the assignment is
+# an argument of the export command, not a bare prefix, and reaches
+# every later process (Codex P1 on PR #442 r11).
+assert_rc_contains "exported-via-export-command non-author identity blocked" 2 "author identity" \
+  'export GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+assert_rc_contains "exported-via-export-command matching author identity allowed" 0 "" \
+  'export GH_AS_AUTHOR_IDENTITY=nathanjohnpayne && scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+assert_rc_contains "exported-via-export-command non-reviewer identity blocked" 2 "expected reviewer" \
+  'export GH_AS_REVIEWER_IDENTITY=nathanpayne-codex ; scripts/gh-as-reviewer.sh -- gh pr comment 123 --body "ping"' "CLEAN" ""
+
 # The custom-author shape from the r3 finding: standalone assignment of
 # the CUSTOM identity must NOT satisfy the guard — the wrapper would
 # actually verify its stock default.

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -230,6 +230,59 @@ cd "$ORIG_DIR"
 assert_rc_contains "compound direct guarded write blocked" 2 "#348" \
   'gh issue close 7 && gh pr merge --admin 123'
 
+# --- author-wrapper identity pin (#438) -------------------------------
+
+assert_rc_contains "author wrapper inline non-author identity blocked" 2 "author identity" \
+  'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+assert_rc_contains "author wrapper inline matching author identity allowed" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=nathanjohnpayne scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+assert_rc_contains "author wrapper inline non-author identity blocked on pr create" 2 "author identity" \
+  'GH_AS_AUTHOR_IDENTITY=nathanpayne-cursor scripts/gh-as-author.sh -- gh pr create --title "t" --body "Authoring-Agent: claude
+
+## Self-Review
+- ok"'
+
+assert_rc_contains "author wrapper inline non-author identity blocked on codex trigger" 2 "author identity" \
+  'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex scripts/gh-as-author.sh -- gh pr comment 123 --body "@codex review"'
+
+# Exported (non-inline) GH_AS_AUTHOR_IDENTITY must be caught too — the
+# wrapper reads its environment, so the hook must read the same.
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=nathanpayne-codex run_hook 'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "author wrapper exported non-author identity blocked"
+else
+  fail "author wrapper exported non-author identity blocked: rc=$rc; output: $out"
+fi
+
+# Custom expected author: identity must match the override...
+set +e
+out=$(GH_PR_GUARD_EXPECTED_AUTHOR=custom-owner run_hook 'GH_AS_AUTHOR_IDENTITY=custom-owner scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "author wrapper custom expected author with matching identity allowed"
+else
+  fail "author wrapper custom expected author with matching identity allowed: rc=$rc; output: $out"
+fi
+
+# ...and an UNSET identity fails closed under a custom expected author,
+# because the wrapper would verify its stock default (nathanjohnpayne),
+# not the override.
+set +e
+out=$(GH_PR_GUARD_EXPECTED_AUTHOR=custom-owner run_hook 'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "author wrapper unset identity under custom expected author fails closed"
+else
+  fail "author wrapper unset identity under custom expected author fails closed: rc=$rc; output: $out"
+fi
+
 echo ""
 echo "test_gh_pr_guard: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -247,6 +247,17 @@ assert_rc_contains "author wrapper inline non-author identity blocked on pr crea
 assert_rc_contains "author wrapper inline non-author identity blocked on codex trigger" 2 "author identity" \
   'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex scripts/gh-as-author.sh -- gh pr comment 123 --body "@codex review"'
 
+# A stale inline assignment scoped to an EARLIER command segment must
+# not leak into the author byline guard — the shell would not pass it
+# to the wrapper (Codex P2 on PR #442).
+assert_rc_contains "stale inline author identity from earlier segment does not block" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex echo ok ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# Standalone assignment (no command in its segment) still counts — it
+# persists in the shell, mirroring the CODEX_CLEARED standalone rule.
+assert_rc_contains "standalone inline author identity assignment still blocks" 2 "author identity" \
+  'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
 # Exported (non-inline) GH_AS_AUTHOR_IDENTITY must be caught too — the
 # wrapper reads its environment, so the hook must read the same.
 set +e

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -305,14 +305,23 @@ assert_rc_contains "author identity from review-policy.yml blocks the stock defa
   'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 cd "$ORIG_DIR"
 
-# Quoted author_identity is valid YAML — quotes must be stripped before
-# comparison (Codex P2 on PR #442 r6).
+# Quoted author_identity is valid YAML — double AND single quotes must
+# be stripped before comparison (Codex P2s on PR #442 r6/r7).
 mkdir -p "$WORKDIR/repo-quoted-author/.github"
 cat >"$WORKDIR/repo-quoted-author/.github/review-policy.yml" <<'YML'
 author_identity: "custom-owner"
 YML
 cd "$WORKDIR/repo-quoted-author"
-assert_rc_contains "quoted author_identity from review-policy.yml allows matching wrapper identity" 0 "" \
+assert_rc_contains "double-quoted author_identity allows matching wrapper identity" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=custom-owner scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+cd "$ORIG_DIR"
+
+mkdir -p "$WORKDIR/repo-squoted-author/.github"
+cat >"$WORKDIR/repo-squoted-author/.github/review-policy.yml" <<'YML'
+author_identity: 'custom-owner'
+YML
+cd "$WORKDIR/repo-squoted-author"
+assert_rc_contains "single-quoted author_identity allows matching wrapper identity" 0 "" \
   'GH_AS_AUTHOR_IDENTITY=custom-owner scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 cd "$ORIG_DIR"
 

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -287,6 +287,14 @@ assert_rc_contains "prefix-then-export non-author identity blocked" 2 "author id
 assert_rc_contains "prefix-then-export matching author identity allowed" 0 "" \
   'GH_AS_AUTHOR_IDENTITY=nathanjohnpayne export GH_AS_AUTHOR_IDENTITY ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 
+# declare -x is export-equivalent (Codex P1 r12 family, preempted).
+assert_rc_contains "declare -x non-author identity blocked" 2 "author identity" \
+  'declare -x GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# env-prefix on the wrapper command is a definitive same-segment prefix.
+assert_rc_contains "env-prefixed non-author identity blocked" 2 "author identity" \
+  'env GH_AS_AUTHOR_IDENTITY=nathanpayne-codex scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
 # The custom-author shape from the r3 finding: standalone assignment of
 # the CUSTOM identity must NOT satisfy the guard — the wrapper would
 # actually verify its stock default.

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -253,15 +253,19 @@ assert_rc_contains "author wrapper inline non-author identity blocked on codex t
 assert_rc_contains "stale inline author identity from earlier segment does not block" 0 "" \
   'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex echo ok ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 
-# A standalone assignment (no command in its segment) sets an
-# UNEXPORTED shell variable the wrapper process never receives — the
-# wrapper runs with its default identity, so the hook must not treat
-# it as the wrapper's configuration (Codex P2 on PR #442 r3: in a
-# custom-author repo the carried value would mask the wrapper falling
-# back to its stock default — a wrong-byline hole). Exported variables
-# are still caught via the hook's own environment.
-assert_rc_contains "standalone inline author identity assignment does not reach the wrapper" 0 "" \
+# A standalone assignment (no command in its segment) persists as a
+# shell variable, and IF the name carries the export attribute in the
+# calling shell it ALSO reaches the wrapper (Codex P1 on PR #442 r4).
+# The hook cannot observe the export attribute, so a standalone
+# non-author value must fail closed even though it might be inert.
+assert_rc_contains "standalone non-author identity assignment fails closed" 2 "author identity" \
   'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# ...but a standalone assignment of the EXPECTED author is fine either
+# way (exported: wrapper gets the expected value; unexported: wrapper
+# default is the same value).
+assert_rc_contains "standalone matching author identity assignment allowed" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=nathanjohnpayne ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 
 # The custom-author shape from the r3 finding: standalone assignment of
 # the CUSTOM identity must NOT satisfy the guard — the wrapper would

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -253,10 +253,27 @@ assert_rc_contains "author wrapper inline non-author identity blocked on codex t
 assert_rc_contains "stale inline author identity from earlier segment does not block" 0 "" \
   'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex echo ok ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 
-# Standalone assignment (no command in its segment) still counts — it
-# persists in the shell, mirroring the CODEX_CLEARED standalone rule.
-assert_rc_contains "standalone inline author identity assignment still blocks" 2 "author identity" \
+# A standalone assignment (no command in its segment) sets an
+# UNEXPORTED shell variable the wrapper process never receives — the
+# wrapper runs with its default identity, so the hook must not treat
+# it as the wrapper's configuration (Codex P2 on PR #442 r3: in a
+# custom-author repo the carried value would mask the wrapper falling
+# back to its stock default — a wrong-byline hole). Exported variables
+# are still caught via the hook's own environment.
+assert_rc_contains "standalone inline author identity assignment does not reach the wrapper" 0 "" \
   'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# The custom-author shape from the r3 finding: standalone assignment of
+# the CUSTOM identity must NOT satisfy the guard — the wrapper would
+# actually verify its stock default.
+mkdir -p "$WORKDIR/repo-custom-author-standalone/.github"
+cat >"$WORKDIR/repo-custom-author-standalone/.github/review-policy.yml" <<'YML'
+author_identity: custom-owner
+YML
+cd "$WORKDIR/repo-custom-author-standalone"
+assert_rc_contains "standalone custom-identity assignment does not mask the wrapper default" 2 "author identity" \
+  'GH_AS_AUTHOR_IDENTITY=custom-owner && scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+cd "$ORIG_DIR"
 
 # Exported (non-inline) GH_AS_AUTHOR_IDENTITY must be caught too — the
 # wrapper reads its environment, so the hook must read the same.

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -391,6 +391,27 @@ cd "$ORIG_DIR"
 assert_rc_contains "env -u identity unset allowed in default repo" 0 "" \
   'env -u GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 
+# Space-separated long form: `env --unset NAME` (Codex P1 r18) — the
+# value flag must be consumed or the walk loses the wrapper entirely
+# and skips ALL checks.
+cd "$WORKDIR/repo-custom-author-empty"
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=custom-owner run_hook 'env --unset GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "env --unset NAME (space form) fails closed in custom-author repo"
+else
+  fail "env --unset NAME (space form) fails closed in custom-author repo: rc=$rc; output: $out"
+fi
+cd "$ORIG_DIR"
+
+# ...and in a default repo the walk must still SEE the wrapper and
+# evaluate the merge-state checks (BLOCKED state proves the walk
+# reached the merge guard rather than bailing at the unset arg).
+assert_rc_contains "env --unset NAME still reaches merge-state checks" 2 "mergeStateStatus is BLOCKED" \
+  'env --unset GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "BLOCKED" ""
+
 # The unset BUILTIN persists past separators (preempted, r17 family).
 cd "$WORKDIR/repo-custom-author-empty"
 set +e

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -270,6 +270,20 @@ else
   fail "author wrapper exported non-author identity blocked: rc=$rc; output: $out"
 fi
 
+# The expected author defaults from review-policy.yml author_identity
+# when GH_PR_GUARD_EXPECTED_AUTHOR is unset (Codex P2 on PR #442 r2) —
+# custom-author repos need no hook-specific variable.
+mkdir -p "$WORKDIR/repo-custom-author/.github"
+cat >"$WORKDIR/repo-custom-author/.github/review-policy.yml" <<'YML'
+author_identity: custom-owner
+YML
+cd "$WORKDIR/repo-custom-author"
+assert_rc_contains "author identity from review-policy.yml allows matching wrapper identity" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=custom-owner scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+assert_rc_contains "author identity from review-policy.yml blocks the stock default" 2 "author identity" \
+  'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+cd "$ORIG_DIR"
+
 # Custom expected author: identity must match the override...
 set +e
 out=$(GH_PR_GUARD_EXPECTED_AUTHOR=custom-owner run_hook 'GH_AS_AUTHOR_IDENTITY=custom-owner scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -305,6 +305,17 @@ assert_rc_contains "author identity from review-policy.yml blocks the stock defa
   'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
 cd "$ORIG_DIR"
 
+# Quoted author_identity is valid YAML — quotes must be stripped before
+# comparison (Codex P2 on PR #442 r6).
+mkdir -p "$WORKDIR/repo-quoted-author/.github"
+cat >"$WORKDIR/repo-quoted-author/.github/review-policy.yml" <<'YML'
+author_identity: "custom-owner"
+YML
+cd "$WORKDIR/repo-quoted-author"
+assert_rc_contains "quoted author_identity from review-policy.yml allows matching wrapper identity" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=custom-owner scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+cd "$ORIG_DIR"
+
 # Custom expected author: identity must match the override...
 set +e
 out=$(GH_PR_GUARD_EXPECTED_AUTHOR=custom-owner run_hook 'GH_AS_AUTHOR_IDENTITY=custom-owner scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
Closes the three Codex P2s from the b10671e wave (#438) — all pre-existing identity/token-resolution gaps in propagated scripts:

1. **`gh-pr-guard.sh` — author-wrapper identity pin (the byline-integrity hole).** The hook never validated `GH_AS_AUTHOR_IDENTITY` on the `gh-as-author.sh` path, so `GH_AS_AUTHOR_IDENTITY=nathanpayne-codex scripts/gh-as-author.sh -- gh pr merge ...` would verify the *codex* token and merge under it while the hook permitted the write (the #359 wrong-byline class). The guard now compares the wrapper's effective identity (inline > env > the wrapper's hard default `nathanjohnpayne`) against `GH_PR_GUARD_EXPECTED_AUTHOR`, mirroring the existing reviewer-identity pin. The unset-identity case compares against the wrapper's *actual* default rather than the override, so a custom expected author fails closed.
2. **`coderabbit-wait.sh` — token-derived expected reviewer.** When run with only `GH_TOKEN` (the `agent-review.yml` shape: `secrets.REVIEWER_ASSIGNMENT_TOKEN`, no `MERGEPATH_AGENT`/`OP_PREFLIGHT_AGENT`/`GH_AS_REVIEWER_IDENTITY`), the expected login hard-defaulted to `nathanpayne-claude`, so a different allowed reviewer token failed identity verification before posting a rate-limit retry/status probe. Now: explicit envs still win; otherwise the expected login is derived from the token at write time, **constrained to `available_reviewers`** (so the check stays fail-closed — a non-allow-listed token falls back to the static default and fails verification exactly as before). Derivation is lazy so read-only runs pay no extra API call.
3. **`codex-review-request.sh` — inline author-PAT bridging.** `gh-as-author.sh`'s resolver ignores ambient `GH_TOKEN` by design, so the still-documented `GH_TOKEN=<author PAT> codex-review-request.sh` fallback passed read checks then failed the trigger write in CI/fresh shells (no preflight cache, no keyring), forcing needless Phase 4b. The ambient token is now bridged into the wrapper as `OP_PREFLIGHT_AUTHOR_PAT` **only after** `identity-check.sh --expect-token-identity` verifies it as the configured `author_identity` (read from review-policy.yml, default `nathanjohnpayne`). Reviewer-PAT sessions are untouched; missing checker ⇒ no bridge.

All three scripts propagate to consumers via existing `.mergepath-sync.yml` entries.

Closes #438

## Testing
- [x] `tests/test_gh_pr_guard.sh` — 38 pass (6 new: inline/exported non-author identity blocked across merge/create/codex-trigger; matching identity allowed; custom expected-author cases incl. unset-identity fail-closed)
- [x] New `tests/test_coderabbit_wait_identity_derivation.sh` — 3 pass (derived allow-listed identity; non-allow-listed fail-closed with no write posted; explicit env wins with no derivation lookup); wired into `scripts/ci/check_coderabbit_wait`
- [x] `tests/test_codex_review_request_ack.sh` — 12 pass (3 new: verified author PAT bridged; non-author token not bridged; missing checker skips bridge)
- [x] `check_coderabbit_wait`, `check_codex_scripts`, `check_gh_as_author`, `check_no_bare_gh_writes`, `check_op_preflight_contract` all PASS

## Self-Review
- [x] Correctness: changes match stated requirements
- [x] Regression risk: status-probe suite (6) and all pre-existing guard/ack cases pass unchanged
- [x] Style and conventions: follows repository standards (rationale comments cite issue lineage)
- [x] Test coverage: every new branch has a positive and a fail-closed case
- [x] Security and dependency hygiene: all three changes tighten or preserve fail-closed identity verification