### PR TITLE
fix(audit): align pr-audit.yml external-clearance with the merge gate (#445, #449, #450)

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -425,9 +425,9 @@ jobs:
                   reactions = [];
                 }
 
-                // HEAD committer date — the reaction-window lower bound.
-                // Unavailable → reaction path stays off (fail closed for
-                // that path; the review path is unaffected).
+                // HEAD committer date — the BASE reaction-window lower
+                // bound. Unavailable → reaction path stays off (fail closed
+                // for that path; the review path is unaffected).
                 let headCommitterDate = '';
                 try {
                   const commitResp = await github.rest.repos.getCommit({
@@ -445,6 +445,51 @@ jobs:
                   );
                   headCommitterDate = '';
                 }
+
+                // Raise the lower bound to the latest force-push time when
+                // it is newer than the committer date — mirrors
+                // codex-review-check.sh's HEAD_PUSHED_AT = max(committer
+                // date, head_ref_force_pushed). A PR force-pushed to an
+                // old/reused commit carries an OLD committer date, so
+                // without this a stale +1 from before the force-push could
+                // satisfy the window and falsely clear the audit for
+                // exactly the force-push bypass it exists to catch (Codex
+                // P2 on PR #460).
+                let lastForcePushAt = '';
+                try {
+                  const timeline = await github.paginate(
+                    github.rest.issues.listEventsForTimeline,
+                    {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: pr.number,
+                      per_page: 100,
+                    }
+                  );
+                  for (const ev of timeline) {
+                    if (ev.event === 'head_ref_force_pushed' &&
+                        ev.created_at && ev.created_at > lastForcePushAt) {
+                      lastForcePushAt = ev.created_at;
+                    }
+                  }
+                } catch (e) {
+                  console.log(
+                    `WARNING: could not fetch timeline for PR #${pr.number}; ` +
+                    `force-push reaction anchor unavailable. Error: ${e.message}`
+                  );
+                  lastForcePushAt = '';
+                }
+
+                // Reaction-window lower bound = max(committer date, last
+                // force-push), lexicographic on ISO-8601. Empty committer
+                // date keeps the reaction path off (fail closed); force-push
+                // only RAISES an existing base, never substitutes for it.
+                const reactionLowerBound = headCommitterDate
+                  ? ((lastForcePushAt > headCommitterDate)
+                      ? lastForcePushAt
+                      : headCommitterDate)
+                  : '';
+
                 const mergedAt = pr.merged_at || '';
 
                 // ── Clearance algorithm (#249/#449/#450) ──────────────
@@ -490,13 +535,14 @@ jobs:
                   }
 
                   // Latest qualifying Codex +1 reaction in the merge-time
-                  // window. Empty latestReactionTime sorts below any ISO
-                  // timestamp, so the first qualifier always sets it.
+                  // window [reactionLowerBound, merged_at]. Empty
+                  // latestReactionTime sorts below any ISO timestamp, so the
+                  // first qualifier always sets it.
                   let latestReactionTime = '';
                   for (const x of reactions) {
                     if (x.user && x.user.login === codexBotLogin &&
                         x.content === '+1' &&
-                        headCommitterDate && x.created_at >= headCommitterDate &&
+                        reactionLowerBound && x.created_at >= reactionLowerBound &&
                         mergedAt && x.created_at <= mergedAt &&
                         x.created_at > latestReactionTime) {
                       latestReactionTime = x.created_at;

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -486,6 +486,15 @@ jobs:
                 // satisfy the window and falsely clear the audit for
                 // exactly the force-push bypass it exists to catch (Codex
                 // P2 on PR #460).
+                //
+                // Only force-pushes at or before merged_at are part of
+                // merge-time state. A branch force-pushed AFTER merge would
+                // otherwise raise reactionLowerBound past merged_at, emptying
+                // the [lowerBound, merged_at] window and falsely flagging a PR
+                // that legitimately cleared via a pre-merge 👍 (Codex P2 on
+                // PR #460 round 2). Mirrors labelWasPresentAtMerge /
+                // resolvedAtMerge merge-time reconstruction.
+                const mergedAt = pr.merged_at || '';
                 let lastForcePushAt = '';
                 try {
                   const timeline = await github.paginate(
@@ -499,7 +508,9 @@ jobs:
                   );
                   for (const ev of timeline) {
                     if (ev.event === 'head_ref_force_pushed' &&
-                        ev.created_at && ev.created_at > lastForcePushAt) {
+                        ev.created_at &&
+                        (!mergedAt || ev.created_at <= mergedAt) &&
+                        ev.created_at > lastForcePushAt) {
                       lastForcePushAt = ev.created_at;
                     }
                   }
@@ -510,8 +521,6 @@ jobs:
                   );
                   lastForcePushAt = '';
                 }
-
-                const mergedAt = pr.merged_at || '';
 
                 // Merge-time freshness floor for +1 reactions (#460 Codex
                 // P2): the merge gate's reaction lower bound is

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -55,16 +55,20 @@ jobs:
             let reviewerAccounts;
             let authorIdentity;
             let codexBotLogin;
+            let reactionFreshnessWindowSeconds;
             try {
               const config = yaml.load(fs.readFileSync('.github/review-policy.yml', 'utf8'));
               reviewerAccounts = config.available_reviewers || [];
               authorIdentity = config.author_identity || 'nathanjohnpayne';
               codexBotLogin = (config.codex && config.codex.bot_login) || 'chatgpt-codex-connector[bot]';
+              reactionFreshnessWindowSeconds =
+                (config.codex && config.codex.reaction_freshness_window_seconds) || 1800;
             } catch (e) {
               console.log('WARNING: Could not read review-policy.yml, using defaults');
               reviewerAccounts = ['nathanpayne-claude', 'nathanpayne-codex', 'nathanpayne-cursor'];
               authorIdentity = 'nathanjohnpayne';
               codexBotLogin = 'chatgpt-codex-connector[bot]';
+              reactionFreshnessWindowSeconds = 1800;
             }
 
             // The Codex bot's review-state semantics differ from
@@ -503,17 +507,39 @@ jobs:
                   lastForcePushAt = '';
                 }
 
-                // Reaction-window lower bound = max(committer date, last
-                // force-push), lexicographic on ISO-8601. Empty committer
-                // date keeps the reaction path off (fail closed); force-push
-                // only RAISES an existing base, never substitutes for it.
-                const reactionLowerBound = headCommitterDate
-                  ? ((lastForcePushAt > headCommitterDate)
-                      ? lastForcePushAt
-                      : headCommitterDate)
-                  : '';
-
                 const mergedAt = pr.merged_at || '';
+
+                // Merge-time freshness floor for +1 reactions (#460 Codex
+                // P2): the merge gate's reaction lower bound is
+                // max(HEAD_PUSHED_AT, NOW - reaction_freshness_window). An
+                // ordinary push to a commit with an OLD committer date leaves
+                // the committer/force-push anchor early, so a stale
+                // prior-HEAD 👍 the merge gate would reject (older than its
+                // NOW-window floor) could otherwise clear this retrospective
+                // audit. Anchor the equivalent floor to MERGE time:
+                // merged_at - window. Strip the .000 ms so it compares
+                // lexicographically against the ms-less ISO timestamps.
+                let mergedAtFloor = '';
+                if (mergedAt) {
+                  const t = Date.parse(mergedAt);
+                  if (!Number.isNaN(t)) {
+                    mergedAtFloor = new Date(t - reactionFreshnessWindowSeconds * 1000)
+                      .toISOString().replace(/\.\d{3}Z$/, 'Z');
+                  }
+                }
+
+                // Reaction-window lower bound = max(committer date, last
+                // force-push, merged_at - window), lexicographic on ISO-8601
+                // — the merge gate's max(HEAD_PUSHED_AT, NOW - window) adapted
+                // to merge time. Empty committer date keeps the reaction path
+                // off (fail closed); the force-push and merge-time-floor only
+                // RAISE an existing base, never substitute for it.
+                let reactionLowerBound = '';
+                if (headCommitterDate) {
+                  reactionLowerBound = headCommitterDate;
+                  if (lastForcePushAt > reactionLowerBound) reactionLowerBound = lastForcePushAt;
+                  if (mergedAtFloor > reactionLowerBound) reactionLowerBound = mergedAtFloor;
+                }
 
                 // ── Clearance algorithm (#249/#449/#450) ──────────────
                 // KEEP IN SYNC with the mirrored runner in

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -56,6 +56,7 @@ jobs:
             let authorIdentity;
             let codexBotLogin;
             let reactionFreshnessWindowSeconds;
+            let codexEnabled;
             try {
               const config = yaml.load(fs.readFileSync('.github/review-policy.yml', 'utf8'));
               reviewerAccounts = config.available_reviewers || [];
@@ -63,12 +64,15 @@ jobs:
               codexBotLogin = (config.codex && config.codex.bot_login) || 'chatgpt-codex-connector[bot]';
               reactionFreshnessWindowSeconds =
                 (config.codex && config.codex.reaction_freshness_window_seconds) || 1800;
+              // Default true (matches codex-review-check.sh CODEX_ENABLED:-true).
+              codexEnabled = !(config.codex && config.codex.enabled === false);
             } catch (e) {
               console.log('WARNING: Could not read review-policy.yml, using defaults');
               reviewerAccounts = ['nathanpayne-claude', 'nathanpayne-codex', 'nathanpayne-cursor'];
               authorIdentity = 'nathanjohnpayne';
               codexBotLogin = 'chatgpt-codex-connector[bot]';
               reactionFreshnessWindowSeconds = 1800;
+              codexEnabled = true;
             }
 
             // The Codex bot's review-state semantics differ from
@@ -544,8 +548,17 @@ jobs:
                 // ── Clearance algorithm (#249/#449/#450) ──────────────
                 // KEEP IN SYNC with the mirrored runner in
                 // scripts/ci/check_pr_audit_codex_clearance.
+                //
+                // Gate on codexEnabled (#460 Codex P2): when codex.enabled is
+                // false, scripts/codex-review-check.sh ignores Codex bot
+                // reviews/reactions entirely (gate (c) clears only via a Phase
+                // 4b substitute APPROVED). The audit must match — otherwise a
+                // stray 👍 from a still-installed App on a codex-disabled repo
+                // would mark a merge compliant the merge gate never cleared.
+                // codexCleared stays false, so the audit falls through to the
+                // CLI-APPROVED requirement below.
                 let codexCleared = false;
-                if (inlineComments !== null) {
+                if (codexEnabled && inlineComments !== null) {
                   // Latest Codex COMMENTED review on HEAD (max submitted_at).
                   let latestCodexReview = null;
                   if (codexCommentedOnHead.length > 0) {

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -353,13 +353,27 @@ jobs:
                   inlineComments = null;
                 }
 
-                // Comment-databaseId → isResolved map, paginated over all
-                // review threads. null = lookup failed → fail CLOSED
-                // (#449): every P0/P1 finding is then treated as
+                // Comment-databaseId → { resolved, threadLatestAt } map,
+                // paginated over all review threads. null = lookup failed →
+                // fail CLOSED (#449): every P0/P1 finding is then treated as
                 // unresolved, so the review path cannot clear on a lookup
                 // failure. Inner comments(first:100) matches
                 // scripts/codex-p1-gate.sh (a single P0/P1 thread with
                 // >100 replies is not a real shape).
+                //
+                // threadLatestAt is the newest comment time in the thread.
+                // GitHub exposes NO thread resolvedAt and NO resolve
+                // timeline event (verified by schema introspection), so this
+                // retrospective audit cannot read WHEN a thread was resolved.
+                // A thread resolved AFTER merge would otherwise wrongly clear
+                // (Codex P1 on #460). The clearance algorithm below bounds
+                // resolution by merge time using the newest comment as a
+                // proxy: a resolved thread is honored only when it shows no
+                // comment activity after merged_at (and merged_at is known).
+                // Residual: a silent UI-button resolve with no following
+                // comment can't be dated — the codex-p1-gate REQUIRED check
+                // is the at-merge primary enforcement, this audit the
+                // retrospective backstop.
                 let resolutionByCommentId = {};
                 try {
                   let cursor = null;
@@ -370,7 +384,7 @@ jobs:
                            pullRequest(number:$pr){
                              reviewThreads(first:100, after:$cursor){
                                pageInfo { hasNextPage endCursor }
-                               nodes { isResolved comments(first:100){ nodes { databaseId } } }
+                               nodes { isResolved comments(first:100){ nodes { databaseId createdAt } } }
                              }
                            }
                          }
@@ -384,8 +398,17 @@ jobs:
                     );
                     const rt = tresp.repository.pullRequest.reviewThreads;
                     for (const t of rt.nodes) {
+                      let threadLatestAt = '';
                       for (const c of t.comments.nodes) {
-                        resolutionByCommentId[String(c.databaseId)] = t.isResolved;
+                        if (c.createdAt && c.createdAt > threadLatestAt) {
+                          threadLatestAt = c.createdAt;
+                        }
+                      }
+                      for (const c of t.comments.nodes) {
+                        resolutionByCommentId[String(c.databaseId)] = {
+                          resolved: t.isResolved,
+                          threadLatestAt,
+                        };
                       }
                     }
                     if (!rt.pageInfo.hasNextPage) break;
@@ -516,7 +539,8 @@ jobs:
                   // Codex embeds; scope to the bot author so an author
                   // quote-reply doesn't read as a finding (#249). A
                   // finding counts as unresolved unless its thread is
-                  // RESOLVED (#449).
+                  // RESOLVED *and that resolution is bounded by merge time*
+                  // (#449 + #460).
                   const p01Regex = /!\[P[01] Badge\]/;
                   let reviewHasUnresolvedP01 = false;
                   if (latestCodexReview) {
@@ -528,9 +552,22 @@ jobs:
                     if (resolutionByCommentId === null) {
                       reviewHasUnresolvedP01 = p01.length > 0; // fail closed
                     } else {
-                      reviewHasUnresolvedP01 = p01.some(
-                        c => resolutionByCommentId[String(c.id)] !== true
-                      );
+                      // A P0/P1 finding counts as resolved ONLY when its
+                      // thread is resolved AND that resolution is bounded by
+                      // merge: merged_at is known and the thread shows no
+                      // comment activity after it. GitHub exposes no
+                      // resolvedAt, so post-merge comment activity is the
+                      // conservative proxy — a thread resolved after merge
+                      // must not retroactively clear the audit (Codex P1 on
+                      // #460). Fail closed on unknown merged_at.
+                      const resolvedAtMerge = (cid) => {
+                        const e = resolutionByCommentId[String(cid)];
+                        if (!e || e.resolved !== true) return false;
+                        if (!mergedAt) return false;
+                        if (e.threadLatestAt && e.threadLatestAt > mergedAt) return false;
+                        return true;
+                      };
+                      reviewHasUnresolvedP01 = p01.some(c => !resolvedAtMerge(c.id));
                     }
                   }
 

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -619,18 +619,41 @@ jobs:
                     }
                   }
 
+                  // Same-agent context (Codex P2 on #460 r3): a Codex +1
+                  // substitutes for gate (b)'s reviewer approval ONLY when the
+                  // PR's Authoring-Agent resolves to an available reviewer
+                  // identity (e.g. `Authoring-Agent: claude` → nathanpayne-
+                  // claude). codex-review-check.sh gates branch 2 (#170) on
+                  // this; the audit must too, or a cross-agent / missing-
+                  // Authoring-Agent PR merged with only a 👍 (which the merge
+                  // gate rejects) would pass this audit. Mirrors the shell's
+                  // AUTHORING_AGENT → SAME_AGENT_REVIEWER suffix match.
+                  let sameAgentContext = false;
+                  const agentMatch = (pr.body || '').match(
+                    /^Authoring-Agent:[ \t]*([A-Za-z0-9_-]+)/im
+                  );
+                  if (agentMatch) {
+                    const authoringAgent = agentMatch[1].toLowerCase();
+                    sameAgentContext = reviewerAccounts.some(
+                      r => String(r).toLowerCase().endsWith('-' + authoringAgent)
+                    );
+                  }
+
                   // Latest qualifying Codex +1 reaction in the merge-time
                   // window [reactionLowerBound, merged_at]. Empty
                   // latestReactionTime sorts below any ISO timestamp, so the
-                  // first qualifier always sets it.
+                  // first qualifier always sets it. Gated on sameAgentContext:
+                  // a +1 from a non-same-agent PR does not clear gate (b).
                   let latestReactionTime = '';
-                  for (const x of reactions) {
-                    if (x.user && x.user.login === codexBotLogin &&
-                        x.content === '+1' &&
-                        reactionLowerBound && x.created_at >= reactionLowerBound &&
-                        mergedAt && x.created_at <= mergedAt &&
-                        x.created_at > latestReactionTime) {
-                      latestReactionTime = x.created_at;
+                  if (sameAgentContext) {
+                    for (const x of reactions) {
+                      if (x.user && x.user.login === codexBotLogin &&
+                          x.content === '+1' &&
+                          reactionLowerBound && x.created_at >= reactionLowerBound &&
+                          mergedAt && x.created_at <= mergedAt &&
+                          x.created_at > latestReactionTime) {
+                        latestReactionTime = x.created_at;
+                      }
                     }
                   }
 

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -319,71 +319,201 @@ jobs:
                   r => r.state === 'COMMENTED'
                 );
 
-                // Two-condition Codex clearance: at least one
-                // COMMENTED review on HEAD, AND no unresolved
-                // P0/P1 inline findings on the latest round.
-                // Findings are scoped to the latest Codex review's
-                // pull_request_review_id (same as merge gate (c))
-                // so an earlier round's already-addressed findings
-                // don't keep the audit failing.
-                let codexCleared = false;
-                if (codexCommentedOnHead.length > 0) {
-                  // Latest Codex review on HEAD (max by submitted_at).
-                  const latestCodexReview = codexCommentedOnHead.reduce(
-                    (latest, r) => {
-                      if (!latest) return r;
-                      return (r.submitted_at > latest.submitted_at) ? r : latest;
-                    },
-                    null
+                // Codex clearance mirrors scripts/codex-review-check.sh
+                // gate (c): a PR clears when the LATEST qualifying Codex
+                // signal on the merge HEAD is either
+                //   - a COMMENTED review with no UNRESOLVED P0/P1 inline
+                //     findings (#249 + resolution-aware, #449), OR
+                //   - a 👍/+1 reaction from the Codex bot inside the
+                //     merge-time freshness window (#450).
+                // Latest-signal-wins decides between them, identically to
+                // the merge gate, so a PR legitimately merged on either
+                // form is not retroactively flagged. Resolves TODO(#235).
+                //
+                // Inline P0/P1 findings live on /pulls/{pr}/comments,
+                // keyed to a review via pull_request_review_id; resolution
+                // state lives on the GraphQL reviewThreads view, joined by
+                // comment databaseId (same join as scripts/codex-p1-gate.sh).
+                let inlineComments = [];
+                try {
+                  inlineComments = await github.paginate(
+                    github.rest.pulls.listReviewComments,
+                    {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pull_number: pr.number,
+                      per_page: 100,
+                    }
                   );
+                } catch (e) {
+                  console.log(
+                    `WARNING: could not fetch inline comments for PR #${pr.number}; ` +
+                    `treating Codex clearance as NOT met for safety. Error: ${e.message}`
+                  );
+                  inlineComments = null;
+                }
 
-                  // Fetch inline review comments for this PR. The
-                  // outer review-fetch (listReviews) returns review
-                  // metadata only — inline P0/P1 findings live on
-                  // the /pulls/{pr}/comments endpoint, keyed back
-                  // to a review via pull_request_review_id.
-                  let inlineComments = [];
-                  try {
-                    inlineComments = await github.paginate(
-                      github.rest.pulls.listReviewComments,
+                // Comment-databaseId → isResolved map, paginated over all
+                // review threads. null = lookup failed → fail CLOSED
+                // (#449): every P0/P1 finding is then treated as
+                // unresolved, so the review path cannot clear on a lookup
+                // failure. Inner comments(first:100) matches
+                // scripts/codex-p1-gate.sh (a single P0/P1 thread with
+                // >100 replies is not a real shape).
+                let resolutionByCommentId = {};
+                try {
+                  let cursor = null;
+                  for (;;) {
+                    const tresp = await github.graphql(
+                      `query($owner:String!,$name:String!,$pr:Int!,$cursor:String){
+                         repository(owner:$owner,name:$name){
+                           pullRequest(number:$pr){
+                             reviewThreads(first:100, after:$cursor){
+                               pageInfo { hasNextPage endCursor }
+                               nodes { isResolved comments(first:100){ nodes { databaseId } } }
+                             }
+                           }
+                         }
+                       }`,
                       {
                         owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        pull_number: pr.number,
-                        per_page: 100,
+                        name: context.repo.repo,
+                        pr: pr.number,
+                        cursor,
                       }
                     );
-                  } catch (e) {
-                    console.log(
-                      `WARNING: could not fetch inline comments for PR #${pr.number}; ` +
-                      `treating Codex clearance as NOT met for safety. Error: ${e.message}`
-                    );
-                    inlineComments = null;
+                    const rt = tresp.repository.pullRequest.reviewThreads;
+                    for (const t of rt.nodes) {
+                      for (const c of t.comments.nodes) {
+                        resolutionByCommentId[String(c.databaseId)] = t.isResolved;
+                      }
+                    }
+                    if (!rt.pageInfo.hasNextPage) break;
+                    cursor = rt.pageInfo.endCursor;
                   }
+                } catch (e) {
+                  console.log(
+                    `WARNING: reviewThreads resolution lookup failed for PR #${pr.number}; ` +
+                    `failing closed (P0/P1 findings treated as unresolved). Error: ${e.message}`
+                  );
+                  resolutionByCommentId = null;
+                }
 
-                  if (inlineComments !== null && latestCodexReview) {
-                    // P0/P1 finding heuristic — same regex used by
-                    // scripts/codex-review-check.sh gate (c):
-                    // Codex inlines `![P0 Badge]` / `![P1 Badge]`
-                    // markdown images into each finding body.
-                    // Filter on bot author too — review-thread
-                    // replies (e.g., a quote-reply from the PR
-                    // author addressing a Codex finding) inherit
-                    // the same pull_request_review_id and would
-                    // otherwise be misclassified as unaddressed
-                    // findings (see codex-review-check.sh § P0/P1
-                    // for the nathanpaynedotcom #180 round 3
-                    // history on that filter).
-                    const p01Regex = /!\[P[01] Badge\]/;
-                    const unresolvedP01 = inlineComments.filter(
+                // Codex bot 👍/+1 reactions on the PR issue. The merge
+                // gate anchors freshness to max(HEAD push, NOW - window);
+                // the WEEKLY audit instead anchors to MERGE time, because
+                // a valid merge-time +1 is week-old by audit time and a
+                // NOW - window floor would wrongly reject it (#450). The
+                // window is [HEAD committer date, merged_at]: on/after the
+                // HEAD freshness floor and not a post-merge reaction.
+                let reactions = [];
+                try {
+                  reactions = await github.paginate(
+                    github.rest.reactions.listForIssue,
+                    {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: pr.number,
+                      per_page: 100,
+                    }
+                  );
+                } catch (e) {
+                  console.log(
+                    `WARNING: could not fetch reactions for PR #${pr.number}; ` +
+                    `reaction-clearance path disabled. Error: ${e.message}`
+                  );
+                  reactions = [];
+                }
+
+                // HEAD committer date — the reaction-window lower bound.
+                // Unavailable → reaction path stays off (fail closed for
+                // that path; the review path is unaffected).
+                let headCommitterDate = '';
+                try {
+                  const commitResp = await github.rest.repos.getCommit({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: headSha,
+                  });
+                  headCommitterDate =
+                    (commitResp.data.commit.committer &&
+                     commitResp.data.commit.committer.date) || '';
+                } catch (e) {
+                  console.log(
+                    `WARNING: could not fetch HEAD commit for PR #${pr.number}; ` +
+                    `reaction-clearance lower bound unavailable. Error: ${e.message}`
+                  );
+                  headCommitterDate = '';
+                }
+                const mergedAt = pr.merged_at || '';
+
+                // ── Clearance algorithm (#249/#449/#450) ──────────────
+                // KEEP IN SYNC with the mirrored runner in
+                // scripts/ci/check_pr_audit_codex_clearance.
+                let codexCleared = false;
+                if (inlineComments !== null) {
+                  // Latest Codex COMMENTED review on HEAD (max submitted_at).
+                  let latestCodexReview = null;
+                  if (codexCommentedOnHead.length > 0) {
+                    latestCodexReview = codexCommentedOnHead.reduce(
+                      (latest, r) => {
+                        if (!latest) return r;
+                        return (r.submitted_at > latest.submitted_at) ? r : latest;
+                      },
+                      null
+                    );
+                  }
+                  const latestReviewTime =
+                    latestCodexReview ? (latestCodexReview.submitted_at || '') : '';
+
+                  // Unresolved P0/P1 findings on the latest review. P0/P1
+                  // markers are the `![P0 Badge]` / `![P1 Badge]` images
+                  // Codex embeds; scope to the bot author so an author
+                  // quote-reply doesn't read as a finding (#249). A
+                  // finding counts as unresolved unless its thread is
+                  // RESOLVED (#449).
+                  const p01Regex = /!\[P[01] Badge\]/;
+                  let reviewHasUnresolvedP01 = false;
+                  if (latestCodexReview) {
+                    const p01 = inlineComments.filter(
                       c => c.user && c.user.login === codexBotLogin &&
                            c.pull_request_review_id === latestCodexReview.id &&
                            p01Regex.test(c.body || '')
                     );
-
-                    if (unresolvedP01.length === 0) {
-                      codexCleared = true;
+                    if (resolutionByCommentId === null) {
+                      reviewHasUnresolvedP01 = p01.length > 0; // fail closed
+                    } else {
+                      reviewHasUnresolvedP01 = p01.some(
+                        c => resolutionByCommentId[String(c.id)] !== true
+                      );
                     }
+                  }
+
+                  // Latest qualifying Codex +1 reaction in the merge-time
+                  // window. Empty latestReactionTime sorts below any ISO
+                  // timestamp, so the first qualifier always sets it.
+                  let latestReactionTime = '';
+                  for (const x of reactions) {
+                    if (x.user && x.user.login === codexBotLogin &&
+                        x.content === '+1' &&
+                        headCommitterDate && x.created_at >= headCommitterDate &&
+                        mergedAt && x.created_at <= mergedAt &&
+                        x.created_at > latestReactionTime) {
+                      latestReactionTime = x.created_at;
+                    }
+                  }
+
+                  // Latest-signal-wins — mirrors codex-review-check.sh:
+                  // a newer +1 clears an older review-with-findings; a
+                  // newer review-with-findings blocks an older +1.
+                  if (latestReactionTime && latestReviewTime) {
+                    codexCleared = (latestReactionTime > latestReviewTime)
+                      ? true
+                      : !reviewHasUnresolvedP01;
+                  } else if (latestReactionTime) {
+                    codexCleared = true;
+                  } else if (latestReviewTime) {
+                    codexCleared = !reviewHasUnresolvedP01;
                   }
                 }
 

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -30,6 +30,7 @@
 #   - forcepush-stale-plus1-rejected.json — +1 predates a later force-push → raised lower bound, NOT cleared (Codex P2 #460)
 #   - forcepush-fresh-plus1-clears.json   — +1 after the force-push → cleared (anchor must not over-reject, Codex P2 #460)
 #   - stale-prior-head-plus1-rejected.json — +1 before merged_at-window floor → NOT cleared (merge-time freshness floor, Codex P2 #460)
+#   - codex-disabled-plus1-rejected.json — codex.enabled=false + fresh +1, no CLI APPROVED → NOT cleared (codexEnabled gate, Codex P2 #460)
 #
 # Inline-literal pattern: the algorithm under test is duplicated
 # from the workflow YAML into the Node script below, the same way
@@ -74,6 +75,8 @@ const fx = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
 
 const codexBotLogin = fx.codex_bot_login;
 const headSha = fx.head_sha;
+// codex.enabled gate (#460 Codex P2): default true, absent → true.
+const codexEnabled = fx.codex_enabled !== false;
 const reviews = fx.reviews || [];
 // Preserve an explicit JSON null for inline_comments instead of
 // collapsing it to an empty array (CodeRabbit on PR 460). In the
@@ -137,8 +140,10 @@ const codexCommentedOnHead = codexReviewsOnHead.filter(
 );
 
 // --- mirrored from .github/workflows/pr-audit.yml (#249/#449/#450) -
+// Gate on codexEnabled (#460 Codex P2): codex.enabled=false → Codex bot
+// signals are ignored (codexCleared stays false), matching codex-review-check.sh.
 let codexCleared = false;
-if (inlineComments !== null) {
+if (codexEnabled && inlineComments !== null) {
   let latestCodexReview = null;
   if (codexCommentedOnHead.length > 0) {
     latestCodexReview = codexCommentedOnHead.reduce(
@@ -323,6 +328,24 @@ if grep -qF 'reactionFreshnessWindowSeconds' "$WORKFLOW" && \
 else
   fail=$((fail + 1))
   echo "  FAIL: $WORKFLOW must add the merged_at - reaction_freshness_window_seconds floor to the reaction lower bound — Codex P2 #460" >&2
+fi
+
+# Structural assertion (Codex P2 on #460): the workflow honors
+# codex.enabled before accepting any Codex bot clearance signal. When
+# codex.enabled=false, codex-review-check.sh ignores Codex reviews and
+# reactions (gate (c) clears only via a Phase 4b substitute APPROVED);
+# the retrospective audit must match, or a stray 👍 from a still-installed
+# App on a codex-disabled repo would mark a merge compliant that the merge
+# gate never cleared. Captured from policy as codexEnabled, then gated on
+# the clearance algorithm. The codex-disabled-plus1-rejected fixture
+# exercises the runtime path; this canary guards the workflow source.
+if grep -qF 'config.codex.enabled === false' "$WORKFLOW" && \
+   grep -qF 'if (codexEnabled && inlineComments !== null)' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW honors codex.enabled before accepting Codex bot clearance (Codex P2 #460)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must gate Codex clearance on codexEnabled (codex.enabled===false → ignore bot signals) — Codex P2 #460" >&2
 fi
 
 # Structural assertion: the workflow references #449 and #450 for

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -31,6 +31,7 @@
 #   - forcepush-fresh-plus1-clears.json   — +1 after the force-push → cleared (anchor must not over-reject, Codex P2 #460)
 #   - stale-prior-head-plus1-rejected.json — +1 before merged_at-window floor → NOT cleared (merge-time freshness floor, Codex P2 #460)
 #   - codex-disabled-plus1-rejected.json — codex.enabled=false + fresh +1, no CLI APPROVED → NOT cleared (codexEnabled gate, Codex P2 #460)
+#   - postmerge-forcepush-plus1-clears.json — force-push AFTER merge ignored; pre-merge +1 still clears (merge-time force-push bound, Codex P2 #460 r2)
 #
 # Inline-literal pattern: the algorithm under test is duplicated
 # from the workflow YAML into the Node script below, the same way
@@ -89,8 +90,15 @@ const reviews = fx.reviews || [];
 const inlineComments = (fx.inline_comments === undefined) ? [] : fx.inline_comments;
 const reactions = fx.reactions || [];
 const headCommitterDate = fx.head_committer_date || '';
-const lastForcePushAt = fx.last_force_push_at || '';
 const mergedAt = fx.merged_at || '';
+// Only force-pushes at or before merged_at are merge-time state; a
+// post-merge force-push must not raise the reaction lower bound past
+// merged_at (Codex P2 on PR 460 round 2). Mirrors the workflow filter of
+// head_ref_force_pushed events to created_at <= merged_at.
+let lastForcePushAt = fx.last_force_push_at || '';
+if (lastForcePushAt && mergedAt && lastForcePushAt > mergedAt) {
+  lastForcePushAt = '';
+}
 const reactionFreshnessWindowSeconds = fx.reaction_freshness_window_seconds || 1800;
 // Merge-time freshness floor: merged_at - window (ms stripped to compare
 // against ms-less ISO timestamps). Mirrors the workflow (#460 Codex P2).
@@ -314,6 +322,22 @@ if grep -qF 'head_ref_force_pushed' "$WORKFLOW" && \
 else
   fail=$((fail + 1))
   echo "  FAIL: $WORKFLOW must anchor reactions to head_ref_force_pushed (max with committer date) — Codex P2 #460" >&2
+fi
+
+# Structural assertion (Codex P2 on #460 round 2): the workflow bounds
+# head_ref_force_pushed events to those at or before merged_at when
+# reconstructing merge-time state. Without it a force-push AFTER merge
+# raises reactionLowerBound past merged_at, empties the [lowerBound,
+# merged_at] reaction window, and falsely flags a PR that legitimately
+# cleared via a pre-merge 👍. Mirrors labelWasPresentAtMerge /
+# resolvedAtMerge. The postmerge-forcepush-plus1-clears fixture exercises
+# the runtime path; this canary guards the workflow source.
+if grep -qF 'ev.created_at <= mergedAt' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW bounds force-push events to merged_at (merge-time state, Codex P2 #460 r2)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must exclude post-merge force-pushes (ev.created_at <= mergedAt) from the reaction lower bound — Codex P2 #460 r2" >&2
 fi
 
 # Structural assertion (Codex P2 on #460): the reaction lower bound also

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -6,7 +6,7 @@
 # script`, so the gate logic itself is JavaScript embedded in YAML.
 # This check extracts the clearance algorithm into a small Node
 # script that mirrors the workflow's logic verbatim, then runs it
-# against six fixture payloads under
+# against fixture payloads under
 # `scripts/ci/fixtures/pr-audit-codex-clearance/` covering:
 #
 #   - clean-clear.json            — COMMENTED on HEAD, zero P0/P1 → cleared
@@ -16,6 +16,14 @@
 #   - p2-only.json                — only P2/P3 inline findings → cleared (P2/P3 advisory)
 #   - quote-reply-from-author.json — author quote-reply containing `![P1 Badge]` text →
 #                                     cleared (filter scopes to bot author only)
+#   - p1-resolved-clears.json     — P1 finding whose thread isResolved → cleared (#449)
+#   - p1-unresolved-blocks.json   — P1 finding, thread unresolved → NOT cleared (#449)
+#   - resolution-lookup-failed.json — P1 finding, resolution lookup failed → NOT cleared / fail-closed (#449)
+#   - fresh-plus1-clears.json     — Codex +1 inside [HEAD date, merged_at] → cleared (#450)
+#   - stale-plus1-rejected.json   — +1 before the HEAD freshness floor → NOT cleared (#450)
+#   - post-merge-plus1-rejected.json — +1 after merged_at → NOT cleared (#450)
+#   - review-newer-than-reaction-blocks.json — newer review w/ unresolved P1 beats older +1 → NOT cleared (#450)
+#   - reaction-newer-than-review-clears.json — newer +1 beats older review w/ P1 → cleared (#450)
 #
 # Inline-literal pattern: the algorithm under test is duplicated
 # from the workflow YAML into the Node script below, the same way
@@ -62,8 +70,25 @@ const codexBotLogin = fx.codex_bot_login;
 const headSha = fx.head_sha;
 const reviews = fx.reviews || [];
 const inlineComments = fx.inline_comments || [];
+const reactions = fx.reactions || [];
+const headCommitterDate = fx.head_committer_date || '';
+const mergedAt = fx.merged_at || '';
 
-// --- mirrored from .github/workflows/pr-audit.yml (#249) ----------
+// Build the comment-databaseId → isResolved map that the workflow
+// derives from its GraphQL reviewThreads fetch. `resolution_lookup_failed`
+// simulates a GraphQL failure → null (fail closed). Absent review_threads
+// → empty map (every finding unresolved), preserving pre-#449 fixtures.
+let resolutionByCommentId = {};
+if (fx.resolution_lookup_failed === true) {
+  resolutionByCommentId = null;
+} else if (Array.isArray(fx.review_threads)) {
+  for (const t of fx.review_threads) {
+    for (const cid of (t.comment_ids || [])) {
+      resolutionByCommentId[String(cid)] = t.is_resolved === true;
+    }
+  }
+}
+
 const codexReviewsOnHead = reviews.filter(
   r => r.user.login === codexBotLogin &&
        headSha &&
@@ -73,25 +98,58 @@ const codexCommentedOnHead = codexReviewsOnHead.filter(
   r => r.state === 'COMMENTED'
 );
 
+// --- mirrored from .github/workflows/pr-audit.yml (#249/#449/#450) -
 let codexCleared = false;
-if (codexCommentedOnHead.length > 0) {
-  const latestCodexReview = codexCommentedOnHead.reduce(
-    (latest, r) => {
-      if (!latest) return r;
-      return (r.submitted_at > latest.submitted_at) ? r : latest;
-    },
-    null
-  );
+if (inlineComments !== null) {
+  let latestCodexReview = null;
+  if (codexCommentedOnHead.length > 0) {
+    latestCodexReview = codexCommentedOnHead.reduce(
+      (latest, r) => {
+        if (!latest) return r;
+        return (r.submitted_at > latest.submitted_at) ? r : latest;
+      },
+      null
+    );
+  }
+  const latestReviewTime =
+    latestCodexReview ? (latestCodexReview.submitted_at || '') : '';
 
   const p01Regex = /!\[P[01] Badge\]/;
-  const unresolvedP01 = inlineComments.filter(
-    c => c.user && c.user.login === codexBotLogin &&
-         c.pull_request_review_id === latestCodexReview.id &&
-         p01Regex.test(c.body || '')
-  );
+  let reviewHasUnresolvedP01 = false;
+  if (latestCodexReview) {
+    const p01 = inlineComments.filter(
+      c => c.user && c.user.login === codexBotLogin &&
+           c.pull_request_review_id === latestCodexReview.id &&
+           p01Regex.test(c.body || '')
+    );
+    if (resolutionByCommentId === null) {
+      reviewHasUnresolvedP01 = p01.length > 0; // fail closed
+    } else {
+      reviewHasUnresolvedP01 = p01.some(
+        c => resolutionByCommentId[String(c.id)] !== true
+      );
+    }
+  }
 
-  if (unresolvedP01.length === 0) {
+  let latestReactionTime = '';
+  for (const x of reactions) {
+    if (x.user && x.user.login === codexBotLogin &&
+        x.content === '+1' &&
+        headCommitterDate && x.created_at >= headCommitterDate &&
+        mergedAt && x.created_at <= mergedAt &&
+        x.created_at > latestReactionTime) {
+      latestReactionTime = x.created_at;
+    }
+  }
+
+  if (latestReactionTime && latestReviewTime) {
+    codexCleared = (latestReactionTime > latestReviewTime)
+      ? true
+      : !reviewHasUnresolvedP01;
+  } else if (latestReactionTime) {
     codexCleared = true;
+  } else if (latestReviewTime) {
+    codexCleared = !reviewHasUnresolvedP01;
   }
 }
 // --- end mirrored algorithm --------------------------------------
@@ -147,6 +205,44 @@ if grep -qF '#249' "$WORKFLOW"; then
 else
   fail=$((fail + 1))
   echo "  FAIL: $WORKFLOW must reference #249 in a comment for traceability" >&2
+fi
+
+# Structural assertion (#449): the workflow fetches review-thread
+# resolution state via GraphQL reviewThreads. Without it the audit
+# would flag an author-resolved P1 (the sanctioned codex-p1-gate
+# override path) as an unresolved finding — the exact false positive
+# #449 closes. The fixture tests above consume a pre-built resolution
+# map, so they can't catch a dropped fetch at the API call site.
+if grep -qF 'reviewThreads(first:100' "$WORKFLOW" && grep -qF 'isResolved' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW fetches reviewThreads resolution state (#449)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must fetch reviewThreads/isResolved for resolution-aware P0/P1 filtering (#449)" >&2
+fi
+
+# Structural assertion (#450): the workflow reads Codex bot +1
+# reactions and anchors them to merge time (pr.merged_at), not the
+# audit run time. A regression to a NOW-window floor would reject
+# every week-old merge-time +1.
+if grep -qF 'reactions.listForIssue' "$WORKFLOW" && \
+   grep -qF "x.content === '+1'" "$WORKFLOW" && \
+   grep -qF 'pr.merged_at' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW accepts merge-time-anchored Codex +1 clearance (#450)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must read Codex +1 reactions anchored to pr.merged_at (#450)" >&2
+fi
+
+# Structural assertion: the workflow references #449 and #450 for
+# traceability back to the clearance-semantics issues.
+if grep -qF '#449' "$WORKFLOW" && grep -qF '#450' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW references #449 and #450"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must reference #449 and #450 in comments for traceability" >&2
 fi
 
 # Structural assertion: the per-PR review fetch is paginated. PRs

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -16,7 +16,9 @@
 #   - p2-only.json                — only P2/P3 inline findings → cleared (P2/P3 advisory)
 #   - quote-reply-from-author.json — author quote-reply containing `![P1 Badge]` text →
 #                                     cleared (filter scopes to bot author only)
-#   - p1-resolved-clears.json     — P1 finding whose thread isResolved → cleared (#449)
+#   - p1-resolved-clears.json     — P1 thread resolved, last touched pre-merge → cleared (#449 + #460)
+#   - p1-resolved-postmerge-blocks.json — P1 thread resolved but touched after merge → NOT cleared (Codex P1 #460)
+#   - p1-resolved-no-mergedat-blocks.json — P1 thread resolved but merged_at unknown → fail-closed, NOT cleared (Codex P1 #460)
 #   - p1-unresolved-blocks.json   — P1 finding, thread unresolved → NOT cleared (#449)
 #   - resolution-lookup-failed.json — P1 finding, resolution lookup failed → NOT cleared / fail-closed (#449)
 #   - fresh-plus1-clears.json     — Codex +1 inside [HEAD date, merged_at] → cleared (#450)
@@ -103,7 +105,10 @@ if (fx.resolution_lookup_failed === true) {
 } else if (Array.isArray(fx.review_threads)) {
   for (const t of fx.review_threads) {
     for (const cid of (t.comment_ids || [])) {
-      resolutionByCommentId[String(cid)] = t.is_resolved === true;
+      resolutionByCommentId[String(cid)] = {
+        resolved: t.is_resolved === true,
+        threadLatestAt: t.latest_comment_at || '',
+      };
     }
   }
 }
@@ -144,9 +149,18 @@ if (inlineComments !== null) {
     if (resolutionByCommentId === null) {
       reviewHasUnresolvedP01 = p01.length > 0; // fail closed
     } else {
-      reviewHasUnresolvedP01 = p01.some(
-        c => resolutionByCommentId[String(c.id)] !== true
-      );
+      // Resolved counts only when bounded by merge: thread resolved AND
+      // merged_at known AND no thread comment after merged_at (#460 — no
+      // resolvedAt exists, so post-merge activity is the proxy; fail
+      // closed on unknown merged_at).
+      const resolvedAtMerge = (cid) => {
+        const e = resolutionByCommentId[String(cid)];
+        if (!e || e.resolved !== true) return false;
+        if (!mergedAt) return false;
+        if (e.threadLatestAt && e.threadLatestAt > mergedAt) return false;
+        return true;
+      };
+      reviewHasUnresolvedP01 = p01.some(c => !resolvedAtMerge(c.id));
     }
   }
 
@@ -238,6 +252,21 @@ if grep -qF 'reviewThreads(first:100' "$WORKFLOW" && grep -qF 'isResolved' "$WOR
 else
   fail=$((fail + 1))
   echo "  FAIL: $WORKFLOW must fetch reviewThreads/isResolved for resolution-aware P0/P1 filtering (#449)" >&2
+fi
+
+# Structural assertion (Codex P1 on #460): the retrospective audit must
+# bound thread resolution by merge time. GitHub exposes no resolvedAt, so
+# the workflow uses the thread's newest comment time (createdAt) vs
+# merged_at as the proxy and fails closed otherwise. A regression to bare
+# isResolved would let a post-merge resolve clear a real violation.
+if grep -qF 'resolvedAtMerge' "$WORKFLOW" && \
+   grep -qF 'threadLatestAt' "$WORKFLOW" && \
+   grep -qF 'comments(first:100){ nodes { databaseId createdAt } }' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW bounds thread resolution by merge time (Codex P1 #460)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must bound resolution by merge time (resolvedAtMerge proxy + comment createdAt) — Codex P1 #460" >&2
 fi
 
 # Structural assertion (#450): the workflow reads Codex bot +1

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -25,6 +25,8 @@
 #   - review-newer-than-reaction-blocks.json — newer review w/ unresolved P1 beats older +1 → NOT cleared (#450)
 #   - reaction-newer-than-review-clears.json — newer +1 beats older review w/ P1 → cleared (#450)
 #   - inline-fetch-failed.json    — inline_comments=null (fetch failed) → fail-closed, NOT cleared (CodeRabbit #460)
+#   - forcepush-stale-plus1-rejected.json — +1 predates a later force-push → raised lower bound, NOT cleared (Codex P2 #460)
+#   - forcepush-fresh-plus1-clears.json   — +1 after the force-push → cleared (anchor must not over-reject, Codex P2 #460)
 #
 # Inline-literal pattern: the algorithm under test is duplicated
 # from the workflow YAML into the Node script below, the same way
@@ -81,6 +83,14 @@ const reviews = fx.reviews || [];
 const inlineComments = (fx.inline_comments === undefined) ? [] : fx.inline_comments;
 const reactions = fx.reactions || [];
 const headCommitterDate = fx.head_committer_date || '';
+const lastForcePushAt = fx.last_force_push_at || '';
+// Reaction-window lower bound mirrors the workflow: max(committer date,
+// last force-push), lexicographic ISO-8601. Empty committer date keeps
+// the reaction path off; force-push only raises an existing base
+// (Codex P2 on PR 460).
+const reactionLowerBound = headCommitterDate
+  ? ((lastForcePushAt > headCommitterDate) ? lastForcePushAt : headCommitterDate)
+  : '';
 const mergedAt = fx.merged_at || '';
 
 // Build the comment-databaseId → isResolved map that the workflow
@@ -144,7 +154,7 @@ if (inlineComments !== null) {
   for (const x of reactions) {
     if (x.user && x.user.login === codexBotLogin &&
         x.content === '+1' &&
-        headCommitterDate && x.created_at >= headCommitterDate &&
+        reactionLowerBound && x.created_at >= reactionLowerBound &&
         mergedAt && x.created_at <= mergedAt &&
         x.created_at > latestReactionTime) {
       latestReactionTime = x.created_at;
@@ -242,6 +252,20 @@ if grep -qF 'reactions.listForIssue' "$WORKFLOW" && \
 else
   fail=$((fail + 1))
   echo "  FAIL: $WORKFLOW must read Codex +1 reactions anchored to pr.merged_at (#450)" >&2
+fi
+
+# Structural assertion (Codex P2 on #460): the workflow raises the
+# reaction-window lower bound to the latest head_ref_force_pushed time,
+# mirroring the merge gate. Without it a stale +1 on a PR force-pushed to
+# an old/reused commit could satisfy the window and falsely clear.
+if grep -qF 'head_ref_force_pushed' "$WORKFLOW" && \
+   grep -qF 'listEventsForTimeline' "$WORKFLOW" && \
+   grep -qF 'reactionLowerBound' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW raises the reaction lower bound to the force-push anchor (Codex P2 #460)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must anchor reactions to head_ref_force_pushed (max with committer date) — Codex P2 #460" >&2
 fi
 
 # Structural assertion: the workflow references #449 and #450 for

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -24,6 +24,7 @@
 #   - post-merge-plus1-rejected.json — +1 after merged_at → NOT cleared (#450)
 #   - review-newer-than-reaction-blocks.json — newer review w/ unresolved P1 beats older +1 → NOT cleared (#450)
 #   - reaction-newer-than-review-clears.json — newer +1 beats older review w/ P1 → cleared (#450)
+#   - inline-fetch-failed.json    — inline_comments=null (fetch failed) → fail-closed, NOT cleared (CodeRabbit #460)
 #
 # Inline-literal pattern: the algorithm under test is duplicated
 # from the workflow YAML into the Node script below, the same way
@@ -69,7 +70,15 @@ const fx = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
 const codexBotLogin = fx.codex_bot_login;
 const headSha = fx.head_sha;
 const reviews = fx.reviews || [];
-const inlineComments = fx.inline_comments || [];
+// Preserve an explicit JSON null for inline_comments instead of
+// collapsing it to an empty array (CodeRabbit on PR 460). In the
+// workflow a failed inline-comment fetch leaves inlineComments as null
+// and the clearance block is skipped to fail closed; mapping only an
+// omitted key keeps that branch testable. Note: this comment avoids
+// backticks/apostrophes on purpose — the runner lives in a single-quoted
+// bash heredoc inside a command substitution, where bash 3.2 mis-parses
+// stray quotes while scanning for the closing paren.
+const inlineComments = (fx.inline_comments === undefined) ? [] : fx.inline_comments;
 const reactions = fx.reactions || [];
 const headCommitterDate = fx.head_committer_date || '';
 const mergedAt = fx.merged_at || '';

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -29,6 +29,7 @@
 #   - inline-fetch-failed.json    — inline_comments=null (fetch failed) → fail-closed, NOT cleared (CodeRabbit #460)
 #   - forcepush-stale-plus1-rejected.json — +1 predates a later force-push → raised lower bound, NOT cleared (Codex P2 #460)
 #   - forcepush-fresh-plus1-clears.json   — +1 after the force-push → cleared (anchor must not over-reject, Codex P2 #460)
+#   - stale-prior-head-plus1-rejected.json — +1 before merged_at-window floor → NOT cleared (merge-time freshness floor, Codex P2 #460)
 #
 # Inline-literal pattern: the algorithm under test is duplicated
 # from the workflow YAML into the Node script below, the same way
@@ -86,14 +87,27 @@ const inlineComments = (fx.inline_comments === undefined) ? [] : fx.inline_comme
 const reactions = fx.reactions || [];
 const headCommitterDate = fx.head_committer_date || '';
 const lastForcePushAt = fx.last_force_push_at || '';
-// Reaction-window lower bound mirrors the workflow: max(committer date,
-// last force-push), lexicographic ISO-8601. Empty committer date keeps
-// the reaction path off; force-push only raises an existing base
-// (Codex P2 on PR 460).
-const reactionLowerBound = headCommitterDate
-  ? ((lastForcePushAt > headCommitterDate) ? lastForcePushAt : headCommitterDate)
-  : '';
 const mergedAt = fx.merged_at || '';
+const reactionFreshnessWindowSeconds = fx.reaction_freshness_window_seconds || 1800;
+// Merge-time freshness floor: merged_at - window (ms stripped to compare
+// against ms-less ISO timestamps). Mirrors the workflow (#460 Codex P2).
+let mergedAtFloor = '';
+if (mergedAt) {
+  const t = Date.parse(mergedAt);
+  if (!Number.isNaN(t)) {
+    mergedAtFloor = new Date(t - reactionFreshnessWindowSeconds * 1000)
+      .toISOString().replace(/\.\d{3}Z$/, 'Z');
+  }
+}
+// Reaction-window lower bound = max(committer date, last force-push,
+// merged_at - window). Empty committer date keeps the reaction path off;
+// the other two only raise an existing base (Codex P2 on PR 460).
+let reactionLowerBound = '';
+if (headCommitterDate) {
+  reactionLowerBound = headCommitterDate;
+  if (lastForcePushAt > reactionLowerBound) reactionLowerBound = lastForcePushAt;
+  if (mergedAtFloor > reactionLowerBound) reactionLowerBound = mergedAtFloor;
+}
 
 // Build the comment-databaseId → isResolved map that the workflow
 // derives from its GraphQL reviewThreads fetch. `resolution_lookup_failed`
@@ -295,6 +309,20 @@ if grep -qF 'head_ref_force_pushed' "$WORKFLOW" && \
 else
   fail=$((fail + 1))
   echo "  FAIL: $WORKFLOW must anchor reactions to head_ref_force_pushed (max with committer date) — Codex P2 #460" >&2
+fi
+
+# Structural assertion (Codex P2 on #460): the reaction lower bound also
+# carries the merge-time freshness floor (merged_at - reaction_freshness_
+# window_seconds), so a stale prior-HEAD +1 the merge gate would reject
+# cannot clear the retrospective audit on an ordinary-push-to-old-commit PR.
+if grep -qF 'reactionFreshnessWindowSeconds' "$WORKFLOW" && \
+   grep -qF 'mergedAtFloor' "$WORKFLOW" && \
+   grep -qF 'reaction_freshness_window_seconds' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW applies the merge-time freshness floor (merged_at - window) to the reaction lower bound (Codex P2 #460)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must add the merged_at - reaction_freshness_window_seconds floor to the reaction lower bound — Codex P2 #460" >&2
 fi
 
 # Structural assertion: the workflow references #449 and #450 for

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -32,6 +32,7 @@
 #   - stale-prior-head-plus1-rejected.json — +1 before merged_at-window floor → NOT cleared (merge-time freshness floor, Codex P2 #460)
 #   - codex-disabled-plus1-rejected.json — codex.enabled=false + fresh +1, no CLI APPROVED → NOT cleared (codexEnabled gate, Codex P2 #460)
 #   - postmerge-forcepush-plus1-clears.json — force-push AFTER merge ignored; pre-merge +1 still clears (merge-time force-push bound, Codex P2 #460 r2)
+#   - cross-agent-plus1-rejected.json — fresh +1 but no same-agent Authoring-Agent → +1 cannot substitute reviewer approval, NOT cleared (same-agent gate, Codex P2 #460 r3)
 #
 # Inline-literal pattern: the algorithm under test is duplicated
 # from the workflow YAML into the Node script below, the same way
@@ -191,14 +192,32 @@ if (codexEnabled && inlineComments !== null) {
     }
   }
 
+  // Same-agent context (Codex P2 on PR 460 r3): a Codex +1 substitutes for
+  // gate (b) reviewer approval only when the PR Authoring-Agent resolves to
+  // an available reviewer identity. Mirrors codex-review-check.sh
+  // AUTHORING_AGENT to SAME_AGENT_REVIEWER suffix match. A missing or non-
+  // matching authoring agent leaves sameAgentContext false, so a cross-agent
+  // +1 does not clear (the round-3 finding case).
+  const reviewerAccounts = fx.available_reviewers ||
+    ['nathanpayne-claude', 'nathanpayne-cursor', 'nathanpayne-codex'];
+  let sameAgentContext = false;
+  if (fx.authoring_agent) {
+    const authoringAgent = String(fx.authoring_agent).toLowerCase();
+    sameAgentContext = reviewerAccounts.some(
+      r => String(r).toLowerCase().endsWith('-' + authoringAgent)
+    );
+  }
+
   let latestReactionTime = '';
-  for (const x of reactions) {
-    if (x.user && x.user.login === codexBotLogin &&
-        x.content === '+1' &&
-        reactionLowerBound && x.created_at >= reactionLowerBound &&
-        mergedAt && x.created_at <= mergedAt &&
-        x.created_at > latestReactionTime) {
-      latestReactionTime = x.created_at;
+  if (sameAgentContext) {
+    for (const x of reactions) {
+      if (x.user && x.user.login === codexBotLogin &&
+          x.content === '+1' &&
+          reactionLowerBound && x.created_at >= reactionLowerBound &&
+          mergedAt && x.created_at <= mergedAt &&
+          x.created_at > latestReactionTime) {
+        latestReactionTime = x.created_at;
+      }
     }
   }
 
@@ -370,6 +389,24 @@ if grep -qF 'config.codex.enabled === false' "$WORKFLOW" && \
 else
   fail=$((fail + 1))
   echo "  FAIL: $WORKFLOW must gate Codex clearance on codexEnabled (codex.enabled===false → ignore bot signals) — Codex P2 #460" >&2
+fi
+
+# Structural assertion (Codex P2 on #460 round 3): the workflow gates the
+# Codex +1 reaction path on same-agent context, mirroring the merge gate
+# branch-2 (#170) rule that a 👍 substitutes for reviewer approval only when
+# the PR Authoring-Agent resolves to an available reviewer identity. Without
+# it a cross-agent / missing-Authoring-Agent PR merged with only a 👍 (which
+# codex-review-check.sh rejects) would pass the audit. The
+# cross-agent-plus1-rejected fixture exercises the runtime path; this canary
+# guards the workflow source.
+if grep -qF 'sameAgentContext' "$WORKFLOW" && \
+   grep -qF 'Authoring-Agent:' "$WORKFLOW" && \
+   grep -qF 'if (sameAgentContext)' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW gates the +1 reaction path on same-agent context (Codex P2 #460 r3)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must gate the Codex +1 reaction on sameAgentContext (Authoring-Agent → reviewer) — Codex P2 #460 r3" >&2
 fi
 
 # Structural assertion: the workflow references #449 and #450 for

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/codex-disabled-plus1-rejected.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/codex-disabled-plus1-rejected.json
@@ -1,0 +1,18 @@
+{
+  "description": "Same fresh Codex +1 as fresh-plus1-clears, but codex.enabled=false → Codex bot signals ignored, no CLI APPROVED → NOT cleared (Codex P2 on #460). Without the codexEnabled gate this +1 would wrongly clear a merge the gate never honored.",
+  "expected_cleared": false,
+  "codex_enabled": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "head_committer_date": "2026-05-12T10:00:00Z",
+  "merged_at": "2026-05-12T10:30:00Z",
+  "reviews": [],
+  "inline_comments": [],
+  "reactions": [
+    {
+      "content": "+1",
+      "created_at": "2026-05-12T10:15:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/codex-disabled-plus1-rejected.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/codex-disabled-plus1-rejected.json
@@ -1,6 +1,7 @@
 {
   "description": "Same fresh Codex +1 as fresh-plus1-clears, but codex.enabled=false → Codex bot signals ignored, no CLI APPROVED → NOT cleared (Codex P2 on #460). Without the codexEnabled gate this +1 would wrongly clear a merge the gate never honored.",
   "expected_cleared": false,
+  "authoring_agent": "claude",
   "codex_enabled": false,
   "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
   "codex_bot_login": "chatgpt-codex-connector[bot]",

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/cross-agent-plus1-rejected.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/cross-agent-plus1-rejected.json
@@ -1,0 +1,18 @@
+{
+  "description": "Same fresh Codex +1 as fresh-plus1-clears, but the PR has NO Authoring-Agent trailer (or one that does not resolve to an available reviewer) → sameAgentContext is false, so the +1 cannot substitute for gate (b) reviewer approval and does NOT clear (Codex P2 on #460 round 3). The merge gate (codex-review-check.sh branch 2) rejects this exact case; the audit must match. A non-matching authoring_agent (e.g. one absent from available_reviewers) behaves identically.",
+  "expected_cleared": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "head_committer_date": "2026-05-12T10:00:00Z",
+  "merged_at": "2026-05-12T10:30:00Z",
+  "reaction_freshness_window_seconds": 1800,
+  "reviews": [],
+  "inline_comments": [],
+  "reactions": [
+    {
+      "content": "+1",
+      "created_at": "2026-05-12T10:15:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/forcepush-fresh-plus1-clears.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/forcepush-fresh-plus1-clears.json
@@ -1,0 +1,18 @@
+{
+  "description": "PR force-pushed (old committer date) but the +1 lands AFTER the force-push → inside [force-push, merged_at], cleared (force-push anchor must not over-reject, Codex P2 on PR 460)",
+  "expected_cleared": true,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "head_committer_date": "2026-05-12T09:00:00Z",
+  "last_force_push_at": "2026-05-12T10:00:00Z",
+  "merged_at": "2026-05-12T10:30:00Z",
+  "reviews": [],
+  "inline_comments": [],
+  "reactions": [
+    {
+      "content": "+1",
+      "created_at": "2026-05-12T10:15:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/forcepush-fresh-plus1-clears.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/forcepush-fresh-plus1-clears.json
@@ -1,6 +1,7 @@
 {
   "description": "PR force-pushed (old committer date) but the +1 lands AFTER the force-push → inside [force-push, merged_at], cleared (force-push anchor must not over-reject, Codex P2 on PR 460)",
   "expected_cleared": true,
+  "authoring_agent": "claude",
   "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
   "codex_bot_login": "chatgpt-codex-connector[bot]",
   "head_committer_date": "2026-05-12T09:00:00Z",

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/forcepush-stale-plus1-rejected.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/forcepush-stale-plus1-rejected.json
@@ -1,6 +1,7 @@
 {
   "description": "PR force-pushed to an old/reused commit (old committer date) after a +1 that predates the force-push → lower bound raised to force-push time, NOT cleared (Codex P2 on PR 460)",
   "expected_cleared": false,
+  "authoring_agent": "claude",
   "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
   "codex_bot_login": "chatgpt-codex-connector[bot]",
   "head_committer_date": "2026-05-12T09:00:00Z",

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/forcepush-stale-plus1-rejected.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/forcepush-stale-plus1-rejected.json
@@ -1,0 +1,18 @@
+{
+  "description": "PR force-pushed to an old/reused commit (old committer date) after a +1 that predates the force-push → lower bound raised to force-push time, NOT cleared (Codex P2 on PR 460)",
+  "expected_cleared": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "head_committer_date": "2026-05-12T09:00:00Z",
+  "last_force_push_at": "2026-05-12T10:00:00Z",
+  "merged_at": "2026-05-12T10:30:00Z",
+  "reviews": [],
+  "inline_comments": [],
+  "reactions": [
+    {
+      "content": "+1",
+      "created_at": "2026-05-12T09:30:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/fresh-plus1-clears.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/fresh-plus1-clears.json
@@ -1,0 +1,17 @@
+{
+  "description": "Codex +1 reaction inside [HEAD committer date, merged_at], no COMMENTED review → cleared (#450 reaction path)",
+  "expected_cleared": true,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "head_committer_date": "2026-05-12T10:00:00Z",
+  "merged_at": "2026-05-12T10:30:00Z",
+  "reviews": [],
+  "inline_comments": [],
+  "reactions": [
+    {
+      "content": "+1",
+      "created_at": "2026-05-12T10:15:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/fresh-plus1-clears.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/fresh-plus1-clears.json
@@ -1,6 +1,7 @@
 {
   "description": "Codex +1 reaction inside [HEAD committer date, merged_at], no COMMENTED review → cleared (#450 reaction path)",
   "expected_cleared": true,
+  "authoring_agent": "claude",
   "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
   "codex_bot_login": "chatgpt-codex-connector[bot]",
   "head_committer_date": "2026-05-12T10:00:00Z",

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/inline-fetch-failed.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/inline-fetch-failed.json
@@ -1,0 +1,16 @@
+{
+  "description": "Inline-comment fetch failed (inline_comments=null) → fail closed even with a clean COMMENTED review on HEAD, NOT cleared (CodeRabbit #460)",
+  "expected_cleared": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "inline_comments": null,
+  "reviews": [
+    {
+      "id": 1001,
+      "state": "COMMENTED",
+      "commit_id": "deadbeefcafe1234567890abcdef1234567890ab",
+      "submitted_at": "2026-05-12T10:00:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/p1-resolved-clears.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/p1-resolved-clears.json
@@ -1,0 +1,26 @@
+{
+  "description": "Codex COMMENTED on HEAD with a P1 finding whose review thread is RESOLVED → cleared (#449 resolution-aware)",
+  "expected_cleared": true,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "reviews": [
+    {
+      "id": 1001,
+      "state": "COMMENTED",
+      "commit_id": "deadbeefcafe1234567890abcdef1234567890ab",
+      "submitted_at": "2026-05-12T10:00:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "inline_comments": [
+    {
+      "id": 5001,
+      "pull_request_review_id": 1001,
+      "body": "![P1 Badge](https://example.com/p1.svg) Author resolved this via the codex-p1-gate override path.",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "review_threads": [
+    { "is_resolved": true, "comment_ids": [5001] }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/p1-resolved-no-mergedat-blocks.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/p1-resolved-no-mergedat-blocks.json
@@ -1,9 +1,8 @@
 {
-  "description": "Codex COMMENTED on HEAD with a P1 finding whose thread is RESOLVED and last touched BEFORE merge → resolution bounded by merge, cleared (#449 + #460)",
-  "expected_cleared": true,
+  "description": "Codex P1 thread is RESOLVED and last touched before merge, but merged_at is unknown → cannot bound resolution to merge, fail closed, NOT cleared (Codex P1 on #460)",
+  "expected_cleared": false,
   "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
   "codex_bot_login": "chatgpt-codex-connector[bot]",
-  "merged_at": "2026-05-12T10:30:00Z",
   "reviews": [
     {
       "id": 1001,
@@ -17,7 +16,7 @@
     {
       "id": 5001,
       "pull_request_review_id": 1001,
-      "body": "![P1 Badge](https://example.com/p1.svg) Author resolved this via the codex-p1-gate override path.",
+      "body": "![P1 Badge](https://example.com/p1.svg) Finding resolved pre-merge but merge time is unknown.",
       "user": { "login": "chatgpt-codex-connector[bot]" }
     }
   ],

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/p1-resolved-postmerge-blocks.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/p1-resolved-postmerge-blocks.json
@@ -1,6 +1,6 @@
 {
-  "description": "Codex COMMENTED on HEAD with a P1 finding whose thread is RESOLVED and last touched BEFORE merge → resolution bounded by merge, cleared (#449 + #460)",
-  "expected_cleared": true,
+  "description": "Codex P1 thread is RESOLVED now, but the thread has comment activity AFTER merge → resolution not bounded by merge, NOT cleared (Codex P1 on #460: a post-merge resolve must not retroactively clear the audit)",
+  "expected_cleared": false,
   "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
   "codex_bot_login": "chatgpt-codex-connector[bot]",
   "merged_at": "2026-05-12T10:30:00Z",
@@ -17,11 +17,11 @@
     {
       "id": 5001,
       "pull_request_review_id": 1001,
-      "body": "![P1 Badge](https://example.com/p1.svg) Author resolved this via the codex-p1-gate override path.",
+      "body": "![P1 Badge](https://example.com/p1.svg) Unbounded retry on 5xx.",
       "user": { "login": "chatgpt-codex-connector[bot]" }
     }
   ],
   "review_threads": [
-    { "is_resolved": true, "comment_ids": [5001], "latest_comment_at": "2026-05-12T10:05:00Z" }
+    { "is_resolved": true, "comment_ids": [5001], "latest_comment_at": "2026-05-12T18:00:00Z" }
   ]
 }

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/p1-unresolved-blocks.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/p1-unresolved-blocks.json
@@ -1,0 +1,26 @@
+{
+  "description": "Codex COMMENTED on HEAD with a P1 finding whose review thread is UNRESOLVED → NOT cleared (#449)",
+  "expected_cleared": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "reviews": [
+    {
+      "id": 1001,
+      "state": "COMMENTED",
+      "commit_id": "deadbeefcafe1234567890abcdef1234567890ab",
+      "submitted_at": "2026-05-12T10:00:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "inline_comments": [
+    {
+      "id": 5001,
+      "pull_request_review_id": 1001,
+      "body": "![P1 Badge](https://example.com/p1.svg) Unbounded retry on 5xx.",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "review_threads": [
+    { "is_resolved": false, "comment_ids": [5001] }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/post-merge-plus1-rejected.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/post-merge-plus1-rejected.json
@@ -1,6 +1,7 @@
 {
   "description": "Codex +1 reaction created AFTER merged_at → not merge-time clearance, NOT cleared (#450)",
   "expected_cleared": false,
+  "authoring_agent": "claude",
   "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
   "codex_bot_login": "chatgpt-codex-connector[bot]",
   "head_committer_date": "2026-05-12T10:00:00Z",

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/post-merge-plus1-rejected.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/post-merge-plus1-rejected.json
@@ -1,0 +1,17 @@
+{
+  "description": "Codex +1 reaction created AFTER merged_at → not merge-time clearance, NOT cleared (#450)",
+  "expected_cleared": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "head_committer_date": "2026-05-12T10:00:00Z",
+  "merged_at": "2026-05-12T10:30:00Z",
+  "reviews": [],
+  "inline_comments": [],
+  "reactions": [
+    {
+      "content": "+1",
+      "created_at": "2026-05-12T11:00:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/postmerge-forcepush-plus1-clears.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/postmerge-forcepush-plus1-clears.json
@@ -1,0 +1,19 @@
+{
+  "description": "Branch force-pushed AFTER merge; a legitimate pre-merge Codex +1 must still clear. The post-merge head_ref_force_pushed event is excluded from merge-time state, so it does not raise the reaction lower bound past merged_at and empty the window (Codex P2 on #460 round 2). Without the merge-time bound, lastForcePushAt (11:00) > merged_at (10:30) would reject the valid +1.",
+  "expected_cleared": true,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "head_committer_date": "2026-05-12T10:00:00Z",
+  "merged_at": "2026-05-12T10:30:00Z",
+  "last_force_push_at": "2026-05-12T11:00:00Z",
+  "reaction_freshness_window_seconds": 1800,
+  "reviews": [],
+  "inline_comments": [],
+  "reactions": [
+    {
+      "content": "+1",
+      "created_at": "2026-05-12T10:15:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/postmerge-forcepush-plus1-clears.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/postmerge-forcepush-plus1-clears.json
@@ -1,6 +1,7 @@
 {
   "description": "Branch force-pushed AFTER merge; a legitimate pre-merge Codex +1 must still clear. The post-merge head_ref_force_pushed event is excluded from merge-time state, so it does not raise the reaction lower bound past merged_at and empty the window (Codex P2 on #460 round 2). Without the merge-time bound, lastForcePushAt (11:00) > merged_at (10:30) would reject the valid +1.",
   "expected_cleared": true,
+  "authoring_agent": "claude",
   "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
   "codex_bot_login": "chatgpt-codex-connector[bot]",
   "head_committer_date": "2026-05-12T10:00:00Z",

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/reaction-newer-than-review-clears.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/reaction-newer-than-review-clears.json
@@ -1,6 +1,7 @@
 {
   "description": "A Codex COMMENTED review (10:05) with an unresolved P1 is older than a +1 reaction (10:20) → newer +1 wins, cleared (#450 latest-signal-wins)",
   "expected_cleared": true,
+  "authoring_agent": "claude",
   "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
   "codex_bot_login": "chatgpt-codex-connector[bot]",
   "head_committer_date": "2026-05-12T10:00:00Z",

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/reaction-newer-than-review-clears.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/reaction-newer-than-review-clears.json
@@ -1,0 +1,35 @@
+{
+  "description": "A Codex COMMENTED review (10:05) with an unresolved P1 is older than a +1 reaction (10:20) → newer +1 wins, cleared (#450 latest-signal-wins)",
+  "expected_cleared": true,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "head_committer_date": "2026-05-12T10:00:00Z",
+  "merged_at": "2026-05-12T10:30:00Z",
+  "reviews": [
+    {
+      "id": 1003,
+      "state": "COMMENTED",
+      "commit_id": "deadbeefcafe1234567890abcdef1234567890ab",
+      "submitted_at": "2026-05-12T10:05:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "inline_comments": [
+    {
+      "id": 5003,
+      "pull_request_review_id": 1003,
+      "body": "![P1 Badge](https://example.com/p1.svg) Flagged, then addressed and re-approved with a +1.",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "review_threads": [
+    { "is_resolved": false, "comment_ids": [5003] }
+  ],
+  "reactions": [
+    {
+      "content": "+1",
+      "created_at": "2026-05-12T10:20:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/resolution-lookup-failed.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/resolution-lookup-failed.json
@@ -1,0 +1,24 @@
+{
+  "description": "Codex COMMENTED on HEAD with a P1 finding, but the reviewThreads resolution lookup failed → fail closed, NOT cleared (#449)",
+  "expected_cleared": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "resolution_lookup_failed": true,
+  "reviews": [
+    {
+      "id": 1001,
+      "state": "COMMENTED",
+      "commit_id": "deadbeefcafe1234567890abcdef1234567890ab",
+      "submitted_at": "2026-05-12T10:00:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "inline_comments": [
+    {
+      "id": 5001,
+      "pull_request_review_id": 1001,
+      "body": "![P1 Badge](https://example.com/p1.svg) Finding whose resolution state cannot be determined.",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/review-newer-than-reaction-blocks.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/review-newer-than-reaction-blocks.json
@@ -1,6 +1,7 @@
 {
   "description": "A valid +1 (10:05) is older than a Codex COMMENTED review (10:20) carrying an unresolved P1 → newer review wins, NOT cleared (#450 latest-signal-wins)",
   "expected_cleared": false,
+  "authoring_agent": "claude",
   "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
   "codex_bot_login": "chatgpt-codex-connector[bot]",
   "head_committer_date": "2026-05-12T10:00:00Z",

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/review-newer-than-reaction-blocks.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/review-newer-than-reaction-blocks.json
@@ -1,0 +1,35 @@
+{
+  "description": "A valid +1 (10:05) is older than a Codex COMMENTED review (10:20) carrying an unresolved P1 → newer review wins, NOT cleared (#450 latest-signal-wins)",
+  "expected_cleared": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "head_committer_date": "2026-05-12T10:00:00Z",
+  "merged_at": "2026-05-12T10:30:00Z",
+  "reviews": [
+    {
+      "id": 1002,
+      "state": "COMMENTED",
+      "commit_id": "deadbeefcafe1234567890abcdef1234567890ab",
+      "submitted_at": "2026-05-12T10:20:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "inline_comments": [
+    {
+      "id": 5002,
+      "pull_request_review_id": 1002,
+      "body": "![P1 Badge](https://example.com/p1.svg) Regression introduced after the +1.",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "review_threads": [
+    { "is_resolved": false, "comment_ids": [5002] }
+  ],
+  "reactions": [
+    {
+      "content": "+1",
+      "created_at": "2026-05-12T10:05:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/stale-plus1-rejected.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/stale-plus1-rejected.json
@@ -1,0 +1,17 @@
+{
+  "description": "Codex +1 reaction BEFORE the HEAD committer date (freshness floor) → not a clearance for this HEAD, NOT cleared (#450)",
+  "expected_cleared": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "head_committer_date": "2026-05-12T10:00:00Z",
+  "merged_at": "2026-05-12T10:30:00Z",
+  "reviews": [],
+  "inline_comments": [],
+  "reactions": [
+    {
+      "content": "+1",
+      "created_at": "2026-05-12T09:00:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/stale-plus1-rejected.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/stale-plus1-rejected.json
@@ -1,6 +1,7 @@
 {
   "description": "Codex +1 reaction BEFORE the HEAD committer date (freshness floor) → not a clearance for this HEAD, NOT cleared (#450)",
   "expected_cleared": false,
+  "authoring_agent": "claude",
   "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
   "codex_bot_login": "chatgpt-codex-connector[bot]",
   "head_committer_date": "2026-05-12T10:00:00Z",

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/stale-prior-head-plus1-rejected.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/stale-prior-head-plus1-rejected.json
@@ -1,6 +1,7 @@
 {
   "description": "PR advanced by an ordinary push to an OLD-committer-date commit; a stale prior-HEAD +1 lands after the old committer date but before merged_at - window → merge-time floor rejects it, NOT cleared (Codex P2 on #460). Without the floor it would wrongly clear.",
   "expected_cleared": false,
+  "authoring_agent": "claude",
   "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
   "codex_bot_login": "chatgpt-codex-connector[bot]",
   "head_committer_date": "2026-05-12T08:00:00Z",

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/stale-prior-head-plus1-rejected.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/stale-prior-head-plus1-rejected.json
@@ -1,0 +1,18 @@
+{
+  "description": "PR advanced by an ordinary push to an OLD-committer-date commit; a stale prior-HEAD +1 lands after the old committer date but before merged_at - window → merge-time floor rejects it, NOT cleared (Codex P2 on #460). Without the floor it would wrongly clear.",
+  "expected_cleared": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "head_committer_date": "2026-05-12T08:00:00Z",
+  "merged_at": "2026-05-12T10:30:00Z",
+  "reaction_freshness_window_seconds": 1800,
+  "reviews": [],
+  "inline_comments": [],
+  "reactions": [
+    {
+      "content": "+1",
+      "created_at": "2026-05-12T08:30:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
Aligns the retroactive weekly audit (`.github/workflows/pr-audit.yml`) with the merge gate (`scripts/codex-review-check.sh`), closing two false-positive classes surfaced by the #425 weekly-sweep validation. Parent: #445.

- **#449 — resolution-aware P0/P1.** The `unresolvedP01` filter ignored thread resolution, so an author-resolved P1 (the sanctioned codex-p1-gate override path) still produced an audit violation. The audit now fetches review-thread resolution via **paginated GraphQL `reviewThreads`** and joins it to inline P0/P1 findings by **comment `databaseId`** (the same join as `scripts/codex-p1-gate.sh`). A finding is unresolved unless its thread `isResolved`. Resolves the inline `TODO(#235)`. **Fails closed**: if the resolution lookup fails, every P0/P1 is treated as unresolved, so the review path cannot clear on a lookup failure.
- **#450 — merge-time +1 clearance.** The audit accepted only CLI-APPROVED / COMMENTED-on-HEAD clearance; the merge gate also accepts a freshness-anchored 👍. The audit now reads Codex bot `+1` reactions **anchored to merge time** (`[HEAD committer date, merged_at]`) — *not* the merge gate's `NOW − window` floor, because a valid merge-time +1 is week-old by audit time and a `NOW`-window floor would wrongly reject it. **Latest-signal-wins** mirrors the merge gate: a newer +1 clears an older review-with-findings; a newer review-with-findings blocks an older +1.

## Testing
- [x] `scripts/ci/check_pr_audit_codex_clearance` — **22 tests** (14 fixtures + 8 structural). The clearance algorithm is mirrored verbatim into the check's Node runner (inline-literal pattern). New fixtures: `p1-resolved-clears`, `p1-unresolved-blocks`, `resolution-lookup-failed` (fail-closed), `fresh-plus1-clears`, `stale-plus1-rejected`, `post-merge-plus1-rejected`, `review-newer-than-reaction-blocks`, `reaction-newer-than-review-clears`.
- [x] New structural assertions pin the `reviewThreads(first:100` + `isResolved` fetch (#449), the `reactions.listForIssue` + `'+1'` + `pr.merged_at` merge-time anchor (#450), and #449/#450 traceability.
- [x] Embedded github-script JS passes `node --check`; `pr-audit.yml` parses under yq; `check_pr_audit_sync_exemption` passes.

## Self-Review
- [x] Correctness: mirrors `codex-review-check.sh` gate (c) (resolution join + latest-signal-wins) and `codex-p1-gate.sh` (GraphQL join); merge-time anchor is the deliberate audit-vs-gate difference.
- [x] Regression risk: 6 pre-existing fixtures unchanged and still green; absent `review_threads`/`reactions` in old fixtures degrade to prior behavior.
- [x] Style and conventions: inline-literal pattern preserved; structural canaries added.
- [x] Test coverage: every new acceptance path has a fixture, including fail-closed and both latest-signal-wins directions.
- [x] Security: resolution-lookup failure and HEAD-date/inline-fetch failures all fail **closed**; reaction window cannot be satisfied by a post-merge or pre-HEAD +1.

Closes #445
Closes #449
Closes #450
