### PR TITLE
fix(eslint): fold device-source-of-truth into the canonical ESLint floor (#458)

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -103,16 +103,24 @@ consumers:
     visibility: private
     facts:
       frameworks: [astro, typescript]
-  # overridebroadway has zero lintable JS/TS surface area today; it's
-  # excluded from the ESLint templated entry's consumers list rather
-  # than carrying empty facts. No facts block needed.
+  # overridebroadway is excluded from the ESLint templated entry's
+  # consumers list. Its original "zero lintable surface" rationale is
+  # under review (#461): it actually has a root package.json and ~81
+  # .ts/.tsx files, so the exclusion is likely wrong — but it is CJS +
+  # TypeScript and the CJS entry has no TS consumer yet, so folding it in
+  # needs CJS-template verification first. No facts block until #461.
   - name: overridebroadway
     repo: nathanjohnpayne/overridebroadway
     visibility: private
-  # Same exclusion rationale as overridebroadway above.
+  # device-source-of-truth is a React 19 + TypeScript + Vite SPA with a
+  # root package.json and ~148 .ts/.tsx files, so it IS in scope for the
+  # canonical ESLint floor (#458). Folded into the ESM templated entry
+  # below; the prior "zero lintable surface" exclusion was false.
   - name: device-source-of-truth
     repo: nathanjohnpayne/device-source-of-truth
     visibility: public
+    facts:
+      frameworks: [react, typescript]
   - name: friends-and-family-billing
     repo: nathanjohnpayne/friends-and-family-billing
     visibility: public
@@ -685,16 +693,20 @@ paths:
   # maintains both source files in parallel; the body inside the
   # export is byte-identical, only the import/export syntax differs.
   #
-  # Consumers excluded from both entries: device-source-of-truth
-  # and overridebroadway have zero lintable JS/TS surface area;
-  # the ESLint policy floor doesn't apply (rules/repo_rules.md §
-  # ESLint policy).
+  # Consumer excluded from both entries: overridebroadway. Its
+  # "zero lintable surface" rationale is under review (#461) — it has a
+  # root package.json + ~81 .ts/.tsx files, but it is CJS + TypeScript and
+  # the CJS entry has no TS consumer yet, so folding it in needs template
+  # verification first. device-source-of-truth was previously excluded on
+  # the same (false) rationale; #458 folds it into the ESM entry below
+  # (React 19 + TypeScript + Vite SPA, root package.json, ~148 .ts/.tsx).
   #
   # Per-consumer rendered shapes (driven by facts.frameworks; module
   # syntax driven by which entry the consumer is in below):
   #   matchline (ESM)                  → JS + TS + React + react-hooks
   #   nathanpaynedotcom (ESM)          → JS + TS + Astro
   #   tadlockpsychiatry (ESM)          → JS + TS + React + react-hooks
+  #   device-source-of-truth (ESM)     → JS + TS + React + react-hooks
   #   friends-and-family-billing (CJS) → JS + React + react-hooks
   #   device-platform-reporting (CJS)  → JS + React + react-hooks
   #   swipewatch (CJS)                 → JS baseline only
@@ -708,6 +720,7 @@ paths:
       - matchline
       - nathanpaynedotcom
       - tadlockpsychiatry
+      - device-source-of-truth
 
   # CJS variant — consumers without `"type": "module"` (default
   # CJS resolution). Same body as the ESM variant; only the


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
Fixes #458. `.mergepath-sync.yml` excluded **device-source-of-truth** from the canonical ESLint templated entry on the false rationale that it *"has zero lintable JS/TS surface area today."* It is a **React 19 + TypeScript + Vite SPA** with a root `package.json` and **~148 `.ts`/`.tsx` files** — per `rules/repo_rules.md § ESLint policy` it is in scope (only repos *without* a root `package.json` are exempt). It was the only React+TS ESM consumer not tracking the floor, and the gap was invisible to both guards (the drift audit only compares in-manifest paths; CI only checks *a* config exists).

- Adds device-source-of-truth to the **ESM** `examples/eslint.config.js` templated entry with `facts: { frameworks: [react, typescript] }`. Verified locally that the render produces the same React+TS floor as matchline/tadlockpsychiatry.
- Corrects the false "zero lintable surface" rationale comments.

**mergepath-only** (per the chosen scope): the rendered `eslint.config.js` lands on device-source-of-truth via the next sync wave, which runs `npm run lint` and reconciles any findings the canonical floor surfaces over its prior 16-line hand-config.

## Side finding → #461
overridebroadway was chained to the *same* false rationale (`"Same exclusion rationale as overridebroadway above"`). I verified it too: root `package.json` + **~81 `.ts`/`.tsx` files**, so it is **also** likely mis-excluded. But it is **CJS + TypeScript** and the CJS templated entry has no TS consumer yet, so folding it in needs CJS-template verification — filed as #461 and left excluded here (rationale comment updated to point at it rather than assert the false claim).

## Testing
- [x] `yq` parses the manifest; `scripts/ci/check_sync_manifest` passes.
- [x] `scripts/ci/check_eslint_config_policy`, `check_template_substitution` pass.
- [x] Rendered `examples/eslint.config.js` with device-source-of-truth facts → valid ESM React+TS flat config (imports `typescript-eslint`, `eslint-plugin-react`, `eslint-plugin-react-hooks`).

## Self-Review
- [x] Correctness: matches #458 remediation option 1 (fold into ESM floor + facts); ESM is correct (`"type": "module"`).
- [x] Regression risk: manifest-only; downstream render deferred to the sync wave per scope.
- [x] Style and conventions: comments corrected, not just deleted; cross-references #458/#461.
- [x] Test coverage: manifest + template-render validated locally.
- [x] Security/hygiene: no new deps; removes a false rationale and a structurally-invisible coverage gap.

Closes #458
