### PR TITLE
fix(gates): close fail-open and early-clear paths in review automation (#465)

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -606,7 +606,18 @@ jobs:
 
       - name: Enable auto-merge
         if: steps.author_merge_token.outputs.enabled == 'true'
-        run: gh pr merge --squash --auto "$PR_URL" || gh pr merge --squash "$PR_URL"
+        run: |
+          # Do NOT fall back to an unconditional "gh pr merge --squash" when
+          # --auto is unavailable (#465): an immediate merge bypasses the
+          # status-check and label guards re-verified above. A sibling job
+          # could apply a blocking label between that re-verify and this step,
+          # and the unconditional fallback would merge it anyway. Fail closed:
+          # if auto-merge cannot be enabled, surface the error and let a human
+          # or a re-run handle it.
+          if ! gh pr merge --squash --auto "$PR_URL"; then
+            echo "::error::Could not enable auto-merge for $PR_URL; refusing to merge unconditionally (#465)."
+            exit 1
+          fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.AUTHOR_MERGE_TOKEN }}

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -241,13 +241,16 @@ jobs:
             case "$rc" in
               0)
                 echo "Gate passes — removing needs-external-review label."
-                if ! with_gh_retry gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
-                  # The gate passed but the removal API call failed —
-                  # the label is still stuck. That is an infra error,
-                  # not a warning: the job must not report success
-                  # when it failed to do its one job. (CodeRabbit
-                  # Major, #271.)
-                  echo "::error::Failed to remove needs-external-review on PR #$PR — label still stuck."
+                # Single (non-retried) removal of the non-idempotent write,
+                # then verify end state with a retried READ (#465): retrying
+                # --remove-label can double-fire downstream label-event
+                # workflows and can hit a post-success "label not found" that
+                # looks transient. Authoritative success = the label is gone,
+                # not the write's exit code (still fail-closed per #271).
+                gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review 2>/dev/null || true
+                still_present=$(with_gh_retry gh pr view "$PR" --repo "$REPO" --json labels --jq 'any(.labels[]?.name == "needs-external-review")' 2>/dev/null || echo "unknown")
+                if [ "$still_present" != "false" ]; then
+                  echo "::error::Failed to remove needs-external-review on PR #$PR — label still stuck (state: $still_present)."
                   had_infra_error=1
                   failing_prs="$failing_prs $PR"
                   echo "::endgroup::"
@@ -469,15 +472,20 @@ jobs:
             case "$rc" in
               0)
                 echo "Gate passes — removing needs-external-review label."
-                if with_gh_retry gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
+                # Single (non-retried) removal + retried verify (#465) — see
+                # the evaluate-and-clear job above for the full rationale.
+                gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review 2>/dev/null || true
+                still_present=$(with_gh_retry gh pr view "$PR" --repo "$REPO" --json labels --jq 'any(.labels[]?.name == "needs-external-review")' 2>/dev/null || echo "unknown")
+                if [ "$still_present" = "false" ]; then
                   comment_body='**Automated label removal (scheduled sweep).** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD between event triggers (typical: Codex 👍 after the last push, with no synchronize / review / workflow_run event to fire the event-driven path). Removed `needs-external-review`. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#197) for the sweep doctrine.'
                   with_gh_retry gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
                     || echo "::warning::Failed to post attribution comment for PR #$PR"
                 else
-                  # Gate passed but the removal failed — infra error,
-                  # not warning-only. The label is still stuck; the
-                  # sweep must not report success. (CodeRabbit Major, #271.)
-                  echo "::error::Failed to remove needs-external-review on PR #$PR — label still stuck."
+                  # Removal did not take (label still present or verify read
+                  # failed) — infra error, not warning-only. The sweep must
+                  # not report success when the label is still stuck
+                  # (CodeRabbit Major, #271; verify-end-state per #465).
+                  echo "::error::Failed to remove needs-external-review on PR #$PR — label still stuck (state: $still_present)."
                   had_infra_error=1
                   failing_prs="$failing_prs $PR"
                 fi

--- a/.github/workflows/daily-feedback-rollup.yml
+++ b/.github/workflows/daily-feedback-rollup.yml
@@ -53,7 +53,14 @@ jobs:
 
     steps:
       - name: Checkout
+        # Pin to the trusted default branch (#465): this workflow has
+        # issues:write and a workflow_dispatch trigger, so without an explicit
+        # ref the checkout would honor an attacker-influenceable GITHUB_REF and
+        # could run an untrusted version of the rollup scripts under the write
+        # token. Always run the canonical scripts from the default branch.
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Ensure jq + gh present
         run: |

--- a/.github/workflows/merge-clearance-gate.yml
+++ b/.github/workflows/merge-clearance-gate.yml
@@ -181,8 +181,17 @@ jobs:
           # clean pass when both per-class knobs are off, so we don't
           # filter by label/author here. `--limit 500` mirrors
           # codex-p1-gate.yml's bound.
+          # Fetch the head SHA WITH the number in one list query (#465
+          # nathanpayne-codex round 2): resolving head_sha per-PR in a
+          # separate `gh api` call (as before) could fail for an individual
+          # PR, and without a SHA the sweep cannot post a fresh check_run —
+          # leaving that PR's PREVIOUS green "Merge clearance gate" as the
+          # branch-protection signal (fail open). Sourcing headRefOid from
+          # the list removes that per-PR failure point: every listed PR
+          # carries its SHA, so a red check_run can always be posted.
           if ! prs_raw=$(gh pr list --repo "$REPO" --state open \
-            --limit 500 --json number --jq '.[].number'); then
+            --limit 500 --json number,headRefOid \
+            --jq '.[] | "\(.number)\t\(.headRefOid)"'); then
             echo "::error::Failed to list open PRs on $REPO"
             exit 1
           fi
@@ -212,20 +221,20 @@ jobs:
         run: |
           set -euo pipefail
           had_infra_error=0
-          while IFS= read -r PR; do
+          while IFS=$'\t' read -r PR head_sha; do
             [ -z "$PR" ] && continue
             echo "::group::Sweep PR #$PR"
 
-            if ! head_sha=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null) \
-               || [ -z "$head_sha" ] || [ "$head_sha" = "null" ]; then
-              # Cannot resolve the PR head SHA, so we cannot post a fresh
-              # check_run to supersede the stale one. Skipping silently would
-              # leave the PR's PREVIOUS green "Merge clearance gate" standing
-              # and the gate would fail OPEN on exactly the no-event refresh
-              # path this sweep exists to close (#465). Fail closed: flag the
-              # infra error so the sweep run ends non-zero (line below) and
-              # the gap is surfaced instead of silently swallowed.
-              echo "::error::Could not resolve head SHA for PR #$PR; cannot refresh its Merge clearance gate — failing the sweep (#465)."
+            if [ -z "$head_sha" ] || [ "$head_sha" = "null" ]; then
+              # The head SHA was unavailable even from the list query — rare
+              # for an open PR (a transient list hiccup or a PR that closed
+              # mid-sweep). Without a SHA we cannot post a check_run, so the
+              # PR's PREVIOUS green "Merge clearance gate" could remain the
+              # branch-protection signal. Fail closed: flag the infra error so
+              # the sweep run ends non-zero and the gap is surfaced. (#465;
+              # sourcing head_sha from the list removed the per-PR resolve
+              # call that previously failed OPEN here — nathanpayne-codex r2.)
+              echo "::error::No head SHA for PR #$PR from the open-PR list; cannot refresh its Merge clearance gate — failing the sweep (#465)."
               had_infra_error=1
               echo "::endgroup::"
               continue

--- a/.github/workflows/merge-clearance-gate.yml
+++ b/.github/workflows/merge-clearance-gate.yml
@@ -216,9 +216,17 @@ jobs:
             [ -z "$PR" ] && continue
             echo "::group::Sweep PR #$PR"
 
-            head_sha=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')
-            if [ -z "$head_sha" ] || [ "$head_sha" = "null" ]; then
-              echo "::warning::Could not resolve head SHA for PR #$PR; skipping"
+            if ! head_sha=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null) \
+               || [ -z "$head_sha" ] || [ "$head_sha" = "null" ]; then
+              # Cannot resolve the PR head SHA, so we cannot post a fresh
+              # check_run to supersede the stale one. Skipping silently would
+              # leave the PR's PREVIOUS green "Merge clearance gate" standing
+              # and the gate would fail OPEN on exactly the no-event refresh
+              # path this sweep exists to close (#465). Fail closed: flag the
+              # infra error so the sweep run ends non-zero (line below) and
+              # the gap is surfaced instead of silently swallowed.
+              echo "::error::Could not resolve head SHA for PR #$PR; cannot refresh its Merge clearance gate — failing the sweep (#465)."
+              had_infra_error=1
               echo "::endgroup::"
               continue
             fi

--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -473,6 +473,11 @@ paths:
   - path: tests/test_codex_review_check_resolution.sh
     type: canonical
     consumers: all
+  # #465 fail-closed structural guards. check_codex_scripts hard-runs it.
+  # Propagation-safe (skips workflows/scripts a consumer does not carry).
+  - path: tests/test_465_fail_closed.sh
+    type: canonical
+    consumers: all
   # Pairs with scripts/merge-clearance-gate.sh +
   # scripts/ci/check_merge_clearance_gate (kit-propagated). The check
   # wrapper hard-requires this test file; same #264/#266 coupling class
@@ -692,6 +697,7 @@ paths:
       - "tests/test_export_consumer_facts.sh"  # check_export_consumer_facts
       - "tests/test_codex_review_request_ack.sh"  # check_codex_scripts
       - "tests/test_codex_review_check_resolution.sh"  # check_codex_scripts (#460 Option B)
+      - "tests/test_465_fail_closed.sh"        # check_codex_scripts (#465)
       - "tests/test_audit_propagation_lane.sh" # check_propagation_lane_audit
       - "scripts/audit-propagation-lane.sh"    # check_propagation_lane_audit
       - "scripts/codex-p1-gate.sh"             # check_codex_p1_gate

--- a/scripts/ci/check_codex_scripts
+++ b/scripts/ci/check_codex_scripts
@@ -48,5 +48,8 @@ echo "check_codex_scripts: running codex-review-request ack tests"
 echo "check_codex_scripts: running codex-review-check gate (c) resolution tests"
 "$REPO_ROOT/tests/test_codex_review_check_resolution.sh"
 
+echo "check_codex_scripts: running #465 fail-closed structural guards"
+"$REPO_ROOT/tests/test_465_fail_closed.sh"
+
 echo "check_codex_scripts: PASS"
 exit 0

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -635,32 +635,52 @@ ROLLUP_JSON=$(with_gh_retry gh pr view "$PR_NUMBER" --repo "$REPO" --json status
 # checks listed in required_status_checks.contexts AND/OR
 # required_status_checks.checks[].context block the gate.
 BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.base.ref')
-REQUIRED_CHECK_NAMES=$(gh api "repos/$REPO/branches/$BASE_BRANCH/protection/required_status_checks" 2>/dev/null \
-  | jq -r '[.contexts[]?, .checks[]?.context] | unique | .[]' 2>/dev/null \
-  || true)
+# Fetch the branch-protection required-check list, DISTINGUISHING
+# "read OK, none required" (gate (a) imposes no filter, passes) from
+# "could not read" (fail closed) — #465 Option A. The prior code swallowed
+# the gh failure and treated BOTH cases as "no required checks = pass",
+# which fails OPEN: when the token cannot read branch protection (403) or
+# the API errors (5xx), a genuinely-failing required check went unnoticed.
+#
+# gh api exits non-zero on any 4xx/5xx; capture stderr to tell a 404 (the
+# required_status_checks sub-resource is not configured → legitimately NO
+# required checks) apart from 403 (token lacks Administration:read scope) or
+# 5xx/network (transient) — the latter leave the required list UNKNOWN.
+protection_err=$(mktemp)
+if protection_json=$(gh api "repos/$REPO/branches/$BASE_BRANCH/protection/required_status_checks" 2>"$protection_err"); then
+  REQUIRED_CHECK_NAMES=$(printf '%s' "$protection_json" | jq -r '[.contexts[]?, .checks[]?.context] | unique | .[]' 2>/dev/null || true)
+  protection_readable=1
+elif grep -q 'HTTP 404' "$protection_err"; then
+  REQUIRED_CHECK_NAMES=""
+  protection_readable=1   # 404 → no required_status_checks protection → none required
+else
+  REQUIRED_CHECK_NAMES=""
+  protection_readable=0   # 403 token scope / 5xx / network → could not read
+fi
+rm -f "$protection_err"
 
-if [ -z "$REQUIRED_CHECK_NAMES" ]; then
-  # No required-check list available. This can happen because:
-  #   - The branch has no branch protection rules at all, OR
-  #   - The token lacks Administration:read scope (which the
-  #     required_status_checks endpoint requires).
-  #
-  # Earlier versions treated "no list" as "all checks required",
-  # which caused over-strict blocking when the token lacked perms
-  # and optional/flaky checks happened to be failing. Codex caught
-  # this on swipewatch propagation PR #33 round 8.
-  #
-  # New behavior: log a warning and SKIP the required-check filter
-  # entirely, letting gate (a) pass. The rationale is that if
-  # branch protection isn't configured or the token can't read it,
-  # the BRANCH PROTECTION ITSELF doesn't enforce required checks,
-  # so gate (a) shouldn't either.
-  log "gate (a): WARNING — could not determine required checks from branch protection for $BASE_BRANCH (no rules configured or token lacks Administration:read scope). Skipping required-check filter — all checks treated as passing this gate."
-  # Skip gate (a) entirely for this case
+if [ "$protection_readable" -eq 0 ]; then
+  # FAIL CLOSED (#465): the required-check list is UNKNOWN (token lacks
+  # Administration:read, or the API errored). Do NOT optimistically treat
+  # this as "no required checks = pass". Keep the FULL rollup and leave
+  # REQUIRED_JSON empty — the BAD_CHECKS filter below treats an empty
+  # required list as "all checks required", so every non-skipped check must
+  # be green. SKIPPED/NEUTRAL still pass (optional jobs that skip by design
+  # do not block), so this closes the fail-open hole while only blocking on
+  # ACTUAL failures (a narrower reversal of the swipewatch #33 skip than a
+  # blanket exit-3). To restore the precise required-check filter, grant the
+  # token Administration:read.
+  log "gate (a): WARNING — could not read branch-protection required checks for $BASE_BRANCH (token lacks Administration:read scope, or API error). Failing closed: every non-skipped rollup check must be green (#465)."
+  REQUIRED_JSON='[]'
+elif [ -z "$REQUIRED_CHECK_NAMES" ]; then
+  # Read succeeded; branch protection lists NO required checks (404 or empty
+  # contexts). Nothing to enforce — gate (a) imposes no required-check
+  # filter (the other gates still run).
+  log "gate (a): branch protection for $BASE_BRANCH lists no required checks; gate (a) imposes no required-check filter."
   ROLLUP_JSON='{"statusCheckRollup":[]}'
   REQUIRED_JSON='[]'
 else
-  # Build a jq array of required check names
+  # Build a jq array of required check names.
   REQUIRED_JSON=$(echo "$REQUIRED_CHECK_NAMES" | jq -R . | jq -s .)
 fi
 

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -744,10 +744,15 @@ while :; do
 
   NOW=$(date +%s)
   if [ "$NOW" -ge "$DEADLINE" ]; then
-    log "TIMEOUT after ${ELAPSED}s — no Codex review or reaction on HEAD"
-    log "emitting JSON with review=null, reaction=null; exit code 4 (FALLBACK_REQUIRED)"
-    # Fall through to JSON emission so the caller still gets a structured
-    # answer (all nulls), then exit 4.
+    # Final scan at the deadline (#465): a Codex signal that arrived between
+    # the last poll and now must not be emitted as a stale timeout. Refresh
+    # FINAL_SCAN so BOTH the JSON emission and the exit-code decision below
+    # reflect current state — if a signal landed, has_*_signal sees it and
+    # the script exits 0 instead of 4 (FALLBACK_REQUIRED) on stale data.
+    if ! FINAL_SCAN=$(scan_codex_state); then
+      die 3 "final timeout-path scan failed"
+    fi
+    log "deadline reached after ${ELAPSED}s — emitted scan is the final one; exit code decided below"
     break
   fi
 

--- a/tests/test_465_fail_closed.sh
+++ b/tests/test_465_fail_closed.sh
@@ -32,9 +32,15 @@ refute_grep() {  # <label> <file> <fixed-string-that-must-be-absent>
 
 W=.github/workflows
 
-# Defect 1: head-SHA resolve failure fails the sweep (had_infra_error), not a silent skip.
+# Defect 1: head_sha is sourced from the list query (so a check_run can
+# always be posted); a missing SHA flags infra error rather than skipping,
+# and the fragile per-PR head_sha resolve is gone (#465 + r2).
+assert_grep "D1: merge-clearance sources head_sha from the list query" \
+  "$W/merge-clearance-gate.yml" '--json number,headRefOid'
 assert_grep "D1: merge-clearance head-SHA failure flags infra error" \
   "$W/merge-clearance-gate.yml" 'cannot refresh its Merge clearance gate'
+refute_grep "D1: merge-clearance no longer does a fragile per-PR head_sha resolve" \
+  "$W/merge-clearance-gate.yml" 'head_sha=$(gh api "repos/$REPO/pulls/'
 refute_grep "D1: merge-clearance no longer silently skips on unresolved head SHA" \
   "$W/merge-clearance-gate.yml" 'Could not resolve head SHA for PR #$PR; skipping'
 

--- a/tests/test_465_fail_closed.sh
+++ b/tests/test_465_fail_closed.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Structural regression guards for the #465 fail-open / early-clear fixes.
+#
+# The six defects span four YAML workflows and two shell scripts; the
+# workflow ones cannot be unit-executed without a full Actions runner, so
+# this suite asserts each fail-closed invariant is present in source. The
+# scripts' overall behavior stays covered by the existing execution suites
+# (test_merge_clearance_gate.sh, test_codex_review_check_resolution.sh,
+# test_codex_review_request_ack.sh).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PASS=0; FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+SKIP=0
+# Propagation-safe: a consumer that does not carry a given workflow/script
+# simply has nothing to regress, so skip (not fail) when the file is absent.
+assert_grep() {  # <label> <file> <fixed-string>
+  if [ ! -f "$2" ]; then echo "SKIP: $1 ($2 absent)"; SKIP=$((SKIP + 1)); return; fi
+  # `--` so a pattern starting with `-`/`--` is not mis-read as a grep flag.
+  if grep -qF -- "$3" "$2"; then pass "$1"; else fail "$1 (missing in $2: $3)"; fi
+}
+refute_grep() {  # <label> <file> <fixed-string-that-must-be-absent>
+  if [ ! -f "$2" ]; then echo "SKIP: $1 ($2 absent)"; SKIP=$((SKIP + 1)); return; fi
+  if grep -qF -- "$3" "$2"; then fail "$1 (still present in $2: $3)"; else pass "$1"; fi
+}
+
+W=.github/workflows
+
+# Defect 1: head-SHA resolve failure fails the sweep (had_infra_error), not a silent skip.
+assert_grep "D1: merge-clearance head-SHA failure flags infra error" \
+  "$W/merge-clearance-gate.yml" 'cannot refresh its Merge clearance gate'
+refute_grep "D1: merge-clearance no longer silently skips on unresolved head SHA" \
+  "$W/merge-clearance-gate.yml" 'Could not resolve head SHA for PR #$PR; skipping'
+
+# Defect 2: no unconditional immediate-merge fallback when --auto is unavailable.
+refute_grep "D2: agent-review dropped the '|| gh pr merge --squash' immediate fallback" \
+  "$W/agent-review.yml" '--auto "$PR_URL" || gh pr merge --squash "$PR_URL"'
+assert_grep "D2: agent-review fails closed when auto-merge cannot be enabled" \
+  "$W/agent-review.yml" 'refusing to merge unconditionally'
+
+# Defect 3: label removal verifies end-state instead of retrying the non-idempotent write.
+assert_grep "D3: auto-clear verifies label end-state (still_present)" \
+  "$W/auto-clear-blocking-labels.yml" 'still_present'
+refute_grep "D3: auto-clear no longer retries the --remove-label write" \
+  "$W/auto-clear-blocking-labels.yml" 'with_gh_retry gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review'
+
+# Defect 4: codex-review-request re-scans at the deadline before emitting.
+assert_grep "D4: codex-review-request final scan at deadline" \
+  scripts/codex-review-request.sh 'Final scan at the deadline'
+refute_grep "D4: codex-review-request no longer breaks on timeout without a final scan" \
+  scripts/codex-review-request.sh 'TIMEOUT after ${ELAPSED}s — no Codex review or reaction on HEAD'
+
+# Defect 5: daily-feedback-rollup pins checkout to the trusted default branch.
+assert_grep "D5: daily-feedback-rollup pins checkout ref" \
+  "$W/daily-feedback-rollup.yml" 'ref: ${{ github.event.repository.default_branch }}'
+
+# Defect 6: gate (a) distinguishes unreadable (403/5xx, fail closed) from 404 (none required).
+assert_grep "D6: codex-review-check distinguishes protection readability" \
+  scripts/codex-review-check.sh 'protection_readable'
+assert_grep "D6: codex-review-check tells 404 apart via HTTP status" \
+  scripts/codex-review-check.sh 'HTTP 404'
+refute_grep "D6: codex-review-check dropped the unconditional skip-all-checks fail-open" \
+  scripts/codex-review-check.sh 'Skipping required-check filter — all checks treated as passing this gate.'
+
+echo ""
+echo "test_465_fail_closed: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
Closes #465. Six fail-open / early-clear paths in review automation, all now fail closed.

1. merge-clearance-gate: an unresolved PR head SHA was warning-skipped, leaving a stale green check standing; now flags had_infra_error (fails the sweep) and catches hard gh api failures.
2. agent-review: the auto-merge step fell back from unavailable --auto to an UNCONDITIONAL immediate merge, bypassing the guards verified just above; removed the fallback, fail closed.
3. auto-clear-blocking-labels (both jobs): retried the non-idempotent --remove-label write; now does a single removal then verifies end-state via a retried read.
4. codex-review-request: timeout broke the poll loop without a final scan, emitting stale FINAL_SCAN; now re-scans at the deadline so a last-moment signal yields exit 0.
5. daily-feedback-rollup: issues write plus workflow_dispatch with an unpinned checkout; pinned to the default branch.
6. codex-review-check gate (a): unreadable required-check metadata was treated as an empty passing rollup; now distinguishes 404 (none required, pass) from 403/5xx (fail closed, require all non-skipped checks green).

REVIEW FOCUS: Defect 6 narrows the swipewatch #33 fail-open skip. Per maintainer direction (Option A), 403 (token lacks Administration:read) and 5xx now fail closed by requiring every non-skipped rollup check green, while 404 (no required_status_checks configured) still passes. SKIPPED/NEUTRAL do not block, so optional jobs that skip by design are unaffected; only ACTUAL failures block. This changes CI gate (a) behavior whenever the running token cannot read branch protection.

Authoring-Agent: claude

## Self-Review
- Correctness: each fix verified; tests/test_465_fail_closed.sh structurally guards all six fail-closed invariants (propagation-safe), and the existing execution suites pass unchanged (merge_clearance_gate 22, codex_review_check_resolution 3, codex_review_request_ack 14).
- Regression risk: Defect 6 is the notable behavior change (see REVIEW FOCUS); the others tighten existing error handling. All four workflows yq-parse; both scripts bash -n clean.
- Style and conventions: matches the existing had_infra_error / fail-closed patterns and the codex-review gate style.
- Test coverage: structural guards wired into check_codex_scripts and added to .mergepath-sync.yml consumers all; check_sync_manifest green.
- Security and dependency hygiene: this PR is itself fail-closed hardening; Defect 5 closes an untrusted-ref code-execution path; no new dependencies.