### PR TITLE
fix(lane): default the propagation lane ON; add weekly lane-audit regression net (#434)

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -59,6 +59,14 @@ external_review_paths:
 # because the content is not novel. See REVIEW_POLICY.md § Propagation
 # PR review lane.
 #
+# DEFAULT-ON (#434): the lane is enabled when this block (or the
+# `enabled` key) is ABSENT from a repo's review-policy.yml. This file
+# is intentionally not synced, so requiring an explicit `enabled: true`
+# here left the lane dormant on every consumer — the enable flag must
+# not live solely in a never-propagated file. The block below is
+# therefore documentary for mergepath itself; consumers need no edit.
+# `branch_prefix` likewise defaults to "mergepath-sync/" when absent.
+#
 # Set enabled: false to require full external review on sync PRs too
 # (e.g. a security-sensitive consumer that wants every byte re-reviewed
 # on arrival regardless of upstream provenance).

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -101,6 +101,15 @@ jobs:
           #   1. config (enabled / branch_prefix / author_identity) is
           #      read from the BASE commit's review-policy.yml — a PR
           #      cannot self-qualify by editing policy in the PR.
+          #      The lane defaults ON when the propagation_prs block is
+          #      absent (mergepath#434): the enable flag lived only in
+          #      consumer review-policy.yml, which is intentionally NOT
+          #      synced, so no consumer ever had the block and the lane
+          #      was dormant fleet-wide. An explicit `enabled: false`
+          #      remains the opt-out. The default adds no new trust —
+          #      recognition is still gated on the byte-level verify in
+          #      step 3, and a PR cannot grant itself the default
+          #      because it cannot edit its own BASE commit.
           #   2. branch name must start with propagation_prs.branch_prefix
           #      and PR author must be author_identity.
           #   3. the <sha> in the branch name (mergepath-sync/[sync-all-]
@@ -137,7 +146,12 @@ jobs:
             : > "$BASE_POLICY"   # absent on base → lane simply won't match
           fi
           PROP_ENABLED=$(prop_field "$BASE_POLICY" propagation_prs enabled)
+          # Default ON when the key/block is absent (mergepath#434);
+          # explicit `enabled: false` opts out.
+          PROP_ENABLED=${PROP_ENABLED:-true}
           PROP_PREFIX=$(prop_field "$BASE_POLICY" propagation_prs branch_prefix)
+          # Must match SYNC_BRANCH_PREFIX in scripts/sync-to-downstream.sh.
+          PROP_PREFIX=${PROP_PREFIX:-mergepath-sync/}
           AUTHOR_ID=$(grep -m1 '^author_identity:' "$BASE_POLICY" | awk '{print $2}')
           HEAD_REF="${{ github.event.pull_request.head.ref }}"
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"

--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -138,6 +138,14 @@ jobs:
       - name: check_verify_propagation_pr
         run: ./scripts/ci/check_verify_propagation_pr
 
+      # check_propagation_lane_audit exercises the #434 lane regression
+      # net (scripts/audit-propagation-lane.sh): the lane's per-consumer
+      # preconditions are evaluated offline against fixture file pairs,
+      # and the audit's default-ON marker is pinned to the literal in
+      # pr-review-policy.yml so the two cannot silently diverge.
+      - name: check_propagation_lane_audit
+        run: ./scripts/ci/check_propagation_lane_audit
+
       # check_workflow_verify_propagation_templated exercises the
       # templated-surface arm of verify-propagation-pr.sh (#323) —
       # the re-render + byte-verify path that closes the propagation

--- a/.github/workflows/weekly-drift-audit.yml
+++ b/.github/workflows/weekly-drift-audit.yml
@@ -183,6 +183,45 @@ jobs:
               ;;
           esac
 
+      # Propagation lane regression net (#434): the lane defaults ON in
+      # the synced pr-review-policy.yml, but a consumer can still end
+      # up lane-dark (pre-#434 workflow, explicit enabled: false, or
+      # missing author_identity). This audit reads each consumer's LIVE
+      # default branch and fails the run when the lane would not fire —
+      # surfacing the regression weekly instead of at the next sync
+      # wave. Runs after the file-drift audit so both reports land even
+      # when one of them fails; its own rc gates the job at the end.
+      - name: Propagation lane audit
+        if: steps.audit.outputs.result == 'clean' || steps.audit.outputs.result == 'drift'
+        env:
+          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
+        run: |
+          set -uo pipefail
+          chmod +x scripts/audit-propagation-lane.sh
+          set +e
+          scripts/audit-propagation-lane.sh 2>&1 | tee lane-audit-output.txt
+          rc=${PIPESTATUS[0]}
+          set -e
+          {
+            echo
+            echo "## Propagation lane audit (#434)"
+            echo
+            echo '```'
+            cat lane-audit-output.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          case "${rc}" in
+            0) ;;
+            1)
+              echo "::error::Propagation lane would NOT fire on at least one consumer (see lane audit output). Sync pr-review-policy.yml or investigate the consumer's review-policy.yml."
+              exit 1
+              ;;
+            *)
+              echo "::error::audit-propagation-lane.sh exited ${rc} (fetch/usage error) — infrastructure failure, not lane drift."
+              exit "${rc}"
+              ;;
+          esac
+
       - name: Write job summary
         # Runs for both clean (result=clean) and drift (result=drift).
         # The exit-2/3 paths above already failed the job and never

--- a/.github/workflows/weekly-drift-audit.yml
+++ b/.github/workflows/weekly-drift-audit.yml
@@ -185,13 +185,21 @@ jobs:
 
       # Propagation lane regression net (#434): the lane defaults ON in
       # the synced pr-review-policy.yml, but a consumer can still end
-      # up lane-dark (pre-#434 workflow, explicit enabled: false, or
-      # missing author_identity). This audit reads each consumer's LIVE
-      # default branch and fails the run when the lane would not fire —
-      # surfacing the regression weekly instead of at the next sync
-      # wave. Runs after the file-drift audit so both reports land even
-      # when one of them fails; its own rc gates the job at the end.
+      # up lane-dark (pre-#434 workflow, explicit enabled: false,
+      # overridden branch_prefix, or missing author_identity). This
+      # audit reads each consumer's LIVE default branch and fails the
+      # run when the lane would not fire — surfacing the regression
+      # weekly instead of at the next sync wave.
+      #
+      # IMPORTANT: this step only RECORDS its result (lane_rc output).
+      # Failing here would abort the job before the drift tracking
+      # issue is opened/updated below, losing the file-drift visibility
+      # in the same run that found a lane regression (Codex P2 on PR
+      # #444). The "Fail on propagation lane regression" step at the
+      # END of the job turns a recorded non-zero rc into the job
+      # failure once the drift-issue path has completed.
       - name: Propagation lane audit
+        id: lane_audit
         if: steps.audit.outputs.result == 'clean' || steps.audit.outputs.result == 'drift'
         env:
           GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
@@ -210,17 +218,8 @@ jobs:
             cat lane-audit-output.txt
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          case "${rc}" in
-            0) ;;
-            1)
-              echo "::error::Propagation lane would NOT fire on at least one consumer (see lane audit output). Sync pr-review-policy.yml or investigate the consumer's review-policy.yml."
-              exit 1
-              ;;
-            *)
-              echo "::error::audit-propagation-lane.sh exited ${rc} (fetch/usage error) — infrastructure failure, not lane drift."
-              exit "${rc}"
-              ;;
-          esac
+          echo "lane_rc=${rc}" >> "$GITHUB_OUTPUT"
+          echo "Lane audit exited ${rc} (deferred to the end-of-job gate)"
 
       - name: Write job summary
         # Runs for both clean (result=clean) and drift (result=drift).
@@ -368,3 +367,19 @@ jobs:
             gh issue close "$n" --repo "$REPO" \
               --comment ":white_check_mark: Audit clean as of ${today} (UTC) — all consumers back in sync with mergepath's canonical/kit surface. Closing automatically. See [run](${RUN_URL})."
           done
+
+      # Deferred gate for the lane audit (#434 / Codex P2 on PR #444):
+      # runs LAST so the drift tracking-issue path above always
+      # completes first, then turns a recorded lane regression into the
+      # job failure it deserves.
+      - name: Fail on propagation lane regression
+        if: steps.lane_audit.outputs.lane_rc != '' && steps.lane_audit.outputs.lane_rc != '0'
+        env:
+          LANE_RC: ${{ steps.lane_audit.outputs.lane_rc }}
+        run: |
+          if [ "${LANE_RC}" = "1" ]; then
+            echo "::error::Propagation lane would NOT fire on at least one consumer (see lane audit output above). Sync pr-review-policy.yml or investigate the consumer's review-policy.yml."
+          else
+            echo "::error::audit-propagation-lane.sh exited ${LANE_RC} (fetch/usage error) — infrastructure failure, not lane drift."
+          fi
+          exit "${LANE_RC}"

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -291,6 +291,15 @@ paths:
   - path: scripts/codex-p1-gate.sh
     type: canonical
     consumers: all
+  # Hub-side fleet audit for the propagation lane (#434); consumers
+  # receive it because the scripts/ci kit's check_propagation_lane_audit
+  # hard-requires it (and its offline test) on every lint run.
+  - path: scripts/audit-propagation-lane.sh
+    type: canonical
+    consumers: all
+  - path: tests/test_audit_propagation_lane.sh
+    type: canonical
+    consumers: all
   - path: scripts/merge-clearance-gate.sh
     # HEAD-pinned merge-clearance gate (#427/#428). The external-review
     # path delegates to scripts/codex-review-check.sh (with CI checking
@@ -615,6 +624,8 @@ paths:
       - "tests/test_template_substitution.sh"  # check_template_substitution
       - "tests/test_export_consumer_facts.sh"  # check_export_consumer_facts
       - "tests/test_codex_review_request_ack.sh"  # check_codex_scripts
+      - "tests/test_audit_propagation_lane.sh" # check_propagation_lane_audit
+      - "scripts/audit-propagation-lane.sh"    # check_propagation_lane_audit
       - "scripts/codex-p1-gate.sh"             # check_codex_p1_gate
       - "scripts/merge-clearance-gate.sh"      # check_merge_clearance_gate
       - "scripts/codex-review-request.sh"      # check_codex_scripts

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -380,10 +380,12 @@ A **propagation PR** — one opened by `scripts/sync-to-downstream.sh` to mirror
 
 The lane closes that mismatch. `.github/workflows/pr-review-policy.yml`'s External Review Check recognizes a propagation PR and **exempts it from the `needs-external-review` label** — and removes the label if a prior run applied it — when **all** of the following hold:
 
-1. `propagation_prs.enabled: true` in `.github/review-policy.yml`.
-2. The PR branch name starts with `propagation_prs.branch_prefix` (must match `SYNC_BRANCH_PREFIX` in `scripts/sync-to-downstream.sh`).
+1. The lane is enabled. **Default: ON** ([#434](https://github.com/nathanjohnpayne/mergepath/issues/434)) — an absent `propagation_prs:` block (or absent `enabled` key) in `.github/review-policy.yml` counts as enabled; an explicit `propagation_prs.enabled: false` opts the repo out. The flag originally required an explicit `enabled: true`, but `review-policy.yml` is intentionally never propagated, so no consumer had the block and the lane was dormant fleet-wide — an enable flag must not live solely in a never-synced file. The default adds no new trust: recognition is still gated on criterion 4's byte-level verification, and a PR cannot grant itself the default because the config is read from the PR's base commit.
+2. The PR branch name starts with `propagation_prs.branch_prefix` (default `mergepath-sync/` when absent; must match `SYNC_BRANCH_PREFIX` in `scripts/sync-to-downstream.sh`).
 3. The PR author is `author_identity` — the propagation actor.
 4. The PR is a **verified byte-for-byte faithful mirror** of `mergepath` at the source commit. This is the load-bearing teeth.
+
+A regression net rides the weekly drift audit: `scripts/audit-propagation-lane.sh` checks every consumer's live default branch for the three lane preconditions a file-drift audit alone can't see together (lane code present in the synced workflow, no unexpected `enabled: false`, `author_identity` present) and fails the `weekly-drift-audit.yml` run when the lane would not fire on a consumer.
 
 Path-confinement alone is **not** sufficient — `.github/workflows/*` *is* propagation surface, so a check that only asked "is every changed file under a manifest path?" would let a `mergepath-sync/**` PR hand-edit a workflow and skip review (Codex P1 on [#268](https://github.com/nathanjohnpayne/mergepath/issues/268)). Criterion 4 is therefore a real content comparison:
 

--- a/scripts/audit-propagation-lane.sh
+++ b/scripts/audit-propagation-lane.sh
@@ -59,6 +59,14 @@ LANE_DEFAULT_MARKER='PROP_ENABLED=${PROP_ENABLED:-true}'
 # healthy lane (Codex P2 on PR #444).
 SYNC_BRANCH_PREFIX='mergepath-sync/'
 
+# The actor scripts/sync-to-downstream.sh creates consumer PRs under.
+# The lane's fingerprint requires PR author == the consumer's
+# author_identity, so a present-but-wrong value (typo, stale identity,
+# stray quoting that survives the same grep/awk extraction the lane
+# uses) means the lane never matches a real sync PR (Codex P2 on
+# PR #444 r3).
+SYNC_AUTHOR_IDENTITY='nathanjohnpayne'
+
 # Read a 2-space-indented scalar from a named YAML block — same
 # state-machine awk as pr-review-policy.yml's prop_field, so this audit
 # evaluates the exact predicate the lane evaluates.
@@ -115,6 +123,10 @@ lane_status_for_files() {  # <label> <policy-file-or-empty> <workflow-file-or-em
   fi
   if [ -z "$author_id" ]; then
     echo "  ✗ $label: review-policy.yml has no author_identity — the lane's PR-author fingerprint cannot match"
+    return 1
+  fi
+  if [ "$author_id" != "$SYNC_AUTHOR_IDENTITY" ]; then
+    echo "  ✗ $label: review-policy.yml author_identity is '$author_id' but sync PRs are authored by '$SYNC_AUTHOR_IDENTITY' — the lane's PR-author fingerprint will never match a real sync PR"
     return 1
   fi
 

--- a/scripts/audit-propagation-lane.sh
+++ b/scripts/audit-propagation-lane.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# scripts/audit-propagation-lane.sh
+#
+# Regression net for the propagation PR review lane (#434, Option 3).
+#
+# The lane defaults ON in the synced pr-review-policy.yml workflow, but
+# three per-consumer preconditions can still silently disable it — and
+# a file-level drift audit alone can't see them together:
+#
+#   1. the consumer's live default branch carries the default-ON lane
+#      code in .github/workflows/pr-review-policy.yml (a consumer that
+#      has not received the #434 sync still requires an explicit
+#      propagation_prs.enabled: true it does not have);
+#   2. the consumer's .github/review-policy.yml does not explicitly set
+#      propagation_prs.enabled: false (the intentional opt-out — valid,
+#      but it must be VISIBLE, not a surprise at the next sync wave);
+#   3. the consumer's .github/review-policy.yml has an author_identity
+#      (the lane's PR-author fingerprint check requires it).
+#
+# For each consumer in .mergepath-sync.yml, this script reads BOTH
+# files from the consumer's live default branch via the GitHub contents
+# API and reports lane status. Any consumer where the lane would NOT
+# fire fails the audit.
+#
+# Usage:
+#   scripts/audit-propagation-lane.sh                 # all consumers
+#   scripts/audit-propagation-lane.sh --repos r1,r2   # subset
+#   scripts/audit-propagation-lane.sh --check-files <review-policy.yml> <pr-review-policy.yml>
+#       Offline single-pair mode for tests: prints the same status line
+#       a live consumer would get, using local files instead of the API.
+#
+# Exit codes:
+#   0  lane fires on every audited consumer (explicit opt-outs included
+#      in output but reported as ⚠ and DO fail the audit — an opt-out
+#      should be acknowledged by --repos-excluding it from the audit
+#      invocation, keeping the intent visible in the caller).
+#   1  lane would not fire on at least one consumer.
+#   2  usage error / missing prerequisite.
+#   3  fetch error (could not read a consumer's live files).
+#
+# Bash 3.2 portable. Requires yq (mikefarah v4+) for manifest parsing
+# in live mode; --check-files mode needs no yq.
+
+set -euo pipefail
+
+err() { echo "ERROR: $*" >&2; }
+
+MANIFEST=".mergepath-sync.yml"
+
+# The marker that proves the default-ON lane code is present in a
+# consumer's synced workflow. Single-sourced here; the workflow carries
+# the literal.
+LANE_DEFAULT_MARKER='PROP_ENABLED=${PROP_ENABLED:-true}'
+
+# Read a 2-space-indented scalar from a named YAML block — same
+# state-machine awk as pr-review-policy.yml's prop_field, so this audit
+# evaluates the exact predicate the lane evaluates.
+prop_field() {  # <file> <block> <key>
+  awk -v blk="$2" -v key="$3" '
+    $0 ~ "^" blk ":" { in_blk = 1; next }
+    in_blk && /^[^[:space:]#]/ { in_blk = 0 }
+    in_blk && $1 == key":" {
+      sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+      sub(/[[:space:]]*#.*$/, "", $0)
+      gsub(/^"|"$/, "", $0)
+      print
+      exit
+    }
+  ' "$1"
+}
+
+# Evaluate the lane preconditions for one (review-policy, workflow)
+# file pair. Prints a status line; returns 0 if the lane fires, 1 if
+# not.
+lane_status_for_files() {  # <label> <policy-file-or-empty> <workflow-file-or-empty>
+  local label=$1 policy=$2 workflow=$3
+  local enabled author_id
+
+  if [ -z "$workflow" ] || [ ! -f "$workflow" ]; then
+    echo "  ✗ $label: pr-review-policy.yml ABSENT on the live default branch — lane cannot fire"
+    return 1
+  fi
+  if ! grep -qF "$LANE_DEFAULT_MARKER" "$workflow"; then
+    echo "  ✗ $label: pr-review-policy.yml predates the #434 default-ON lane (marker '$LANE_DEFAULT_MARKER' missing) — lane requires an explicit enabled: true the consumer does not get; re-sync the workflow"
+    return 1
+  fi
+
+  enabled=""
+  author_id=""
+  if [ -n "$policy" ] && [ -f "$policy" ]; then
+    enabled=$(prop_field "$policy" propagation_prs enabled)
+    author_id=$(grep -m1 '^author_identity:' "$policy" | awk '{print $2}' || true)
+  fi
+
+  if [ "$enabled" = "false" ]; then
+    echo "  ⚠ $label: propagation_prs.enabled: false — explicit opt-out; lane will NOT fire (exclude this consumer via --repos if intentional)"
+    return 1
+  fi
+  if [ -z "$author_id" ]; then
+    echo "  ✗ $label: review-policy.yml has no author_identity — the lane's PR-author fingerprint cannot match"
+    return 1
+  fi
+
+  if [ -z "$enabled" ]; then
+    echo "  ✓ $label: lane fires (default-ON, author_identity=$author_id)"
+  else
+    echo "  ✓ $label: lane fires (enabled: $enabled, author_identity=$author_id)"
+  fi
+  return 0
+}
+
+# --- offline test mode ------------------------------------------------------
+
+if [ "${1:-}" = "--check-files" ]; then
+  [ $# -eq 3 ] || { err "--check-files needs exactly two file arguments"; exit 2; }
+  if lane_status_for_files "check-files" "$2" "$3"; then
+    exit 0
+  fi
+  exit 1
+fi
+
+# --- live mode --------------------------------------------------------------
+
+FILTER_REPOS=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repos)
+      [ -n "${2:-}" ] || { err "missing argument for --repos"; exit 2; }
+      FILTER_REPOS="$2"
+      shift 2
+      ;;
+    --help|-h)
+      sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      err "unknown argument: $1"
+      exit 2
+      ;;
+  esac
+done
+
+command -v yq >/dev/null 2>&1 || { err "yq is required (brew install yq)"; exit 2; }
+yq --version 2>&1 | grep -q "mikefarah/yq" || { err "mikefarah/yq v4+ required"; exit 2; }
+command -v gh >/dev/null 2>&1 || { err "gh is required"; exit 2; }
+[ -f "$MANIFEST" ] || { err "$MANIFEST not found (run from the mergepath root)"; exit 2; }
+
+in_repo_filter() {
+  local name=$1
+  [ -z "$FILTER_REPOS" ] && return 0
+  case ",$FILTER_REPOS," in
+    *",$name,"*) return 0 ;;
+  esac
+  return 1
+}
+
+fetch_live_file() {  # <repo> <path> <dest>; returns 0 fetched, 1 absent (404), 3 error
+  local repo=$1 path=$2 dest=$3 rc=0 out
+  out=$(gh api "repos/$repo/contents/$path" --jq '.content' 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    case "$out" in
+      *"Not Found"*|*"404"*) return 1 ;;
+      *) err "$repo: could not fetch $path: $out"; return 3 ;;
+    esac
+  fi
+  printf '%s' "$out" | base64 -d > "$dest" 2>/dev/null || { err "$repo: could not decode $path"; return 3; }
+  return 0
+}
+
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/lane-audit.XXXXXX")
+trap 'rm -rf "$WORKDIR"' EXIT
+
+LANE_BROKEN=0
+FETCH_ERROR=0
+
+echo "Propagation lane audit (#434) — live default-branch preconditions per consumer"
+
+while IFS=$'\t' read -r consumer_name consumer_repo; do
+  [ -z "$consumer_name" ] && continue
+  in_repo_filter "$consumer_name" || continue
+
+  policy_file="$WORKDIR/$consumer_name-policy.yml"
+  workflow_file="$WORKDIR/$consumer_name-workflow.yml"
+
+  rc=0
+  fetch_live_file "$consumer_repo" ".github/review-policy.yml" "$policy_file" || rc=$?
+  if [ "$rc" -eq 3 ]; then FETCH_ERROR=1; continue; fi
+  [ "$rc" -eq 1 ] && policy_file=""
+
+  rc=0
+  fetch_live_file "$consumer_repo" ".github/workflows/pr-review-policy.yml" "$workflow_file" || rc=$?
+  if [ "$rc" -eq 3 ]; then FETCH_ERROR=1; continue; fi
+  [ "$rc" -eq 1 ] && workflow_file=""
+
+  if ! lane_status_for_files "$consumer_name" "$policy_file" "$workflow_file"; then
+    LANE_BROKEN=1
+  fi
+done <<EOF
+$(yq -r '.consumers[] | (.name + "\t" + .repo)' "$MANIFEST")
+EOF
+
+if [ "$FETCH_ERROR" -eq 1 ]; then
+  echo "Propagation lane audit: FETCH ERROR (one or more consumers unreadable)"
+  exit 3
+fi
+if [ "$LANE_BROKEN" -eq 1 ]; then
+  echo "Propagation lane audit: FAIL (lane would not fire on at least one consumer)"
+  exit 1
+fi
+echo "Propagation lane audit: PASS (lane fires on every audited consumer)"
+exit 0

--- a/scripts/audit-propagation-lane.sh
+++ b/scripts/audit-propagation-lane.sh
@@ -52,6 +52,13 @@ MANIFEST=".mergepath-sync.yml"
 # the literal.
 LANE_DEFAULT_MARKER='PROP_ENABLED=${PROP_ENABLED:-true}'
 
+# The branch prefix scripts/sync-to-downstream.sh actually uses for the
+# PRs it opens. A consumer whose review-policy.yml overrides
+# propagation_prs.branch_prefix to anything else has a lane that never
+# matches real sync branches — that's a would-not-fire condition, not a
+# healthy lane (Codex P2 on PR #444).
+SYNC_BRANCH_PREFIX='mergepath-sync/'
+
 # Read a 2-space-indented scalar from a named YAML block — same
 # state-machine awk as pr-review-policy.yml's prop_field, so this audit
 # evaluates the exact predicate the lane evaluates.
@@ -74,7 +81,7 @@ prop_field() {  # <file> <block> <key>
 # not.
 lane_status_for_files() {  # <label> <policy-file-or-empty> <workflow-file-or-empty>
   local label=$1 policy=$2 workflow=$3
-  local enabled author_id
+  local enabled author_id prefix
 
   if [ -z "$workflow" ] || [ ! -f "$workflow" ]; then
     echo "  ✗ $label: pr-review-policy.yml ABSENT on the live default branch — lane cannot fire"
@@ -87,13 +94,23 @@ lane_status_for_files() {  # <label> <policy-file-or-empty> <workflow-file-or-em
 
   enabled=""
   author_id=""
+  prefix=""
   if [ -n "$policy" ] && [ -f "$policy" ]; then
     enabled=$(prop_field "$policy" propagation_prs enabled)
+    prefix=$(prop_field "$policy" propagation_prs branch_prefix)
     author_id=$(grep -m1 '^author_identity:' "$policy" | awk '{print $2}' || true)
   fi
 
   if [ "$enabled" = "false" ]; then
     echo "  ⚠ $label: propagation_prs.enabled: false — explicit opt-out; lane will NOT fire (exclude this consumer via --repos if intentional)"
+    return 1
+  fi
+  # An overridden branch_prefix that doesn't match what
+  # sync-to-downstream.sh actually opens means the lane never matches a
+  # real sync PR — report would-not-fire, not healthy (Codex P2 on
+  # PR #444). Absent defaults to the sync prefix, mirroring the lane.
+  if [ -n "$prefix" ] && [ "$prefix" != "$SYNC_BRANCH_PREFIX" ]; then
+    echo "  ✗ $label: propagation_prs.branch_prefix is '$prefix' but sync-to-downstream.sh opens '$SYNC_BRANCH_PREFIX*' branches — lane will never match a real sync PR"
     return 1
   fi
   if [ -z "$author_id" ]; then

--- a/scripts/audit-propagation-lane.sh
+++ b/scripts/audit-propagation-lane.sh
@@ -113,6 +113,15 @@ lane_status_for_files() {  # <label> <policy-file-or-empty> <workflow-file-or-em
     echo "  ⚠ $label: propagation_prs.enabled: false — explicit opt-out; lane will NOT fire (exclude this consumer via --repos if intentional)"
     return 1
   fi
+  # The lane enters only when PROP_ENABLED is exactly 'true' after
+  # defaulting (absent → true). Any other present value — TRUE, False,
+  # typos — leaves the lane dark even though YAML may consider it a
+  # boolean; mirror the lane's exact-match semantics here (Codex P2 on
+  # PR #444 r4).
+  if [ -n "$enabled" ] && [ "$enabled" != "true" ]; then
+    echo "  ✗ $label: propagation_prs.enabled is '$enabled' — the lane only fires on exactly 'true' (or an absent key); normalize the value or remove the key"
+    return 1
+  fi
   # An overridden branch_prefix that doesn't match what
   # sync-to-downstream.sh actually opens means the lane never matches a
   # real sync PR — report would-not-fire, not healthy (Codex P2 on

--- a/scripts/ci/check_propagation_lane_audit
+++ b/scripts/ci/check_propagation_lane_audit
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# check_propagation_lane_audit
+#
+# CI wrapper for scripts/audit-propagation-lane.sh (#434). Runs the
+# offline --check-files test matrix, which also pins the audit's
+# default-ON marker to the literal actually present in
+# .github/workflows/pr-review-policy.yml — so a lane-code edit that
+# silently breaks the audit's detection fails here instead of at the
+# next weekly drift run.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST="$REPO_ROOT/tests/test_audit_propagation_lane.sh"
+
+if [ ! -f "$REPO_ROOT/scripts/audit-propagation-lane.sh" ]; then
+  echo "check_propagation_lane_audit: ERROR scripts/audit-propagation-lane.sh missing" >&2
+  exit 1
+fi
+
+if [ ! -f "$TEST" ]; then
+  echo "check_propagation_lane_audit: ERROR $TEST missing" >&2
+  exit 1
+fi
+
+echo "check_propagation_lane_audit: running propagation-lane audit tests"
+bash "$TEST"
+echo "check_propagation_lane_audit: PASS"

--- a/tests/test_audit_propagation_lane.sh
+++ b/tests/test_audit_propagation_lane.sh
@@ -48,6 +48,8 @@ POLICY_STD_PREFIX="$WORKDIR/policy-std-prefix.yml"  # explicit standard prefix
 printf 'propagation_prs:\n  enabled: true\n  branch_prefix: "mergepath-sync/"\nauthor_identity: nathanjohnpayne\n' >"$POLICY_STD_PREFIX"
 POLICY_WRONG_AUTHOR="$WORKDIR/policy-wrong-author.yml"  # author that sync never uses
 printf 'propagation_prs:\n  enabled: true\nauthor_identity: nathanpayne-claude\n' >"$POLICY_WRONG_AUTHOR"
+POLICY_CASED="$WORKDIR/policy-cased.yml"  # YAML-boolean-ish but not the lane's exact match
+printf 'propagation_prs:\n  enabled: TRUE\nauthor_identity: nathanjohnpayne\n' >"$POLICY_CASED"
 
 run_check() {  # <policy> <workflow> — sets OUT and RC
   set +e
@@ -117,6 +119,13 @@ if [ "$RC" = "1" ] && echo "$OUT" | grep -q "sync PRs are authored by"; then
   pass "author_identity that is not the sync actor fails the audit"
 else
   fail "non-sync author_identity should fail; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_CASED" "$WF_NEW"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "only fires on exactly"; then
+  pass "non-lowercase enabled value fails the audit (lane matches exactly 'true')"
+else
+  fail "enabled: TRUE should fail; got rc=$RC, out: $OUT"
 fi
 
 echo ""

--- a/tests/test_audit_propagation_lane.sh
+++ b/tests/test_audit_propagation_lane.sh
@@ -46,6 +46,8 @@ POLICY_ALT_PREFIX="$WORKDIR/policy-alt-prefix.yml"  # prefix that sync never ope
 printf 'propagation_prs:\n  enabled: true\n  branch_prefix: "other-prefix/"\nauthor_identity: nathanjohnpayne\n' >"$POLICY_ALT_PREFIX"
 POLICY_STD_PREFIX="$WORKDIR/policy-std-prefix.yml"  # explicit standard prefix
 printf 'propagation_prs:\n  enabled: true\n  branch_prefix: "mergepath-sync/"\nauthor_identity: nathanjohnpayne\n' >"$POLICY_STD_PREFIX"
+POLICY_WRONG_AUTHOR="$WORKDIR/policy-wrong-author.yml"  # author that sync never uses
+printf 'propagation_prs:\n  enabled: true\nauthor_identity: nathanpayne-claude\n' >"$POLICY_WRONG_AUTHOR"
 
 run_check() {  # <policy> <workflow> — sets OUT and RC
   set +e
@@ -108,6 +110,13 @@ if [ "$RC" = "0" ]; then
   pass "explicit standard branch_prefix fires the lane"
 else
   fail "explicit mergepath-sync/ prefix should fire; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_WRONG_AUTHOR" "$WF_NEW"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "sync PRs are authored by"; then
+  pass "author_identity that is not the sync actor fails the audit"
+else
+  fail "non-sync author_identity should fail; got rc=$RC, out: $OUT"
 fi
 
 echo ""

--- a/tests/test_audit_propagation_lane.sh
+++ b/tests/test_audit_propagation_lane.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Offline coverage for scripts/audit-propagation-lane.sh (#434) via its
+# --check-files mode, which evaluates the same lane predicate the live
+# per-consumer loop evaluates.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/audit-propagation-lane.sh"
+
+[[ -x "$SCRIPT" ]] || { echo "missing or non-executable $SCRIPT" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/lane-audit-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# A workflow file carrying the #434 default-ON lane marker, and one
+# predating it. The marker literal must match the one in the REAL
+# synced workflow — assert that first so the audit can't silently
+# diverge from what pr-review-policy.yml actually ships.
+MARKER='PROP_ENABLED=${PROP_ENABLED:-true}'
+if grep -qF "$MARKER" "$ROOT/.github/workflows/pr-review-policy.yml"; then
+  pass "lane default-ON marker present in the real pr-review-policy.yml"
+else
+  fail "lane default-ON marker missing from .github/workflows/pr-review-policy.yml — audit marker and workflow have diverged"
+fi
+
+WF_NEW="$WORKDIR/wf-new.yml"
+printf 'jobs:\n  x:\n    run: |\n      %s\n' "$MARKER" >"$WF_NEW"
+WF_OLD="$WORKDIR/wf-old.yml"
+printf 'jobs:\n  x:\n    run: |\n      PROP_ENABLED=$(prop_field f propagation_prs enabled)\n' >"$WF_OLD"
+
+POLICY_BARE="$WORKDIR/policy-bare.yml"        # no propagation_prs block (the fleet-wide #434 shape)
+printf 'author_identity: nathanjohnpayne\n' >"$POLICY_BARE"
+POLICY_ON="$WORKDIR/policy-on.yml"            # explicit enabled: true
+printf 'propagation_prs:\n  enabled: true\nauthor_identity: nathanjohnpayne\n' >"$POLICY_ON"
+POLICY_OFF="$WORKDIR/policy-off.yml"          # explicit opt-out
+printf 'propagation_prs:\n  enabled: false\nauthor_identity: nathanjohnpayne\n' >"$POLICY_OFF"
+POLICY_NO_AUTHOR="$WORKDIR/policy-no-author.yml"
+printf 'propagation_prs:\n  enabled: true\n' >"$POLICY_NO_AUTHOR"
+
+run_check() {  # <policy> <workflow> — sets OUT and RC
+  set +e
+  OUT=$("$SCRIPT" --check-files "$1" "$2" 2>&1)
+  RC=$?
+  set -e
+}
+
+run_check "$POLICY_BARE" "$WF_NEW"
+if [ "$RC" = "0" ] && echo "$OUT" | grep -q "default-ON"; then
+  pass "absent propagation_prs block fires the lane under the default-ON workflow"
+else
+  fail "absent block should fire (rc=0, default-ON); got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_ON" "$WF_NEW"
+if [ "$RC" = "0" ]; then
+  pass "explicit enabled: true fires the lane"
+else
+  fail "explicit enabled: true should fire; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_OFF" "$WF_NEW"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "explicit opt-out"; then
+  pass "explicit enabled: false is flagged as an opt-out and fails the audit"
+else
+  fail "explicit enabled: false should fail with opt-out message; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_BARE" "$WF_OLD"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "predates the #434"; then
+  pass "pre-#434 workflow without the default-ON marker fails the audit"
+else
+  fail "pre-#434 workflow should fail with marker message; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_NO_AUTHOR" "$WF_NEW"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "no author_identity"; then
+  pass "missing author_identity fails the audit"
+else
+  fail "missing author_identity should fail; got rc=$RC, out: $OUT"
+fi
+
+run_check "" "$WF_NEW"
+if [ "$RC" = "1" ]; then
+  pass "absent review-policy.yml fails the audit (no author fingerprint)"
+else
+  fail "absent review-policy.yml should fail; got rc=$RC, out: $OUT"
+fi
+
+echo ""
+echo "test_audit_propagation_lane: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_audit_propagation_lane.sh
+++ b/tests/test_audit_propagation_lane.sh
@@ -42,6 +42,10 @@ POLICY_OFF="$WORKDIR/policy-off.yml"          # explicit opt-out
 printf 'propagation_prs:\n  enabled: false\nauthor_identity: nathanjohnpayne\n' >"$POLICY_OFF"
 POLICY_NO_AUTHOR="$WORKDIR/policy-no-author.yml"
 printf 'propagation_prs:\n  enabled: true\n' >"$POLICY_NO_AUTHOR"
+POLICY_ALT_PREFIX="$WORKDIR/policy-alt-prefix.yml"  # prefix that sync never opens
+printf 'propagation_prs:\n  enabled: true\n  branch_prefix: "other-prefix/"\nauthor_identity: nathanjohnpayne\n' >"$POLICY_ALT_PREFIX"
+POLICY_STD_PREFIX="$WORKDIR/policy-std-prefix.yml"  # explicit standard prefix
+printf 'propagation_prs:\n  enabled: true\n  branch_prefix: "mergepath-sync/"\nauthor_identity: nathanjohnpayne\n' >"$POLICY_STD_PREFIX"
 
 run_check() {  # <policy> <workflow> — sets OUT and RC
   set +e
@@ -90,6 +94,20 @@ if [ "$RC" = "1" ]; then
   pass "absent review-policy.yml fails the audit (no author fingerprint)"
 else
   fail "absent review-policy.yml should fail; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_ALT_PREFIX" "$WF_NEW"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "never match a real sync PR"; then
+  pass "overridden branch_prefix that sync never opens fails the audit"
+else
+  fail "non-sync branch_prefix should fail; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_STD_PREFIX" "$WF_NEW"
+if [ "$RC" = "0" ]; then
+  pass "explicit standard branch_prefix fires the lane"
+else
+  fail "explicit mergepath-sync/ prefix should fire; got rc=$RC, out: $OUT"
 fi
 
 echo ""


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
Implements #434 Option 1 (preferred) + Option 3, hitting all four acceptance criteria:

- **Lane defaults ON** (`PROP_ENABLED=${PROP_ENABLED:-true}`, `PROP_PREFIX=${PROP_PREFIX:-mergepath-sync/}`) when the `propagation_prs` block is absent from the BASE commit's `review-policy.yml`. This removes the structural flaw — a lane whose enablement depends on a never-propagated file — without any per-consumer `review-policy.yml` edits. Explicit `enabled: false` remains the opt-out.
- **Teeth unchanged:** recognition is still gated on `verify-propagation-pr.sh`'s byte-level comparison sourced from immutable public `mergepath@<sha>`; config still reads from the PR's base commit, so a PR cannot self-qualify (it can neither edit its base nor grant itself a default).
- **Drift guard:** new `scripts/audit-propagation-lane.sh` reads each consumer's **live default branch** for the three lane preconditions (default-ON lane code present in the synced workflow, no unexpected `enabled: false`, `author_identity` present) and fails `weekly-drift-audit.yml` when the lane would not fire on any consumer.
- **CI:** new `scripts/ci/check_propagation_lane_audit` (wired into `repo_lint.yml` per the check-wiring contract) runs the offline test matrix and pins the audit's default-ON marker to the literal in `pr-review-policy.yml` so the audit and the lane cannot silently diverge.
- Docs updated: REVIEW_POLICY.md § Propagation PR review lane and the `review-policy.yml` block comment.

The fix self-applies on the next sync wave: `pull_request` events run the workflow from the PR's merge ref, so the very sync PRs that carry the updated `pr-review-policy.yml` evaluate the default-ON lane and auto-exempt once byte-verified (acceptance criterion 4 verifies on that wave).

Closes #434

## Testing
- [x] New `tests/test_audit_propagation_lane.sh` — 7 pass (marker pinned to real workflow; absent block fires; explicit true fires; explicit false flagged opt-out; pre-#434 workflow fails; missing author_identity fails; absent policy fails)
- [x] `check_ci_scripts_wired`, `check_workflow_parsers`, `check_verify_propagation_pr`, `check_propagation_lane_audit`, `check_workflow_verify_propagation_templated`, `check_sync_manifest`, `check_pr_audit_sync_exemption` all PASS

## Self-Review
- [x] Correctness: changes match stated requirements
- [x] Regression risk: explicit-config consumers unchanged; byte-verification gate untouched
- [x] Style and conventions: follows repository standards
- [x] Test coverage: full predicate matrix + marker-divergence pin
- [x] Security and dependency hygiene: trust inputs unchanged (base-commit config + immutable public mergepath@sha)