### PR TITLE
fix(coderabbit-wait): tighten findings-gate precision + pin reviewer PAT (#535)

### DIFF
--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -227,7 +227,7 @@ fi
 
 if [ -z "${GH_TOKEN:-}" ]; then
   echo "ERROR: GH_TOKEN is required. Either:" >&2
-  echo "  - Run: eval \"\$(scripts/op-preflight.sh --agent <agent> --mode review)\"" >&2
+  echo "  - Run: eval \"\$(scripts/op-preflight.sh --agent <agent> --mode all)\"" >&2
   echo "    so this helper auto-sources OP_PREFLIGHT_REVIEWER_PAT, OR" >&2
   echo "  - Set GH_TOKEN to the expected reviewer PAT." >&2
   exit 3
@@ -253,7 +253,10 @@ fi
 
 gh_reviewer() (
   unset GITHUB_TOKEN
-  gh "$@"
+  # Pin reviewer writes to the reviewer PAT rather than inheriting ambient
+  # creds (#533): prefer the preflight-cached reviewer PAT, falling back to
+  # GH_TOKEN. Mirrors scripts/resolve-pr-threads.sh's PAT_GH_TOKEN pattern.
+  GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}" gh "$@"
 )
 
 # --- config readers ---------------------------------------------------------
@@ -770,10 +773,17 @@ scan_latest_comment_best_effort() {
 count_potential_issues() {
   local reviews pulls_comments latest_review_id
   reviews=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/reviews" "reviews")
-  latest_review_id=$(echo "$reviews" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
+  # Pin the latest-review selection to the current HEAD commit
+  # (`commit_id == HEAD_SHA`), not just freshness (`submitted_at >=
+  # HEAD_ANCHOR`). A review submitted after the anchor but referencing an
+  # intermediate commit (e.g. a rapid push sequence where CodeRabbit
+  # reviewed an earlier SHA) must not be chosen as the HEAD review. Mirror
+  # the HEAD-pinning in scripts/codex-review-check.sh (commit_id == $sha).
+  latest_review_id=$(echo "$reviews" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" --arg head_sha "$HEAD_SHA" '
     [ .[]
       | select(.user.login == $bot)
       | select(.submitted_at >= $after)
+      | select(.commit_id == $head_sha)
     ]
     | sort_by(.submitted_at) | last
     | if . == null then null else .id end
@@ -802,6 +812,32 @@ count_potential_issues() {
       | select(.id as $id | ($addressed_root_ids | index($id)) == null)
     ] | length
   '
+}
+
+# Returns 0 (true) if the latest PR-level CodeRabbit SUMMARY comment body
+# carries a `Potential issue` / ⚠️ marker, else 1.
+#
+# count_potential_issues() scans only INLINE `pulls/{pr}/comments`. When
+# CodeRabbit surfaces a finding solely in its PR-level summary body
+# (issues/{pr}/comments) while the inline count is zero, the findings gate
+# would otherwise wrongly clear. This OR-side check closes that gap (#535).
+# Mirrors latest_comment_from_issue_comments: filter to the bot login,
+# newest comment on/after the HEAD anchor (max of created_at/updated_at,
+# since CodeRabbit edits the summary in place).
+summary_body_has_potential_issue_marker() {
+  local issue_comments latest_body
+  issue_comments=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/comments" "issue comments")
+  latest_body=$(echo "$issue_comments" | jq -r --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
+    [ .[]
+      | select(.user.login == $bot)
+      | . + {fresh_at: ([.created_at, (.updated_at // .created_at)] | max)}
+      | select(.fresh_at >= $after)
+    ]
+    | sort_by(.fresh_at)
+    | last
+    | (.body // "")
+  ')
+  printf '%s' "$latest_body" | grep -qiE 'Potential issue|⚠️'
 }
 
 # SHA-scoped variant of count_potential_issues, used by the StatusContext
@@ -1043,8 +1079,14 @@ emit_terminal_review_after_probe_if_present() {
     review)
       potential_issues=$(count_potential_issues)
       review_json=$(echo "$latest" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
+      # #535: also honor a PR-level summary-body marker (the inline count
+      # scans only pulls/{pr}/comments) so the probe-wait clearance path
+      # cannot false-clear over a summary-only finding either.
       if [ "$potential_issues" -gt 0 ]; then
         log "CodeRabbit review landed during status-probe wait with $potential_issues Potential issue/⚠️ marker(s) — emitting findings (exit 2)"
+        emit_json_and_exit "findings" 2 "$review_json" "$potential_issues"
+      elif summary_body_has_potential_issue_marker; then
+        log "CodeRabbit review landed during status-probe wait with 0 inline markers but a Potential issue/⚠️ marker in the PR-level summary body — emitting findings (exit 2)"
         emit_json_and_exit "findings" 2 "$review_json" "$potential_issues"
       fi
       log "CodeRabbit review landed during status-probe wait with no high-severity markers — emitting cleared (exit 0)"
@@ -1588,8 +1630,14 @@ while :; do
     review)
       POTENTIAL_ISSUES=$(count_potential_issues)
       REVIEW_JSON=$(echo "$LATEST" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
+      # #535: the inline count scans only pulls/{pr}/comments. Also honor a
+      # PR-level summary-body marker so a finding surfaced solely in the
+      # summary body still yields findings instead of false-clearing.
       if [ "$POTENTIAL_ISSUES" -gt 0 ]; then
         log "CodeRabbit review posted with $POTENTIAL_ISSUES Potential issue/⚠️ markers"
+        emit_json_and_exit "findings" 2 "$REVIEW_JSON" "$POTENTIAL_ISSUES"
+      elif summary_body_has_potential_issue_marker; then
+        log "CodeRabbit review posted with 0 inline markers but a Potential issue/⚠️ marker in the PR-level summary body — findings"
         emit_json_and_exit "findings" 2 "$REVIEW_JSON" "$POTENTIAL_ISSUES"
       else
         log "CodeRabbit review posted with no high-severity markers — cleared"

--- a/tests/test_coderabbit_wait_status_probe.sh
+++ b/tests/test_coderabbit_wait_status_probe.sh
@@ -182,10 +182,22 @@ case "$endpoint" in
           count=$(cat "$state_dir/probe-count")
         fi
         if [ "$count" -gt 0 ] && [ "$(fake_now)" -ge 2000000006 ]; then
-          printf '[{"id":9901,"user":{"login":"%s"},"submitted_at":"%s"}]\n' "$bot" "$reply_time"
+          printf '[{"id":9901,"user":{"login":"%s"},"submitted_at":"%s","commit_id":"head-sha"}]\n' "$bot" "$reply_time"
         else
           printf '[]\n'
         fi
+        ;;
+      summary_marker_only)
+        # #535.1: one CodeRabbit review on HEAD, no inline findings, but the
+        # PR-level summary body carries a Potential issue marker.
+        printf '[{"id":9921,"user":{"login":"%s"},"submitted_at":"%s","commit_id":"head-sha"}]\n' "$bot" "$head_time"
+        ;;
+      intermediate_review_head_pin)
+        # #535.2: a NEWER review (later submitted_at) references an
+        # intermediate commit, while the HEAD review is older. The
+        # HEAD-pinned selection must pick the HEAD review (9931), not the
+        # newer intermediate one (9932).
+        printf '[{"id":9931,"user":{"login":"%s"},"submitted_at":"%s","commit_id":"head-sha"},{"id":9932,"user":{"login":"%s"},"submitted_at":"%s","commit_id":"intermediate-sha"}]\n' "$bot" "$head_time" "$bot" "$reply_time"
         ;;
       *)
         printf '[]\n'
@@ -204,6 +216,17 @@ case "$endpoint" in
         else
           printf '[]\n'
         fi
+        ;;
+      summary_marker_only)
+        # #535.1: no inline findings at all — the marker lives only in the
+        # PR-level summary body (issues endpoint below).
+        printf '[]\n'
+        ;;
+      intermediate_review_head_pin)
+        # #535.2: the ⚠️ inline finding is tied to the HEAD review (9931).
+        # The newer intermediate review (9932) has no inline findings, so
+        # selecting it (the pre-fix freshness-only behavior) would clear.
+        printf '[{"id":9933,"user":{"login":"%s"},"created_at":"%s","updated_at":"%s","commit_id":"head-sha","pull_request_review_id":9931,"in_reply_to_id":null,"body":"_⚠️ Potential issue_ | _🟠 Major_\\n\\nFinding on the HEAD review."}]\n' "$bot" "$head_time" "$head_time"
         ;;
       *)
         printf '[]\n'
@@ -239,6 +262,19 @@ case "$endpoint" in
         else
           printf '[]\n'
         fi
+        ;;
+      summary_marker_only)
+        # #535.1: latest PR-level summary classifies as a review (not a
+        # rate-limit/paused/in-progress/status-probe narration) and carries a
+        # Potential issue marker in its body. The inline count is 0, so the
+        # gate must rely on this summary-body marker to emit findings.
+        printf '[{"id":8821,"user":{"login":"%s"},"created_at":"%s","updated_at":"%s","body":"**Actionable comments posted: 1**\\n\\n<details>\\n<summary>foo.sh (1)</summary>\\n\\n_⚠️ Potential issue_\\n\\nThis only appears in the summary body."}]\n' "$bot" "$head_time" "$head_time"
+        ;;
+      intermediate_review_head_pin)
+        # #535.2: a plain review-completed summary with NO Potential issue
+        # marker, so clearance is decided purely by the HEAD-pinned inline
+        # count (which finds the finding on the HEAD review).
+        printf '[{"id":8831,"user":{"login":"%s"},"created_at":"%s","updated_at":"%s","body":"**Actionable comments posted: 1**\\n\\nSee inline findings on the latest HEAD review."}]\n' "$bot" "$head_time" "$head_time"
         ;;
       reply_poll_failure)
         count=0
@@ -462,6 +498,66 @@ test_review_during_probe_wait_emits_findings() {
   fi
 }
 
+# #535.1: the findings gate must also honor a PR-level summary-body marker.
+# A CodeRabbit review on HEAD with ZERO inline findings but a "Potential
+# issue"/⚠️ marker in its PR-level summary body must emit findings (exit 2),
+# not false-clear. Pre-fix this cleared (exit 0) because count_potential_
+# issues scans only the inline pulls/{pr}/comments list. max_wait is large
+# so the first poll reaches the in-loop `review)` arm before any timeout.
+test_535_1_summary_body_marker_emits_findings() {
+  local dir rc status potential review_endpoint
+  dir=$(make_case "summary-marker-only" 600 false 0 2)
+  rc=$(run_case "$dir" summary_marker_only)
+  if [ "$rc" != "2" ]; then
+    fail "#535.1 summary-body marker: exit $rc, expected findings 2; stderr=$(cat "$dir/err.log")"
+    return
+  elif [ ! -s "$dir/out.json" ]; then
+    fail "#535.1 summary-body marker: missing findings JSON output; stderr=$(cat "$dir/err.log")"
+    return
+  fi
+  status=$(jq -r '.status' "$dir/out.json")
+  potential=$(jq -r '.potential_issue_count' "$dir/out.json")
+  review_endpoint=$(jq -r '.review.endpoint' "$dir/out.json")
+  if [ "$status" != "findings" ]; then
+    fail "#535.1 summary-body marker: status=$status, expected findings"
+  elif [ "$potential" != "0" ]; then
+    fail "#535.1 summary-body marker: potential_issue_count=$potential, expected 0 (marker is summary-only, inline count is 0)"
+  elif [ "$review_endpoint" != "issues" ]; then
+    fail "#535.1 summary-body marker: review.endpoint=$review_endpoint, expected issues"
+  else
+    pass "#535.1: PR-level summary-body Potential issue/⚠️ marker yields findings even with 0 inline findings"
+  fi
+}
+
+# #535.2: latest-review selection must be pinned to the HEAD commit, not just
+# freshness. A NEWER review (later submitted_at) that references an
+# intermediate commit must not be chosen over the HEAD review. Here the HEAD
+# review carries the only ⚠️ inline finding; the newer intermediate review
+# has none. Pre-fix (freshness-only `submitted_at >= anchor`) selected the
+# intermediate review and cleared (exit 0); with the commit_id == HEAD_SHA
+# pin the HEAD review is selected and the finding is counted (exit 2).
+test_535_2_head_pinned_review_selection_emits_findings() {
+  local dir rc status potential
+  dir=$(make_case "intermediate-review-head-pin" 600 false 0 2)
+  rc=$(run_case "$dir" intermediate_review_head_pin)
+  if [ "$rc" != "2" ]; then
+    fail "#535.2 head-pinned review: exit $rc, expected findings 2; stderr=$(cat "$dir/err.log")"
+    return
+  elif [ ! -s "$dir/out.json" ]; then
+    fail "#535.2 head-pinned review: missing findings JSON output; stderr=$(cat "$dir/err.log")"
+    return
+  fi
+  status=$(jq -r '.status' "$dir/out.json")
+  potential=$(jq -r '.potential_issue_count' "$dir/out.json")
+  if [ "$status" != "findings" ]; then
+    fail "#535.2 head-pinned review: status=$status, expected findings (HEAD review's inline finding must count)"
+  elif [ "$potential" != "1" ]; then
+    fail "#535.2 head-pinned review: potential_issue_count=$potential, expected 1"
+  else
+    pass "#535.2: latest-review selection pins to HEAD commit; a newer intermediate-commit review does not shadow the HEAD finding"
+  fi
+}
+
 # #446: fast-path StatusContext clearance race. A NEWER rate-limit/
 # in-progress comment than the StatusContext success must suppress the
 # fast-path EVEN WHEN it does not reference the current HEAD — otherwise the
@@ -516,6 +612,8 @@ test_rate_limit_stalled_does_not_probe
 test_probe_post_failure_stays_timeout_advisory
 test_probe_reply_poll_failure_stays_timeout_advisory
 test_review_during_probe_wait_emits_findings
+test_535_1_summary_body_marker_emits_findings
+test_535_2_head_pinned_review_selection_emits_findings
 
 echo
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
Authoring-Agent: claude

Closes #535. Refs #533 item 4. Under-threshold (154 lines), no protected paths.

## Summary

Tightens `scripts/coderabbit-wait.sh` clearance precision. mergepath-propagated; coderabbit-wait.sh is edited ONCE here (both #535 and the #533 PAT-pin) per the edit-each-file-once rule.

- #535.1: the review clearance path decided solely on inline POTENTIAL_ISSUES, so a Potential-issue / warning marker in the PR-level summary body (with 0 inline) exited cleared. Added summary_body_has_potential_issue_marker() (newest bot summary comment on/after HEAD anchor) and OR'd it into BOTH comment-driven review arms (in-loop + probe-wait — they share the exact blind spot).
- #535.2: count_potential_issues() now pins latest-review selection to the HEAD commit (select commit_id == HEAD_SHA alongside submitted_at >= anchor), matching codex-review-check.sh, so a review referencing an intermediate commit is not chosen as the latest.
- #535.3: the missing-token help text now points at --mode all (canonical session-start guidance), not --mode review.
- #533 item 4: gh_reviewer() now pins the reviewer PAT (OP_PREFLIGHT_REVIEWER_PAT with ambient fallback) instead of a bare invocation inheriting ambient creds.

## Testing
- [x] check_coderabbit_wait PASS (status-probe 10, identity 5, paused 9, codex-failover 4, automerge-gate 11)
- [x] Two new hermetic fixtures (summary-marker-only, intermediate-commit review) each verified to FAIL against the pre-fix script and PASS after; bash -n clean

## Self-Review
- [x] Correctness: summary-body helper mirrors the existing newest-fresh-comment selection; HEAD-pin matches the codex-review-check idiom
- [x] Regression risk: additive (a new OR-condition + a tighter jq select); existing clearance behavior unchanged when no summary marker and the review is on HEAD
- [x] Style and conventions: bash 3.2 portable, jq idioms match the rest of the file
- [x] Test coverage: regression cases for #535.1 and #535.2 (red-before / green-after)
- [x] Security and dependency hygiene: PAT-pin closes the bare-creds inheritance; no new deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)