### PR TITLE
fix(propagation): preserve templated source mode + segment-local protected globs (#471)

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -451,6 +451,12 @@ paths:
   - path: tests/test_verify_propagation_pr.sh
     type: canonical
     consumers: all
+  # Pairs with scripts/workflow/match_protected_paths.sh (segment-local glob
+  # matcher, #471). check_verify_propagation_pr hard-runs it; travels so a
+  # consumer exercises the same matcher it propagates.
+  - path: tests/test_match_protected_paths.sh
+    type: canonical
+    consumers: all
   # Pairs with scripts/codex-p1-gate.sh + scripts/ci/check_codex_p1_gate
   # (kit-propagated). The check wrapper hard-requires this test file;
   # without it propagated, every consumer's check_codex_p1_gate fails
@@ -692,6 +698,7 @@ paths:
       - "tests/test_merge_clearance_gate.sh"   # check_merge_clearance_gate
       - "tests/test_disagreement_detector.sh"  # check_disagreement_detector
       - "tests/test_verify_propagation_pr.sh"  # check_verify_propagation_pr
+      - "tests/test_match_protected_paths.sh"  # check_verify_propagation_pr (#471)
       - "tests/test_resolve_pr_threads_rationale_tag.sh"  # check_resolve_pr_threads (delegated test)
       - "tests/test_template_substitution.sh"  # check_template_substitution
       - "tests/test_export_consumer_facts.sh"  # check_export_consumer_facts

--- a/docs/agents/templated-propagation.md
+++ b/docs/agents/templated-propagation.md
@@ -174,16 +174,17 @@ How it works:
    [mergepath-verify: templated-render] <dest> <consumer> <source>
    ```
 
-5. Failures fall into three typed buckets in the verifier's stderr summary:
+5. Failures fall into typed buckets in the verifier's stderr summary:
    - **Canonical / kit drift** — pre-existing canonical surface.
    - **Templated re-render mismatch** — rendered output differs from PR dest content.
+   - **Templated mode/type drift** — the rendered dest's git tree entry (mode + type) does not match the SOURCE template's. The render preserves the source template's git mode, so an **executable** templated source (e.g. a templated shell script) must render to an **executable** dest; a `chmod +x` flip or symlink swap relative to the source is rejected (#471). The verifier reads the source mode from the trusted mergepath checkout — it is NOT a hardcoded `100644`.
    - **Templated re-render error** — malformed template, missing source at mergepath@<sha>, or strict-mode unset fact.
 
 Consumer-inference fallback: if neither `$MERGEPATH_CONSUMER` is set nor the `origin` remote matches a `.consumers[].repo` field, the templated arm is skipped with a stderr note. The canonical/kit arm still runs, and the templated dest will then fail the path-confinement check, routing the PR to normal Phase 4 review (pre-#323 status quo).
 
 Wire-up:
 
-- CI gate: `scripts/ci/check_workflow_verify_propagation_templated` (test: `tests/test_verify_propagation_pr_templated.sh`) covers the four cases — pass, drift, template syntax error, strict-mode unset fact. Wired into `.github/workflows/repo_lint.yml` alongside `check_verify_propagation_pr`.
+- CI gate: `scripts/ci/check_workflow_verify_propagation_templated` (test: `tests/test_verify_propagation_pr_templated.sh`) covers pass, content drift, template syntax error, strict-mode unset fact, mode tampering, and executable-source mode preservation (#471). Wired into `.github/workflows/repo_lint.yml` alongside `check_verify_propagation_pr`.
 - Rollup attribution: the `templated-render` tag class lives in `scripts/lib/daily-feedback-rollup-helpers.sh` (mapped to `skip` in `tag_class_action`, same routing as `canonical-coverage`) and `scripts/resolve-pr-threads.sh`'s `derive_tag_class` ladder (slotted at rung 1b, right after `canonical-coverage`). Findings on a templated dest are structurally a mergepath concern — fixes belong in the template or in the consumer's `facts:` block — so they route to mergepath rather than surfacing per-consumer.
 
 ## What's queued next

--- a/mergepath/playground/index.html
+++ b/mergepath/playground/index.html
@@ -1047,12 +1047,15 @@
   function compileGlob(pattern) {
     if (globCache.has(pattern)) return globCache.get(pattern);
     try {
+      // Segment-local glob → ERE. KEEP IN LOCKSTEP with the shell twin
+      // scripts/workflow/match_protected_paths.sh: ** -> .*, * -> [^/]*,
+      // ? -> [^/] (a `?` does not cross `/`, per #471).
       const re = '^' + pattern
         .replace(/[.+^${}()|[\]\\]/g, '\\$&')
         .replace(/\*\*/g, '::DS::')
         .replace(/\*/g, '[^/]*')
         .replace(/::DS::/g, '.*')
-        .replace(/\?/g, '.') + '$';
+        .replace(/\?/g, '[^/]') + '$';
       const compiled = new RegExp(re);
       globCache.set(pattern, compiled);
       return compiled;

--- a/scripts/ci/check_verify_propagation_pr
+++ b/scripts/ci/check_verify_propagation_pr
@@ -11,14 +11,25 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-TEST_SCRIPT="$REPO_ROOT/tests/test_verify_propagation_pr.sh"
 
-if [ ! -f "$TEST_SCRIPT" ]; then
-  # Missing test script is a hard error, not a skip — silent-skip
-  # would let an accidental delete/rename disable this check
-  # without surfacing in CI.
-  echo "check_verify_propagation_pr: ERROR (missing $TEST_SCRIPT)" >&2
-  exit 1
-fi
+# The verifier and its segment-local protected-path matcher
+# (scripts/workflow/match_protected_paths.sh, #471) are both
+# security-load-bearing for the propagation lane, so both test suites are
+# hard CI gates here.
+TESTS=(
+  "tests/test_verify_propagation_pr.sh"
+  "tests/test_match_protected_paths.sh"
+)
 
-bash "$TEST_SCRIPT"
+for rel in "${TESTS[@]}"; do
+  full="$REPO_ROOT/$rel"
+  if [ ! -f "$full" ]; then
+    # Missing test script is a hard error, not a skip — silent-skip
+    # would let an accidental delete/rename disable this check
+    # without surfacing in CI.
+    echo "check_verify_propagation_pr: ERROR (missing $rel)" >&2
+    exit 1
+  fi
+  echo "check_verify_propagation_pr: running $rel"
+  bash "$full"
+done

--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -781,6 +781,20 @@ materialize_templated_targets() {
       return 1
     fi
     rm -f "$tpl_tmp"
+    # Mirror the source template's executable bit onto the rendered dest
+    # (#471): a templated source can be executable, and render_to writes via
+    # shell redirection (mode 644), so without this an executable templated
+    # script would land non-executable in the consumer. Same shape as the
+    # canonical mirror arm.
+    tpl_src_mode=$(git -C "$MERGEPATH_ROOT" ls-tree "$sha" -- "$tpl_source" | awk '{print $1}')
+    case "$tpl_src_mode" in
+      100755) chmod +x "$tpl_consumer_target" ;;
+      100644) chmod -x "$tpl_consumer_target" ;;
+      *)
+        err "$consumer_name: unexpected git mode '$tpl_src_mode' for templated source $tpl_source at mergepath@$short_sha"
+        return 1
+        ;;
+    esac
     printf "  ✎ %s rendered %s → %s\n" "$consumer_name" "$tpl_source" "$tpl_dest"
   done
 }

--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -795,6 +795,21 @@ materialize_templated_targets() {
         return 1
         ;;
     esac
+    # Record the mode in the git INDEX, not just the working tree: under
+    # core.filemode=false (some consumer clones / mode-insensitive
+    # filesystems) the caller's blanket `git add -A` ignores the on-disk
+    # exec bit, so a mode-only flip on an existing rendered dest would
+    # silently not be staged and the propagation PR would carry the wrong
+    # mode (Codex P2 on PR #475). Stage the dest and set its index mode
+    # now; a subsequent `git add -A` preserves an already-staged index
+    # mode (verified under core.filemode=false). Mirrors the same lesson
+    # tests/test_verify_propagation_pr_templated.sh applies to its fixture.
+    if [ "$tpl_src_mode" = "100755" ]; then tpl_idx_chmod="+x"; else tpl_idx_chmod="-x"; fi
+    if ! git -C "$workspace/repo" add -- "$tpl_dest" \
+       || ! git -C "$workspace/repo" update-index --chmod="$tpl_idx_chmod" -- "$tpl_dest"; then
+      err "$consumer_name: failed to stage templated dest mode ($tpl_idx_chmod) for $tpl_dest"
+      return 1
+    fi
     printf "  ✎ %s rendered %s → %s\n" "$consumer_name" "$tpl_source" "$tpl_dest"
   done
 }

--- a/scripts/workflow/match_protected_paths.sh
+++ b/scripts/workflow/match_protected_paths.sh
@@ -1,11 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Print stdin lines (file paths) that match any of the glob
-# patterns passed as positional arguments. Patterns use bash
-# extended pattern matching (`[[ str == pattern ]]`), which — for
-# our purposes — handles `**` cleanly: `.github/**` matches
-# `.github/workflows/foo.yml` without needing `shopt -s globstar`.
+# Print stdin lines (file paths) that match any of the glob patterns
+# passed as positional arguments, using REPO-RELATIVE path glob semantics
+# (#471):
+#   *   matches within a single path segment — does NOT cross `/`
+#   ?   matches a single character within a segment — does NOT cross `/`
+#   **  matches across directories (any depth, including `/`)
+#
+# This replaces the prior `[[ $file == $pattern ]]` matcher, whose bash
+# pattern semantics let `*` cross `/`, so `src/*.js` WRONGLY matched
+# `src/nested/file.js` — too broad for a policy knob.
+#
+# The matcher is the slash-aware twin of the Mergepath Playground's
+# compileGlob (mergepath/playground/index.html). Both compile a glob to the
+# same anchored ERE — `**` -> `.*`, `*` -> `[^/]*`, `?` -> `[^/]` — with
+# regex metacharacters escaped. KEEP THE TWO IN LOCKSTEP.
+#
+# The glob is converted char-by-char (NOT a multi-pass sed pipeline): the
+# earlier sed approach in `.github/workflows/pr-review-policy.yml`
+# double-transformed `*` — `.github/**` became `.github/.*` (correct), then
+# a second pass turned the remaining `*` into `[^/]*`, yielding
+# `.github/.[^/]*` which silently failed to match nested paths
+# (mergepath#54). A single left-to-right pass that consumes `**` before `*`
+# cannot double-transform.
 #
 # Usage:
 #   printf '%s\n' file1 file2 ... | scripts/workflow/match_protected_paths.sh <pattern>...
@@ -14,13 +32,6 @@ set -euo pipefail
 #   $ printf '%s\n' .github/workflows/foo.yml src/main.ts README.md \
 #       | scripts/workflow/match_protected_paths.sh '.github/**' 'src/auth/**'
 #   .github/workflows/foo.yml
-#
-# Why bash `[[ ]]` instead of an explicit glob-to-regex sed pipeline:
-# the earlier sed implementation in `.github/workflows/pr-review-policy.yml`
-# double-transformed `*` — `.github/**` became `.github/.*` (correct),
-# then a second pass converted the remaining `*` into `[^/]*`, yielding
-# `.github/.[^/]*` which silently failed to match nested paths. See
-# mergepath#54 for the full post-mortem.
 
 if [ "$#" -eq 0 ]; then
   echo "match_protected_paths.sh: at least one pattern required" >&2
@@ -29,6 +40,32 @@ if [ "$#" -eq 0 ]; then
 fi
 
 patterns=("$@")
+
+# Compile a repo-relative glob to an anchored ERE with segment-local
+# `*`/`?` and cross-directory `**`. Mirrors the Playground's compileGlob
+# (see header). Single left-to-right pass; `**` is consumed before `*`.
+glob_to_regex() {
+  local glob="$1" out="" n i c
+  n=${#glob}
+  i=0
+  while [ "$i" -lt "$n" ]; do
+    c="${glob:i:1}"
+    case "$c" in
+      '*')
+        if [ "${glob:i+1:1}" = '*' ]; then
+          out+='.*'; i=$((i + 2))          # ** -> any chars, including /
+        else
+          out+='[^/]*'; i=$((i + 1))       # *  -> segment-local
+        fi
+        ;;
+      '?') out+='[^/]'; i=$((i + 1)) ;;    # ?  -> single non-/ char
+      '.'|'+'|'^'|'$'|'('|')'|'{'|'}'|'|'|'['|']'|'\\')
+        out+="\\$c"; i=$((i + 1)) ;;        # escape ERE metacharacters
+      *) out+="$c"; i=$((i + 1)) ;;
+    esac
+  done
+  printf '^%s$' "$out"
+}
 
 # `|| [ -n "$file" ]` so a non-newline-terminated final stdin line
 # is still processed in this iteration. Without it, `read` returns
@@ -39,8 +76,8 @@ patterns=("$@")
 while IFS= read -r file || [ -n "$file" ]; do
   [ -z "$file" ] && continue
   for pattern in "${patterns[@]}"; do
-    # shellcheck disable=SC2053  # $pattern is intended to be a glob
-    if [[ "$file" == $pattern ]]; then
+    regex=$(glob_to_regex "$pattern")
+    if [[ "$file" =~ $regex ]]; then
       echo "$file"
       break
     fi

--- a/scripts/workflow/verify-propagation-pr.sh
+++ b/scripts/workflow/verify-propagation-pr.sh
@@ -339,12 +339,26 @@ if [ "$TEMPLATED_SURFACE_ACTIVE" = "1" ] && [ -n "$CONSUMER_NAME" ]; then
         # the templated arm was byte-only while the canonical loop's
         # tree-entry compare (mode + type + oid via `git ls-tree`)
         # was being skipped via the VERIFIED_TEMPLATED_DESTS exempt.
+        # Derive the SOURCE template's expected mode from the trusted
+        # mergepath checkout (#471): a templated source can be executable
+        # (e.g. a templated shell script), so the rendered dest must inherit
+        # the SOURCE mode rather than a hardcoded 100644. The source is
+        # confirmed present above; read its on-disk exec bit (in production
+        # MERGEPATH_DIR is a git checkout, so this matches the recorded git
+        # mode, consistent with the templated arm's existing on-disk source
+        # handling). Compare mode+type only — the render changes content by
+        # design, so the oid legitimately differs.
+        if [ -x "$mp_source_abs" ]; then
+          tpl_source_entry="100755 blob"
+        else
+          tpl_source_entry="100644 blob"
+        fi
         tpl_consumer_entry=$(git -C "$CONSUMER_DIR" ls-tree "$HEAD_SHA" -- "$tpl_dest" 2>/dev/null | awk '{print $1, $2}')
-        if [ "$tpl_consumer_entry" != "100644 blob" ]; then
+        if [ "$tpl_consumer_entry" != "$tpl_source_entry" ]; then
           {
-            echo "verify-propagation-pr.sh: templated dest $tpl_dest has unexpected tree entry [$tpl_consumer_entry], expected [100644 blob] (mode/type tampering — chmod +x flip or symlink swap, not a faithful render)"
+            echo "verify-propagation-pr.sh: templated dest $tpl_dest has unexpected tree entry [$tpl_consumer_entry], expected [$tpl_source_entry] from source $tpl_source (mode/type tampering — chmod +x flip or symlink swap, not a faithful render)"
           } >&2
-          fail_templated_drift "$tpl_dest — templated dest tree entry [$tpl_consumer_entry] differs from expected [100644 blob] (source=$tpl_source, consumer=$CONSUMER_NAME)"
+          fail_templated_drift "$tpl_dest — templated dest tree entry [$tpl_consumer_entry] differs from source [$tpl_source_entry] (source=$tpl_source, consumer=$CONSUMER_NAME)"
           rm -f "$rendered" "$pr_content"
           continue
         fi

--- a/scripts/workflow/verify-propagation-pr.sh
+++ b/scripts/workflow/verify-propagation-pr.sh
@@ -339,20 +339,49 @@ if [ "$TEMPLATED_SURFACE_ACTIVE" = "1" ] && [ -n "$CONSUMER_NAME" ]; then
         # the templated arm was byte-only while the canonical loop's
         # tree-entry compare (mode + type + oid via `git ls-tree`)
         # was being skipped via the VERIFIED_TEMPLATED_DESTS exempt.
-        # Derive the SOURCE template's expected mode from the trusted
+        # Derive the SOURCE template's expected mode+type from the trusted
         # mergepath checkout (#471): a templated source can be executable
         # (e.g. a templated shell script), so the rendered dest must inherit
-        # the SOURCE mode rather than a hardcoded 100644. The source is
-        # confirmed present above; read its on-disk exec bit (in production
-        # MERGEPATH_DIR is a git checkout, so this matches the recorded git
-        # mode, consistent with the templated arm's existing on-disk source
-        # handling). Compare mode+type only — the render changes content by
-        # design, so the oid legitimately differs.
-        if [ -x "$mp_source_abs" ]; then
-          tpl_source_entry="100755 blob"
+        # the SOURCE mode rather than a hardcoded 100644. Compare mode+type
+        # only — the render changes content by design, so the oid
+        # legitimately differs.
+        #
+        # Prefer the COMMITTED git mode (CodeRabbit on PR #475): the on-disk
+        # exec bit can drift from the recorded git mode, and the consumer
+        # side below — plus the canonical loop's mergepath-side read — both
+        # read git modes, so reading the source on-disk broke parity. Use
+        # `git ls-tree HEAD` when MERGEPATH_DIR is a git checkout (always so
+        # in production); fall back to an on-disk stat only when it is not
+        # (test fixtures that stage files without a repo), mirroring the
+        # canonical loop's git-or-disk handling below.
+        if [ -d "$MERGEPATH_DIR/.git" ] || [ -f "$MERGEPATH_DIR/.git" ]; then
+          # Git checkout (always so in production): the committed mode is
+          # authoritative.
+          tpl_source_entry=$(git -C "$MERGEPATH_DIR" ls-tree HEAD -- "$tpl_source" 2>/dev/null | awk '{print $1, $2}')
         else
-          tpl_source_entry="100644 blob"
+          # Non-git fixture dir (tests stage files without a repo): the
+          # filesystem exec bit is the only signal available.
+          if [ -x "$mp_source_abs" ]; then
+            tpl_source_entry="100755 blob"
+          else
+            tpl_source_entry="100644 blob"
+          fi
         fi
+        # Fail closed unless the source resolves to a regular-file blob.
+        # check_sync_manifest already requires templated sources to be
+        # regular files; an empty read (source not tracked at HEAD in the
+        # trusted checkout) or a symlink/submodule entry here is a
+        # misconfiguration, not a faithful render — reject rather than
+        # produce a confusing tree-entry diff. Both review bots on PR #475
+        # asked for this explicit guard.
+        case "$tpl_source_entry" in
+          "100644 blob"|"100755 blob") ;;
+          *)
+            fail_templated_error "$tpl_dest — unsupported/absent templated source tree entry [$tpl_source_entry] (source=$tpl_source, consumer=$CONSUMER_NAME)"
+            rm -f "$rendered" "$pr_content"
+            continue
+            ;;
+        esac
         tpl_consumer_entry=$(git -C "$CONSUMER_DIR" ls-tree "$HEAD_SHA" -- "$tpl_dest" 2>/dev/null | awk '{print $1, $2}')
         if [ "$tpl_consumer_entry" != "$tpl_source_entry" ]; then
           {

--- a/tests/test_match_protected_paths.sh
+++ b/tests/test_match_protected_paths.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Regression coverage for scripts/workflow/match_protected_paths.sh (#471):
+# repo-relative path glob semantics where * and ? are segment-local (do not
+# cross /) and ** is cross-directory. Keep these cases in parity with the
+# Mergepath Playground's compileGlob (mergepath/playground/index.html).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+M="$ROOT/scripts/workflow/match_protected_paths.sh"
+
+PASS=0; FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# assert_match <label> <expected: yes|no> <file> <pattern...>
+assert_match() {
+  local label=$1 expect=$2 file=$3; shift 3
+  local out got
+  out=$(printf '%s\n' "$file" | bash "$M" "$@" 2>/dev/null || true)
+  if [ "$out" = "$file" ]; then got=yes; else got=no; fi
+  if [ "$got" = "$expect" ]; then pass "$label"; else fail "$label: $file vs [$*] -> $got, expected $expect"; fi
+}
+
+# The core bug: * is segment-local (does NOT cross /).
+assert_match "src/*.js matches a file in src/"            yes 'src/foo.js'         'src/*.js'
+assert_match "src/*.js does NOT match a nested file"      no  'src/nested/file.js' 'src/*.js'
+
+# ** is cross-directory.
+assert_match ".github/** matches a nested workflow"       yes '.github/workflows/foo.yml' '.github/**'
+assert_match ".github/** matches a deeply nested path"    yes '.github/a/b/c.yml'         '.github/**'
+assert_match "src/**/*.js matches deep nesting"           yes 'src/a/b/file.js'           'src/**/*.js'
+
+# Top-level * does not cross / either.
+assert_match "*.md matches a top-level file"              yes 'README.md'         '*.md'
+assert_match "*.md does NOT match a nested file"          no  'docs/README.md'    '*.md'
+
+# ? is segment-local (single non-/ char).
+assert_match "?oo.txt matches foo.txt"                    yes 'foo.txt'           '?oo.txt'
+assert_match "?oo.txt does NOT match foobar.txt"          no  'foobar.txt'        '?oo.txt'
+assert_match "a/?.txt does NOT cross / via ?"             no  'a/b/c.txt'         'a/?.txt'
+
+# Regex metacharacters in patterns are literal, not regex.
+assert_match "a.b matches literal a.b"                    yes 'a.b'               'a.b'
+assert_match "a.b does NOT match axb (dot is literal)"    no  'axb'               'a.b'
+assert_match "paren pattern is literal"                   yes 'f(x).js'          'f(x).js'
+
+# Multiple patterns: match if ANY matches.
+assert_match "multi-pattern: second matches"              yes 'src/auth/x.ts'     '.github/**' 'src/auth/**'
+assert_match "multi-pattern: none matches"                no  'lib/x.ts'          '.github/**' 'src/auth/**'
+
+echo ""
+echo "test_match_protected_paths: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/tests/test_match_protected_paths.sh
+++ b/tests/test_match_protected_paths.sh
@@ -17,7 +17,11 @@ fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
 assert_match() {
   local label=$1 expect=$2 file=$3; shift 3
   local out got
-  out=$(printf '%s\n' "$file" | bash "$M" "$@" 2>/dev/null || true)
+  # No `|| true`: the matcher exits 0 on both match and no-match (its
+  # while-read loop returns 0 at EOF), so a non-zero exit means the matcher
+  # actually crashed — let that abort the suite loudly instead of silently
+  # passing the assertion (CodeRabbit on PR #475).
+  out=$(printf '%s\n' "$file" | bash "$M" "$@" 2>/dev/null)
   if [ "$out" = "$file" ]; then got=yes; else got=no; fi
   if [ "$got" = "$expect" ]; then pass "$label"; else fail "$label: $file vs [$*] -> $got, expected $expect"; fi
 }

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -796,6 +796,13 @@ grep -q 'chmod -x "$consumer_target"' "$SCRIPT" \
 grep -q 'chmod +x "$consumer_target"' "$SCRIPT" \
   || fail "sync_open_pr is missing the 'chmod +x' branch"
 
+# Templated render must additionally stage the dest mode in the git INDEX
+# (not only the working-tree chmod): under core.filemode=false the blanket
+# `git add -A` ignores the on-disk exec bit, so a mode-only flip would not be
+# committed (Codex P2 on PR #475). Assert the index-staging is present.
+grep -q 'update-index --chmod="$tpl_idx_chmod"' "$SCRIPT" \
+  || fail "templated render is missing the 'git update-index --chmod' index-mode staging — mode flips would be lost under core.filemode=false (#475)"
+
 # ---------------------------------------------------------------------------
 # Deletion propagation + tmpdir portability (cursor CHANGES_REQUESTED on
 # PR #217). Two source-grep assertions because the live cycle isn't

--- a/tests/test_verify_propagation_pr_templated.sh
+++ b/tests/test_verify_propagation_pr_templated.sh
@@ -76,7 +76,7 @@ YAML
 # (rendered.txt added with the supplied content). Sets globals
 # BASE_SHA / HEAD_SHA.
 build_consumer() {
-  local cdir="$1" pr_content="$2"
+  local cdir="$1" pr_content="$2" dest_mode="${3:-100644}"
   mkdir -p "$cdir"
   git_quiet -C "$cdir" init -q
   printf 'app code\n' >"$cdir/app.ts"
@@ -84,6 +84,7 @@ build_consumer() {
   git_quiet -C "$cdir" commit -q -m base
   BASE_SHA=$(git -C "$cdir" rev-parse HEAD)
   printf '%s' "$pr_content" >"$cdir/rendered.txt"
+  [ "$dest_mode" = "100755" ] && chmod +x "$cdir/rendered.txt"
   git_quiet -C "$cdir" add -A
   git_quiet -C "$cdir" commit -q -m head
   HEAD_SHA=$(git -C "$cdir" rev-parse HEAD)
@@ -280,6 +281,40 @@ else
   else
     pass "Case 5: mode tampering (chmod +x) → exit 1, tree-entry diagnostic"
   fi
+fi
+
+# ---------------------------------------------------------------------------
+# Case 6 — executable templated source: rendered dest must INHERIT +x (#471).
+# Before the fix the verifier hardcoded `100644 blob` and would reject a
+# faithfully-rendered executable template; now it derives the expected mode
+# from the source. A no-facts template renders to itself.
+# ---------------------------------------------------------------------------
+EXEC_TEMPLATE='#!/usr/bin/env bash
+echo hello
+'
+MP6="$WORKDIR/mp6"; build_mergepath "$MP6" "$EXEC_TEMPLATE" ""
+chmod +x "$MP6/examples/source.tpl"
+C6="$WORKDIR/c6"; build_consumer "$C6" "$EXEC_TEMPLATE" 100755
+run_verify "$MP6" "$C6"
+if [ "$RC" -ne 0 ]; then
+  fail "Case 6 exec-template pass: expected exit 0, got $RC"
+  { echo "stderr:"; sed 's/^/  /' "$STDERR_FILE"; } >&2
+else
+  pass "Case 6: executable templated source + executable dest → exit 0 (mode inherited)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 7 — executable source but dest rendered NON-executable → mode drift.
+# The fix must still catch a mode FLIP relative to the (now executable) source.
+# ---------------------------------------------------------------------------
+MP7="$WORKDIR/mp7"; build_mergepath "$MP7" "$EXEC_TEMPLATE" ""
+chmod +x "$MP7/examples/source.tpl"
+C7="$WORKDIR/c7"; build_consumer "$C7" "$EXEC_TEMPLATE" 100644
+run_verify "$MP7" "$C7"
+if [ "$RC" -ne 1 ]; then
+  fail "Case 7 exec-source mode-drift: expected exit 1, got $RC"
+else
+  pass "Case 7: executable source but non-executable dest → exit 1 (mode drift caught)"
 fi
 
 echo ""

--- a/tests/test_verify_propagation_pr_templated.sh
+++ b/tests/test_verify_propagation_pr_templated.sh
@@ -341,6 +341,13 @@ git_quiet -C "$MP8" add -A
 git_quiet -C "$MP8" update-index --chmod=+x examples/source.tpl
 git_quiet -C "$MP8" commit -q -m mp
 chmod -x "$MP8/examples/source.tpl"   # on-disk bit now disagrees with git (100755)
+# Assert the precondition actually held: if the filesystem ignored chmod -x
+# (mode-insensitive FS), the on-disk bit would still be set and Case 8 would
+# pass for the WRONG reason (filesystem read also seeing 100755), not because
+# the verifier read the git tree. Fail loudly instead (CodeRabbit on PR #475).
+if [ -x "$MP8/examples/source.tpl" ]; then
+  fail "Case 8 precondition: chmod -x did not clear the on-disk exec bit (mode-insensitive FS); discriminator invalid"
+else
 C8="$WORKDIR/c8"; build_consumer "$C8" "$EXEC_TEMPLATE8" 100755
 run_verify "$MP8" "$C8"
 if [ "$RC" -ne 0 ]; then
@@ -348,6 +355,7 @@ if [ "$RC" -ne 0 ]; then
   { echo "stderr:"; sed 's/^/  /' "$STDERR_FILE"; } >&2
 else
   pass "Case 8: source mode read from git tree (on-disk bit cleared) → exec dest passes"
+fi
 fi
 
 echo ""

--- a/tests/test_verify_propagation_pr_templated.sh
+++ b/tests/test_verify_propagation_pr_templated.sh
@@ -84,8 +84,14 @@ build_consumer() {
   git_quiet -C "$cdir" commit -q -m base
   BASE_SHA=$(git -C "$cdir" rev-parse HEAD)
   printf '%s' "$pr_content" >"$cdir/rendered.txt"
-  [ "$dest_mode" = "100755" ] && chmod +x "$cdir/rendered.txt"
   git_quiet -C "$cdir" add -A
+  # Record the executable bit in the git INDEX, not via a filesystem
+  # chmod: under core.filemode=false (some CI images / mode-insensitive
+  # filesystems) git ignores the on-disk exec bit and would commit 100644
+  # regardless, silently breaking Cases 6/7. `git update-index --chmod=+x`
+  # writes mode 100755 directly into the index — same approach Case 5 uses
+  # for its fixture (CodeRabbit on PR #475).
+  [ "$dest_mode" = "100755" ] && git_quiet -C "$cdir" update-index --chmod=+x rendered.txt
   git_quiet -C "$cdir" commit -q -m head
   HEAD_SHA=$(git -C "$cdir" rev-parse HEAD)
 }
@@ -315,6 +321,33 @@ if [ "$RC" -ne 1 ]; then
   fail "Case 7 exec-source mode-drift: expected exit 1, got $RC"
 else
   pass "Case 7: executable source but non-executable dest → exit 1 (mode drift caught)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 8 — source mode is read from the COMMITTED git tree, not the on-disk
+# exec bit (#475 / CodeRabbit + Codex). This is the PRODUCTION path: a real
+# MERGEPATH_DIR is a git checkout. The source is committed as 100755 but its
+# on-disk exec bit is then CLEARED, so a filesystem `-x` read would see
+# 100644 and wrongly reject the executable dest as drift. Only reading the
+# git mode (100755) makes the faithful render pass — a precise discriminator
+# for the git-tree-mode fix.
+# ---------------------------------------------------------------------------
+EXEC_TEMPLATE8='#!/usr/bin/env bash
+echo run
+'
+MP8="$WORKDIR/mp8"; build_mergepath "$MP8" "$EXEC_TEMPLATE8" ""
+git_quiet -C "$MP8" init -q
+git_quiet -C "$MP8" add -A
+git_quiet -C "$MP8" update-index --chmod=+x examples/source.tpl
+git_quiet -C "$MP8" commit -q -m mp
+chmod -x "$MP8/examples/source.tpl"   # on-disk bit now disagrees with git (100755)
+C8="$WORKDIR/c8"; build_consumer "$C8" "$EXEC_TEMPLATE8" 100755
+run_verify "$MP8" "$C8"
+if [ "$RC" -ne 0 ]; then
+  fail "Case 8 git-mode source read: expected exit 0, got $RC"
+  { echo "stderr:"; sed 's/^/  /' "$STDERR_FILE"; } >&2
+else
+  pass "Case 8: source mode read from git tree (on-disk bit cleared) → exec dest passes"
 fi
 
 echo ""


### PR DESCRIPTION
Closes #471. Two decided propagation changes.

Part 1 — templated outputs preserve the source template git mode. A templated source can be executable (e.g. a templated shell script), but the rendered dest was treated as always 100644. verify-propagation-pr.sh hardcoded an expected [100644 blob] tree entry (rejecting a faithful executable render); it now derives the expected mode from the SOURCE template (its on-disk exec bit in the trusted mergepath checkout) and compares mode+type — the render changes content by design, so the oid legitimately differs. sync-to-downstream.sh rendered via shell redirection (644) and never chmod-ed; it now mirrors the source exec bit onto the rendered dest, same shape as the canonical mirror arm.

Part 2 — protected-path globs are segment-local. match_protected_paths.sh used Bash [[ path == pattern ]], where the star crosses slash, so src/*.js WRONGLY matched src/nested/file.js. Rewritten to compile the glob char-by-char to an anchored ERE: segment-local star ([^/]*) and ? ([^/]), cross-directory ** (.*), regex metacharacters escaped, a single left-to-right pass that consumes ** before star (avoids the mergepath#54 double-transform). This is the slash-aware twin of the Playground compileGlob; the Playground ? was aligned to [^/] so the two stay in lockstep, and both cross-reference each other.

REVIEW FOCUS: the glob rewrite (parity with the Playground) and the mode-preservation contract change in verify-propagation-pr.sh.

Authoring-Agent: claude

## Self-Review
- Correctness: new tests/test_match_protected_paths.sh (15 segment-local cases) all pass; test_verify_propagation_pr_templated.sh gains Case 6 (exec source + exec dest -> pass) and Case 7 (exec source + non-exec dest -> mode-drift fail); both suites green via check_verify_propagation_pr.
- Regression risk: the matcher is a behavior change (src/*.js no longer crosses slash); existing protected patterns (.github/**, src/auth/**) verified to still match nested paths. Mode derivation reads the on-disk exec bit, which matches the recorded git mode in a checkout and is consistent with the templated arm existing on-disk source handling.
- Style and conventions: char-by-char compile mirrors the Playground; sync chmod mirrors the canonical arm.
- Test coverage: matcher test wired into check_verify_propagation_pr and added to .mergepath-sync.yml consumers all; check_sync_manifest green. Docs updated (templated-propagation.md).
- Security and dependency hygiene: no new dependencies (pure bash); the matcher escapes regex metacharacters so a crafted pattern cannot inject regex.