### PR TITLE
fix(sync): fail closed in export_consumer_facts on yq parse error (#457)

### DIFF
--- a/scripts/lib/manifest-fact-helpers.sh
+++ b/scripts/lib/manifest-fact-helpers.sh
@@ -49,18 +49,35 @@ export_consumer_facts() {
     unset "$var"
   done
 
-  while IFS=$'\t' read -r key value; do
-    [ -z "$key" ] && continue
-    local upper
-    upper=$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-    export "MERGEPATH_FACT_$upper=$value"
-  done < <(MERGEPATH_CONSUMER_NAME="$consumer_name" yq -r '
+  # Capture yq's output up front so a parse failure surfaces as a
+  # non-zero return (fail CLOSED). A `while ... done < <(yq ...)` process
+  # substitution masks yq's exit code — the loop's status is the last
+  # `read` (or 0 if the body ran), never yq's — so a malformed manifest
+  # would export no facts yet return 0 (fail OPEN), letting a verification
+  # caller proceed on empty/wrong MERGEPATH_FACT_* state. See #457.
+  local facts_tsv
+  if ! facts_tsv=$(MERGEPATH_CONSUMER_NAME="$consumer_name" yq -r '
     env(MERGEPATH_CONSUMER_NAME) as $cn
     | .consumers[] | select(.name == $cn) | .facts // {} | to_entries[]
     | .key + "\t"
       + ((.value | select(tag == "!!seq") | join(" "))
          // (.value | tostring))
-  ' "$manifest")
+  ' "$manifest"); then
+    echo "export_consumer_facts: yq failed to parse $manifest (consumer=$consumer_name)" >&2
+    return 1
+  fi
+
+  # Iterate via a here-string, NOT a `yq | while` pipe: a pipe subshells
+  # the loop body and the MERGEPATH_FACT_* exports would not survive into
+  # the caller's shell. The here-string adds a trailing newline, which the
+  # empty-key guard below absorbs, so empty-facts consumers behave exactly
+  # as before.
+  while IFS=$'\t' read -r key value; do
+    [ -z "$key" ] && continue
+    local upper
+    upper=$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+    export "MERGEPATH_FACT_$upper=$value"
+  done <<< "$facts_tsv"
   # NOTE on the value-typed serialization: mikefarah/yq v4 does NOT
   # accept a top-level `if`-then-else expression in this filter
   # position (the lexer rejects `if` at column-after-pipe). An

--- a/scripts/workflow/verify-propagation-pr.sh
+++ b/scripts/workflow/verify-propagation-pr.sh
@@ -298,7 +298,13 @@ if [ "$TEMPLATED_SURFACE_ACTIVE" = "1" ] && [ -n "$CONSUMER_NAME" ]; then
       render_err=$(mktemp "${TMPDIR:-/tmp}/verify-prop-render-err.XXXXXX")
       render_rc=0
       (
-        export_consumer_facts "$CONSUMER_NAME" "$MANIFEST"
+        # `|| exit $?` explicitly propagates a fail-closed export rc as the
+        # subshell's exit status. Relying on `set -e` alone is unsafe here:
+        # the subshell is the left operand of `|| render_rc=$?`, a context
+        # in which bash suppresses `set -e` for the commands inside it, so
+        # export_consumer_facts returning 1 would otherwise be masked by
+        # template_substitution::render's rc. See #457.
+        export_consumer_facts "$CONSUMER_NAME" "$MANIFEST" || exit $?
         template_substitution::render "$mp_source_abs"
       ) > "$rendered" 2> "$render_err" || render_rc=$?
 

--- a/tests/test_export_consumer_facts.sh
+++ b/tests/test_export_consumer_facts.sh
@@ -186,6 +186,36 @@ else
   fail "Case 7 (#322): expected:\n$expected\ngot:\n$out"
 fi
 
+# Case 8 (#457): the helper must fail CLOSED on a manifest yq cannot
+# parse. The earlier `while ... done < <(yq ...)` form masked yq's exit
+# code (the loop's status is the last `read`, never yq's), so a malformed
+# manifest exported no facts yet returned 0 — letting a verification
+# caller proceed on empty/wrong MERGEPATH_FACT_* state. This case sources
+# the lib and calls export_consumer_facts directly (the cases above only
+# exercise a mirror of the filter) to assert non-zero rc AND no exports.
+# shellcheck source=scripts/lib/manifest-fact-helpers.sh
+source "$LIB"
+cat > "$WORKDIR/malformed.yml" <<'EOF'
+version: 1
+consumers:
+  - name: broken
+    facts: {frameworks: [react, typescript
+EOF
+# Precondition: confirm the fixture is genuinely unparseable, else the
+# case would pass vacuously if yq ever grows lenient about this input.
+if yq -r '.' "$WORKDIR/malformed.yml" >/dev/null 2>&1; then
+  fail "Case 8 precondition: fixture parsed cleanly; need a manifest yq rejects"
+else
+  facts_rc=0
+  export_consumer_facts broken "$WORKDIR/malformed.yml" >/dev/null 2>&1 || facts_rc=$?
+  leaked=$(env | awk -F= '/^MERGEPATH_FACT_/ {print $1}')
+  if [ "$facts_rc" -ne 0 ] && [ -z "$leaked" ]; then
+    pass "Case 8 (#457): export_consumer_facts fails closed (rc=$facts_rc) on unparseable manifest, no facts exported"
+  else
+    fail "Case 8 (#457): expected non-zero rc and no exports; got rc=$facts_rc, leaked=[$leaked]"
+  fi
+fi
+
 echo
 TOTAL=$((PASS + FAIL))
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Fixes #457: `export_consumer_facts()` in `scripts/lib/manifest-fact-helpers.sh` swallowed `yq` parse failures. The `yq` ran inside `while ... done < <(yq ...)`, so the loop's exit status (last `read`) masked yq's — a manifest yq couldn't parse exported **no** `MERGEPATH_FACT_*` yet returned `0` (**fail open**), letting the templated-render verifier proceed on empty/wrong facts.
- **Helper:** capture yq output into a variable, `return 1` on parse failure, iterate via a here-string. A `yq | while` pipe would subshell the loop and the `MERGEPATH_FACT_*` exports would not survive into the caller — so the here-string is deliberate. The yq filter string is **byte-unchanged** (the test's `select(tag == "!!seq") | join(" ")` shape guard and broken-form-absence guard still hold).
- **Call site** (`scripts/workflow/verify-propagation-pr.sh`): `export_consumer_facts ... || exit $?` so the render subshell propagates the fail-closed rc. `set -e` alone is unsafe — the subshell is the left operand of `|| render_rc=$?`, a context where bash suppresses `set -e` for the commands inside it, so the helper's non-zero would otherwise be masked by `template_substitution::render`'s rc.

No user-visible behavior change on the happy path; the success path still exports facts identically (verified against the live manifest: `matchline` → `MERGEPATH_FACT_FRAMEWORKS=react typescript`).

## Testing
- [x] Tests pass — `tests/test_export_consumer_facts.sh` now 9 cases incl. new **Case 8** (sources the lib, asserts non-zero rc + no exports on an unparseable manifest, with a precondition that the fixture is genuinely unparseable so it can't pass vacuously).
- [x] CI checks pass locally: `check_export_consumer_facts`, `check_verify_propagation_pr`, `check_workflow_verify_propagation_templated`, `check_mktemp_portability`.
- [x] Manual verification: success path unchanged; malformed manifest → rc=1, no facts exported.

## Self-Review
- [x] Correctness: matches #457's suggested helper fix and the secondary call-site fail-closed hardening.
- [x] Regression risk: filter string unchanged; here-string trailing newline absorbed by the existing empty-key guard, so empty-facts consumers behave as before.
- [x] Style and conventions: follows repository standards.
- [x] Test coverage: new fail-closed path covered; existing cases passing.
- [x] Security and dependency hygiene: no new deps; the change makes a verification helper fail **closed**.

Closes #457
