### PR TITLE
fix(propagation): stage canonical + kit dest modes in the git index (#476)

### DIFF
--- a/scripts/sync-to-downstream.sh
+++ b/scripts/sync-to-downstream.sh
@@ -1612,6 +1612,22 @@ sync_open_pr() {
         return 1
         ;;
     esac
+    # Stage the dest mode in the git INDEX, not just the working tree:
+    # under core.filemode=false (some consumer clones / mode-insensitive
+    # filesystems) the caller's blanket `git add -A` ignores the on-disk
+    # exec bit, so a mode-only flip on an existing tracked file would not
+    # be staged and the propagation PR would carry the wrong mode. Same
+    # fix the templated arm got in #471 (PR #475); extended to the
+    # canonical arms in #476 (executable canonical scripts are far more
+    # common than templated ones). A subsequent `git add -A` preserves an
+    # already-staged index mode (verified under core.filemode=false).
+    local idx_chmod
+    if [ "$src_mode" = "100755" ]; then idx_chmod="+x"; else idx_chmod="-x"; fi
+    if ! git -C "$workspace/repo" add -- "$target" \
+       || ! git -C "$workspace/repo" update-index --chmod="$idx_chmod" -- "$target"; then
+      err "$consumer_name: failed to stage dest mode ($idx_chmod) for $target"
+      return 1
+    fi
   done <<< "$targets"
 
   # Templated materialize — render mergepath@$sha's source templates
@@ -1993,6 +2009,17 @@ sync_all_open_pr() {
         return 1
         ;;
     esac
+    # Stage the dest mode in the git INDEX as well — see the sync_open_pr
+    # canonical arm above. Under core.filemode=false the caller's blanket
+    # `git add -A` drops a mode-only flip, so an executable canonical file
+    # would propagate non-executable (#476).
+    local idx_chmod
+    if [ "$src_mode" = "100755" ]; then idx_chmod="+x"; else idx_chmod="-x"; fi
+    if ! git -C "$workspace/repo" add -- "$target" \
+       || ! git -C "$workspace/repo" update-index --chmod="$idx_chmod" -- "$target"; then
+      err "$consumer_name: failed to stage dest mode ($idx_chmod) for $target"
+      return 1
+    fi
   done <<< "$canonical_targets"
 
   # Materialize kit directories with allow-extras semantics: copy every
@@ -2035,6 +2062,17 @@ sync_all_open_pr() {
           return 1
           ;;
       esac
+      # Stage the kit dest mode in the git INDEX as well — see the
+      # canonical arms above. Under core.filemode=false the caller's
+      # blanket `git add -A` drops a mode-only flip, so an executable kit
+      # file would propagate non-executable (#476).
+      local kit_idx_chmod
+      if [ "$kit_mode" = "100755" ]; then kit_idx_chmod="+x"; else kit_idx_chmod="-x"; fi
+      if ! git -C "$workspace/repo" add -- "$kit_file" \
+         || ! git -C "$workspace/repo" update-index --chmod="$kit_idx_chmod" -- "$kit_file"; then
+        err "$consumer_name: failed to stage kit dest mode ($kit_idx_chmod) for $kit_file"
+        return 1
+      fi
     done <<< "$kit_files"
   done <<< "$kit_targets"
 

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -803,6 +803,26 @@ grep -q 'chmod +x "$consumer_target"' "$SCRIPT" \
 grep -q 'update-index --chmod="$tpl_idx_chmod"' "$SCRIPT" \
   || fail "templated render is missing the 'git update-index --chmod' index-mode staging — mode flips would be lost under core.filemode=false (#475)"
 
+# Canonical mirror arms (sync_open_pr AND sync_all_open_pr) must ALSO stage
+# the dest mode in the git INDEX, exactly like the templated arm — under
+# core.filemode=false the blanket `git add -A` drops a mode-only flip on an
+# existing tracked file, so an executable canonical script (far more common
+# than a templated executable) would propagate non-executable (#476). Both
+# arms share the `$idx_chmod` var, so require the staging to appear twice
+# (one per arm). `|| true`: grep -c exits 1 on zero matches under set -e —
+# the real assertion is the count check below, this just captures the count.
+canonical_idx_count=$(grep -c 'update-index --chmod="$idx_chmod"' "$SCRIPT" || true)
+[ "${canonical_idx_count:-0}" -ge 2 ] \
+  || fail "canonical mirror arms are missing 'git update-index --chmod=\$idx_chmod' index-mode staging in both sync_open_pr and sync_all_open_pr (found ${canonical_idx_count:-0}, need 2) — exec-mode flips would be lost under core.filemode=false (#476)"
+
+# Kit mirror arm: mirror both the chmod-branch greps and the index-staging.
+grep -q 'chmod -x "$consumer_kit_target"' "$SCRIPT" \
+  || fail "kit mirror is missing the 'chmod -x' branch — mode drift would persist on 100644 kit sources (#476)"
+grep -q 'chmod +x "$consumer_kit_target"' "$SCRIPT" \
+  || fail "kit mirror is missing the 'chmod +x' branch (#476)"
+grep -q 'update-index --chmod="$kit_idx_chmod"' "$SCRIPT" \
+  || fail "kit mirror is missing the 'git update-index --chmod' index-mode staging — kit exec-mode flips would be lost under core.filemode=false (#476)"
+
 # ---------------------------------------------------------------------------
 # Deletion propagation + tmpdir portability (cursor CHANGES_REQUESTED on
 # PR #217). Two source-grep assertions because the live cycle isn't


### PR DESCRIPTION
Resolves #476.

scripts/sync-to-downstream.sh mirrors a source files executable bit onto the consumer copy by chmod-ing the working-tree file, then relying on a later blanket git add -A to stage it. Under core.filemode=false (some consumer clones or mode-insensitive filesystems) git add ignores the on-disk exec bit, so a mode-only flip on an existing tracked file is not recorded and the propagation PR carries the wrong mode.

PR #475 (#471) fixed the templated arm via git update-index --chmod after the working-tree chmod. This extends the same fix to the three pre-existing mirror arms that predate it: sync_open_pr canonical, sync_all_open_pr canonical, and sync_all_open_pr kit. These carry executable canonical files (propagated scripts), far more common than templated executables, so the blast radius is broader.

Authoring-Agent: claude

## Self-Review

- Empirically verified in a core.filemode=false repo, both directions: a working-tree chmod then a plain git add leaves the index mode unchanged (the bug); git update-index --chmod records the intended mode; a later git add -A preserves it.
- Mirrors the templated arm, including the fail-closed err plus return 1 on a failed add or update-index.
- Additive only. The three wired CI checks touching this script (check_export_consumer_facts, check_sync_manifest, check_mktemp_portability) and tests/test_sync_to_downstream.sh all pass.
- Structural assertions added mirror the existing chmod-branch greps and the #475 templated assertion: canonical staging must appear in both arms (count at least 2); the kit arm must carry both chmod branches plus the staging.
- Flagged separately (out of scope): tests/test_sync_to_downstream.sh is not wired into repo_lint.yml, so these structural assertions and the #475 one are local guards, not CI gates. I will file a follow-up to wire the suite.