### PR TITLE
fix(guards): harden GitHub write guards and reviewer-token routing (#466)

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -420,6 +420,12 @@ paths:
   - path: tests/test_gh_wrapper_parallel.sh
     type: canonical
     consumers: all
+  # Pairs with scripts/ci/check_no_bare_gh_writes, now run by
+  # check_gh_as_author (#466). Without it propagated, a consumer's
+  # check_gh_as_author fails pre-flight with `Missing required file`.
+  - path: tests/test_check_no_bare_gh_writes.sh
+    type: canonical
+    consumers: all
   # Pairs with scripts/identity-check.sh (#284). The helper is called
   # from the top of every WRITE-path helper script; the test exercises
   # all four assert modes against `gh config get` shims plus an
@@ -488,7 +494,7 @@ paths:
     consumers: all
   # Pairs with scripts/op-preflight.sh + scripts/lib/preflight-helpers.sh
   # + scripts/ci/check_op_preflight_contract. The check wrapper requires
-  # all three test files; same coupling pattern as the gh-as-author and
+  # all four test files; same coupling pattern as the gh-as-author and
   # codex-p1-gate suites above. See #282/#374.
   - path: tests/test_op_preflight_check.sh
     type: canonical
@@ -497,6 +503,12 @@ paths:
     type: canonical
     consumers: all
   - path: tests/test_helper_autosource.sh
+    type: canonical
+    consumers: all
+  # Agent-name path-injection guard for preflight_agent (#466). Added to
+  # check_op_preflight_contract's suite; must travel with the others or a
+  # consumer's check_op_preflight_contract fails on `Missing required file`.
+  - path: tests/test_preflight_agent_name.sh
     type: canonical
     consumers: all
   # Pairs with scripts/resolve-pr-threads.sh +

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -676,6 +676,11 @@ paths:
       - "tests/test_gh_as_author.sh"           # check_gh_as_author
       - "tests/test_gh_as_reviewer.sh"         # check_gh_as_author
       - "tests/test_gh_wrapper_parallel.sh"    # check_gh_as_author
+      - "tests/test_check_no_bare_gh_writes.sh"  # check_gh_as_author (#466)
+      - "tests/test_op_preflight_check.sh"     # check_op_preflight_contract
+      - "tests/test_op_preflight_token_mode.sh"  # check_op_preflight_contract
+      - "tests/test_helper_autosource.sh"      # check_op_preflight_contract
+      - "tests/test_preflight_agent_name.sh"   # check_op_preflight_contract (#466)
       - "tests/test_coderabbit_wait_status_probe.sh"  # check_coderabbit_wait
       - "tests/test_coderabbit_wait_identity_derivation.sh"  # check_coderabbit_wait (#438)
       - "tests/test_codex_p1_gate.sh"          # check_codex_p1_gate

--- a/scripts/ci/check_gh_as_author
+++ b/scripts/ci/check_gh_as_author
@@ -19,6 +19,7 @@ TESTS=(
   "tests/test_gh_as_reviewer.sh"
   "tests/test_gh_wrapper_parallel.sh"
   "tests/test_gh_pr_guard.sh"
+  "tests/test_check_no_bare_gh_writes.sh"
 )
 
 FAILED=0

--- a/scripts/ci/check_no_bare_gh_writes
+++ b/scripts/ci/check_no_bare_gh_writes
@@ -32,7 +32,10 @@ set +e
 awk -v root="$REPO_ROOT/" '
 function bare_write(line) {
   if (line ~ /^[[:space:]]*($|#)/) return 0
-  if (line ~ /NO_BARE_GH_WRITE_EXEMPT:/) return 0
+  # Exemption requires a documented reason after the colon (#466): a bare
+  # NO_BARE_GH_WRITE_EXEMPT: marker with no justification is too weak a
+  # bypass. The error message has always promised "with a reason"; enforce it.
+  if (line ~ /NO_BARE_GH_WRITE_EXEMPT:[[:space:]]*[^[:space:]]/) return 0
   if (line ~ /\\`[^`]*gh[[:space:]]+(pr|issue|api)[^`]*\\`/) return 0
   if (line ~ /^[[:space:]]*(echo|printf)[[:space:]]/ &&
       line !~ /\$\([[:space:]]*gh[[:space:]]+(pr|issue|api)[[:space:]]/ &&
@@ -48,7 +51,10 @@ function bare_write(line) {
   if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+secret[[:space:]]+set([[:space:]]|$)/) return 1
   if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+variable[[:space:]]+set([[:space:]]|$)/) return 1
   if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+project[[:space:]]+(create|edit|field-create|item-add|item-edit)([[:space:]]|$)/) return 1
-  if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+api[[:space:]].*(-X[[:space:]]+|--method[[:space:]]+)(POST|PATCH|PUT|DELETE)([[:space:]]|$)/) return 1
+  # Compact and spaced method forms (#466): catch -X POST, -XPOST,
+  # --method POST, and --method=POST (the compact -X<METHOD> / --method=<METHOD>
+  # forms previously slipped through the space-requiring matcher).
+  if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+api[[:space:]].*(-X[[:space:]]*|--method[[:space:]]*=?[[:space:]]*)(POST|PATCH|PUT|DELETE)([[:space:]]|$)/) return 1
   if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+api[[:space:]]+graphql/ && line ~ /(mutation|resolveReviewThread|addPullRequestReviewThreadReply|addComment|updateIssue|closeIssue)/) return 1
   return 0
 }

--- a/scripts/ci/check_op_preflight_contract
+++ b/scripts/ci/check_op_preflight_contract
@@ -20,6 +20,7 @@ TESTS=(
   "tests/test_op_preflight_check.sh"
   "tests/test_op_preflight_token_mode.sh"
   "tests/test_helper_autosource.sh"
+  "tests/test_preflight_agent_name.sh"
 )
 
 FAILED=0

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -221,7 +221,13 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 # middle of an unrelated command are caught downstream by the token
 # walk, which exits 0 if no `gh pr (create|merge)` subcommand is
 # present.
-if ! echo "$COMMAND" | grep -qE '(^|[[:space:]])([^[:space:]]*/)?gh([[:space:]]|$)'; then
+# Strip quotes before the quick-exit scan (#466 r2): a quoted, path-
+# qualified invocation like '/usr/bin/gh' pr merge would otherwise leave
+# the closing quote glued to `gh` and slip past the boundary. The shlex
+# token walk below strips quotes itself and the */gh case catches it — but
+# only if we do NOT early-exit here. Stripping quotes for this fast-path
+# probe is safe; it only governs whether the authoritative tokenizer runs.
+if ! echo "$COMMAND" | tr -d "\"'" | grep -qE '(^|[[:space:]])([^[:space:]]*/)?gh([[:space:]]|$)'; then
   exit 0
 fi
 

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -221,7 +221,7 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 # middle of an unrelated command are caught downstream by the token
 # walk, which exits 0 if no `gh pr (create|merge)` subcommand is
 # present.
-if ! echo "$COMMAND" | grep -qE '(^|\s)gh(\s|$)'; then
+if ! echo "$COMMAND" | grep -qE '(^|[[:space:]])([^[:space:]]*/)?gh([[:space:]]|$)'; then
   exit 0
 fi
 
@@ -546,7 +546,7 @@ for i in "${!TOKENS[@]}"; do
       fi
       continue
       ;;
-    gh)
+    gh|*/gh)
       COMPOUND_GH_COUNT=$((COMPOUND_GH_COUNT + 1))
       if guarded_label=$(guarded_gh_invocation_label "$i"); then
         COMPOUND_GUARDED_COUNT=$((COMPOUND_GUARDED_COUNT + 1))
@@ -996,7 +996,7 @@ for i in "${!TOKENS[@]}"; do
       CURRENT_PREFIX="$tok"
       continue
       ;;
-    gh)
+    gh|*/gh)
       SAW_GH=1
       continue
       ;;

--- a/scripts/lib/preflight-helpers.sh
+++ b/scripts/lib/preflight-helpers.sh
@@ -39,13 +39,34 @@ preflight_cache_dir() {
 #   2. $OP_PREFLIGHT_AGENT (left over from a prior eval in this shell)
 #   3. The single cache file under the cache dir (if exactly one exists)
 # Returns empty string if no agent can be determined.
+# Reject agent names that are not a safe path component (#466). The
+# resolved name is interpolated into a cache file path that
+# auto_source_preflight then SOURCES, so a value like "../../etc/evil" or
+# one with shell metacharacters must never reach the path builder. Allow
+# only [A-Za-z0-9_-]; anything else is treated as "no agent" (fail-closed:
+# auto-source skips and no credentials are loaded). Bash 3.2 portable.
+_preflight_agent_name_is_safe() {
+  case "$1" in
+    "" | *[!A-Za-z0-9_-]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 preflight_agent() {
   if [[ -n "${MERGEPATH_AGENT:-}" ]]; then
-    printf '%s' "$MERGEPATH_AGENT"
+    if _preflight_agent_name_is_safe "$MERGEPATH_AGENT"; then
+      printf '%s' "$MERGEPATH_AGENT"
+    else
+      echo "preflight: ignoring unsafe MERGEPATH_AGENT (must match [A-Za-z0-9_-]+)" >&2
+    fi
     return 0
   fi
   if [[ -n "${OP_PREFLIGHT_AGENT:-}" ]]; then
-    printf '%s' "$OP_PREFLIGHT_AGENT"
+    if _preflight_agent_name_is_safe "$OP_PREFLIGHT_AGENT"; then
+      printf '%s' "$OP_PREFLIGHT_AGENT"
+    else
+      echo "preflight: ignoring unsafe OP_PREFLIGHT_AGENT (must match [A-Za-z0-9_-]+)" >&2
+    fi
     return 0
   fi
   local cache_dir
@@ -56,7 +77,11 @@ preflight_agent() {
     local base="${files[0]##*/}"
     base="${base#op-preflight-}"
     base="${base%.env}"
-    printf '%s' "$base"
+    # Defense in depth: a glob match cannot contain '/', but still refuse
+    # to emit a name that is not a safe path component.
+    if _preflight_agent_name_is_safe "$base"; then
+      printf '%s' "$base"
+    fi
     return 0
   fi
   return 0

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -751,16 +751,25 @@ emit_from_session_file() (
     printf 'export OP_PREFLIGHT_AUTHOR_PAT=%q\n' "$OP_PREFLIGHT_AUTHOR_PAT"
   [[ "${OP_PREFLIGHT_TOKEN_MODE:-0}" == "1" ]] && \
     printf 'export OP_PREFLIGHT_TOKEN_MODE=1\n'
-  [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] && \
-    printf 'export GOOGLE_APPLICATION_CREDENTIALS=%q\n' "$GOOGLE_APPLICATION_CREDENTIALS"
-  [[ -n "${OP_PREFLIGHT_ADC_TMPFILE:-}" ]] && \
-    printf 'export OP_PREFLIGHT_ADC_TMPFILE=%q\n' "$OP_PREFLIGHT_ADC_TMPFILE"
-  [[ -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" ]] && \
-    printf 'export OP_PREFLIGHT_FIREBASE_SA_TMPFILE=%q\n' "$OP_PREFLIGHT_FIREBASE_SA_TMPFILE"
-  [[ -n "${OP_PREFLIGHT_FIREBASE_PROJECT:-}" ]] && \
-    printf 'export OP_PREFLIGHT_FIREBASE_PROJECT=%q\n' "$OP_PREFLIGHT_FIREBASE_PROJECT"
-  [[ -n "${CF_API_TOKEN:-}" ]] && \
-    printf 'export CF_API_TOKEN=%q\n' "$CF_API_TOKEN"
+  # Mode-scope the deploy-credential emission (#466): a review-mode (or
+  # default --check) cache hit must NOT re-export deploy credentials that a
+  # prior `--mode deploy` / `--mode all` run left in the session file. The
+  # deploy-validation block above is already skipped for review mode, so
+  # without this gate a review request silently re-exports stale deploy
+  # creds (GOOGLE_APPLICATION_CREDENTIALS, Firebase SA, CF_API_TOKEN).
+  # Emit them only when the CURRENT request actually asked for deploy creds.
+  if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
+    [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] && \
+      printf 'export GOOGLE_APPLICATION_CREDENTIALS=%q\n' "$GOOGLE_APPLICATION_CREDENTIALS"
+    [[ -n "${OP_PREFLIGHT_ADC_TMPFILE:-}" ]] && \
+      printf 'export OP_PREFLIGHT_ADC_TMPFILE=%q\n' "$OP_PREFLIGHT_ADC_TMPFILE"
+    [[ -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" ]] && \
+      printf 'export OP_PREFLIGHT_FIREBASE_SA_TMPFILE=%q\n' "$OP_PREFLIGHT_FIREBASE_SA_TMPFILE"
+    [[ -n "${OP_PREFLIGHT_FIREBASE_PROJECT:-}" ]] && \
+      printf 'export OP_PREFLIGHT_FIREBASE_PROJECT=%q\n' "$OP_PREFLIGHT_FIREBASE_PROJECT"
+    [[ -n "${CF_API_TOKEN:-}" ]] && \
+      printf 'export CF_API_TOKEN=%q\n' "$CF_API_TOKEN"
+  fi
   printf 'export OP_PREFLIGHT_DONE=1\n'
   printf 'export OP_PREFLIGHT_AGENT=%q\n' "$AGENT"
   exit 0

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -769,6 +769,13 @@ emit_from_session_file() (
       printf 'export OP_PREFLIGHT_FIREBASE_PROJECT=%q\n' "$OP_PREFLIGHT_FIREBASE_PROJECT"
     [[ -n "${CF_API_TOKEN:-}" ]] && \
       printf 'export CF_API_TOKEN=%q\n' "$CF_API_TOKEN"
+  else
+    # Review-only request (#466 r2): actively clear any deploy credentials a
+    # prior --mode deploy / --mode all eval exported into the caller's
+    # shell, so a review session does not retain stale deploy creds in its
+    # environment (not just refrain from re-exporting them). Emitting unset
+    # is idempotent when the caller never had them.
+    printf 'unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE OP_PREFLIGHT_FIREBASE_SA_TMPFILE OP_PREFLIGHT_FIREBASE_PROJECT CF_API_TOKEN\n'
   fi
   printf 'export OP_PREFLIGHT_DONE=1\n'
   printf 'export OP_PREFLIGHT_AGENT=%q\n' "$AGENT"

--- a/tests/test_check_no_bare_gh_writes.sh
+++ b/tests/test_check_no_bare_gh_writes.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Regression coverage for scripts/ci/check_no_bare_gh_writes (#466).
+#
+# The check computes REPO_ROOT from its own location and scans
+# REPO_ROOT/scripts. We copy it into a temp repo root, drop fixture
+# scripts under scripts/, and assert the bare-gh-write detector:
+#   - flags compact `gh api` write forms (-XPOST, --method=POST) that the
+#     prior space-requiring matcher missed,
+#   - still flags the spaced forms (-X POST),
+#   - refuses a bare NO_BARE_GH_WRITE_EXEMPT: marker with no reason,
+#   - honors NO_BARE_GH_WRITE_EXEMPT: WITH a reason.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK="$ROOT/scripts/ci/check_no_bare_gh_writes"
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Run the check against a temp repo whose scripts/fixture.sh contains $1.
+# Echoes the check's exit code.
+run_check_on() {
+  local content="$1"
+  local tmp
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/no-bare-gh.XXXXXX")"
+  mkdir -p "$tmp/scripts/ci"
+  cp "$CHECK" "$tmp/scripts/ci/check_no_bare_gh_writes"
+  chmod +x "$tmp/scripts/ci/check_no_bare_gh_writes"
+  printf '%s\n' "$content" > "$tmp/scripts/fixture.sh"
+  local rc=0
+  ( cd "$tmp" && ./scripts/ci/check_no_bare_gh_writes ) >/dev/null 2>&1 || rc=$?
+  rm -rf "$tmp"
+  printf '%s' "$rc"
+}
+
+assert_flagged() {
+  local label="$1" content="$2"
+  local rc; rc=$(run_check_on "$content")
+  if [ "$rc" -eq 1 ]; then pass "$label (flagged)"; else fail "$label: expected flag (rc 1), got rc=$rc"; fi
+}
+
+assert_clean() {
+  local label="$1" content="$2"
+  local rc; rc=$(run_check_on "$content")
+  if [ "$rc" -eq 0 ]; then pass "$label (clean)"; else fail "$label: expected clean (rc 0), got rc=$rc"; fi
+}
+
+# Compact gh api write forms — the #466 gap.
+assert_flagged "compact -XPOST merge"        'gh api -XPOST repos/o/r/pulls/1/merge'
+assert_flagged "compact --method=POST"       'gh api --method=POST repos/o/r/issues/1/comments'
+assert_flagged "compact -XDELETE"            'gh api -XDELETE repos/o/r/issues/comments/9'
+# Spaced forms still flagged (no regression).
+assert_flagged "spaced -X POST still flagged" 'gh api -X POST repos/o/r/pulls/1/merge'
+assert_flagged "spaced --method PATCH"        'gh api --method PATCH repos/o/r/pulls/comments/9'
+# A plain read is not flagged.
+assert_clean   "gh api GET not flagged"       'gh api repos/o/r/pulls/1 --jq .state'
+
+# Exemption marker hardening — bare marker no longer bypasses.
+assert_flagged "bare exemption marker rejected" 'gh pr merge 1 --squash  # NO_BARE_GH_WRITE_EXEMPT:'
+assert_clean   "exemption WITH reason honored"  'gh pr merge 1 --squash  # NO_BARE_GH_WRITE_EXEMPT: covered by gh-as-author in caller'
+
+echo ""
+echo "test_check_no_bare_gh_writes: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -139,6 +139,15 @@ assert_rc_contains "path-qualified gh pr create blocked (#466)" 2 "token-verifyi
 assert_rc_contains "path-qualified gh pr merge blocked (#466)" 2 "" \
   '/usr/bin/gh pr merge 123 --squash --delete-branch'
 
+# #466 r2: a QUOTED path-qualified (or bare) gh must not bypass either.
+# The closing quote glued to `gh` previously slipped past the quick-exit
+# grep boundary (verified live by the nathanpayne-codex review).
+assert_rc_contains "quoted path-qualified gh pr merge blocked (#466 r2)" 2 "" \
+  "'/usr/bin/gh' pr merge 123 --squash --delete-branch"
+
+assert_rc_contains "quoted bare gh pr merge blocked (#466 r2)" 2 "" \
+  "'gh' pr merge 5 --squash"
+
 assert_rc_contains "wrapper state does not cross separator" 2 "token-verifying wrapper" \
   'scripts/gh-as-author.sh -- echo ok ; gh pr create --title "t" --body "Authoring-Agent: claude
 

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -127,6 +127,18 @@ assert_rc_contains "wrapper substring spoof still blocked" 2 "token-verifying wr
 ## Self-Review
 - ok"'
 
+# #466: a path-qualified gh (e.g. /usr/bin/gh) must NOT bypass the guard.
+# Before the fix the quick-exit grep only matched bare `gh`, so a
+# path-qualified write skipped the hook entirely (exit 0).
+assert_rc_contains "path-qualified gh pr create blocked (#466)" 2 "token-verifying wrapper" \
+  '/usr/bin/gh pr create --title "t" --body "Authoring-Agent: claude
+
+## Self-Review
+- ok"'
+
+assert_rc_contains "path-qualified gh pr merge blocked (#466)" 2 "" \
+  '/usr/bin/gh pr merge 123 --squash --delete-branch'
+
 assert_rc_contains "wrapper state does not cross separator" 2 "token-verifying wrapper" \
   'scripts/gh-as-author.sh -- echo ok ; gh pr create --title "t" --body "Authoring-Agent: claude
 

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -984,6 +984,40 @@ EOF
   pass "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: file mismatch forces refresh"
 }
 
+# #466: a review-mode (default) --check cache hit must NOT re-export deploy
+# credentials that a prior --mode deploy / --mode all run left in the
+# session file. Mode-scoping the emission closes the cross-mode leak.
+test_check_review_mode_omits_deploy_creds() {
+  local case_dir="$WORKDIR/case_modescope"
+  make_fresh_cache "$case_dir" claude "rev-pat-ms" "author-pat-ms"
+  # Append deploy creds, as a prior --mode all run would have.
+  cat >> "$case_dir/op-preflight-claude.env" <<EOF
+GOOGLE_APPLICATION_CREDENTIALS=/tmp/should-not-leak-adc.json
+CF_API_TOKEN=cf-secret-should-not-leak
+EOF
+
+  local out rc=0
+  out=$(PATH="$STUB_DIR:$PATH" OP_PREFLIGHT_CACHE_DIR="$case_dir" \
+    "$SCRIPT" --agent claude --check 2>/dev/null) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "test_check_review_mode_omits_deploy_creds: expected rc=0, got rc=$rc"
+    return
+  fi
+  if ! echo "$out" | grep -q "OP_PREFLIGHT_REVIEWER_PAT=rev-pat-ms"; then
+    fail "test_check_review_mode_omits_deploy_creds: review PAT missing; out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "GOOGLE_APPLICATION_CREDENTIALS"; then
+    fail "test_check_review_mode_omits_deploy_creds: deploy ADC leaked into review-mode output; out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "CF_API_TOKEN"; then
+    fail "test_check_review_mode_omits_deploy_creds: CF_API_TOKEN leaked into review-mode output; out=$out"
+    return
+  fi
+  pass "test_check_review_mode_omits_deploy_creds: review --check omits stale deploy creds (#466)"
+}
+
 test_check_fresh_cache
 test_check_missing_cache
 test_check_stale_cache
@@ -998,6 +1032,7 @@ test_deploy_mode_prefers_firebase_sa_over_gcp_adc
 test_deploy_mode_refreshes_unusable_cached_firebase_sa
 test_deploy_mode_refreshes_mismatched_cached_firebase_sa
 test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch
+test_check_review_mode_omits_deploy_creds
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -1007,15 +1007,25 @@ EOF
     fail "test_check_review_mode_omits_deploy_creds: review PAT missing; out=$out"
     return
   fi
-  if echo "$out" | grep -q "GOOGLE_APPLICATION_CREDENTIALS"; then
-    fail "test_check_review_mode_omits_deploy_creds: deploy ADC leaked into review-mode output; out=$out"
+  if echo "$out" | grep -q "export GOOGLE_APPLICATION_CREDENTIALS"; then
+    fail "test_check_review_mode_omits_deploy_creds: deploy ADC exported into review-mode output; out=$out"
     return
   fi
-  if echo "$out" | grep -q "CF_API_TOKEN"; then
-    fail "test_check_review_mode_omits_deploy_creds: CF_API_TOKEN leaked into review-mode output; out=$out"
+  if echo "$out" | grep -q "export CF_API_TOKEN"; then
+    fail "test_check_review_mode_omits_deploy_creds: CF_API_TOKEN exported into review-mode output; out=$out"
     return
   fi
-  pass "test_check_review_mode_omits_deploy_creds: review --check omits stale deploy creds (#466)"
+  # #466 r2: review mode must ALSO actively unset stale deploy vars that a
+  # prior --mode deploy/all eval left in the caller's shell.
+  if ! echo "$out" | grep -q "unset .*GOOGLE_APPLICATION_CREDENTIALS"; then
+    fail "test_check_review_mode_omits_deploy_creds: review mode did not unset stale deploy vars; out=$out"
+    return
+  fi
+  if ! echo "$out" | grep -q "unset .*CF_API_TOKEN"; then
+    fail "test_check_review_mode_omits_deploy_creds: review mode did not unset CF_API_TOKEN; out=$out"
+    return
+  fi
+  pass "test_check_review_mode_omits_deploy_creds: review --check omits AND unsets stale deploy creds (#466)"
 }
 
 test_check_fresh_cache

--- a/tests/test_preflight_agent_name.sh
+++ b/tests/test_preflight_agent_name.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Regression coverage for preflight_agent() agent-name validation (#466).
+#
+# An unsafe MERGEPATH_AGENT / OP_PREFLIGHT_AGENT (path traversal or shell
+# metacharacters) must never reach the cache-file path builder, which
+# auto_source_preflight then SOURCES. An invalid name is treated as "no
+# agent" (empty) so auto-source fails closed.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../scripts/lib/preflight-helpers.sh
+. "$ROOT/scripts/lib/preflight-helpers.sh"
+
+PASS=0; FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Resolve preflight_agent for a given MERGEPATH_AGENT value, with an empty
+# scratch cache dir so the single-file fallback can't interfere. The lib is
+# already sourced, so the subshell inherits preflight_agent.
+agent_for() {
+  local val="$1" tmp
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/pf-agent.XXXXXX")"
+  ( unset OP_PREFLIGHT_AGENT
+    export MERGEPATH_AGENT="$val" OP_PREFLIGHT_CACHE_DIR="$tmp"
+    preflight_agent ) 2>/dev/null
+  rm -rf "$tmp"
+}
+
+assert_eq() {
+  local label="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then pass "$label"; else fail "$label: got '$got' want '$want'"; fi
+}
+
+assert_eq "safe agent 'claude' passes"        "$(agent_for claude)"            "claude"
+assert_eq "safe dash/underscore passes"       "$(agent_for my-agent_1)"        "my-agent_1"
+assert_eq "path traversal rejected"           "$(agent_for '../../etc/evil')"  ""
+assert_eq "bare slash rejected"               "$(agent_for 'a/b')"             ""
+assert_eq "semicolon rejected"                "$(agent_for 'x;rm -rf')"        ""
+assert_eq "space rejected"                    "$(agent_for 'a b')"             ""
+assert_eq "command-substitution char rejected" "$(agent_for 'a$(id)')"         ""
+
+echo ""
+echo "test_preflight_agent_name: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
Hardens GitHub write guards and reviewer-token routing. Closes #466.

Four defect classes from the #456 rollup:
1. gh-pr-guard missed path-qualified gh (e.g. /usr/bin/gh) in the quick-exit grep and both command-position scans, so a path-qualified write skipped the hook entirely. Now matches gh and */gh.
2. check_no_bare_gh_writes accepted a bare exemption marker with no reason and missed compact gh api forms (-XPOST, --method=POST). Now requires a reason and catches the compact forms.
3. preflight-helpers interpolated an unchecked agent name into a sourced cache-file path (path-traversal vector). Now validates against the safe charset, fail-closed.
4. op-preflight cache-hit emission was not mode-scoped: a review-mode request re-exported deploy credentials. Now gates deploy-cred emission on deploy/all mode.

Authoring-Agent: claude

## Self-Review
- Correctness: all four fixes verified by new regression tests (path-qualified gh blocked; compact api forms plus exemption-reason; review-mode omits deploy creds; agent-name validation). 100 assertions across the four suites pass.
- Regression risk: low. Existing test_gh_pr_guard (70), op-preflight contract (15), and check_no_bare_gh_writes self-run pass unchanged. The grep broadening is a superset (never fewer matches); mode-scoping only narrows review-mode output.
- Style and conventions: matches the existing hook scan and awk matcher style; bash 3.2 portable case globs.
- Test coverage: two new test files wired into check_gh_as_author and check_op_preflight_contract; both added to .mergepath-sync.yml consumers all so the propagation closure holds (check_sync_manifest green).
- Security and dependency hygiene: this PR is itself security hardening; no new dependencies. The gh-as-reviewer transient-token defect from the issue was investigated and found already sound.