### PR TITLE
fix(ci): wire test_sync_to_downstream.sh into repo_lint so its assertions gate CI (#488)

### DIFF
--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -226,6 +226,16 @@ jobs:
         # mirror lane silently re-overwriting them.
         run: ./scripts/ci/check_sync_overrides
 
+      - name: check_sync_to_downstream
+        # Exercises tests/test_sync_to_downstream.sh — the propagation
+        # engine suite that structurally guards scripts/sync-to-downstream.sh:
+        # the executable-bit mode-mirror chmod branches (#217), mktemp
+        # portability, and the git-index mode staging that keeps
+        # propagation core.filemode-robust (templated #475, canonical/kit
+        # #476). Ordered after install_yq_for_sync_manifest so the suite
+        # runs rather than self-skipping on a missing yq. Wired in #488.
+        run: ./scripts/ci/check_sync_to_downstream
+
       - name: check_template_substitution
         # Exercises tests/test_template_substitution.sh — verifies the
         # Layer 5 template-substitution lib's v1 syntax (variable

--- a/scripts/ci/check_sync_to_downstream
+++ b/scripts/ci/check_sync_to_downstream
@@ -9,8 +9,14 @@
 # branches (#217), mktemp portability, and the git-index mode staging
 # that keeps propagation core.filemode-robust (templated #475,
 # canonical/kit #476). Until this wrapper existed the suite was not run
-# in CI, so those assertions gated nothing on PRs. Mirrors the pattern
-# used by check_sync_overrides and the other check_* scripts here.
+# in CI, so those assertions gated nothing on PRs.
+#
+# Consumer-safe like check_workflow_verify_propagation_templated (#467):
+# the scripts/ci/ kit propagates this wrapper to every consumer, but the
+# suite AND the scripts/sync-to-downstream.sh propagation engine it
+# exercises are mergepath-only (neither is in the manifest's consumer
+# set), so the wrapper SKIPs when the manifest is absent rather than
+# red-ing a consumer's repo-lint (Codex P1 on #493).
 #
 # Requires mikefarah/yq (the test SKIPs without it); repo_lint.yml runs
 # this step AFTER install_yq_for_sync_manifest so the suite actually
@@ -22,10 +28,19 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEST_SCRIPT="$REPO_ROOT/tests/test_sync_to_downstream.sh"
 
 if [ ! -f "$TEST_SCRIPT" ]; then
-  # Missing test script is a hard error, not a skip — a silent skip
-  # would let an accidental delete/rename disable this check without
-  # surfacing in CI (same rationale as check_sync_overrides, CodeRabbit
-  # Major on PR #228).
+  # Distinguish a canonical mergepath checkout from a consumer one by the
+  # manifest (mirrors check_workflow_verify_propagation_templated):
+  #   - .mergepath-sync.yml present → mergepath; the test MUST exist, so a
+  #     missing test is an accidental delete/rename → hard error (surfaces
+  #     in CI rather than silently disabling the check).
+  #   - .mergepath-sync.yml absent  → consumer checkout that received this
+  #     wrapper via the scripts/ci/ kit but not the mergepath-only test or
+  #     engine → SKIP (a hard error would red every consumer's repo-lint
+  #     for files they never receive). Codex P1 on #493.
+  if [ ! -f "$REPO_ROOT/.mergepath-sync.yml" ]; then
+    echo "check_sync_to_downstream: SKIP (consumer checkout: tests/test_sync_to_downstream.sh + .mergepath-sync.yml both absent)"
+    exit 0
+  fi
   echo "check_sync_to_downstream: ERROR (missing $TEST_SCRIPT)" >&2
   exit 1
 fi

--- a/scripts/ci/check_sync_to_downstream
+++ b/scripts/ci/check_sync_to_downstream
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# scripts/ci/check_sync_to_downstream — CI entry point for the
+# sync-to-downstream propagation engine test suite (#488).
+#
+# Wraps tests/test_sync_to_downstream.sh so it runs as an explicit
+# repo_lint.yml step (and is enforced wired by check_ci_scripts_wired,
+# #269). The suite carries the structural regression guards for
+# scripts/sync-to-downstream.sh — the executable-bit mode-mirror chmod
+# branches (#217), mktemp portability, and the git-index mode staging
+# that keeps propagation core.filemode-robust (templated #475,
+# canonical/kit #476). Until this wrapper existed the suite was not run
+# in CI, so those assertions gated nothing on PRs. Mirrors the pattern
+# used by check_sync_overrides and the other check_* scripts here.
+#
+# Requires mikefarah/yq (the test SKIPs without it); repo_lint.yml runs
+# this step AFTER install_yq_for_sync_manifest so the suite actually
+# executes rather than self-skipping.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_sync_to_downstream.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  # Missing test script is a hard error, not a skip — a silent skip
+  # would let an accidental delete/rename disable this check without
+  # surfacing in CI (same rationale as check_sync_overrides, CodeRabbit
+  # Major on PR #228).
+  echo "check_sync_to_downstream: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/tests/test_sync_to_downstream.sh
+++ b/tests/test_sync_to_downstream.sh
@@ -1280,11 +1280,21 @@ echo "$sa_out" | grep -qE "branch mergepath-sync/${sa_short} " \
 # ---------------------------------------------------------------------------
 # --version / --help smoke
 # ---------------------------------------------------------------------------
-"$SCRIPT" --version | grep -q "sync-to-downstream.sh" || fail "--version output unexpected"
-"$SCRIPT" --help    | grep -q "Usage:"                || fail "--help output unexpected"
-"$SCRIPT" --help    | grep -q "no-pr"                 || fail "--help missing --no-pr documentation"
-"$SCRIPT" --help    | grep -q "recreate-existing"     || fail "--help missing --recreate-existing documentation"
-"$SCRIPT" --help    | grep -q "verbose"               || fail "--help missing --verbose documentation"
-"$SCRIPT" --help    | grep -q "sync-all"              || fail "--help missing --sync-all documentation"
+# Capture once, then match via here-strings. The direct form
+# `"$SCRIPT" --help | grep -q PATTERN` is fragile under `set -o pipefail`
+# (line 13): grep -q closes the pipe on its first match, the script — still
+# writing its long --help — takes SIGPIPE (exit 141), and pipefail propagates
+# that 141 as the pipeline status, so `|| fail` fires even though PATTERN was
+# present. macOS buffered the whole help before grep closed so it passed
+# there; Linux CI did not (#488). A here-string has no producer process to
+# SIGPIPE, so the match is reliable (and --help/--version run once, not 6x).
+version_out=$("$SCRIPT" --version)
+grep -q "sync-to-downstream.sh" <<<"$version_out" || fail "--version output unexpected"
+help_out=$("$SCRIPT" --help)
+grep -q "Usage:"            <<<"$help_out" || fail "--help output unexpected"
+grep -q "no-pr"             <<<"$help_out" || fail "--help missing --no-pr documentation"
+grep -q "recreate-existing" <<<"$help_out" || fail "--help missing --recreate-existing documentation"
+grep -q "verbose"           <<<"$help_out" || fail "--help missing --verbose documentation"
+grep -q "sync-all"          <<<"$help_out" || fail "--help missing --sync-all documentation"
 
 echo "test_sync_to_downstream: PASS"


### PR DESCRIPTION
Resolves #488.

tests/test_sync_to_downstream.sh carries the structural regression guards for scripts/sync-to-downstream.sh (the mode-mirror chmod branches from #217, mktemp portability, and the git-index mode staging that keeps propagation core.filemode-robust: templated #475, canonical/kit #476). But no scripts/ci/check_* invoked it, so repo_lint.yml never ran it and check_ci_scripts_wired (which only governs check_* scripts) did not flag the gap. Those assertions gated nothing on PRs.

This adds scripts/ci/check_sync_to_downstream (a thin wrapper mirroring check_sync_overrides, hard-erroring on a missing test rather than skipping) and wires it into repo_lint.yml as an explicit step ordered after install_yq_for_sync_manifest so the mikefarah-yq-dependent suite runs rather than self-skipping.

Authoring-Agent: claude

## Self-Review

- check_ci_scripts_wired PASS (45 check_* scripts, all wired or exempt) so the meta-guard now enforces the new wrapper stays wired.
- The wrapper runs the suite locally to test_sync_to_downstream: PASS; it is committed mode 100755; repo_lint.yml parses via mikefarah yq.
- Scanned the suite for BSD/macOS-isms (sed -i, stat -f, mktemp -t, BSD date) and found none; it builds hermetic temp git repos with commit.gpgsign=false. This PR run is its first execution on Linux CI, the definitive portability check.
- Touches .github/ workflows, so it correctly trips the protected-path external-review gate for Phase 4b.