### PR TITLE
fix(op-preflight): harden --mode deploy + export preflight mode (#534)

### DIFF
--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -156,12 +156,20 @@ ssh_host_for() {
 }
 
 # ── Cache layout ──────────────────────────────────────────────────────
-# Cache directory is intentionally shared across all consumer repos:
-#   - The session file is keyed by --agent (see SESSION_FILE below).
-#   - PATs are agent-keyed and currently uniform across the Phase 4
-#     propagation set, so a shared cache is functionally correct.
-# Re-evaluate if per-repo PATs ever diverge — at that point, namespace
-# the cache path per consumer repo (e.g. $HOME/.cache/mergepath/$REPO).
+# Cache directory is intentionally shared across all consumer repos and is
+# NOT namespaced per repo. The session file is keyed by --agent (see
+# SESSION_FILE below), and each agent's credentials are per-identity and
+# machine-wide: one reviewer PAT per agent, not per-repo (see CLAUDE.md /
+# REVIEW_POLICY.md PAT lookup table). So the same agent's cached token is
+# identical regardless of which repo invoked preflight — a shared,
+# agent-keyed cache is correct today and a per-repo cache would only
+# duplicate identical material.
+#
+# Per-repo namespacing (e.g. $HOME/.cache/mergepath/$REPO) is a DEFERRED
+# fleet-wide architecture decision (mergepath#532), to revisit only if any
+# consumer ever needs a repo-scoped PAT for the same agent. Until then, do
+# NOT namespace this path — it would fragment the cache and multiply the
+# biometric burst across repos for no security gain.
 DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/mergepath"
 CACHE_DIR="${OP_PREFLIGHT_CACHE_DIR:-$DEFAULT_CACHE_DIR}"
 DEFAULT_TTL_SECONDS=14400  # 4 hours
@@ -237,8 +245,16 @@ if $PURGE_ALL; then
   exit 0
 fi
 
-if [[ "$MODE" == "review" || "$MODE" == "all" || "$PURGE" == "true" || "$CHECK" == "true" ]] && [[ -z "$AGENT" ]]; then
-  echo "Error: --agent is required for review, all, --purge, or --check mode." >&2
+# --agent is required for every mode except --purge-all (handled above).
+# `deploy` MUST stay in this gate: cache paths are unconditionally
+# $AGENT-interpolated (op-preflight-$AGENT.env / -adc.json /
+# -firebase-sa.json), so `--mode deploy` with no --agent writes a shared
+# anonymous ("") bucket that `--purge --agent <name>` can never reclaim and
+# that concurrent agent sessions clobber. This was added in #259, silently
+# dropped by a bulk sync, and restored in #534 — the regression test
+# test_deploy_mode_requires_agent guards against another drop.
+if [[ "$MODE" == "review" || "$MODE" == "all" || "$MODE" == "deploy" || "$PURGE" == "true" || "$CHECK" == "true" ]] && [[ -z "$AGENT" ]]; then
+  echo "Error: --agent is required for review, deploy, all, --purge, or --check mode." >&2
   echo "Usage: eval \"\$(scripts/op-preflight.sh --agent claude --mode review)\"" >&2
   exit 1
 fi
@@ -787,6 +803,12 @@ emit_from_session_file() (
   fi
   printf 'export OP_PREFLIGHT_DONE=1\n'
   printf 'export OP_PREFLIGHT_AGENT=%q\n' "$AGENT"
+  # Keep exporting the preflight mode on the cache-hit path (#521): a
+  # consumer that evals this output (e.g. a deploy wrapper that took the
+  # fast path and skipped a fresh fetch) can read OP_PREFLIGHT_MODE to see
+  # which mode actually ran. $MODE is this invocation's mode, which the
+  # cross-mode validation above already proved the cache satisfies.
+  printf 'export OP_PREFLIGHT_MODE=%q\n' "$MODE"
   exit 0
 )
 
@@ -1143,7 +1165,13 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
     chmod 600 "$ADC_TMPFILE"
 
     log_deploy_biometric_once
-    if op read "$DEFAULT_ADC_OP_URI" > "$ADC_TMPFILE" 2>/dev/null && [[ -s "$ADC_TMPFILE" ]]; then
+    # Capture op's stderr so the could-not-read warning can say WHY (vault
+    # locked / item not found / sign-in expired) instead of a bare "not
+    # available" (#534.3). Routed through scrub_op_error so a service-account
+    # token can never leak into the diagnostic, mirroring the Phase 1 reader.
+    ADC_OP_ERR="$(mktemp "${TMPDIR:-/tmp}/op-preflight-adc-err.XXXXXX")"
+    if op read "$DEFAULT_ADC_OP_URI" > "$ADC_TMPFILE" 2>"$ADC_OP_ERR" && [[ -s "$ADC_TMPFILE" ]]; then
+      rm -f "$ADC_OP_ERR"
       if adc_is_usable "$ADC_TMPFILE"; then
         EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
         EXPORTS+=("export OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
@@ -1154,11 +1182,25 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
         rm -f "$ADC_TMPFILE"
         log_stale_adc_guidance
         SUMMARY+=("GCP ADC: STALE (refresh_token rejected — see warning above)")
+        # Fail closed (#534.2): under `--mode deploy` a deploy script needs a
+        # real credential. Degrading in place (continuing to OP_PREFLIGHT_DONE=1
+        # with no GOOGLE_APPLICATION_CREDENTIALS) is the cache-hit path's
+        # `exit 2` failure mode replayed on the full-fetch path — symmetric to
+        # the line-696 cache-hit guard. `--mode all` deliberately keeps
+        # degrading (callers still want the PATs), so scope this to deploy.
+        if [[ "$MODE" == "deploy" ]]; then exit 1; fi
       fi
     else
-      rm -f "$ADC_TMPFILE"
-      echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2
+      adc_op_reason="$(scrub_op_error "$ADC_OP_ERR")"
+      rm -f "$ADC_TMPFILE" "$ADC_OP_ERR"
+      if [[ -n "$adc_op_reason" ]]; then
+        echo "# Warning: could not read GCP ADC. Deploy credentials not cached. (op: ${adc_op_reason})" >&2
+      else
+        echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2
+      fi
       SUMMARY+=("GCP ADC: SKIPPED (not available)")
+      # Fail closed (#534.2): see STALE branch above.
+      if [[ "$MODE" == "deploy" ]]; then exit 1; fi
     fi
   fi
 
@@ -1206,6 +1248,10 @@ chmod 600 "$SESSION_FILE"
 # ── Output ────────────────────────────────────────────────────────────
 EXPORTS+=("export OP_PREFLIGHT_DONE=1")
 EXPORTS+=("export OP_PREFLIGHT_AGENT=$(printf '%q' "$AGENT")")
+# Export the mode on the full-fetch path too (#521), symmetric to the
+# cache-hit path above, so consumers can read which mode ran regardless of
+# whether the fetch was fresh or a cache hit.
+EXPORTS+=("export OP_PREFLIGHT_MODE=$(printf '%q' "$MODE")")
 
 # Print export statements to stdout (caller evals them)
 for exp in "${EXPORTS[@]}"; do

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -571,7 +571,7 @@ EOF
     PATH="$bin_dir:$STUB_DIR:$PATH" \
       OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
       GCP_ADC_OP_URI="$shared_adc_uri" \
-      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+      "$SCRIPT" --agent claude --mode deploy >"$case_dir/out" 2>"$case_dir/err"
   ) || rc=$?
   out="$(cat "$case_dir/out")"
   err="$(cat "$case_dir/err")"
@@ -626,17 +626,17 @@ JSON
 
   local epoch
   epoch=$(date +%s)
-  cat > "$cache_dir/op-preflight-.env" <<EOF
+  cat > "$cache_dir/op-preflight-claude.env" <<EOF
 OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
 OP_PREFLIGHT_TTL_SECONDS=14400
-OP_PREFLIGHT_AGENT=''
+OP_PREFLIGHT_AGENT=claude
 OP_PREFLIGHT_MODE=deploy
 OP_PREFLIGHT_DONE=1
 GOOGLE_APPLICATION_CREDENTIALS=$bad_sa_file
 OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$bad_sa_file
 OP_PREFLIGHT_FIREBASE_PROJECT=$project
 EOF
-  chmod 600 "$cache_dir/op-preflight-.env"
+  chmod 600 "$cache_dir/op-preflight-claude.env"
 
   cat > "$bin_dir/op" <<EOF
 #!/usr/bin/env bash
@@ -693,7 +693,7 @@ EOF
     PATH="$bin_dir:$STUB_DIR:$PATH" \
       OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
       GCP_ADC_OP_URI="$shared_adc_uri" \
-      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+      "$SCRIPT" --agent claude --mode deploy >"$case_dir/out" 2>"$case_dir/err"
   ) || rc=$?
   out="$(cat "$case_dir/out")"
   err="$(cat "$case_dir/err")"
@@ -755,17 +755,17 @@ JSON
 
   local epoch
   epoch=$(date +%s)
-  cat > "$cache_dir/op-preflight-.env" <<EOF
+  cat > "$cache_dir/op-preflight-claude.env" <<EOF
 OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
 OP_PREFLIGHT_TTL_SECONDS=14400
-OP_PREFLIGHT_AGENT=''
+OP_PREFLIGHT_AGENT=claude
 OP_PREFLIGHT_MODE=deploy
 OP_PREFLIGHT_DONE=1
 GOOGLE_APPLICATION_CREDENTIALS=$cached_sa_file
 OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$cached_sa_file
 OP_PREFLIGHT_FIREBASE_PROJECT=$cached_project
 EOF
-  chmod 600 "$cache_dir/op-preflight-.env"
+  chmod 600 "$cache_dir/op-preflight-claude.env"
 
   cat > "$bin_dir/op" <<EOF
 #!/usr/bin/env bash
@@ -822,7 +822,7 @@ EOF
     PATH="$bin_dir:$STUB_DIR:$PATH" \
       OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
       GCP_ADC_OP_URI="$shared_adc_uri" \
-      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+      "$SCRIPT" --agent claude --mode deploy >"$case_dir/out" 2>"$case_dir/err"
   ) || rc=$?
   out="$(cat "$case_dir/out")"
   err="$(cat "$case_dir/err")"
@@ -865,7 +865,7 @@ test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch() {
   local shared_adc_uri="op://Private/test-shared-adc-file-mismatch/credential"
   local op_log="$case_dir/op.log"
   mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
-  local cached_sa_file="$cache_dir/op-preflight--firebase-sa.json"
+  local cached_sa_file="$cache_dir/op-preflight-claude-firebase-sa.json"
 
   cat > "$case_dir/.firebaserc" <<JSON
 { "projects": { "default": "$current_project" } }
@@ -885,17 +885,17 @@ JSON
 
   local epoch
   epoch=$(date +%s)
-  cat > "$cache_dir/op-preflight-.env" <<EOF
+  cat > "$cache_dir/op-preflight-claude.env" <<EOF
 OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
 OP_PREFLIGHT_TTL_SECONDS=14400
-OP_PREFLIGHT_AGENT=''
+OP_PREFLIGHT_AGENT=claude
 OP_PREFLIGHT_MODE=deploy
 OP_PREFLIGHT_DONE=1
 GOOGLE_APPLICATION_CREDENTIALS=$cached_sa_file
 OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$cached_sa_file
 OP_PREFLIGHT_FIREBASE_PROJECT=$current_project
 EOF
-  chmod 600 "$cache_dir/op-preflight-.env"
+  chmod 600 "$cache_dir/op-preflight-claude.env"
 
   cat > "$bin_dir/op" <<EOF
 #!/usr/bin/env bash
@@ -956,7 +956,7 @@ EOF
     PATH="$bin_dir:$STUB_DIR:$PATH" \
       OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
       GCP_ADC_OP_URI="$shared_adc_uri" \
-      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+      "$SCRIPT" --agent claude --mode deploy >"$case_dir/out" 2>"$case_dir/err"
   ) || rc=$?
   out="$(cat "$case_dir/out")"
   err="$(cat "$case_dir/err")"
@@ -1053,6 +1053,177 @@ test_source_gcp_adc_stale_forces_refresh() {
   fi
 }
 
+# ---------------------------------------------------------------------------
+# test_deploy_mode_requires_agent (#534.1): `deploy` must stay in the
+# --agent-required gate. Cache paths are unconditionally $AGENT-interpolated,
+# so `--mode deploy` with no --agent writes a shared anonymous ("") bucket
+# that `--purge --agent <name>` can never reclaim and concurrent sessions
+# clobber. This was added in #259, dropped by a bulk sync, and restored in
+# #534. Behavioral + structural guards so another drop fails CI.
+# ---------------------------------------------------------------------------
+test_deploy_mode_requires_agent() {
+  # Behavioral: --mode deploy with no --agent must fail before doing any work.
+  local rc=0
+  PATH="$STUB_DIR:$PATH" OP_PREFLIGHT_CACHE_DIR="$WORKDIR/deploy-no-agent" \
+    "$SCRIPT" --mode deploy >"$WORKDIR/deploy-no-agent.out" 2>"$WORKDIR/deploy-no-agent.err" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    fail "test_deploy_mode_requires_agent: --mode deploy without --agent unexpectedly succeeded"
+    return
+  fi
+  if ! grep -q "agent is required" "$WORKDIR/deploy-no-agent.err"; then
+    fail "test_deploy_mode_requires_agent: missing 'agent is required' diagnostic; stderr=$(cat "$WORKDIR/deploy-no-agent.err")"
+    return
+  fi
+  # The error message itself must enumerate deploy, and no anonymous cache
+  # file may have been written.
+  if ! grep -qi "deploy" "$WORKDIR/deploy-no-agent.err"; then
+    fail "test_deploy_mode_requires_agent: agent-required error does not mention deploy mode"
+    return
+  fi
+  if [ -e "$WORKDIR/deploy-no-agent/op-preflight-.env" ]; then
+    fail "test_deploy_mode_requires_agent: anonymous (empty-agent) cache file was written"
+    return
+  fi
+  # Structural: the gate line that requires --agent (the one testing
+  # `-z "$AGENT"`) must also include the `deploy` mode token. Guards against
+  # a bulk-sync re-dropping deploy even if a future refactor changes the
+  # error string. The gate is the only line carrying both tokens.
+  if ! awk '
+    /-z "\$AGENT" \]\]/ && /"\$MODE" == "deploy"/ { ok = 1 }
+    END { exit (ok ? 0 : 1) }
+  ' "$SCRIPT"; then
+    fail "test_deploy_mode_requires_agent: 'deploy' missing from the --agent-required gate (#534.1 regression)"
+    return
+  fi
+  pass "test_deploy_mode_requires_agent: --mode deploy requires --agent (gate retains deploy)"
+}
+
+# ---------------------------------------------------------------------------
+# test_deploy_full_fetch_fails_closed_on_unreadable_adc (#534.2 / #534.3):
+# on the full-fetch path, when the GCP ADC read fails (op error) under
+# `--mode deploy`, preflight must fail closed (exit non-zero) rather than
+# emitting OP_PREFLIGHT_DONE=1 with no GOOGLE_APPLICATION_CREDENTIALS — the
+# cache-hit path already exit 2's for this. The could-not-read warning must
+# also surface op's stderr reason (#534.3).
+# ---------------------------------------------------------------------------
+test_deploy_full_fetch_fails_closed_on_unreadable_adc() {
+  local case_dir="$WORKDIR/deploy-fail-closed"
+  local cache_dir="$case_dir/cache"
+  local bin_dir="$case_dir/bin"
+  local shared_adc_uri="op://Private/test-unreadable-adc/credential"
+  mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
+  # No .firebaserc → falls through to the GCP ADC branch (not Firebase SA).
+
+  # op stub: every `op read` fails with a recognizable stderr reason; op
+  # inject (Phase 1) is not reached in --mode deploy.
+  cat > "$bin_dir/op" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  read)
+    echo "[ERROR] could not read secret: vault is locked" >&2
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/op"
+
+  local out err rc=0
+  (
+    cd "$case_dir"
+    PATH="$bin_dir:$STUB_DIR:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      GCP_ADC_OP_URI="$shared_adc_uri" \
+      "$SCRIPT" --agent claude --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+  ) || rc=$?
+  out="$(cat "$case_dir/out")"
+  err="$(cat "$case_dir/err")"
+
+  if [ "$rc" -eq 0 ]; then
+    fail "test_deploy_full_fetch_fails_closed_on_unreadable_adc: --mode deploy with unreadable ADC unexpectedly succeeded (rc=0); out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "export GOOGLE_APPLICATION_CREDENTIALS"; then
+    fail "test_deploy_full_fetch_fails_closed_on_unreadable_adc: exported GOOGLE_APPLICATION_CREDENTIALS despite unreadable ADC; out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "export OP_PREFLIGHT_DONE=1"; then
+    fail "test_deploy_full_fetch_fails_closed_on_unreadable_adc: emitted OP_PREFLIGHT_DONE=1 on a failed deploy; out=$out"
+    return
+  fi
+  # #534.3: the warning must include op's stderr reason.
+  if ! echo "$err" | grep -q "could not read GCP ADC"; then
+    fail "test_deploy_full_fetch_fails_closed_on_unreadable_adc: missing could-not-read warning; stderr=$err"
+    return
+  fi
+  if ! echo "$err" | grep -q "vault is locked"; then
+    fail "test_deploy_full_fetch_fails_closed_on_unreadable_adc: warning did not surface op stderr reason (#534.3); stderr=$err"
+    return
+  fi
+  pass "test_deploy_full_fetch_fails_closed_on_unreadable_adc: deploy fails closed on unreadable ADC and surfaces op stderr"
+}
+
+# ---------------------------------------------------------------------------
+# test_deploy_full_fetch_fail_closed_structural (#534.2): structural guard
+# that BOTH the STALE branch and the could-not-read branch of the full-fetch
+# ADC path carry a deploy-scoped `exit 1`, symmetric to
+# test_source_gcp_adc_stale_forces_refresh's exit-2 guard. A behavioral test
+# covers the could-not-read branch; the STALE branch needs a usable-then-
+# rejected ADC + python3 oauth round-trip that is impractical to fixture
+# hermetically, so assert its fail-closed structurally.
+# ---------------------------------------------------------------------------
+test_deploy_full_fetch_fail_closed_structural() {
+  # STALE branch: a 'GCP ADC: STALE' SUMMARY line must be followed by a
+  # deploy-scoped `exit 1` before the branch's closing `fi`.
+  if ! awk '
+    /GCP ADC: STALE/ { found = 1; next }
+    found && /MODE" == "deploy".*exit 1/ { ok = 1 }
+    found && /^[[:space:]]*fi[[:space:]]*$/ { exit (ok ? 0 : 1) }
+    END { exit (ok ? 0 : 1) }
+  ' "$SCRIPT"; then
+    fail "test_deploy_full_fetch_fail_closed_structural: STALE ADC branch missing deploy-scoped exit 1 (#534.2)"
+    return
+  fi
+  # Could-not-read branch: a 'GCP ADC: SKIPPED' SUMMARY line must be followed
+  # by a deploy-scoped `exit 1` before the branch's closing `fi`.
+  if ! awk '
+    /GCP ADC: SKIPPED/ { found = 1; next }
+    found && /MODE" == "deploy".*exit 1/ { ok = 1 }
+    found && /^[[:space:]]*fi[[:space:]]*$/ { exit (ok ? 0 : 1) }
+    END { exit (ok ? 0 : 1) }
+  ' "$SCRIPT"; then
+    fail "test_deploy_full_fetch_fail_closed_structural: could-not-read ADC branch missing deploy-scoped exit 1 (#534.2)"
+    return
+  fi
+  pass "test_deploy_full_fetch_fail_closed_structural: both full-fetch ADC failure branches fail closed under deploy"
+}
+
+# ---------------------------------------------------------------------------
+# test_preflight_mode_is_exported (#521): the preflight mode must be exported
+# on BOTH the cache-hit path and the full-fetch path so a consumer that evals
+# the output (e.g. a deploy wrapper that took the fast path / skipped deploy)
+# can read which mode ran.
+# ---------------------------------------------------------------------------
+test_preflight_mode_is_exported() {
+  # Cache-hit path: a fresh review cache must emit `export OP_PREFLIGHT_MODE`.
+  local case_dir="$WORKDIR/mode-export-cachehit"
+  make_fresh_cache "$case_dir" claude "rev-pat-m" "author-pat-m"
+  local out rc=0
+  out=$(PATH="$STUB_DIR:$PATH" OP_PREFLIGHT_CACHE_DIR="$case_dir" \
+    "$SCRIPT" --agent claude --check 2>/dev/null) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "test_preflight_mode_is_exported: cache-hit --check rc=$rc"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_MODE=review"; then
+    fail "test_preflight_mode_is_exported: cache-hit path did not export OP_PREFLIGHT_MODE; out=$out"
+    return
+  fi
+  pass "test_preflight_mode_is_exported: OP_PREFLIGHT_MODE exported on cache-hit path (#521)"
+}
+
 test_check_fresh_cache
 test_check_missing_cache
 test_check_stale_cache
@@ -1069,6 +1240,10 @@ test_deploy_mode_refreshes_mismatched_cached_firebase_sa
 test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch
 test_check_review_mode_omits_deploy_creds
 test_source_gcp_adc_stale_forces_refresh
+test_deploy_mode_requires_agent
+test_deploy_full_fetch_fails_closed_on_unreadable_adc
+test_deploy_full_fetch_fail_closed_structural
+test_preflight_mode_is_exported
 
 echo
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
Authoring-Agent: claude

Closes #534. Refs #532 (defer+document) and #521 (export-mode item). Under-threshold (271 lines), no protected paths.

## Summary

Hardens `scripts/op-preflight.sh --mode deploy`. mergepath-propagated; fixes land here and re-propagate.

- #534.1: add `deploy` to the --agent-required gate. --mode deploy with no --agent wrote the shared anonymous cache bucket (op-preflight-.env / -adc.json / -firebase-sa.json) that --purge --agent can never clean and concurrent sessions clobber. Added once in #259, dropped by a later bulk-sync; a structural regression test now guards it.
- #534.2: --mode deploy now fails CLOSED when ADC is unavailable (both the STALE and could-not-read-GCP-ADC branches of the full-fetch path exit 1), symmetric to the cache-hit path. Was failing open (DONE=1 with no GOOGLE_APPLICATION_CREDENTIALS so the caller eval proceeded).
- #534.3: capture op read stderr on ADC failure via scrub_op_error (token-leak-safe) and surface the reason in the warning.
- #534 minor (ssh-add -l): SKIPPED with rationale — the existing grep gates nothing (cosmetic SUMMARY label) and ssh-add -l against the 1Password SSH agent risks a false-negative on this machine.
- #532 (DEFER+DOCUMENT, ruled): documented why the shared agent-keyed cache is safe today (per-identity machine-wide PATs); per-repo namespacing stays a deferred fleet-wide decision. No code change.
- #521 export-mode: export OP_PREFLIGHT_MODE on both the cache-hit and full-fetch paths so a consumer eval (incl. a deploy-skip cache hit) can read which mode ran.

## Testing
- [x] check_op_preflight_contract PASS (test_op_preflight_check 20, test_op_preflight_token_mode 8, test_helper_autosource 7, test_preflight_agent_name 7)
- [x] bash -n clean; manifest intact (op-preflight.sh + both test files already declared and in the requires: closure)

## Self-Review
- [x] Correctness: each item maps to its #534 finding; fail-closed is scoped to deploy (all still degrades to keep PATs)
- [x] Regression risk: 4 existing deploy fixtures that called --mode deploy without --agent were updated to --agent claude; structural awk guards lock the gate + fail-closed branches against silent re-removal
- [x] Style and conventions: bash 3.2 portable, matches surrounding style
- [x] Test coverage: behavioral + structural regression tests for #534.1 and #534.2; export-mode test for #521
- [x] Security and dependency hygiene: token-leak-safe stderr capture, no new deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)