### PR TITLE
fix(cleanup): deploy/preflight docs, PyPI metadata, and shell-helper hardening (#469)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -731,6 +731,18 @@ Reference docs:
 [local `.env` validation hook](https://www.1password.dev/environments/agent-hook-validate),
 and [`op run` secret loading](https://www.1password.dev/cli/secrets-environment-variables).
 
+> **Beta / platform caveat (#469):** 1Password Environments, the MCP
+> Server for Codex, and the local `.env` validation hook are early-access
+> (beta) 1Password features at the time of writing (2026-05-21) and carry
+> platform constraints — the MCP Server for Codex is a Codex-specific
+> adapter, and the validation hook depends on the 1Password desktop
+> app + CLI integration on the developer's machine. Treat the model below
+> as descriptive and forward-looking: gate adoption on the 1Password
+> audit ADR workstream (#347/#355/#356/#357) and re-check the upstream
+> docs, since beta surfaces change without notice. The portable-core
+> primitives (`op://` references, `op run`, `op inject`, scoped service
+> accounts) are GA and are the safe baseline.
+
 Mergepath uses a portable core with per-client adapters:
 
 - **Portable core:** 1Password Environments, `op://` secret

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -23,6 +23,7 @@ npm view mergepath           # verify: owner = nathanjohnpayne, version = 0.0.0
 ```bash
 cd packaging/pypi
 python3 -m pip install --upgrade build twine
+rm -rf dist/ build/ ./*.egg-info  # clear stale artifacts so `twine upload dist/*` only sees this build
 python3 -m build             # produces dist/mergepath-0.0.0.tar.gz + .whl
 python3 -m twine upload dist/*   # auth as nathanjohnpayne
 ```

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -9,8 +9,11 @@ description = "Name reservation for the Mergepath umbrella project. No runtime c
 readme = "README.md"
 requires-python = ">=3.8"
 license = { text = "Proprietary" }
+# Name-only author: a placeholder package on a public index should not
+# carry a direct personal email. Contact routes through the project URLs
+# below (matches packaging/npm, which uses name + project site, no email).
 authors = [
-  { name = "Nathan Payne", email = "anthropic@nathanpayne.com" },
+  { name = "Nathan Payne" },
 ]
 keywords = ["mergepath", "placeholder"]
 classifiers = [

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -738,9 +738,17 @@ emit_from_session_file() (
         unset OP_PREFLIGHT_FIREBASE_SA_TMPFILE OP_PREFLIGHT_FIREBASE_PROJECT
         exit 2
       else
-        log_stale_adc_guidance
+        # Force a full re-fetch (exit 2) rather than degrading in place
+        # (#469): the cached ADC tempfile is stale, but the 1Password ADC
+        # item may have been refreshed since this cache was written.
+        # Re-reading from op on the full-fetch path gives it that chance;
+        # if op's copy is ALSO stale, the full-fetch path calls
+        # log_stale_adc_guidance and degrades there. This matches the
+        # Firebase-SA branch above, which already exits 2 on a stale cache.
+        echo "# WARNING: cached GCP ADC is unusable; refreshing deploy credentials." >&2
         unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
         unset OP_PREFLIGHT_FIREBASE_SA_TMPFILE OP_PREFLIGHT_FIREBASE_PROJECT
+        exit 2
       fi
     fi
   fi

--- a/scripts/policy-sim.sh
+++ b/scripts/policy-sim.sh
@@ -12,6 +12,13 @@
 set -euo pipefail
 
 LIMIT="${1:-20}"
+# Validate the limit is a positive integer before handing it to gh (#469):
+# an arbitrary string is otherwise passed straight to `gh pr list --limit`,
+# which errors opaquely (or, for `0`, silently returns nothing).
+if ! [[ "$LIMIT" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: limit must be a positive integer (got: '$LIMIT')" >&2
+  exit 1
+fi
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEMPLATE="$REPO_ROOT/mergepath/playground/index.html"
 
@@ -52,7 +59,12 @@ PRS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mergepath-prs.XXXXXX")"
 PRS_FILE="$PRS_DIR/prs.json"
 trap 'rm -rf "$PRS_DIR"' EXIT
 
-gh pr list \
+# Run from REPO_ROOT so `gh pr list` targets THIS repo regardless of the
+# caller's CWD (#469): gh resolves the repo from the current directory's
+# git remote, so invoking policy-sim.sh from another checkout would
+# otherwise list that repo's PRs despite REPO_ROOT being computed above.
+# PRS_FILE is an absolute mktemp path, so the redirect is unaffected by cd.
+( cd "$REPO_ROOT" && gh pr list \
   --state merged \
   --limit "$LIMIT" \
   --json number,title,additions,deletions,author,files,body \
@@ -65,7 +77,7 @@ gh pr list \
     ),
     lines: (.additions + .deletions),
     paths: [.files[].path]
-  }]' > "$PRS_FILE"
+  }]' ) > "$PRS_FILE"
 
 COUNT=$(jq 'length' < "$PRS_FILE")
 echo "Got $COUNT PRs. Injecting and opening..."

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -1028,6 +1028,31 @@ EOF
   pass "test_check_review_mode_omits_deploy_creds: review --check omits AND unsets stale deploy creds (#466)"
 }
 
+# ---------------------------------------------------------------------------
+# test_source_gcp_adc_stale_forces_refresh (#469): the non-Firebase GCP ADC
+# stale fast-path must force a full re-fetch (exit 2) — symmetric to the
+# Firebase-SA branch, which has a behavioral fixture above
+# (test_deploy_mode_refreshes_unusable_cached_firebase_sa). The cached ADC
+# tempfile may be stale while the 1Password ADC item is fresh; degrading in
+# place would skip that refresh. Structural guard against a revert of the
+# exit 2 (a full GCP-ADC deploy fixture would duplicate the Firebase one's
+# op-stub plumbing for a one-line mirror change).
+# ---------------------------------------------------------------------------
+test_source_gcp_adc_stale_forces_refresh() {
+  # In the stale-ADC else-branch: a 'cached GCP ADC is unusable' warning
+  # must be followed by `exit 2` before the block's closing `fi`.
+  if awk '
+    /cached GCP ADC is unusable/ { found = 1; next }
+    found && /^[[:space:]]*exit 2[[:space:]]*$/ { ok = 1 }
+    found && /^[[:space:]]*fi[[:space:]]*$/ { exit (ok ? 0 : 1) }
+    END { exit (ok ? 0 : 1) }
+  ' "$SCRIPT"; then
+    pass "test_source_gcp_adc_stale_forces_refresh: stale GCP ADC forces refresh (exit 2), symmetric to Firebase SA"
+  else
+    fail "test_source_gcp_adc_stale_forces_refresh: non-Firebase ADC stale path must exit 2 to force a re-fetch (#469)"
+  fi
+}
+
 test_check_fresh_cache
 test_check_missing_cache
 test_check_stale_cache
@@ -1043,6 +1068,7 @@ test_deploy_mode_refreshes_unusable_cached_firebase_sa
 test_deploy_mode_refreshes_mismatched_cached_firebase_sa
 test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch
 test_check_review_mode_omits_deploy_creds
+test_source_gcp_adc_stale_forces_refresh
 
 echo
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
Closes #469. Smaller cleanup findings from the #456 rollup, related by surface area. Two of the six listed defects were already resolved upstream: the gh-pr-guard non-POSIX matcher (now POSIX [[:space:]], #466) and match_protected_paths glob semantics (slash-aware ERE aligned to the Playground, #471).

- DEPLOYMENT.md: beta/platform caveat on the runtime 1Password section. Environments, the MCP Server for Codex, and the local .env validation hook are early-access (beta) with platform constraints; the portable-core primitives are the GA baseline.
- packaging/pypi/pyproject.toml: drop the direct personal email from the placeholder metadata (name-only author, matching packaging/npm; contact via project URLs).
- packaging/README.md: clear stale dist/build/egg-info before build so the twine upload only sees the fresh build.
- scripts/policy-sim.sh: validate the limit arg is a positive integer before gh (rejects non-numeric, 0, negative, injection attempts), and run the PR-list query from REPO_ROOT so it targets THIS repo regardless of caller CWD.
- scripts/op-preflight.sh: the non-Firebase GCP ADC stale fast-path forces a full re-fetch (exit 2) instead of degrading in place, symmetric to the Firebase-SA branch.

REVIEW FOCUS: the op-preflight ADC exit-2 change (load-bearing) and the policy-sim CWD fix.

Authoring-Agent: claude

## Self-Review
- Correctness: new test_source_gcp_adc_stale_forces_refresh guard verified to FAIL if the exit 2 is removed; existing op-preflight suite 16/16; policy-sim rejects 4 bad inputs including an injection attempt; pyproject parses (name-only author).
- Regression risk: the op-preflight ADC change mirrors the already-tested Firebase-SA refresh branch (exit 2 falls through to full-fetch, no loop, since the full-fetch path does not exit 2 on a stale op-side cred but logs guidance and degrades); the policy-sim subshell-cd does not affect the absolute mktemp redirect target.
- Style and conventions: the ADC branch mirrors the Firebase-SA branch; the structural test guard mirrors the source-grep pattern in test_sync_to_downstream.sh.
- Test coverage: the load-bearing op-preflight change is guarded; docs and metadata changes are static (verified by parse and grep).
- Security and dependency hygiene: removes a personal email from public package metadata; policy-sim limit validation blocks argument injection; no new dependencies.