### PR TITLE
fix(sync): declare test_codex_review_request_trigger_only in manifest

### DIFF
--- a/.mergepath-sync.yml
+++ b/.mergepath-sync.yml
@@ -498,6 +498,14 @@ paths:
   - path: tests/test_codex_review_request_ack.sh
     type: canonical
     consumers: all
+  # #489 CodeRabbit-rate-limit Codex-failover trigger-only path of
+  # codex-review-request.sh (posts `@codex review` when CodeRabbit is rate-
+  # limited). check_codex_scripts hard-runs it (same `No such file` exit-127
+  # closure class as the ack suite above), so it must travel to every consumer.
+  # Undeclared by #489; surfaced by the swipewatch canary on the 2120dec wave.
+  - path: tests/test_codex_review_request_trigger_only.sh
+    type: canonical
+    consumers: all
   # Phase 4a entry-decision regression (#486): codex.request_by_default +
   # codex.enabled gating of whether `@codex review` is posted at all.
   # check_codex_scripts hard-runs it (same `No such file` exit-127 coupling
@@ -755,6 +763,8 @@ paths:
       - "tests/test_export_consumer_facts.sh"  # check_export_consumer_facts
       - "tests/test_check_coderabbit_config.sh"  # check_coderabbit_config_tests (#481/#482)
       - "tests/test_codex_review_request_ack.sh"  # check_codex_scripts
+      - "tests/test_codex_review_request_trigger_only.sh"  # check_codex_scripts (#489)
+      - "tests/test_codex_review_request_entry.sh"  # check_codex_scripts (#486)
       - "tests/test_codex_review_check_resolution.sh"  # check_codex_scripts (#460 Option B)
       - "tests/test_465_fail_closed.sh"        # check_codex_scripts (#465)
       - "tests/test_codex_record_feedback.sh"  # check_codex_scripts (#487)


### PR DESCRIPTION
## Summary

Fixes a propagation closure gap surfaced by the **swipewatch canary** on the `2120dec` `--sync-all` wave (canary PR nathanjohnpayne/swipewatch#72): every consumer's `lint` job failed because `scripts/ci/check_codex_scripts` died with exit 127 / `No such file`.

## Root cause

`scripts/ci/check_codex_scripts` hard-runs six test files. Five are declared in `.mergepath-sync.yml`; the sixth — `tests/test_codex_review_request_trigger_only.sh`, added by #489 (the CodeRabbit-rate-limit Codex failover) — was never declared, so it never propagated. The check then fails pre-flight on every consumer.

The `scripts/ci/` `requires:` closure that exists to prevent exactly this (#264) is hand-maintained, and `check_sync_manifest` only validates that *listed* entries have covering paths — it cannot detect a *missing* entry. mergepath's own CI stayed green because the test exists locally.

## Fix

- Declare `tests/test_codex_review_request_trigger_only.sh` as a canonical path (`consumers: all`).
- Add it to the `scripts/ci/` `requires:` closure.
- Also add `tests/test_codex_review_request_entry.sh` (#486) to the `requires:` closure — the same latent gap, not yet failing only because it already propagates via its own path entry.

All six `check_codex_scripts` test deps now carry both a `- path:` entry and a `requires:` entry.

## Verification

- `scripts/ci/check_sync_manifest` → PASS (27 tests, 8 consumers, 71 path entries).
- `scripts/ci/check_codex_scripts` passes locally (test present in mergepath).
- Next: re-run the swipewatch canary on this HEAD; green → resume the riskiest→least fan-out.

## Self-Review

- **Correctness:** All six tests referenced by `scripts/ci/check_codex_scripts` (ack, trigger_only, entry, resolution, 465, record_feedback) now resolve on every consumer; `test_codex_review_request_trigger_only.sh` exists in mergepath HEAD and is now declared. `check_sync_manifest` passes (27 tests, 71 path entries).
- **Regression risk:** Minimal — additive, declarative manifest entries only (one new canonical path + two `requires:` lines). No script/workflow logic touched. Worst case is one extra test file in each consumer's sync payload, which is the intended outcome.
- **Style/conventions:** Mirrors the neighbouring `- path:` / `type: canonical` / `consumers: all` pattern and the `# <check_name> (#NNN)` comment style of existing `requires:` entries.
- **Test coverage:** Declarative change, no new code paths. The propagated test itself is the coverage (now reaching all consumers); `check_sync_manifest`'s 27-case suite exercises the `requires:`-closure invariant.
- **Security/dependency hygiene:** No new dependencies, secrets, tokens, or network surface. Manifest-only.

## Follow-up

The systemic gap — `requires:`-closure completeness is verified by hand, not by diffing each `scripts/ci/check_*`'s referenced test/fixture set against the manifest — will be filed as a separate `post-review`/`observation` issue, so a future undeclared test ref fails mergepath CI instead of a downstream consumer canary.
