### PR TITLE
[codex] Grant Firebase deployer secret metadata access

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -641,6 +641,7 @@ FIREBASE_IMPERSONATION_MEMBER=email@example.com op-firebase-setup {project-id}
 3. Grants the deployer service account these project roles:
    - `roles/firebase.admin`
    - `roles/cloudfunctions.admin`
+   - `roles/secretmanager.viewer`
    - `roles/iam.serviceAccountUser`
    - `roles/artifactregistry.writer`
    - `roles/run.admin`

--- a/scripts/firebase/op-firebase-setup
+++ b/scripts/firebase/op-firebase-setup
@@ -29,6 +29,7 @@ MEMBER_EMAIL="${FIREBASE_IMPERSONATION_MEMBER:-}"
 ROLES=(
   roles/firebase.admin
   roles/cloudfunctions.admin
+  roles/secretmanager.viewer
   roles/iam.serviceAccountUser
   roles/artifactregistry.writer
   roles/run.admin

--- a/tests/test_bootstrap_firebase_and_codereview.sh
+++ b/tests/test_bootstrap_firebase_and_codereview.sh
@@ -28,6 +28,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$ROOT/scripts/bootstrap-new-repo.sh"
+FIREBASE_SETUP_SCRIPT="$ROOT/scripts/firebase/op-firebase-setup"
 
 if ! command -v rsync >/dev/null 2>&1; then
   echo "SKIP: rsync not installed" >&2; exit 0
@@ -40,6 +41,7 @@ if ! yq --version 2>&1 | grep -q "mikefarah/yq"; then
 fi
 
 [ -x "$SCRIPT" ] || { echo "missing or non-executable $SCRIPT" >&2; exit 1; }
+[ -x "$FIREBASE_SETUP_SCRIPT" ] || { echo "missing or non-executable $FIREBASE_SETUP_SCRIPT" >&2; exit 1; }
 
 WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/test-firebase-codereview.XXXXXX")
 trap 'rm -rf "$WORKDIR"' EXIT
@@ -47,6 +49,12 @@ trap 'rm -rf "$WORKDIR"' EXIT
 PASS=0; FAIL=0
 pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Static setup contract: Firebase Functions v2 deploy analysis needs
+# secretmanager.secrets.get for defineSecret() declarations.
+grep -q 'roles/secretmanager.viewer' "$FIREBASE_SETUP_SCRIPT" \
+  && pass "op-firebase-setup grants Secret Manager metadata reads for functions secrets" \
+  || fail "op-firebase-setup must grant roles/secretmanager.viewer for Firebase Functions defineSecret deploys"
 
 # --- build fixture mergepath ----------------------------------------------
 # Sub-B (template-mirror) rsyncs from a fixture mergepath into the

--- a/tests/test_bootstrap_firebase_and_codereview.sh
+++ b/tests/test_bootstrap_firebase_and_codereview.sh
@@ -52,7 +52,7 @@ fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
 
 # Static setup contract: Firebase Functions v2 deploy analysis needs
 # secretmanager.secrets.get for defineSecret() declarations.
-grep -q 'roles/secretmanager.viewer' "$FIREBASE_SETUP_SCRIPT" \
+grep -Fq 'roles/secretmanager.viewer' "$FIREBASE_SETUP_SCRIPT" \
   && pass "op-firebase-setup grants Secret Manager metadata reads for functions secrets" \
   || fail "op-firebase-setup must grant roles/secretmanager.viewer for Firebase Functions defineSecret deploys"
 


### PR DESCRIPTION
## Summary
- Add `roles/secretmanager.viewer` to the canonical `op-firebase-setup` deployer role set.
- Document the role in the Firebase deployment setup contract.
- Pin the role with the existing wired Firebase bootstrap regression test.

## Root Cause
Firebase Functions v2 deploy analysis reads Secret Manager metadata for functions using `defineSecret()`. Repos with Functions secrets can fail at deploy time with `secretmanager.secrets.get` denied when the Firebase deployer service account lacks `roles/secretmanager.viewer`.

## Validation
- `bash tests/test_bootstrap_firebase_and_codereview.sh`

## Self-Review

- Correctness: The setup helper now grants the Secret Manager metadata role required by Firebase Functions v2 secret analysis, matching the reproduced deploy failure.
- Regression risk: Low; the change only adds one IAM role to the deployer role list and updates matching documentation.
- Style/conventions: Follows the existing role-list pattern in `op-firebase-setup` and the existing bootstrap test style.
- Test coverage: `tests/test_bootstrap_firebase_and_codereview.sh` now pins the role using fixed-string matching.
- Security/dependency hygiene: The role is metadata read-only (`secretmanager.viewer`), not secret payload access, and no credentials are committed.
