### PR TITLE
fix(playground): control labels, preset reset, path/spec drift, stacked scroll-sync (#470)

### DIFF
--- a/mergepath/playground/index.html
+++ b/mergepath/playground/index.html
@@ -800,7 +800,7 @@
             <span>Lines changed at or above this value escalate to Phase 4.</span>
           </div>
           <div class="slider-row">
-            <input type="range" id="threshold" min="50" max="1000" step="10" value="300" />
+            <input type="range" id="threshold" min="50" max="1000" step="10" value="300" aria-label="External review threshold (lines changed)" />
             <span class="val"><span id="thresholdVal">300</span> lines</span>
           </div>
         </div>
@@ -830,7 +830,7 @@
             <span>Advisory auto-review on PR open.</span>
           </div>
           <label class="switch">
-            <input type="checkbox" data-toggle="coderabbit" checked />
+            <input type="checkbox" data-toggle="coderabbit" checked aria-label="Enable CodeRabbit advisory auto-review" />
             <span class="track"></span>
           </label>
         </div>
@@ -841,13 +841,13 @@
             <span>Phase 4a automated external review.</span>
           </div>
           <label class="switch">
-            <input type="checkbox" data-toggle="codex" checked />
+            <input type="checkbox" data-toggle="codex" checked aria-label="Enable Codex GitHub App external review" />
             <span class="track"></span>
           </label>
         </div>
         <div class="nested shown" id="codexNested">
           <div class="slider-row">
-            <input type="range" id="codexRounds" min="1" max="5" step="1" value="2" />
+            <input type="range" id="codexRounds" min="1" max="5" step="1" value="2" aria-label="Codex maximum review rounds" />
             <span class="val">max <span id="codexRoundsVal">2</span> rounds</span>
           </div>
           <p class="hint">Beyond this, Mergepath stops the loop and pings a human.</p>
@@ -955,7 +955,9 @@
   // ---------------------------------------------------------------------
   const DEFAULTS = {
     threshold: 300,
-    protectedPaths: ['src/auth/**', 'src/payments/**', '.github/**', 'credentials/**'],
+    // Mirrors external_review_paths in .github/review-policy.yml — keep the
+    // two in sync (#470). Drift here misrepresents how the real gate routes.
+    protectedPaths: ['src/auth/**', 'src/payments/**', '**/*secret*', '**/*credential*', '.github/**'],
     coderabbit: true,
     codex: true,
     codexRounds: 2,
@@ -984,7 +986,7 @@
   // ---------------------------------------------------------------------
   const SYNTHETIC_PRS = [
     { id: '#142', title: 'Fix footer copyright year',            author: 'claude', lines: 2,   paths: ['src/components/Footer.tsx'] },
-    { id: '#141', title: 'Rotate Stripe webhook secret',         author: 'codex',  lines: 15,  paths: ['src/payments/webhook.ts', 'credentials/stripe.yml'] },
+    { id: '#141', title: 'Rotate Stripe webhook secret',         author: 'codex',  lines: 15,  paths: ['src/payments/webhook.ts', 'infra/stripe.credentials.json'] },
     { id: '#140', title: 'Add dark mode toggle',                 author: 'cursor', lines: 183, paths: ['src/components/Layout.tsx', 'src/hooks/useTheme.ts'] },
     { id: '#139', title: 'Refactor billing module',              author: 'claude', lines: 421, paths: ['src/payments/billing.ts', 'src/payments/invoice.ts'], forcedRounds: 2 },
     { id: '#138', title: 'Migrate users table (email_verified)', author: 'codex',  lines: 287, paths: ['db/migrations/20260414_users_verified.sql', 'src/auth/User.ts'] },
@@ -1339,7 +1341,17 @@
   function applyPreset(name) {
     const p = PRESETS[name];
     if (!p) return;
-    Object.assign(state, p);
+    // A preset is a complete starting point, not a partial overlay (#470):
+    // reset the ENTIRE policy to defaults first, then apply the preset's
+    // overrides, so fields a preset does not mention — protected paths and
+    // reviewers — return to a known state instead of retaining the user's
+    // prior edits. Without this, switching presets left stale paths/reviewers
+    // and the rendered policy no longer matched the named preset.
+    const fresh = (typeof structuredClone === 'function')
+      ? structuredClone(DEFAULTS)
+      : JSON.parse(JSON.stringify(DEFAULTS));
+    Object.assign(state, fresh, p);
+    // Re-sync every control from state, not just the four the preset sets.
     $('threshold').value = state.threshold;
     $('thresholdVal').textContent = state.threshold;
     $('codexRounds').value = state.codexRounds;
@@ -1347,7 +1359,10 @@
     document.querySelector('[data-toggle="coderabbit"]').checked = state.coderabbit;
     document.querySelector('[data-toggle="codex"]').checked = state.codex;
     $('codexNested').classList.toggle('shown', state.codex);
-    renderAll();
+    document.querySelectorAll('[data-reviewer]').forEach(cb => {
+      cb.checked = !!state.reviewers[cb.dataset.reviewer];
+    });
+    renderAll();  // re-renders the protected-path chips from the reset state
     announce('Applied ' + name + ' preset.');
   }
   document.querySelectorAll('[data-preset]').forEach(b => {
@@ -1475,21 +1490,25 @@
   // prevents the mirrored assignment from re-firing the opposite
   // handler into an infinite loop.
   //
-  // Either pane can lose its internal scroll range depending on
-  // viewport size and content — most reliably the workspace at the
-  // ≤960px stacked-layout breakpoint. We wire up listeners
-  // unconditionally and let the sMax/tMax guard below no-op when
-  // either side has nothing to scroll. Simpler than attaching and
-  // detaching on resize transitions.
+  // The columns sit side by side only ABOVE the ≤960px breakpoint; at or
+  // below it the CSS @media block stacks them vertically and each becomes
+  // an ordinary block in page flow. Mirroring rail↔workspace scroll in that
+  // stacked layout is meaningless and fights the user, so gate the mirror
+  // on the SAME media query the CSS uses, read live on each scroll. Reading
+  // matchMedia at scroll time avoids attaching/detaching listeners across
+  // resize transitions. (#470 — the prior version wired the sync
+  // unconditionally and relied only on the sMax/tMax no-op, which does NOT
+  // disable it when both stacked panes still have internal scroll range.)
   // ---------------------------------------------------------------------
   function initSyncScroll() {
     const rail = document.querySelector('.rail');
     const workspace = document.querySelector('.workspace');
     if (!rail || !workspace) return;
+    const stacked = window.matchMedia('(max-width: 960px)');
     let syncing = false;
     function mirror(source, target) {
       return () => {
-        if (syncing) return;
+        if (syncing || stacked.matches) return;
         const sMax = source.scrollHeight - source.clientHeight;
         const tMax = target.scrollHeight - target.clientHeight;
         if (sMax <= 0 || tMax <= 0) return;

--- a/specs/mergepath_playground.md
+++ b/specs/mergepath_playground.md
@@ -26,10 +26,14 @@ reserved, see [`BRAND.md`](../BRAND.md).
   exposes.
 - Changing any knob updates stats, flows, and YAML without a full
   reload.
-- The control rail and workspace are their own scroll containers and
-  scroll in sync: scrolling one advances the other proportionally so
-  a long PR list and a short control stack stay aligned without the
-  shorter pane getting stranded.
+- The control rail and workspace are their own scroll containers. In the
+  side-by-side (desktop) layout they scroll in sync: scrolling one
+  advances the other proportionally so a long PR list and a short control
+  stack stay aligned without the shorter pane getting stranded. At the
+  `max-width: 960px` stacked breakpoint the columns stack vertically and
+  scroll independently — the sync is disabled there (it would otherwise
+  fight the user), gated on a `matchMedia('(max-width: 960px)')` check
+  read live on each scroll.
 - The page carries an HTML comment injection marker
   `<!-- MERGEPATH_INJECT -->` that `scripts/policy-sim.sh` rewrites
   to `<script>window.__PRS = [...]</script>`. The legacy marker

--- a/specs/mergepath_playground.md
+++ b/specs/mergepath_playground.md
@@ -62,7 +62,9 @@ reserved, see [`BRAND.md`](../BRAND.md).
 - **Accessibility.** The modal is a true dialog: `role="dialog"`,
   `aria-modal`, `aria-labelledby`, `aria-describedby`, focus moves
   into the dialog on open and returns to the trigger on close, Tab
-  wraps within the dialog, Escape closes. An `aria-live="polite"`
+  wraps within the dialog, and the modal closes on Escape **or** on a
+  click on the backdrop outside the dialog surface (the backdrop click
+  is ignored when it originates inside the dialog). An `aria-live="polite"`
   region announces path add/remove, preset application, YAML and
   command copy. Reduced-motion preferences are respected.
 - **PR normalization.** Injected PR entries are coerced through a


### PR DESCRIPTION
Closes #470. Five Mergepath Playground findings from the #456 rollup (the issue sixth item, the shell/JS glob-semantics mismatch, was already resolved by #471 which aligned match_protected_paths.sh to the Playground compileGlob).

- Default protected paths drifted from .github/review-policy.yml: replaced the stale credentials/** with the actual policy patterns **/*secret* and **/*credential*, reordered to match external_review_paths, and added a keep-in-sync comment. A synthetic PR path now hits **/*credential* so the demo still exercises the pattern.
- Presets did not reset full policy state: applyPreset overlaid only the four fields a preset defines, leaving protected paths and reviewer toggles stale. Now resets the entire state to defaults first, applies the preset, and re-syncs every control.
- Controls lacked programmatic labels: added aria-label to the threshold and codex-rounds sliders and the CodeRabbit/Codex switch checkboxes (their text is in a sibling div, not the wrapping label).
- Stacked-layout scroll-sync: the rail/workspace mirror was wired unconditionally; now gated on matchMedia max-width 960px, read live per scroll.
- Spec omitted the implemented backdrop-click modal close: documented it alongside Escape.

REVIEW FOCUS: the preset full-reset and the protected-path policy alignment.

Authoring-Agent: claude

## Self-Review
- Correctness: verified in-browser against a static server. aria-labels present on all four controls; chips and rendered YAML match the five policy paths; applying Strict removes an added path, re-checks an unchecked reviewer, sets threshold 100; at 375px the matchMedia gate engages and scrolling the rail does NOT mirror the workspace; no console errors.
- Regression risk: the scroll-sync gate is read live per scroll (no detach/reattach across resize); the preset reset uses structuredClone of DEFAULTS with a JSON fallback; the protected-path change is data-only and the matcher is unchanged.
- Style and conventions: matches the existing single-file Playground style; aria-label phrasing mirrors the visible control copy.
- Test coverage: this is a static browser artifact with no unit harness; verified via the preview workflow (snapshot, eval, resize) plus a screenshot.
- Security and dependency hygiene: no new dependencies; no network or auth; the path change brings the demo into line with the real policy so it cannot under-represent the gate.