### PR TITLE
fix(merge-gate): make codex-review-check.sh gate (c) resolution-aware (#460 Option B)

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -440,6 +440,11 @@ paths:
   - path: tests/test_codex_review_request_ack.sh
     type: canonical
     consumers: all
+  # Resolution-aware gate (c) regression (#460 Option B). check_codex_scripts
+  # (scripts/ci kit) hard-runs it, so it must travel to every consumer.
+  - path: tests/test_codex_review_check_resolution.sh
+    type: canonical
+    consumers: all
   # Pairs with scripts/merge-clearance-gate.sh +
   # scripts/ci/check_merge_clearance_gate (kit-propagated). The check
   # wrapper hard-requires this test file; same #264/#266 coupling class
@@ -647,6 +652,7 @@ paths:
       - "tests/test_template_substitution.sh"  # check_template_substitution
       - "tests/test_export_consumer_facts.sh"  # check_export_consumer_facts
       - "tests/test_codex_review_request_ack.sh"  # check_codex_scripts
+      - "tests/test_codex_review_check_resolution.sh"  # check_codex_scripts (#460 Option B)
       - "tests/test_audit_propagation_lane.sh" # check_propagation_lane_audit
       - "scripts/audit-propagation-lane.sh"    # check_propagation_lane_audit
       - "scripts/codex-p1-gate.sh"             # check_codex_p1_gate

--- a/scripts/ci/check_codex_scripts
+++ b/scripts/ci/check_codex_scripts
@@ -45,5 +45,8 @@ fi
 echo "check_codex_scripts: running codex-review-request ack tests"
 "$REPO_ROOT/tests/test_codex_review_request_ack.sh"
 
+echo "check_codex_scripts: running codex-review-check gate (c) resolution tests"
+"$REPO_ROOT/tests/test_codex_review_check_resolution.sh"
+
 echo "check_codex_scripts: PASS"
 exit 0

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -899,6 +899,42 @@ else
   UNADDRESSED_P01='[]'
 fi
 
+# Resolution-aware filter (Option B on #460 / aligns gate (c) with
+# codex-p1-gate.sh and the weekly audit). Thread resolution is the
+# sanctioned override in codex-p1-gate.sh, so gate (c) must honor it too —
+# otherwise the two required checks contradict (codex-p1-gate clears a
+# resolved P0/P1 thread while gate (c) still blocks it, so a legitimately
+# resolved finding can never satisfy both). A P0/P1 finding counts as
+# unaddressed only when its review thread is NOT resolved.
+#
+# This runs at MERGE time (live), so isResolved is the state AT merge — no
+# retrospective staleness applies here (that is the weekly audit's concern,
+# which bounds resolution by merge time). Mirrors codex-p1-gate.sh's
+# GraphQL reviewThreads → comment-databaseId → isResolved join.
+#
+# Fail CLOSED on lookup failure: leave UNADDRESSED_P01 unfiltered (every
+# finding treated as unresolved), so a GraphQL hiccup or a >100-thread PR
+# can't clear a real P0/P1. Only fetched when there is at least one finding.
+if [ "$(echo "$UNADDRESSED_P01" | jq 'length')" -gt 0 ]; then
+  RES_OWNER=${REPO%/*}
+  RES_NAME=${REPO#*/}
+  RES_QUERY='query($owner:String!,$name:String!,$pr:Int!){repository(owner:$owner,name:$name){pullRequest(number:$pr){reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved comments(first:100){nodes{databaseId}}}}}}}'
+  THREADS_JSON=$(with_gh_retry gh api graphql -F owner="$RES_OWNER" -F name="$RES_NAME" -F pr="$PR_NUMBER" -f query="$RES_QUERY" 2>&1) || THREADS_JSON=""
+  if ! echo "$THREADS_JSON" | jq -e '.data.repository.pullRequest.reviewThreads' >/dev/null 2>&1; then
+    log "gate (c): WARNING reviewThreads resolution lookup failed — failing closed (treating all P0/P1 findings as unresolved)"
+  elif [ "$(echo "$THREADS_JSON" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')" = "true" ]; then
+    log "gate (c): WARNING PR has >100 review threads; resolution pagination unsupported — failing closed (treating all P0/P1 findings as unresolved)"
+  else
+    RESOLUTION_MAP=$(echo "$THREADS_JSON" | jq '
+      .data.repository.pullRequest.reviewThreads.nodes
+      | map((.isResolved) as $r | .comments.nodes | map({ key: (.databaseId | tostring), value: $r }))
+      | flatten | from_entries')
+    UNADDRESSED_P01=$(echo "$UNADDRESSED_P01" | jq --argjson map "$RESOLUTION_MAP" '
+      [ .[] | . as $c | ($map[($c.comment_id | tostring)] // false) as $resolved | select($resolved != true) ]')
+    log "gate (c): resolution-aware — $(echo "$UNADDRESSED_P01" | jq 'length') unresolved P0/P1 finding(s) after honoring thread resolution"
+  fi
+fi
+
 UNADDRESSED_COUNT=$(echo "$UNADDRESSED_P01" | jq 'length')
 
 # Latest +1 reaction on the PR issue from the Codex bot, filtered by

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -919,7 +919,11 @@ if [ "$(echo "$UNADDRESSED_P01" | jq 'length')" -gt 0 ]; then
   RES_OWNER=${REPO%/*}
   RES_NAME=${REPO#*/}
   RES_QUERY='query($owner:String!,$name:String!,$pr:Int!){repository(owner:$owner,name:$name){pullRequest(number:$pr){reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved comments(first:100){nodes{databaseId}}}}}}}'
-  THREADS_JSON=$(with_gh_retry gh api graphql -F owner="$RES_OWNER" -F name="$RES_NAME" -F pr="$PR_NUMBER" -f query="$RES_QUERY" 2>&1) || THREADS_JSON=""
+  # 2>/dev/null (not 2>&1): with_gh_retry emits retry diagnostics to stderr;
+  # merging them into THREADS_JSON would make a transient-retry-then-success
+  # look like malformed JSON and force a needless fail-closed block
+  # (CodeRabbit Major + Codex P2 on #464). Keep only stdout (the JSON).
+  THREADS_JSON=$(with_gh_retry gh api graphql -F owner="$RES_OWNER" -F name="$RES_NAME" -F pr="$PR_NUMBER" -f query="$RES_QUERY" 2>/dev/null) || THREADS_JSON=""
   if ! echo "$THREADS_JSON" | jq -e '.data.repository.pullRequest.reviewThreads' >/dev/null 2>&1; then
     log "gate (c): WARNING reviewThreads resolution lookup failed — failing closed (treating all P0/P1 findings as unresolved)"
   elif [ "$(echo "$THREADS_JSON" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')" = "true" ]; then

--- a/tests/test_codex_review_check_resolution.sh
+++ b/tests/test_codex_review_check_resolution.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# tests/test_codex_review_check_resolution.sh
+#
+# Regression coverage for the resolution-aware gate (c) filter in
+# scripts/codex-review-check.sh (Option B on #460): a Codex P0/P1 finding on
+# the latest review counts as UNADDRESSED only when its review thread is NOT
+# resolved — aligning gate (c) with codex-p1-gate.sh and the weekly audit so
+# the two required checks no longer contradict on a resolved P0/P1.
+#
+# The full gate (c) runs the entire codex-review-check flow (CI + gate (b) +
+# reactions + reviewThreads), which test_merge_clearance_gate.sh stubs out;
+# the resolution-join LOGIC is identical to codex-p1-gate.sh's (integration-
+# tested in test_codex_p1_gate.sh via make_threads_fixture). This test pins
+# (1) the structural presence of the join in the real script and (2) the
+# join's jq logic inline — the inline-literal pattern used by
+# scripts/ci/check_pr_audit_codex_clearance.
+#
+# Bash 3.2 portable. Runs without network.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/codex-review-check.sh"
+[ -r "$SCRIPT" ] || { echo "missing $SCRIPT" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not available" >&2; exit 0; }
+
+PASS=0; FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# 1. Structural: gate (c) fetches reviewThreads and filters UNADDRESSED_P01
+#    by thread resolution (joined on comment_id), failing closed.
+if grep -q "reviewThreads(first:100)" "$SCRIPT" \
+   && grep -q "RESOLUTION_MAP" "$SCRIPT" \
+   && grep -q "comment_id | tostring" "$SCRIPT" \
+   && grep -qi "failing closed" "$SCRIPT" \
+   && grep -q "#460" "$SCRIPT"; then
+  pass "codex-review-check.sh gate (c) carries the resolution-aware reviewThreads filter (#460 Option B)"
+else
+  fail "codex-review-check.sh gate (c) is missing the resolution-aware filter (reviewThreads / RESOLUTION_MAP / comment_id join / fail-closed / #460)"
+fi
+
+# 2. Inline logic: the resolution-map filter excludes resolved findings,
+#    keeps unresolved, and treats a finding ABSENT from the map as
+#    unresolved (the fail-closed `// false` default). KEEP IN SYNC with the
+#    `UNADDRESSED_P01 | jq(... $map ...)` filter in codex-review-check.sh.
+UNADDRESSED='[{"path":"a","line":1,"comment_id":5001},{"path":"b","line":2,"comment_id":5002},{"path":"c","line":3,"comment_id":5003}]'
+# 5001 resolved, 5002 unresolved, 5003 absent from the map (→ unresolved).
+MAP='{"5001":true,"5002":false}'
+FILTERED=$(echo "$UNADDRESSED" | jq --argjson map "$MAP" '
+  [ .[] | . as $c | ($map[($c.comment_id | tostring)] // false) as $resolved | select($resolved != true) ]')
+GOT=$(echo "$FILTERED" | jq -c '[.[].comment_id] | sort')
+if [ "$GOT" = "[5002,5003]" ]; then
+  pass "resolution filter: excludes resolved (5001), keeps unresolved (5002) and absent-from-map (5003, fail-closed)"
+else
+  fail "resolution filter wrong: expected [5002,5003], got $GOT"
+fi
+
+# 3. All-resolved → empty (gate (c) then clears via the review path).
+MAP_ALL='{"5001":true,"5002":true,"5003":true}'
+CNT=$(echo "$UNADDRESSED" | jq --argjson map "$MAP_ALL" '
+  [ .[] | . as $c | ($map[($c.comment_id | tostring)] // false) as $r | select($r != true) ] | length')
+if [ "$CNT" = "0" ]; then
+  pass "resolution filter: all-resolved findings → 0 unaddressed (gate clears)"
+else
+  fail "resolution filter: all-resolved should yield 0, got $CNT"
+fi
+
+echo ""
+echo "test_codex_review_check_resolution: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
The maintainer chose **Option B** on #460: make the live merge gate resolution-aware (not the audit). Thread resolution is already the sanctioned override in `codex-p1-gate.sh`, so **gate (c)** in `codex-review-check.sh` must honor it too — otherwise the two required checks contradict (a resolved P0/P1 thread clears `codex-p1-gate` but still blocks gate (c), so a legitimately-resolved finding can never satisfy both), and the `pr-audit.yml` clearance check that mirrors gate (c) diverges from it.

Gate (c) now joins each P0/P1 inline finding on the latest Codex review to its review-thread `isResolved` via GraphQL `reviewThreads` — the **same comment-databaseId join as `codex-p1-gate.sh`** — and counts a finding as unaddressed only when its thread is **unresolved**.

- **Live, not retrospective:** this runs at merge time, so `isResolved` is the state AT merge. No retrospective staleness (that's the weekly audit's concern in #460, which bounds resolution by `merged_at`).
- **Fails CLOSED:** a GraphQL hiccup or a >100-thread PR leaves the findings unfiltered (all treated unresolved), so a lookup failure can't clear a real P0/P1. Only fetched when there's ≥1 finding.

This unblocks #460: with gate (c) resolution-aware, the audit's resolution-aware clearance (#449) is aligned with the live merge gate.

## Testing
- [x] `tests/test_codex_review_check_resolution.sh` (3 cases): structural presence of the reviewThreads/RESOLUTION_MAP/comment_id join + fail-closed marker; the jq filter excludes resolved, keeps unresolved + absent-from-map (fail-closed `// false`); all-resolved → 0 unaddressed. Wired into `check_codex_scripts` + manifest closure.
- [x] All affected `repo_lint` checks pass: `check_codex_scripts`, `check_merge_clearance_gate`, `check_canonical_bugs_263caf3`, `check_codex_p1_gate`, `check_sync_manifest`, `check_ci_scripts_wired`.
- [x] `bash -n` clean.

## Self-Review
- [x] Correctness: mirrors the integration-tested `codex-p1-gate.sh` resolution join (`make_threads_fixture`); `with_gh_retry`-wrapped GraphQL.
- [x] Regression risk: fetch only when there's a finding; fail-closed on any lookup failure preserves prior blocking behavior; `test_merge_clearance_gate` (which stubs codex-review-check) still green.
- [x] Security: gate is a merge blocker — the change only ever *narrows* unaddressed findings via the sanctioned resolution override, and fails closed otherwise.

Refs #460
