### PR TITLE
fix(identity): identity-parsing + review-helper hardening (#448, #446, #447)

### DIFF
--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -139,6 +139,25 @@ jobs:
               }
             ' "$1"
           }
+          # Read a TOP-LEVEL scalar (author_identity), stripping BOTH YAML
+          # quote styles + a trailing comment + whitespace (#452). Mirrors
+          # audit-propagation-lane.sh's policy_top_scalar so the live lane and
+          # its weekly audit normalize author_identity identically — a
+          # quoted-but-correct `author_identity: "nathanjohnpayne"` passes the
+          # PR-author fingerprint below instead of failing on retained quotes.
+          top_field() {  # <file> <key>
+            awk -v key="$2" '
+              /^[^[:space:]#]/ && $1 == key":" {
+                sub(/^[^:]+:[[:space:]]*/, "", $0)
+                gsub(/^["\x27]/, "", $0)
+                gsub(/["\x27][[:space:]]*(#.*)?$/, "", $0)
+                gsub(/[[:space:]]*#.*$/, "", $0)
+                sub(/[[:space:]]+$/, "", $0)
+                print
+                exit
+              }
+            ' "$1"
+          }
           # Lane config + author identity from the BASE commit, not the
           # PR. `git show` the base blobs into tempfiles.
           BASE_POLICY=$(mktemp)
@@ -152,7 +171,7 @@ jobs:
           PROP_PREFIX=$(prop_field "$BASE_POLICY" propagation_prs branch_prefix)
           # Must match SYNC_BRANCH_PREFIX in scripts/sync-to-downstream.sh.
           PROP_PREFIX=${PROP_PREFIX:-mergepath-sync/}
-          AUTHOR_ID=$(grep -m1 '^author_identity:' "$BASE_POLICY" | awk '{print $2}')
+          AUTHOR_ID=$(top_field "$BASE_POLICY" author_identity)
           HEAD_REF="${{ github.event.pull_request.head.ref }}"
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           rm -f "$BASE_POLICY"

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -268,9 +268,21 @@ paths:
   - path: scripts/lib/manifest-fact-helpers.sh
     type: canonical
     consumers: all
+  # Shared available_reviewers reader (#453). Hard-required (exit 3 if
+  # missing) by coderabbit-wait.sh, codex-review-check.sh, and
+  # audit-propagation-lane.sh — the reviewer allow-list parse is a
+  # fail-closed gate input, so a consumer missing this lib must error, not
+  # silently degrade. Declared in each consumer's requires: below.
+  - path: scripts/lib/reviewers-helpers.sh
+    type: canonical
+    consumers: all
   - path: scripts/coderabbit-wait.sh
     type: canonical
     consumers: all
+    # Hard-sources scripts/lib/reviewers-helpers.sh (#453) for the
+    # token-derived expected-reviewer allow-list; exits 3 if absent.
+    requires:
+      - "scripts/lib/reviewers-helpers.sh"
   - path: scripts/codex-review-request.sh
     type: canonical
     consumers: all
@@ -285,6 +297,7 @@ paths:
     # hard rc=3 and the auto-clear stalls.
     requires:
       - "scripts/lib/gh-retry-helpers.sh"
+      - "scripts/lib/reviewers-helpers.sh"   # #453, hard-sourced for the gate (b)/(c) reviewer allow-list
   - path: scripts/phase-4b-classifier.sh
     type: canonical
     consumers: all
@@ -305,6 +318,13 @@ paths:
   - path: scripts/audit-propagation-lane.sh
     type: canonical
     consumers: all
+    # Live mode hard-sources scripts/lib/reviewers-helpers.sh to verify the
+    # reviewer token identity, and (existence-guarded) preflight-helpers.sh
+    # to auto-source it (#454). preflight-helpers is consumers:all already;
+    # both declared here so the #264 closure invariant covers them.
+    requires:
+      - "scripts/lib/reviewers-helpers.sh"
+      - "scripts/lib/preflight-helpers.sh"
   - path: tests/test_audit_propagation_lane.sh
     type: canonical
     consumers: all

--- a/scripts/audit-propagation-lane.sh
+++ b/scripts/audit-propagation-lane.sh
@@ -84,6 +84,28 @@ prop_field() {  # <file> <block> <key>
   ' "$1"
 }
 
+# Read a TOP-LEVEL scalar (e.g. author_identity), stripping BOTH YAML quote
+# styles, a trailing inline comment, and surrounding whitespace — the same
+# normalization codex-review-request.sh's policy_top_field and the
+# gh-pr-guard expected-author parser apply (#452). The lane's PR-author
+# fingerprint in pr-review-policy.yml carries the matching extraction, so a
+# quoted-but-correct `author_identity: "nathanjohnpayne"` passes in both the
+# live lane and this audit instead of failing on the retained quotes.
+policy_top_scalar() {  # <file> <key>
+  [ -f "$1" ] || return 0
+  awk -v key="$2" '
+    /^[^[:space:]#]/ && $1 == key":" {
+      sub(/^[^:]+:[[:space:]]*/, "", $0)
+      gsub(/^["\x27]/, "", $0)
+      gsub(/["\x27][[:space:]]*(#.*)?$/, "", $0)
+      gsub(/[[:space:]]*#.*$/, "", $0)
+      sub(/[[:space:]]+$/, "", $0)
+      print
+      exit
+    }
+  ' "$1"
+}
+
 # Evaluate the lane preconditions for one (review-policy, workflow)
 # file pair. Prints a status line; returns 0 if the lane fires, 1 if
 # not.
@@ -106,7 +128,7 @@ lane_status_for_files() {  # <label> <policy-file-or-empty> <workflow-file-or-em
   if [ -n "$policy" ] && [ -f "$policy" ]; then
     enabled=$(prop_field "$policy" propagation_prs enabled)
     prefix=$(prop_field "$policy" propagation_prs branch_prefix)
-    author_id=$(grep -m1 '^author_identity:' "$policy" | awk '{print $2}' || true)
+    author_id=$(policy_top_scalar "$policy" author_identity || true)
   fi
 
   if [ "$enabled" = "false" ]; then
@@ -182,6 +204,38 @@ command -v yq >/dev/null 2>&1 || { err "yq is required (brew install yq)"; exit 
 yq --version 2>&1 | grep -q "mikefarah/yq" || { err "mikefarah/yq v4+ required"; exit 2; }
 command -v gh >/dev/null 2>&1 || { err "gh is required"; exit 2; }
 [ -f "$MANIFEST" ] || { err "$MANIFEST not found (run from the mergepath root)"; exit 2; }
+
+# --- live-mode credential binding (#454) ------------------------------------
+# Live mode does GitHub reads; bind them to a VERIFIED reviewer token rather
+# than ambient gh state. --check-files mode returned above, so none of this
+# runs offline (that mode needs no token, preflight, gh, or network).
+__LANE_AUDIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Auto-source the op-preflight cache when GH_TOKEN is unset and a fresh cache
+# exists — the #282 pattern the sibling helpers use. A caller-supplied
+# GH_TOKEN is respected and still verified below.
+if [ -r "$__LANE_AUDIT_DIR/lib/preflight-helpers.sh" ]; then
+  # shellcheck source=lib/preflight-helpers.sh
+  . "$__LANE_AUDIT_DIR/lib/preflight-helpers.sh"
+  preflight_require_token reviewer || true
+fi
+if [ -z "${GH_TOKEN:-}" ]; then
+  err "live mode needs a reviewer token. Run: eval \"\$(scripts/op-preflight.sh --agent <agent> --mode review)\", or set GH_TOKEN to a reviewer PAT."
+  exit 3
+fi
+# Verify the effective token identity is an available_reviewers reviewer
+# (fail closed). Hard-require the shared reader: an unverifiable token must
+# error rather than read live data under an unknown identity.
+if [ ! -r "$__LANE_AUDIT_DIR/lib/reviewers-helpers.sh" ]; then
+  err "reviewers-helpers missing: $__LANE_AUDIT_DIR/lib/reviewers-helpers.sh"
+  exit 3
+fi
+# shellcheck source=lib/reviewers-helpers.sh
+. "$__LANE_AUDIT_DIR/lib/reviewers-helpers.sh"
+LANE_TOKEN_LOGIN=$(gh api user --jq .login 2>/dev/null || true)
+if [ -z "$LANE_TOKEN_LOGIN" ] || ! login_is_available_reviewer "$LANE_TOKEN_LOGIN"; then
+  err "live-mode token identity '${LANE_TOKEN_LOGIN:-<unresolvable>}' is not in available_reviewers — fail closed"
+  exit 3
+fi
 
 in_repo_filter() {
   local name=$1

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -1383,6 +1383,36 @@ else
   echo "$out" | sed 's/^/    /' >&2
 fi
 
+# #446 positive direction (CodeRabbit on #463): an unscoped non-HEAD
+# rate-limit comment CREATED after the StatusContext success means
+# CodeRabbit re-entered rate-limit post-success — the real fast-path must
+# SUPPRESS (keep polling → rate_limit_stalled), exercising the created_at
+# arbitration in status_context_fast_path_blocked_by_comment directly.
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    STUB_COMMENT_CREATED_AT="2999-01-01T00:00:05Z" \
+    STUB_COMMENT_UPDATED_AT="2999-01-01T00:00:05Z" \
+    STUB_STATUS_CREATED_AT="2999-01-01T00:00:01Z" \
+    STUB_COMMENT_BODY_SUFFIX="" \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "5" ] &&
+   echo "$out" | grep -q '"status": "rate_limit_stalled"' &&
+   echo "$out" | grep -q "StatusContext success suppressed"; then
+  pass=$((pass + 1))
+  echo "  PASS: unscoped non-HEAD rate-limit comment created AFTER the status success suppresses the fast-path (#446)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: post-success unscoped rate-limit comment should suppress the fast-path (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
 set +e
 out=$(
   cd "$CODERABBIT_FASTPATH_ROOT" &&

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -136,6 +136,18 @@ fi
 # shellcheck source=lib/gh-token-resolver.sh
 . "$__CODERABBIT_WAIT_DIR/lib/gh-token-resolver.sh"
 
+# Shared available_reviewers reader (#453) — one strongest-form parser so
+# the token-derived expected-identity allow-list (login_is_available_reviewer,
+# used at write time) can't be weakened by a quoted/commented reviewer
+# entry. Hard-require it: the token-login derivation is a fail-closed
+# security check, so a missing helper must error, not silently degrade.
+if [ ! -r "$__CODERABBIT_WAIT_DIR/lib/reviewers-helpers.sh" ]; then
+  echo "ERROR: reviewers-helpers missing: $__CODERABBIT_WAIT_DIR/lib/reviewers-helpers.sh" >&2
+  exit 3
+fi
+# shellcheck source=lib/reviewers-helpers.sh
+. "$__CODERABBIT_WAIT_DIR/lib/reviewers-helpers.sh"
+
 # --- argument parsing -------------------------------------------------------
 
 if [ $# -lt 1 ] || [ $# -gt 2 ]; then
@@ -217,28 +229,11 @@ coderabbit_field() {
   ' "$CONFIG"
 }
 
-# Read the available_reviewers list (one login per line). Same
-# state-machine awk pattern as codex-review-check.sh's reader; handles
-# quoted and unquoted list items. Used by the token-derived expected-
-# identity path (#438) to keep the derivation fail-closed: only a
-# login on this allow-list may become the expected reviewer.
-read_available_reviewers() {
-  [ -f "$CONFIG" ] || return 0
-  awk '
-    /^available_reviewers:/ {in_block=1; next}
-    in_block && /^[^[:space:]#]/ {in_block=0}
-    in_block && /^ *-/ {print}
-  ' "$CONFIG" | sed -E "s/^[[:space:]]*-[[:space:]]*//; s/[[:space:]]+#.*\$//; s/^[\"']//; s/[\"']\$//; s/[[:space:]]+\$//"
-}
-
-login_is_available_reviewer() {
-  local login=$1 reviewer
-  [ -n "$login" ] || return 1
-  while IFS= read -r reviewer; do
-    [ "$reviewer" = "$login" ] && return 0
-  done <<< "$(read_available_reviewers)"
-  return 1
-}
+# read_available_reviewers + login_is_available_reviewer now live in
+# scripts/lib/reviewers-helpers.sh (sourced above, #453). They default to
+# $CONFIG, so the call sites below are unchanged. The token-derived
+# expected-identity path (#438) still consumes login_is_available_reviewer
+# to keep the derivation fail-closed.
 
 MAX_WAIT_SECONDS=$(coderabbit_field max_wait_seconds)
 MAX_WAIT_SECONDS=${MAX_WAIT_SECONDS:-300}
@@ -726,6 +721,7 @@ status_context_fast_path_blocked_by_comment() {
     rate_limit|in_progress)
       comment_id=$(echo "$latest" | jq -r '.id')
       comment_fresh_at=$(echo "$latest" | jq -r '.fresh_at // .updated_at // .created_at')
+      comment_created_at=$(echo "$latest" | jq -r '.created_at // .fresh_at // .updated_at')
       comment_body=$(echo "$latest" | jq -r '.body')
       if printf '%s' "$comment_body" | grep -Fq "$HEAD_SHA"; then
         if iso_on_or_after "$comment_fresh_at" "$status_created_at"; then
@@ -735,7 +731,20 @@ status_context_fast_path_blocked_by_comment() {
         log "StatusContext success remains authoritative because latest CodeRabbit comment id=$comment_id class=$class explicitly references current HEAD $HEAD_SHA but fresh_at=$comment_fresh_at is older than status_created=$status_created_at"
         return 1
       fi
-      log "StatusContext success remains authoritative because latest CodeRabbit comment id=$comment_id class=$class does not reference current HEAD $HEAD_SHA"
+      # #446: a rate_limit/in_progress comment POSTED (created) at/after the
+      # StatusContext flipped to success means CodeRabbit re-entered a
+      # rate-limited / in-progress state — the fast-path must not declare
+      # clearance over it even though the notice does not reference HEAD.
+      # Compare CREATED_AT, not fresh_at: an OLD comment from a prior round
+      # that merely got edited after the success is stale and must NOT
+      # suppress (the 263caf3 "Bug 6" regression — an unscoped non-HEAD
+      # comment created before the success still clears). Only a comment
+      # actually posted at/after the success suppresses.
+      if iso_on_or_after "$comment_created_at" "$status_created_at"; then
+        log "StatusContext success suppressed because latest CodeRabbit comment id=$comment_id class=$class created=$comment_created_at is at/after status_created=$status_created_at (no HEAD $HEAD_SHA reference, but a post-success rate-limit/in-progress notice) — keep polling"
+        return 0
+      fi
+      log "StatusContext success remains authoritative because latest CodeRabbit comment id=$comment_id class=$class does not reference current HEAD $HEAD_SHA and was created=$comment_created_at before status_created=$status_created_at"
       return 1
       ;;
   esac

--- a/scripts/codex-p1-gate.sh
+++ b/scripts/codex-p1-gate.sh
@@ -87,33 +87,6 @@ if [ $# -gt 2 ]; then
   exit 2
 fi
 
-# Positional args take precedence; env fallbacks support the
-# workflow_dispatch / scheduled-sweep paths where it's more
-# ergonomic to set env than to build a positional arg list.
-PR_NUMBER=${1:-${PR_NUMBER:-}}
-if [ -z "$PR_NUMBER" ]; then
-  echo "ERROR: PR_NUMBER required (positional arg or \$PR_NUMBER env)" >&2
-  exit 2
-fi
-if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
-  echo "ERROR: PR_NUMBER must be an integer; got '$PR_NUMBER'" >&2
-  exit 2
-fi
-
-REPO=${2:-${REPO:-}}
-if [ -z "$REPO" ]; then
-  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
-  if [ -z "$REPO" ]; then
-    echo "ERROR: could not detect current repo via 'gh repo view'. Pass REPO explicitly." >&2
-    exit 2
-  fi
-fi
-
-if [ -z "${GH_TOKEN:-}" ]; then
-  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
-  exit 2
-fi
-
 # --- config readers ---------------------------------------------------------
 
 CONFIG=".github/review-policy.yml"
@@ -163,6 +136,13 @@ codex_field() {
 # Gate knob: codex.p1_gate.enabled. Default false everywhere except
 # mergepath itself (which sets it true in .github/review-policy.yml).
 # Off-state is a clean pass — no API calls, no work.
+#
+# This off-state short-circuit runs BEFORE the PR_NUMBER/REPO/GH_TOKEN
+# requirements below (#447): the header documents step 1 as
+# "p1_gate.enabled=false → clean pass," so a consumer with the gate
+# disabled must no-op on a bare/ad-hoc invocation instead of erroring on
+# missing PR context. The readers above touch only the local
+# review-policy.yml — no args, no API, no gh.
 P1_GATE_ENABLED=$(codex_p1_gate_field enabled)
 P1_GATE_ENABLED=${P1_GATE_ENABLED:-false}
 case "$P1_GATE_ENABLED" in
@@ -177,6 +157,35 @@ if [ "$P1_GATE_ENABLED" != "true" ]; then
   echo "[codex-p1-gate] codex.p1_gate.enabled=false — skipping (clean pass)"
   echo "Codex P1 unresolved: 0"
   exit 0
+fi
+
+# --- PR context (required only once the gate is enabled) --------------------
+
+# Positional args take precedence; env fallbacks support the
+# workflow_dispatch / scheduled-sweep paths where it's more
+# ergonomic to set env than to build a positional arg list.
+PR_NUMBER=${1:-${PR_NUMBER:-}}
+if [ -z "$PR_NUMBER" ]; then
+  echo "ERROR: PR_NUMBER required (positional arg or \$PR_NUMBER env)" >&2
+  exit 2
+fi
+if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+  echo "ERROR: PR_NUMBER must be an integer; got '$PR_NUMBER'" >&2
+  exit 2
+fi
+
+REPO=${2:-${REPO:-}}
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+  if [ -z "$REPO" ]; then
+    echo "ERROR: could not detect current repo via 'gh repo view'. Pass REPO explicitly." >&2
+    exit 2
+  fi
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  exit 2
 fi
 
 BOT_LOGIN=$(codex_field bot_login)

--- a/scripts/codex-p1-gate.sh
+++ b/scripts/codex-p1-gate.sh
@@ -174,6 +174,14 @@ if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
   exit 2
 fi
 
+# Verify GH_TOKEN BEFORE auto-detecting REPO via `gh repo view` — a
+# missing/invalid token otherwise surfaces as a misleading "could not
+# detect current repo" instead of the real auth error (CodeRabbit on #463).
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  exit 2
+fi
+
 REPO=${2:-${REPO:-}}
 if [ -z "$REPO" ]; then
   REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
@@ -181,11 +189,6 @@ if [ -z "$REPO" ]; then
     echo "ERROR: could not detect current repo via 'gh repo view'. Pass REPO explicitly." >&2
     exit 2
   fi
-fi
-
-if [ -z "${GH_TOKEN:-}" ]; then
-  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
-  exit 2
 fi
 
 BOT_LOGIN=$(codex_field bot_login)

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -119,6 +119,18 @@ else
   with_gh_retry() { "$@"; }
 fi
 
+# Shared available_reviewers reader (#453) — replaces the local
+# double-quote-only parser so coderabbit-wait.sh and this script parse the
+# allow-list identically (dash + inline comment + BOTH quote styles +
+# whitespace). Hard-require it: REVIEWERS below is a fail-closed gate input
+# (an empty list exits 3), so a missing helper must error, not degrade.
+if [ ! -r "$__CODEX_CHECK_DIR/lib/reviewers-helpers.sh" ]; then
+  echo "ERROR: reviewers-helpers missing: $__CODEX_CHECK_DIR/lib/reviewers-helpers.sh" >&2
+  exit 3
+fi
+# shellcheck source=lib/reviewers-helpers.sh
+. "$__CODEX_CHECK_DIR/lib/reviewers-helpers.sh"
+
 # --- argument parsing -------------------------------------------------------
 
 if [ $# -lt 1 ] || [ $# -gt 2 ]; then
@@ -305,19 +317,10 @@ case "$ALLOW_PHASE_4B_SUBSTITUTE" in
     ;;
 esac
 
-# Read the available_reviewers list (one per line). Same state-machine
-# awk pattern, but collecting list items rather than matching a scalar.
-# Outputs one reviewer login per line to stdout. Handles both quoted
-# (`  - "name"`) and unquoted (`  - name`) list item formats.
-read_available_reviewers() {
-  [ -f "$CONFIG" ] || return 0
-  awk '
-    /^available_reviewers:/ {in_block=1; next}
-    in_block && /^[^[:space:]#]/ {in_block=0}
-    in_block && /^ *-/ {print}
-  ' "$CONFIG" | sed -E 's/^[[:space:]]*-[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/'
-}
-
+# read_available_reviewers (and login_is_available_reviewer) now live in
+# scripts/lib/reviewers-helpers.sh (sourced above, #453). They default to
+# $CONFIG, so this call site is unchanged — but the allow-list now parses
+# with the strongest normalization (quoted/commented entries included).
 REVIEWERS=$(read_available_reviewers)
 if [ -z "$REVIEWERS" ]; then
   echo "ERROR: no available_reviewers found in $CONFIG" >&2

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -1023,16 +1023,21 @@ for i in "${!TOKENS[@]}"; do
       fi
       # env's combined/long forms that drop identity variables from
       # the wrapped command's environment (same r15 empty-override
-      # semantics as `env -u NAME` above): --unset=NAME, and -i which
-      # clears the whole environment.
+      # semantics as `env -u NAME` above): --unset=NAME, -u=NAME, the
+      # COMPACT -uNAME (flag and name attached, no `=` — #451), and -i
+      # which clears the whole environment. The space forms `-u NAME` /
+      # `--unset NAME` are consumed by the value-flag path above; only the
+      # attached forms reach this case, and -uNAME is the one
+      # prefix_flag_takes_value (which matches only the bare `-u`) cannot
+      # recognize, so it must be modeled explicitly here.
       if [ "$CURRENT_PREFIX" = "env" ]; then
         case "$tok" in
-          --unset=GH_AS_AUTHOR_IDENTITY|-u=GH_AS_AUTHOR_IDENTITY)
+          --unset=GH_AS_AUTHOR_IDENTITY|-u=GH_AS_AUTHOR_IDENTITY|-uGH_AS_AUTHOR_IDENTITY)
             INLINE_GH_AS_AUTHOR_IDENTITY=""
             INLINE_GH_AS_AUTHOR_IDENTITY_SET=1
             continue
             ;;
-          --unset=GH_AS_REVIEWER_IDENTITY|-u=GH_AS_REVIEWER_IDENTITY)
+          --unset=GH_AS_REVIEWER_IDENTITY|-u=GH_AS_REVIEWER_IDENTITY|-uGH_AS_REVIEWER_IDENTITY)
             INLINE_GH_AS_REVIEWER_IDENTITY=""
             INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
             continue

--- a/scripts/lib/reviewers-helpers.sh
+++ b/scripts/lib/reviewers-helpers.sh
@@ -26,8 +26,14 @@
 
 # Emit one normalized reviewer login per line. Normalization order:
 # strip the list dash + leading space, then a trailing inline comment,
-# then a leading and trailing quote (single OR double), then trailing
-# whitespace.
+# then trailing whitespace, then a leading and trailing quote (single OR
+# double), then any remaining trailing whitespace. Trimming trailing
+# whitespace BEFORE the closing-quote strip is load-bearing: a quoted item
+# with padding but no comment (e.g. `- "name"   `) would otherwise keep its
+# closing quote because `["']$` can't match before the trailing spaces, and
+# the stray quote would drop a valid reviewer from the fail-closed allow-list
+# (Codex P2 on #463). The second trailing-whitespace strip covers a space
+# inside the quotes (`- "name "`).
 read_available_reviewers() {
   local cfg="${1:-${CONFIG:-.github/review-policy.yml}}"
   [ -f "$cfg" ] || return 0
@@ -35,7 +41,7 @@ read_available_reviewers() {
     /^available_reviewers:/ {in_block=1; next}
     in_block && /^[^[:space:]#]/ {in_block=0}
     in_block && /^ *-/ {print}
-  ' "$cfg" | sed -E "s/^[[:space:]]*-[[:space:]]*//; s/[[:space:]]+#.*\$//; s/^[\"']//; s/[\"']\$//; s/[[:space:]]+\$//"
+  ' "$cfg" | sed -E "s/^[[:space:]]*-[[:space:]]*//; s/[[:space:]]+#.*\$//; s/[[:space:]]+\$//; s/^[\"']//; s/[\"']\$//; s/[[:space:]]+\$//"
 }
 
 # Return 0 iff <login> is a non-empty, exact member of the allow-list.

--- a/scripts/lib/reviewers-helpers.sh
+++ b/scripts/lib/reviewers-helpers.sh
@@ -1,0 +1,50 @@
+# scripts/lib/reviewers-helpers.sh
+#
+# Shared reader for the `available_reviewers` allow-list in
+# .github/review-policy.yml. Extracted in #453 so every helper that
+# consults the allow-list parses it IDENTICALLY. Before this, three
+# scripts carried three different readers: coderabbit-wait.sh had the
+# strongest normalization (dash + inline comment + BOTH quote styles +
+# whitespace, hardened across #438 r8/r10), codex-review-check.sh had a
+# weaker double-quote-only reader, and audit-propagation-lane.sh had
+# none. A weaker reader silently drops a quoted/commented-but-valid
+# reviewer from the allow-list, which would make coderabbit-wait.sh's
+# token-login derivation (login_is_available_reviewer at write time)
+# fail OPEN — exactly the fail-closed constraint #438 r-series locked in.
+# One shared, strongest-form reader keeps all consumers in lockstep.
+#
+# Sourcing contract: NO top-level side effects, only function defs.
+# Bash 3.2 portable (no mapfile, no associative arrays).
+#
+#   source scripts/lib/reviewers-helpers.sh
+#   read_available_reviewers [config_path]            # one login per line
+#   login_is_available_reviewer <login> [config_path] # 0 if listed, else 1
+#
+# config_path defaults to $CONFIG (the global the helper scripts set) and
+# then to .github/review-policy.yml, so existing call sites that pass no
+# argument keep working unchanged.
+
+# Emit one normalized reviewer login per line. Normalization order:
+# strip the list dash + leading space, then a trailing inline comment,
+# then a leading and trailing quote (single OR double), then trailing
+# whitespace.
+read_available_reviewers() {
+  local cfg="${1:-${CONFIG:-.github/review-policy.yml}}"
+  [ -f "$cfg" ] || return 0
+  awk '
+    /^available_reviewers:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block && /^ *-/ {print}
+  ' "$cfg" | sed -E "s/^[[:space:]]*-[[:space:]]*//; s/[[:space:]]+#.*\$//; s/^[\"']//; s/[\"']\$//; s/[[:space:]]+\$//"
+}
+
+# Return 0 iff <login> is a non-empty, exact member of the allow-list.
+# Fail-closed: an empty login or an unreadable config returns 1.
+login_is_available_reviewer() {
+  local login=$1 cfg="${2:-${CONFIG:-.github/review-policy.yml}}" reviewer
+  [ -n "$login" ] || return 1
+  while IFS= read -r reviewer; do
+    [ "$reviewer" = "$login" ] && return 0
+  done <<< "$(read_available_reviewers "$cfg")"
+  return 1
+}

--- a/tests/test_audit_propagation_lane.sh
+++ b/tests/test_audit_propagation_lane.sh
@@ -128,6 +128,74 @@ else
   fail "enabled: TRUE should fail; got rc=$RC, out: $OUT"
 fi
 
+# --- #452: quoted author_identity normalization ---------------------------
+# A quoted-but-correct author_identity must pass (the lane and this audit
+# strip both quote styles). Wrong author still fails even when quoted.
+POLICY_QUOTED_DQ="$WORKDIR/policy-quoted-dq.yml"
+printf 'propagation_prs:\n  enabled: true\nauthor_identity: "nathanjohnpayne"\n' >"$POLICY_QUOTED_DQ"
+run_check "$POLICY_QUOTED_DQ" "$WF_NEW"
+if [ "$RC" = "0" ]; then
+  pass "#452: double-quoted author_identity passes (quotes stripped)"
+else
+  fail "#452: double-quoted author_identity should pass; got rc=$RC, out: $OUT"
+fi
+
+POLICY_QUOTED_SQ="$WORKDIR/policy-quoted-sq.yml"
+printf "propagation_prs:\n  enabled: true\nauthor_identity: 'nathanjohnpayne'\n" >"$POLICY_QUOTED_SQ"
+run_check "$POLICY_QUOTED_SQ" "$WF_NEW"
+if [ "$RC" = "0" ]; then
+  pass "#452: single-quoted author_identity passes (quotes stripped)"
+else
+  fail "#452: single-quoted author_identity should pass; got rc=$RC, out: $OUT"
+fi
+
+POLICY_QUOTED_WRONG="$WORKDIR/policy-quoted-wrong.yml"
+printf 'propagation_prs:\n  enabled: true\nauthor_identity: "nathanpayne-claude"\n' >"$POLICY_QUOTED_WRONG"
+run_check "$POLICY_QUOTED_WRONG" "$WF_NEW"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "sync PRs are authored by"; then
+  pass "#452: quoted-but-WRONG author_identity still fails (quote-strip is not author-blind)"
+else
+  fail "#452: quoted wrong author should fail; got rc=$RC, out: $OUT"
+fi
+
+# --- #454: live-mode credential binding -----------------------------------
+# Offline --check-files stays credential-free: no GH_TOKEN required.
+set +e
+OUT=$(env -u GH_TOKEN "$SCRIPT" --check-files "$POLICY_BARE" "$WF_NEW" 2>&1)
+RC=$?
+set -e
+if [ "$RC" = "0" ] && ! echo "$OUT" | grep -qi "reviewer token"; then
+  pass "#454: --check-files mode stays credential-free (no GH_TOKEN required)"
+else
+  fail "#454: --check-files should not need GH_TOKEN; got rc=$RC, out: $OUT"
+fi
+
+# Live mode binds to a VERIFIED reviewer token; with no GH_TOKEN and no
+# fresh preflight cache it fails closed (exit 3) BEFORE any network read.
+# Stub yq/gh on PATH so the test doesn't depend on the CI yq-install order
+# (check_propagation_lane_audit runs before the yq install step).
+STUB_BIN="$WORKDIR/stub-bin"; mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/yq" <<'YQ'
+#!/usr/bin/env bash
+case "${1:-}" in --version) echo "yq (https://github.com/mikefarah/yq/) version v4.44.3" ;; *) echo "[]" ;; esac
+YQ
+cat > "$STUB_BIN/gh" <<'GH'
+#!/usr/bin/env bash
+echo "stub-gh must not be called on the fail-closed path" >&2; exit 99
+GH
+chmod +x "$STUB_BIN/yq" "$STUB_BIN/gh"
+EMPTY_CACHE="$WORKDIR/empty-cache"; mkdir -p "$EMPTY_CACHE"
+set +e
+OUT=$( cd "$ROOT" && PATH="$STUB_BIN:$PATH" OP_PREFLIGHT_CACHE_DIR="$EMPTY_CACHE" \
+  MERGEPATH_AGENT="nobody-xyz" env -u GH_TOKEN "$SCRIPT" --repos __none__ 2>&1 )
+RC=$?
+set -e
+if [ "$RC" = "3" ] && echo "$OUT" | grep -qi "reviewer token"; then
+  pass "#454: live mode fails closed (exit 3) with no token + no fresh cache"
+else
+  fail "#454: live mode should fail closed w/o a token; got rc=$RC, out: $OUT"
+fi
+
 echo ""
 echo "test_audit_propagation_lane: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/test_coderabbit_wait_identity_derivation.sh
+++ b/tests/test_coderabbit_wait_identity_derivation.sh
@@ -34,6 +34,7 @@ make_case() {
   mkdir -p "$dir/scripts/lib" "$dir/.github" "$dir/bin" "$dir/state"
   cp "$ROOT/scripts/coderabbit-wait.sh" "$dir/scripts/coderabbit-wait.sh"
   cp "$ROOT/scripts/lib/gh-token-resolver.sh" "$dir/scripts/lib/gh-token-resolver.sh"
+  cp "$ROOT/scripts/lib/reviewers-helpers.sh" "$dir/scripts/lib/reviewers-helpers.sh"
   chmod +x "$dir/scripts/coderabbit-wait.sh"
 
   cat >"$dir/.github/review-policy.yml" <<'EOF'
@@ -285,6 +286,46 @@ test_derives_identity_from_quoted_commented_entry() {
   fi
 }
 
+# #453: the shared scripts/lib/reviewers-helpers.sh parses the allow-list
+# with the strongest normalization (dash + inline comment + BOTH quote
+# styles + whitespace), so coderabbit-wait.sh and codex-review-check.sh stay
+# in lockstep and a quoted/commented reviewer is never silently dropped from
+# the fail-closed token allow-list. Direct unit test of the shared lib.
+test_453_shared_reviewers_helper() {
+  local lib="$ROOT/scripts/lib/reviewers-helpers.sh"
+  if [ ! -r "$lib" ]; then fail "#453: missing $lib"; return; fi
+  local cfg; cfg="$(mktemp)"
+  cat >"$cfg" <<'EOF'
+available_reviewers:
+  - nathanpayne-claude
+  - "nathanpayne-cursor"
+  - 'nathanpayne-codex'   # single quotes + trailing comment + padding
+default_external_reviewer: nathanpayne-codex
+EOF
+  ( # shellcheck source=../scripts/lib/reviewers-helpers.sh
+    . "$lib"
+    out=$(read_available_reviewers "$cfg" | tr '\n' ',')
+    [ "$out" = "nathanpayne-claude,nathanpayne-cursor,nathanpayne-codex," ] \
+      || { echo "parse mismatch: [$out]" >&2; exit 1; }
+    login_is_available_reviewer "nathanpayne-cursor" "$cfg" \
+      || { echo "double-quoted member not recognized" >&2; exit 1; }
+    login_is_available_reviewer "nathanpayne-codex" "$cfg" \
+      || { echo "single-quoted+commented member not recognized" >&2; exit 1; }
+    ! login_is_available_reviewer "default_external_reviewer" "$cfg" \
+      || { echo "non-member (out-of-block key) wrongly matched" >&2; exit 1; }
+    ! login_is_available_reviewer "" "$cfg" \
+      || { echo "empty login wrongly matched" >&2; exit 1; }
+  )
+  local rc=$?
+  rm -f "$cfg"
+  if [ "$rc" = 0 ]; then
+    pass "#453: shared reviewers-helpers parses quoted/commented/whitespace entries and matches members fail-closed"
+  else
+    fail "#453: shared reviewers-helpers parsing/membership regressed (rc=$rc)"
+  fi
+}
+
+test_453_shared_reviewers_helper
 test_derives_identity_from_allow_listed_token
 test_derives_identity_from_quoted_commented_entry
 test_non_allow_listed_token_fails_closed

--- a/tests/test_coderabbit_wait_identity_derivation.sh
+++ b/tests/test_coderabbit_wait_identity_derivation.sh
@@ -295,13 +295,18 @@ test_453_shared_reviewers_helper() {
   local lib="$ROOT/scripts/lib/reviewers-helpers.sh"
   if [ ! -r "$lib" ]; then fail "#453: missing $lib"; return; fi
   local cfg; cfg="$(mktemp)"
-  cat >"$cfg" <<'EOF'
-available_reviewers:
-  - nathanpayne-claude
-  - "nathanpayne-cursor"
-  - 'nathanpayne-codex'   # single quotes + trailing comment + padding
-default_external_reviewer: nathanpayne-codex
-EOF
+  # `nathanpayne-cursor` is double-quoted WITH trailing padding and NO inline
+  # comment — the Codex P2 on #463 shape (the closing quote must be stripped
+  # despite the trailing spaces). Built with printf so the trailing spaces are
+  # explicit and survive editor/linter whitespace-trimming. `nathanpayne-codex`
+  # is single-quoted with a trailing comment + padding.
+  {
+    printf 'available_reviewers:\n'
+    printf '  - nathanpayne-claude\n'
+    printf '  - "nathanpayne-cursor"   \n'
+    printf "  - 'nathanpayne-codex'   # single quotes + trailing comment + padding\n"
+    printf 'default_external_reviewer: nathanpayne-codex\n'
+  } >"$cfg"
   ( # shellcheck source=../scripts/lib/reviewers-helpers.sh
     . "$lib"
     out=$(read_available_reviewers "$cfg" | tr '\n' ',')

--- a/tests/test_coderabbit_wait_status_probe.sh
+++ b/tests/test_coderabbit_wait_status_probe.sh
@@ -470,7 +470,10 @@ test_review_during_probe_wait_emits_findings() {
 # trust_status_context_for_clearance: true, which the scenario harness above
 # disables, so this regression pairs a STRUCTURAL assertion on the real
 # arbitration with an inline ordering-decision check (the inline-literal
-# pattern used by scripts/ci/check_pr_audit_codex_clearance).
+# pattern used by scripts/ci/check_pr_audit_codex_clearance). The REAL
+# runtime fast-path (trust enabled + StatusContext stub) — including the
+# created-after-suppress and created-before-clear directions — is exercised
+# end-to-end in scripts/ci/check_canonical_bugs_263caf3 "Bug 6".
 test_446_newer_comment_suppresses_stale_status() {
   local script="$ROOT/scripts/coderabbit-wait.sh"
 

--- a/tests/test_coderabbit_wait_status_probe.sh
+++ b/tests/test_coderabbit_wait_status_probe.sh
@@ -27,6 +27,7 @@ make_case() {
   mkdir -p "$dir/scripts/lib" "$dir/.github" "$dir/bin" "$dir/state"
   cp "$ROOT/scripts/coderabbit-wait.sh" "$dir/scripts/coderabbit-wait.sh"
   cp "$ROOT/scripts/lib/gh-token-resolver.sh" "$dir/scripts/lib/gh-token-resolver.sh"
+  cp "$ROOT/scripts/lib/reviewers-helpers.sh" "$dir/scripts/lib/reviewers-helpers.sh"
   chmod +x "$dir/scripts/coderabbit-wait.sh"
 
   cat >"$dir/.github/review-policy.yml" <<EOF
@@ -461,6 +462,51 @@ test_review_during_probe_wait_emits_findings() {
   fi
 }
 
+# #446: fast-path StatusContext clearance race. A NEWER rate-limit/
+# in-progress comment than the StatusContext success must suppress the
+# fast-path EVEN WHEN it does not reference the current HEAD — otherwise the
+# wait can declare clearance while CodeRabbit has just announced it is
+# rate-limited / re-reviewing. The full fast-path is gated on
+# trust_status_context_for_clearance: true, which the scenario harness above
+# disables, so this regression pairs a STRUCTURAL assertion on the real
+# arbitration with an inline ordering-decision check (the inline-literal
+# pattern used by scripts/ci/check_pr_audit_codex_clearance).
+test_446_newer_comment_suppresses_stale_status() {
+  local script="$ROOT/scripts/coderabbit-wait.sh"
+
+  # Structural: the no-HEAD-reference branch must consult comment freshness
+  # (the #446 guard) rather than unconditionally return authoritative.
+  if grep -q "#446" "$script" \
+     && grep -q "StatusContext success suppressed because latest CodeRabbit comment" "$script"; then
+    pass "#446: coderabbit-wait.sh carries the newer-comment freshness guard in the no-HEAD fast-path branch"
+  else
+    fail "#446: coderabbit-wait.sh is missing the newer-comment freshness guard (#446 marker / suppressed-log)"
+  fi
+
+  # Inline ordering decision mirroring status_context_fast_path_blocked_by_comment:
+  # "block" (suppress the fast-path) iff the comment is rate_limit/in_progress
+  # AND not older than the StatusContext success (newer-or-equal), regardless
+  # of HEAD reference. KEEP IN SYNC with the function.
+  decide() {  # <class> <comment_fresh_at> <status_created_at> → block|authoritative
+    case "$1" in
+      rate_limit|in_progress)
+        if [[ "$2" < "$3" ]]; then echo authoritative; else echo block; fi ;;
+      *) echo authoritative ;;
+    esac
+  }
+  local ok=1
+  [[ "$(decide rate_limit  2026-06-04T00:10:00Z 2026-06-04T00:00:00Z)" == block ]]         || ok=0  # no-HEAD newer → block (#446)
+  [[ "$(decide rate_limit  2026-06-03T23:50:00Z 2026-06-04T00:00:00Z)" == authoritative ]] || ok=0  # older → authoritative
+  [[ "$(decide in_progress 2026-06-04T00:10:00Z 2026-06-04T00:00:00Z)" == block ]]         || ok=0  # in_progress newer → block
+  [[ "$(decide normal      2026-06-04T00:10:00Z 2026-06-04T00:00:00Z)" == authoritative ]] || ok=0  # non-rate-limit → authoritative
+  if [ "$ok" = 1 ]; then
+    pass "#446: newer rate-limit/in-progress comment suppresses the fast-path; older or non-rate-limit does not"
+  else
+    fail "#446: fast-path newer-comment-vs-status ordering regressed"
+  fi
+}
+
+test_446_newer_comment_suppresses_stale_status
 test_timeout_probe_posts_once_and_surfaces_reply
 test_existing_status_probe_reply_never_clears
 test_rate_limit_stalled_does_not_probe

--- a/tests/test_codex_p1_gate.sh
+++ b/tests/test_codex_p1_gate.sh
@@ -232,6 +232,44 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 1b (#447): gate disabled + NO env (no PR_NUMBER, REPO, or GH_TOKEN).
+# The enabled=false short-circuit must run BEFORE the PR-context
+# requirements, so a disabled consumer no-ops on a bare/ad-hoc invocation
+# instead of erroring on missing env (the documented step-1 contract).
+# ---------------------------------------------------------------------------
+echo
+echo "--- Test 1b (#447): gate disabled + no PR/REPO/GH_TOKEN env"
+SCRATCH=$(make_scratch_with_config false)
+: > "$WORKDIR/gh-calls.log"
+set +e
+OUT=$( cd "$SCRATCH" && PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/gh-calls.log" \
+  env -u GH_TOKEN -u PR_NUMBER -u REPO "$SCRIPT" 2>&1 )
+RC=$?
+set -e
+if [ "$RC" = 0 ] && echo "$OUT" | grep -q "Codex P1 unresolved: 0" \
+    && ! grep -q "^gh" "$WORKDIR/gh-calls.log"; then
+  pass "#447: disabled gate + no env → exit 0 clean pass (no PR_NUMBER/GH_TOKEN error, no gh calls)"
+else
+  fail "#447: expected rc=0 + 'unresolved: 0' + no gh calls; got rc=$RC, output:"
+  echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# Control: gate ENABLED + no env → still errors (env required once enabled).
+echo "--- Test 1c (#447 control): gate enabled + no PR_NUMBER → exit 2"
+SCRATCH=$(make_scratch_with_config true)
+set +e
+OUT=$( cd "$SCRATCH" && PATH="$STUB_DIR:$PATH" \
+  env -u GH_TOKEN -u PR_NUMBER -u REPO "$SCRIPT" 2>&1 )
+RC=$?
+set -e
+if [ "$RC" = 2 ] && echo "$OUT" | grep -q "PR_NUMBER required"; then
+  pass "#447 control: enabled gate + no env → exit 2 (env still required when enabled)"
+else
+  fail "#447 control: expected rc=2 + 'PR_NUMBER required'; got rc=$RC, output:"
+  echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
 # Test 2: Gate enabled, no P1 comments at all — exit 0.
 # ---------------------------------------------------------------------------
 echo

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -412,6 +412,32 @@ cd "$ORIG_DIR"
 assert_rc_contains "env --unset NAME still reaches merge-state checks" 2 "mergeStateStatus is BLOCKED" \
   'env --unset GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "BLOCKED" ""
 
+# Compact `env -uNAME` form (#451) — flag and name attached, no `=`.
+# prefix_flag_takes_value matches only the bare `-u`, so this token would
+# fall through as a boolean flag unless the case block models it
+# explicitly. Same r15 empty-override semantics as `env -u NAME`.
+cd "$WORKDIR/repo-custom-author-empty"
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=custom-owner run_hook 'env -uGH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "#451: env -uNAME (compact) author unset fails closed in custom-author repo"
+else
+  fail "#451: env -uNAME (compact) author unset fails closed in custom-author repo: rc=$rc; output: $out"
+fi
+cd "$ORIG_DIR"
+
+# ...and in a default repo the compact form must still reach the merge-state
+# checks (BLOCKED proves the walk didn't bail at the unset arg and skip checks).
+assert_rc_contains "#451: env -uNAME (compact) author unset reaches merge-state checks in default repo" 2 "mergeStateStatus is BLOCKED" \
+  'env -uGH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "BLOCKED" ""
+
+# Reviewer analog: the compact unset falls the wrapper back to its default
+# reviewer; with a different expected reviewer that must fail closed.
+assert_rc_contains "#451: env -uNAME (compact) reviewer unset fails closed vs different expected reviewer" 2 "not expected reviewer" \
+  'env -uGH_AS_REVIEWER_IDENTITY scripts/gh-as-reviewer.sh -- gh pr comment 123 --body "ping"' "CLEAN" "" "nathanpayne-codex"
+
 # The unset BUILTIN persists past separators (preempted, r17 family).
 cd "$WORKDIR/repo-custom-author-empty"
 set +e


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
Closes the residual identity-parsing hardening from the cc3487a/#442 wave (parent #448) plus two review-helper bugs. Six fixes:

- **#451** — `gh-pr-guard.sh` models the **compact `env -uNAME`** form (flag+name attached). `prefix_flag_takes_value` matches only the bare `-u`, so `env -uGH_AS_AUTHOR_IDENTITY wrapper` fell through; now maps to the same r15 empty-override semantics for author + reviewer vars.
- **#452** — quoted `author_identity`: both `pr-review-policy.yml` (live lane) and `audit-propagation-lane.sh` (offline + live) strip **both quote styles + trailing comment + whitespace** via a shared `top_field`/`policy_top_scalar` reader, so `author_identity: "nathanjohnpayne"` passes the PR-author fingerprint.
- **#453** — new `scripts/lib/reviewers-helpers.sh` with the strongest `available_reviewers` normalization (dash + inline comment + both quote styles + whitespace). `coderabbit-wait.sh` + `codex-review-check.sh` hard-source it (replacing divergent local parsers), so a quoted/commented reviewer can't be dropped from the **fail-closed token allow-list**. Registered in the manifest with `requires:` closures.
- **#454** — `audit-propagation-lane.sh` live mode binds reads to a **verified reviewer token** (auto-source preflight, fail closed without one, verify login ∈ `available_reviewers`). `--check-files` stays credential-free.
- **#446** — `coderabbit-wait.sh` fast-path: a rate-limit/in-progress comment **posted (created_at) at/after** the StatusContext success now suppresses the fast-path even without a HEAD reference — closing the race where the wait cleared while CodeRabbit had just re-entered rate-limit. Uses `created_at` (not `fresh_at`) so a stale prior-round comment merely edited later still clears (preserves the 263caf3 Bug 6 regression).
- **#447** — `codex-p1-gate.sh`: the `enabled=false` clean-pass short-circuit runs **before** the `PR_NUMBER`/`REPO`/`GH_TOKEN` requirements, so a disabled consumer no-ops on a bare invocation (matches the documented step-1 contract).

## Testing
- [x] New cases: compact `env -u` author/reviewer (`test_gh_pr_guard`, 68 pass); quoted author_identity + live-mode fail-closed/credential-free (`test_audit_propagation_lane`, 16 pass); shared-reviewers lib unit test (`test_coderabbit_wait_identity_derivation`); newer-comment-vs-status fast-path regression (`test_coderabbit_wait_status_probe`); disabled-no-env clean pass (`test_codex_p1_gate`, 15 pass).
- [x] The two coderabbit-wait tests copy the new lib into their temp checkouts (propagation closure).
- [x] **All affected `repo_lint` checks pass locally** incl. `check_canonical_bugs_263caf3` (51/51 — the #446↔Bug-6 reconciliation), `check_sync_manifest`, `check_gh_as_author`, `check_propagation_lane_audit`, `check_op_preflight_contract`, `check_coderabbit_wait`, `check_codex_p1_gate`.
- [x] `bash -n` + yq parse on all modified files.

## Self-Review
- [x] Correctness: each sub-fix matches its issue's acceptance; #446 uses `created_at` to reconcile with the existing 263caf3 Bug-6 regression (a created-before comment still clears).
- [x] Regression risk: shared-lib extraction keeps call sites unchanged (functions default to `$CONFIG`); hard-require + manifest `requires:` closure guarantees consumers get the lib; tests updated for the temp-checkout closure.
- [x] Security/hygiene: reviewer allow-list and live-token paths fail **closed**; no new deps.

Closes #448
Closes #451
Closes #452
Closes #453
Closes #454
Closes #446
Closes #447
