### PR TITLE
fix(audit): default --audit baseline to the live default branch, print baseline per consumer (#439)

### DIFF
--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -37,7 +37,7 @@
 # consumer-side dest using each consumer's manifest facts.
 #
 # Usage:
-#   scripts/sync-to-downstream.sh --audit [--repos r1,r2] [--paths glob]
+#   scripts/sync-to-downstream.sh --audit [--use-local-tree] [--repos r1,r2] [--paths glob]
 #   scripts/sync-to-downstream.sh <commit-ish> [--dry-run] [--repos r1,r2] [--paths glob]
 #                                 [--no-pr] [--skip-existing|--recreate-existing] [--verbose]
 #   scripts/sync-to-downstream.sh --sync-all [--dry-run] [--repos r1,r2] [--paths glob]
@@ -48,6 +48,12 @@
 # Flags:
 #   --audit              Read-only drift detection. Exit 0 (clean), 1 (drift),
 #                        2 (script/usage error), 3 (consumer fetch error).
+#                        Compares each consumer's LIVE default branch (a
+#                        refreshed cache clone of origin/HEAD) against
+#                        mergepath HEAD, and prints the exact baseline
+#                        ref@sha per consumer so the comparison basis is
+#                        never ambiguous (#439). To audit a local sibling
+#                        working tree instead, see --use-local-tree.
 #   --sync-all           Bulk steady-state reconcile. Propagate the current
 #                        HEAD state of EVERY canonical + kit path in the
 #                        manifest to every consumer, ignoring the
@@ -100,9 +106,24 @@
 #                        hunks (Mergepath parent → commit) to each
 #                        affected target line in the plan, so the human
 #                        sees the change set that would propagate.
+#   --use-local-tree     Audit only: compare against a local sibling
+#                        worktree under MERGEPATH_SIBLINGS_DIR (the
+#                        pre-#439 default), falling back to the cache
+#                        clone when no sibling exists. The sibling's
+#                        working tree is used AS-IS (never fetched or
+#                        reset), so results reflect whatever branch /
+#                        commit / uncommitted edits are checked out —
+#                        the audit warns loudly when that baseline
+#                        differs from origin's default branch. Without
+#                        this flag, --audit always compares against a
+#                        refreshed cache clone of the consumer's live
+#                        default branch (#439: stale siblings made the
+#                        default audit confidently report false drift).
 #   --no-clone           Audit only: don't clone-on-demand; only audit
-#                        consumers with a local sibling worktree under
-#                        MERGEPATH_SIBLINGS_DIR.
+#                        consumers that already have a cache clone
+#                        under MERGEPATH_SYNC_CACHE (or, with
+#                        --use-local-tree, a local sibling worktree
+#                        under MERGEPATH_SIBLINGS_DIR).
 #   --no-refresh         Audit only: don't `git fetch` cached consumer
 #                        clones before comparing. Useful for offline /
 #                        sandboxed audits; may report stale results if
@@ -139,7 +160,9 @@
 #   transitively-required files outside the manifest, etc.).
 #
 # Environment:
-#   MERGEPATH_SIBLINGS_DIR  Default: $HOME/GitHub. If a `.git` entry at
+#   MERGEPATH_SIBLINGS_DIR  Default: $HOME/GitHub. Used by the audit ONLY
+#                           under --use-local-tree (#439). If a `.git`
+#                           entry at
 #                           $MERGEPATH_SIBLINGS_DIR/<consumer-name>/.git
 #                           exists (directory OR file — git worktrees use
 #                           a `.git` file), the audit reads from that
@@ -402,6 +425,57 @@ resolve_consumer_worktree() {
     return 0
   fi
   return 1
+}
+
+# Cache-only resolver for the default audit baseline (#439): never
+# considers sibling worktrees. Returns 0 with the path on stdout if a
+# cache clone exists, 1 otherwise (caller clones on demand).
+resolve_consumer_cache_clone() {
+  local consumer_name=$1
+  local cache_dir=${MERGEPATH_SYNC_CACHE:-$HOME/.cache/mergepath-sync}
+
+  if [ -e "$cache_dir/$consumer_name/.git" ]; then
+    echo "$cache_dir/$consumer_name"
+    return 0
+  fi
+  return 1
+}
+
+# Print the audit comparison baseline for one consumer (#439 Option 3):
+# the exact ref@sha being compared, and which kind of tree it is. For a
+# local sibling tree (only reachable under --use-local-tree), also warn
+# loudly when the tree is on a non-default branch or its HEAD differs
+# from the last-known origin default-branch tip — the two stale-baseline
+# shapes that produced confidently-false fleet-wide drift reports.
+# Non-git fixture trees (tests) print "unknown" and skip the warnings.
+print_audit_baseline() {
+  local consumer_root=$1
+  local sha branch
+  sha=$(git -C "$consumer_root" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  branch=$(git -C "$consumer_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+  if path_is_in_cache "$consumer_root"; then
+    if [ "${AUDIT_NO_REFRESH:-0}" = "1" ]; then
+      echo "  baseline: $branch@$sha (cache clone, NOT refreshed — --no-refresh; may lag origin)"
+    else
+      echo "  baseline: $branch@$sha (cache clone, refreshed from origin default branch)"
+    fi
+    return 0
+  fi
+
+  echo "  baseline: $branch@$sha (LOCAL SIBLING TREE at $consumer_root, used as-is — never auto-fetched)"
+
+  # Staleness warnings (best-effort; both probes read only local refs).
+  local default_branch origin_sha
+  default_branch=$(git -C "$consumer_root" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo "")
+  default_branch=${default_branch#origin/}
+  if [ -n "$default_branch" ] && [ "$branch" != "unknown" ] && [ "$branch" != "$default_branch" ]; then
+    echo "  ⚠ sibling tree is on '$branch', not the default branch '$default_branch' — drift results reflect that branch, not origin/$default_branch; re-run without --use-local-tree for live state"
+  fi
+  origin_sha=$(git -C "$consumer_root" rev-parse --short "refs/remotes/origin/${default_branch:-HEAD}" 2>/dev/null || echo "")
+  if [ -n "$origin_sha" ] && [ "$sha" != "unknown" ] && [ "$sha" != "$origin_sha" ]; then
+    echo "  ⚠ sibling tree HEAD ($sha) != last-fetched origin/${default_branch:-HEAD} ($origin_sha) — baseline may be stale or ahead; re-run without --use-local-tree for live state"
+  fi
 }
 
 # Lexical prefix check: does $1 live under MERGEPATH_SYNC_CACHE?
@@ -813,16 +887,39 @@ run_audit() {
     echo "$consumer_name ($consumer_repo)"
 
     local consumer_root
-    if ! consumer_root=$(resolve_consumer_worktree "$consumer_name"); then
-      if [ "${AUDIT_NO_CLONE:-0}" = "1" ]; then
-        echo "  ! no local worktree for $consumer_name (set MERGEPATH_SIBLINGS_DIR or drop --no-clone)"
-        AUDIT_FETCH_ERROR=1
-        continue
+    if [ "${AUDIT_USE_LOCAL_TREE:-0}" = "1" ]; then
+      # Legacy baseline (#439 opt-in): sibling worktree first, cache
+      # fallback. The sibling tree is used AS-IS; the baseline header
+      # + staleness warnings below make that basis explicit.
+      if ! consumer_root=$(resolve_consumer_worktree "$consumer_name"); then
+        if [ "${AUDIT_NO_CLONE:-0}" = "1" ]; then
+          echo "  ! no local worktree for $consumer_name (set MERGEPATH_SIBLINGS_DIR or drop --no-clone)"
+          AUDIT_FETCH_ERROR=1
+          continue
+        fi
+        if ! consumer_root=$(clone_consumer_to_cache "$consumer_name" "$consumer_repo"); then
+          echo "  ! could not fetch $consumer_repo"
+          AUDIT_FETCH_ERROR=1
+          continue
+        fi
       fi
-      if ! consumer_root=$(clone_consumer_to_cache "$consumer_name" "$consumer_repo"); then
-        echo "  ! could not fetch $consumer_repo"
-        AUDIT_FETCH_ERROR=1
-        continue
+    else
+      # Default baseline (#439): the consumer's LIVE default branch via
+      # a refreshed cache clone — never the user's sibling working
+      # tree. A stale sibling (feature branch checked out, behind
+      # main) previously made the audit confidently report massive
+      # false drift with no hint the baseline was stale.
+      if ! consumer_root=$(resolve_consumer_cache_clone "$consumer_name"); then
+        if [ "${AUDIT_NO_CLONE:-0}" = "1" ]; then
+          echo "  ! no cached clone for $consumer_name (drop --no-clone, or pass --use-local-tree to audit a local sibling worktree)"
+          AUDIT_FETCH_ERROR=1
+          continue
+        fi
+        if ! consumer_root=$(clone_consumer_to_cache "$consumer_name" "$consumer_repo"); then
+          echo "  ! could not fetch $consumer_repo"
+          AUDIT_FETCH_ERROR=1
+          continue
+        fi
       fi
     fi
     # If we're reading from a cache path (vs. a sibling worktree),
@@ -836,6 +933,7 @@ run_audit() {
         continue
       fi
     fi
+    print_audit_baseline "$consumer_root"
     local consumer_overrides=""
     if [ -f "$consumer_root/$OVERRIDES_PATH" ]; then
       consumer_overrides="$consumer_root/$OVERRIDES_PATH"
@@ -2402,6 +2500,10 @@ while [ $# -gt 0 ]; do
       FILTER_PATHS="$2"
       shift 2
       ;;
+    --use-local-tree)
+      AUDIT_USE_LOCAL_TREE=1
+      shift
+      ;;
     --no-clone)
       AUDIT_NO_CLONE=1
       shift
@@ -2541,6 +2643,10 @@ if [ "$SYNC_NO_PR" = "1" ] && [ "$MODE" = "audit" ]; then
 fi
 if [ "$SYNC_RECREATE_EXISTING" = "1" ] && [ "$MODE" = "audit" ]; then
   err "--recreate-existing is a sync-mode-only flag; remove it from --audit invocations"
+  exit 2
+fi
+if [ "${AUDIT_USE_LOCAL_TREE:-0}" = "1" ] && [ "$MODE" != "audit" ]; then
+  err "--use-local-tree is an audit-mode-only flag; remove it from sync invocations"
   exit 2
 fi
 if [ "$SYNC_VERBOSE" = "1" ] && [ "$MODE" = "audit" ]; then

--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -544,25 +544,36 @@ refresh_cached_clone() {
   fi
 
   log "refreshing cached clone at $cache_path"
-  # `origin/HEAD` is set by `gh repo clone`'s underlying `git clone` to
-  # the consumer's default branch. Resetting hard is safe here: this
-  # directory is the script's cache, not the user's worktree.
-  if ! git -C "$cache_path" fetch --depth=1 --quiet origin >&2; then
-    err "git fetch failed for cached clone $cache_path"
+  # A bare `git fetch` is not enough here, for two compounding reasons
+  # (Codex P2s on PR #443 rounds 1–2):
+  #   - `git fetch` never updates refs/remotes/origin/HEAD when the
+  #     remote's default branch changes (e.g. a main→trunk rename), so
+  #     a long-lived cache clone would keep resetting to the STALE old
+  #     default while the baseline header claims a refreshed
+  #     default-branch comparison.
+  #   - cache clones are created with --depth=1, which implies
+  #     --single-branch: the clone's refspec only ever fetches the
+  #     OLD default, so the renamed default's ref would never arrive.
+  # Resolve the remote's CURRENT default via ls-remote --symref, fetch
+  # that branch explicitly, re-point origin/HEAD at it, then reset.
+  local default_ref
+  default_ref=$(git -C "$cache_path" ls-remote --symref origin HEAD 2>/dev/null \
+    | awk '/^ref:/ {sub("refs/heads/", "", $2); print $2; exit}')
+  if [ -z "$default_ref" ]; then
+    err "could not resolve the remote default branch for $cache_path (git ls-remote --symref origin HEAD)"
     return 3
   fi
-  # `git fetch` does NOT update refs/remotes/origin/HEAD when the
-  # remote's default branch changes (e.g. a main→trunk rename), so a
-  # long-lived cache clone would keep resetting to the STALE old
-  # default while the baseline header claims a refreshed default-branch
-  # comparison (Codex P2 on PR #443). `remote set-head --auto` queries
-  # the remote and re-points origin/HEAD at the current default.
-  if ! git -C "$cache_path" remote set-head origin --auto >/dev/null 2>&1; then
-    err "git remote set-head origin --auto failed for $cache_path"
+  if ! git -C "$cache_path" fetch --depth=1 --quiet origin \
+       "+refs/heads/$default_ref:refs/remotes/origin/$default_ref" >&2; then
+    err "git fetch failed for cached clone $cache_path (branch $default_ref)"
     return 3
   fi
-  if ! git -C "$cache_path" reset --hard --quiet origin/HEAD >&2; then
-    err "git reset --hard origin/HEAD failed for $cache_path"
+  if ! git -C "$cache_path" remote set-head origin "$default_ref" >/dev/null 2>&1; then
+    err "git remote set-head origin $default_ref failed for $cache_path"
+    return 3
+  fi
+  if ! git -C "$cache_path" reset --hard --quiet "refs/remotes/origin/$default_ref" >&2; then
+    err "git reset --hard origin/$default_ref failed for $cache_path"
     return 3
   fi
 }

--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -455,6 +455,15 @@ print_audit_baseline() {
   branch=$(git -C "$consumer_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 
   if path_is_in_cache "$consumer_root"; then
+    # The refresh resets the working tree to origin/HEAD but never
+    # renames the local branch, so after a remote default-branch
+    # rename the local branch label would lie about what the content
+    # tracks. Label the baseline with origin/HEAD's actual target.
+    local origin_default
+    origin_default=$(git -C "$consumer_root" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo "")
+    if [ -n "$origin_default" ]; then
+      branch="${origin_default#origin/}"
+    fi
     if [ "${AUDIT_NO_REFRESH:-0}" = "1" ]; then
       echo "  baseline: $branch@$sha (cache clone, NOT refreshed — --no-refresh; may lag origin)"
     else
@@ -540,6 +549,16 @@ refresh_cached_clone() {
   # directory is the script's cache, not the user's worktree.
   if ! git -C "$cache_path" fetch --depth=1 --quiet origin >&2; then
     err "git fetch failed for cached clone $cache_path"
+    return 3
+  fi
+  # `git fetch` does NOT update refs/remotes/origin/HEAD when the
+  # remote's default branch changes (e.g. a main→trunk rename), so a
+  # long-lived cache clone would keep resetting to the STALE old
+  # default while the baseline header claims a refreshed default-branch
+  # comparison (Codex P2 on PR #443). `remote set-head --auto` queries
+  # the remote and re-points origin/HEAD at the current default.
+  if ! git -C "$cache_path" remote set-head origin --auto >/dev/null 2>&1; then
+    err "git remote set-head origin --auto failed for $cache_path"
     return 3
   fi
   if ! git -C "$cache_path" reset --hard --quiet origin/HEAD >&2; then

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -259,7 +259,11 @@ git init -q -b main "$live_origin"
 
 live_cache="$WORKDIR/live-cache"
 mkdir -p "$live_cache"
-git clone -q "file://$live_origin" "$live_cache/clean-consumer"
+# --depth=1 matches clone_consumer_to_cache and implies --single-branch,
+# which is exactly the shape that broke the renamed-default refresh
+# (Codex P2 on PR #443 r2): the clone's refspec only fetches the old
+# default, so the rename test below exercises the explicit-ref fetch.
+git clone -q --depth=1 "file://$live_origin" "$live_cache/clean-consumer"
 
 stale_siblings="$WORKDIR/stale-siblings"
 mkdir -p "$stale_siblings/clean-consumer/scripts/hooks" "$stale_siblings/clean-consumer/scripts/ci"

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -336,6 +336,30 @@ set -e
 [[ "$ult_sync_exit" -eq 2 ]] \
   || fail "--use-local-tree in sync mode should exit 2; got $ult_sync_exit"
 
+# Default-branch rename: `git fetch` never moves refs/remotes/origin/HEAD,
+# so the refresh must re-resolve the remote default (`remote set-head
+# --auto`) or a renamed default branch silently audits the stale old one
+# (Codex P2 on PR #443). Rename the origin's default to `trunk` with
+# drifted content; the cached clone (cloned when default was `main`)
+# must follow the rename and report the drift.
+( cd "$live_origin" \
+    && git branch -m main trunk \
+    && git symbolic-ref HEAD refs/heads/trunk \
+    && echo "MUTATED-ON-TRUNK" >scripts/keep-in-sync.sh \
+    && git add -A \
+    && git -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m "drift on renamed default" )
+set +e
+rename_output=$(MERGEPATH_ROOT_OVERRIDE="$MP" \
+  MERGEPATH_SIBLINGS_DIR="$stale_siblings" \
+  MERGEPATH_SYNC_CACHE="$live_cache" \
+  "$SCRIPT" --audit --repos clean-consumer 2>&1)
+rename_exit=$?
+set -e
+[[ "$rename_exit" -eq 1 ]] \
+  || fail "default audit should follow a renamed default branch and report its drift (exit 1); got exit $rename_exit, output: $rename_output"
+echo "$rename_output" | grep -q "baseline: trunk@" \
+  || fail "default audit baseline should show the renamed default branch 'trunk'; got: $rename_output"
+
 # ---------------------------------------------------------------------------
 # Symlink guard on cache refresh (cursor CHANGES_REQUESTED on PR #215).
 # If MERGEPATH_SYNC_CACHE/<consumer> resolves outside the cache dir

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -95,7 +95,7 @@ git init -q "$SIBLINGS/missing-everything"
 cd "$MP"
 set +e
 output=$(MERGEPATH_ROOT_OVERRIDE="$MP" MERGEPATH_SIBLINGS_DIR="$SIBLINGS" \
-  "$SCRIPT" --audit --no-clone 2>&1)
+  "$SCRIPT" --audit --use-local-tree --no-clone 2>&1)
 exit_code=$?
 set -e
 
@@ -149,7 +149,7 @@ echo "$output" | awk '
 # Filter test: --paths restriction must shrink the report
 # ---------------------------------------------------------------------------
 filtered=$(MERGEPATH_ROOT_OVERRIDE="$MP" MERGEPATH_SIBLINGS_DIR="$SIBLINGS" \
-  "$SCRIPT" --audit --no-clone --paths "scripts/hooks/the-hook.sh" 2>&1 || true)
+  "$SCRIPT" --audit --use-local-tree --no-clone --paths "scripts/hooks/the-hook.sh" 2>&1 || true)
 echo "$filtered" | grep -q "scripts/keep-in-sync.sh" \
   && fail "--paths filter should have excluded scripts/keep-in-sync.sh"
 
@@ -187,7 +187,7 @@ git init -q "$AO_SIBLINGS/beta"
 
 set +e
 audit_override_out=$(MERGEPATH_ROOT_OVERRIDE="$AO_MP" MERGEPATH_SIBLINGS_DIR="$AO_SIBLINGS" \
-  "$SCRIPT" --audit --no-clone 2>&1)
+  "$SCRIPT" --audit --use-local-tree --no-clone 2>&1)
 audit_override_rc=$?
 set -e
 [ "$audit_override_rc" -eq 1 ] \
@@ -231,13 +231,110 @@ echo "gitdir: $WORKDIR/fake.git" >"$worktree_siblings/clean-consumer/.git"
 
 set +e
 output=$(MERGEPATH_ROOT_OVERRIDE="$MP" MERGEPATH_SIBLINGS_DIR="$worktree_siblings" \
-  "$SCRIPT" --audit --no-clone --repos clean-consumer 2>&1)
+  "$SCRIPT" --audit --use-local-tree --no-clone --repos clean-consumer 2>&1)
 worktree_exit=$?
 set -e
 [[ "$worktree_exit" -eq 0 ]] \
   || fail "worktree (.git as file) should be accepted as a sibling; got exit $worktree_exit, output: $output"
 echo "$output" | grep -q "no local worktree" \
   && fail "worktree (.git as file) misclassified as missing"
+
+# ---------------------------------------------------------------------------
+# #439: default audit baseline is the LIVE default branch via the cache
+# clone — never the sibling working tree. A stale sibling (feature
+# branch checked out, behind main) must not affect the default audit,
+# and --use-local-tree must surface loud staleness warnings + the exact
+# baseline ref@sha.
+# ---------------------------------------------------------------------------
+live_origin="$WORKDIR/live-origin/clean-consumer"
+mkdir -p "$live_origin/scripts/hooks" "$live_origin/scripts/ci"
+cp "$MP/scripts/keep-in-sync.sh"   "$live_origin/scripts/keep-in-sync.sh"
+cp "$MP/scripts/hooks/the-hook.sh" "$live_origin/scripts/hooks/the-hook.sh"
+cp "$MP/scripts/ci/check_one"      "$live_origin/scripts/ci/check_one"
+cp "$MP/scripts/ci/check_two"      "$live_origin/scripts/ci/check_two"
+git init -q -b main "$live_origin"
+( cd "$live_origin" \
+    && git add -A \
+    && git -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m "clean state" )
+
+live_cache="$WORKDIR/live-cache"
+mkdir -p "$live_cache"
+git clone -q "file://$live_origin" "$live_cache/clean-consumer"
+
+stale_siblings="$WORKDIR/stale-siblings"
+mkdir -p "$stale_siblings/clean-consumer/scripts/hooks" "$stale_siblings/clean-consumer/scripts/ci"
+cp "$MP/scripts/keep-in-sync.sh"   "$stale_siblings/clean-consumer/scripts/keep-in-sync.sh"
+cp "$MP/scripts/hooks/the-hook.sh" "$stale_siblings/clean-consumer/scripts/hooks/the-hook.sh"
+cp "$MP/scripts/ci/check_one"      "$stale_siblings/clean-consumer/scripts/ci/check_one"
+cp "$MP/scripts/ci/check_two"      "$stale_siblings/clean-consumer/scripts/ci/check_two"
+git init -q -b main "$stale_siblings/clean-consumer"
+( cd "$stale_siblings/clean-consumer" \
+    && git add -A \
+    && git -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m "synced state" \
+    && git checkout -q -b feature/stale-work \
+    && echo "MUTATED" >scripts/keep-in-sync.sh \
+    && git add -A \
+    && git -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m "stale feature work" \
+    && git update-ref refs/remotes/origin/main "$(git rev-parse main)" \
+    && git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main )
+
+# Default mode: the clean cache clone is the baseline; the stale sibling
+# (which WOULD drift) must be ignored entirely.
+set +e
+live_output=$(MERGEPATH_ROOT_OVERRIDE="$MP" \
+  MERGEPATH_SIBLINGS_DIR="$stale_siblings" \
+  MERGEPATH_SYNC_CACHE="$live_cache" \
+  "$SCRIPT" --audit --repos clean-consumer 2>&1)
+live_exit=$?
+set -e
+[[ "$live_exit" -eq 0 ]] \
+  || fail "default audit should read the clean cache clone (exit 0) and ignore the stale sibling; got exit $live_exit, output: $live_output"
+echo "$live_output" | grep -q "baseline: .*cache clone, refreshed" \
+  || fail "default audit should print the cache-clone baseline header; got: $live_output"
+echo "$live_output" | grep -q "LOCAL SIBLING TREE" \
+  && fail "default audit must not read the sibling tree; got: $live_output"
+
+# --use-local-tree: the stale sibling IS the baseline; drift is reported
+# and the baseline header + both staleness warnings make the basis loud.
+set +e
+stale_output=$(MERGEPATH_ROOT_OVERRIDE="$MP" \
+  MERGEPATH_SIBLINGS_DIR="$stale_siblings" \
+  MERGEPATH_SYNC_CACHE="$live_cache" \
+  "$SCRIPT" --audit --use-local-tree --no-clone --repos clean-consumer 2>&1)
+stale_exit=$?
+set -e
+[[ "$stale_exit" -eq 1 ]] \
+  || fail "--use-local-tree audit should report the stale sibling's drift (exit 1); got exit $stale_exit, output: $stale_output"
+echo "$stale_output" | grep -q "baseline: feature/stale-work@.*LOCAL SIBLING TREE" \
+  || fail "--use-local-tree audit should print the sibling baseline ref@sha; got: $stale_output"
+echo "$stale_output" | grep -q "⚠ sibling tree is on 'feature/stale-work', not the default branch 'main'" \
+  || fail "--use-local-tree audit should warn about the non-default branch; got: $stale_output"
+echo "$stale_output" | grep -q "⚠ sibling tree HEAD .* != last-fetched origin/main" \
+  || fail "--use-local-tree audit should warn that HEAD differs from origin/main; got: $stale_output"
+
+# Default mode + --no-clone with NO cache clone present: fail closed with
+# a pointer at --use-local-tree rather than silently reading the sibling.
+set +e
+noclone_output=$(MERGEPATH_ROOT_OVERRIDE="$MP" \
+  MERGEPATH_SIBLINGS_DIR="$stale_siblings" \
+  MERGEPATH_SYNC_CACHE="$WORKDIR/empty-cache-nowhere" \
+  "$SCRIPT" --audit --no-clone --repos clean-consumer 2>&1)
+noclone_exit=$?
+set -e
+[[ "$noclone_exit" -eq 3 ]] \
+  || fail "default audit --no-clone with no cache should exit 3; got $noclone_exit, output: $noclone_output"
+echo "$noclone_output" | grep -q "no cached clone for clean-consumer" \
+  || fail "default audit --no-clone should explain the missing cache clone; got: $noclone_output"
+echo "$noclone_output" | grep -q -- "--use-local-tree" \
+  || fail "default audit --no-clone should point at --use-local-tree; got: $noclone_output"
+
+# --use-local-tree is audit-mode-only.
+set +e
+MERGEPATH_ROOT_OVERRIDE="$MP" "$SCRIPT" --sync-all --use-local-tree --dry-run >/dev/null 2>&1
+ult_sync_exit=$?
+set -e
+[[ "$ult_sync_exit" -eq 2 ]] \
+  || fail "--use-local-tree in sync mode should exit 2; got $ult_sync_exit"
 
 # ---------------------------------------------------------------------------
 # Symlink guard on cache refresh (cursor CHANGES_REQUESTED on PR #215).


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
Implements #439 Options 1 + 3 (the recommended combination) plus Option 2's warnings for the opt-in legacy mode:

- **Default baseline is the live remote state.** `--audit` now always compares against a refreshed cache clone of the consumer's `origin/HEAD` — never a sibling working tree. A stale sibling (feature branch checked out, or behind main) previously produced confidently-false fleet-wide drift reports (`merge-clearance-gate.yml missing entirely` on a consumer whose live main was synced).
- **`--use-local-tree` opt-in** restores the as-is sibling behavior for intentional local-tree audits, now with loud `⚠` warnings when the tree is on a non-default branch or its HEAD differs from the last-fetched origin default tip.
- **Baseline transparency:** every consumer block prints `baseline: <ref>@<sha> (cache clone, refreshed… | LOCAL SIBLING TREE…)` so the comparison basis is never ambiguous.
- `--no-clone` in default mode = "existing cache clones only," failing closed with a pointer at `--use-local-tree`. The flag is rejected outside audit mode, matching the existing audit-only-flag validations.
- CI impact: none — `weekly-drift-audit.yml` runs on a hosted runner with no siblings, so it already resolved to the cache path; its behavior is byte-identical.

Closes #439

## Testing
- [x] `tests/test_sync_to_downstream.sh` PASS — existing sibling-fixture audits moved to `--use-local-tree`; 5 new assertions: default mode reads the clean cache clone and ignores a drifted sibling (with baseline header), `--use-local-tree` reports the sibling drift with baseline ref@sha + both staleness warnings, default `--no-clone` with no cache fails closed (exit 3, pointer at `--use-local-tree`), and `--use-local-tree` in sync mode exits 2.
- [x] `bash -n` clean; usage/help text regenerates from the updated header (single-source sed extraction).

## Self-Review
- [x] Correctness: changes match stated requirements
- [x] Regression risk: legacy behavior fully preserved behind --use-local-tree; CI path unchanged
- [x] Style and conventions: follows repository standards
- [x] Test coverage: new default path, opt-in path, fail-closed path, and mode-exclusivity all asserted
- [x] Security and dependency hygiene: no new credentials or write paths; symlink guards untouched and re-verified by existing tests