### PR TITLE
fix(review): fail-closed pr-audit parity + registered-reviewer auto-merge gate (#527, #529)

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -488,7 +488,7 @@ jobs:
   # are event-shape-agnostic. Only the `if:` and the approval-gate step
   # branch on event name.
   auto-merge-on-approval:
-    needs: [detect-disagreement, block-self-approval, triage]
+    needs: [load-config, detect-disagreement, block-self-approval, triage]
     if: >
       always() &&
       ((github.event_name == 'pull_request_review' &&
@@ -528,6 +528,14 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           REPO: ${{ github.repository }}
+          # #529: restrict the re-arm approval to REGISTERED agent reviewer
+          # identities (available_reviewers), matching scripts/codex-review-check.sh
+          # gate (b) and the required merge-clearance-gate. A non-author APPROVED
+          # from an account that is NOT a mapped reviewer identity must not arm
+          # auto-merge — defense-in-depth on the identity mapping the internal
+          # self-peer review relies on now that the CI-side reviewer invocation
+          # is gone.
+          REVIEWERS_JSON: ${{ needs.load-config.outputs.reviewers }}
         run: |
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "::notice::REVIEWER_ASSIGNMENT_TOKEN is not configured; cannot confirm an existing approval for the synchronize re-arm. Skipping auto-merge arming."
@@ -548,15 +556,22 @@ jobs:
             exit 0
           fi
 
-          # Latest opinionated review per non-author reviewer; pass only
-          # when at least one such reviewer's latest state is APPROVED.
-          # `-s` (slurp) merges the per-page arrays into one list-of-arrays;
-          # `add // []` then flattens them to the full review array.
+          # Latest opinionated review per non-author REGISTERED reviewer;
+          # pass only when at least one such reviewer's latest state is
+          # APPROVED. `-s` (slurp) merges the per-page arrays into one
+          # list-of-arrays; `add // []` then flattens to the full review
+          # array. #529: the `IN($reviewers[])` filter restricts to
+          # available_reviewers identities — an approval from a non-reviewer
+          # account does NOT count. Default to [] so an empty/failed
+          # load-config fails CLOSED (no reviewer matches → no re-arm).
+          REVIEWERS_JSON="${REVIEWERS_JSON:-[]}"
           if ! APPROVER=$(printf '%s' "$RAW" | jq -r -s \
-            --arg author "$PR_AUTHOR" '
+            --arg author "$PR_AUTHOR" \
+            --argjson reviewers "$REVIEWERS_JSON" '
               [ (add // []) | .[]
                 | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
                 | select(.user.login != $author)
+                | select(.user.login | IN($reviewers[]))
               ]
               | group_by(.user.login)
               | map(max_by(.submitted_at))
@@ -569,7 +584,7 @@ jobs:
           fi
 
           if [ -z "$APPROVER" ]; then
-            echo "::notice::No valid non-author APPROVED review on PR #$PR_NUMBER; a push does not arm auto-merge without an existing approval (#495)."
+            echo "::notice::No valid non-author APPROVED review from a registered reviewer (available_reviewers) on PR #$PR_NUMBER; a push does not arm auto-merge without one (#495/#529)."
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -522,21 +522,47 @@ jobs:
       # earlier APPROVED, so a withdrawn approval does NOT re-arm.
       - name: Gate require existing non-author approval
         id: require_approval
-        if: github.event_name == 'pull_request'
+        if: >
+          github.event_name == 'pull_request' ||
+          github.event_name == 'pull_request_review'
         env:
           GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           REPO: ${{ github.repository }}
-          # #529: restrict the re-arm approval to REGISTERED agent reviewer
-          # identities (available_reviewers), matching scripts/codex-review-check.sh
-          # gate (b) and the required merge-clearance-gate. A non-author APPROVED
-          # from an account that is NOT a mapped reviewer identity must not arm
-          # auto-merge — defense-in-depth on the identity mapping the internal
-          # self-peer review relies on now that the CI-side reviewer invocation
-          # is gone.
+          # #529 / #544: restrict the approval that arms auto-merge to a
+          # REGISTERED agent reviewer identity (available_reviewers), matching
+          # scripts/codex-review-check.sh gate (b) and the required
+          # merge-clearance-gate. An APPROVED from an account that is NOT a
+          # mapped reviewer identity must not arm auto-merge on EITHER path:
+          # the synchronize re-arm (existing-review API check below) OR the
+          # direct pull_request_review approved event. #544 review: the gate
+          # previously ran only on pull_request, so a direct approval from an
+          # unregistered non-author skipped it (the merge-clearance-gate still
+          # backstopped the actual merge, but the arming gate should be
+          # consistent on both paths).
+          EVENT_REVIEWER: ${{ github.event.review.user.login }}
           REVIEWERS_JSON: ${{ needs.load-config.outputs.reviewers }}
         run: |
+          REVIEWERS_JSON="${REVIEWERS_JSON:-[]}"
+          # Direct approval event: the approval IS the trigger, so verify the
+          # event reviewer is a registered, non-author reviewer here (#544).
+          if [ "${GITHUB_EVENT_NAME:-}" = "pull_request_review" ]; then
+            if [ -z "$EVENT_REVIEWER" ] || [ "$EVENT_REVIEWER" = "$PR_AUTHOR" ]; then
+              echo "::notice::Approval reviewer '$EVENT_REVIEWER' is empty or the PR author; not arming auto-merge."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if ! printf '%s' "$REVIEWERS_JSON" | jq -e --arg r "$EVENT_REVIEWER" 'index($r) != null' >/dev/null 2>&1; then
+              echo "::notice::Approval reviewer '$EVENT_REVIEWER' is not a registered reviewer (available_reviewers); not arming auto-merge (#544)."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Direct approval from registered reviewer $EVENT_REVIEWER; proceeding."
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # --- synchronize / reopened re-arm path (existing API check) ---
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "::notice::REVIEWER_ASSIGNMENT_TOKEN is not configured; cannot confirm an existing approval for the synchronize re-arm. Skipping auto-merge arming."
             echo "proceed=false" >> "$GITHUB_OUTPUT"
@@ -594,10 +620,12 @@ jobs:
 
       - name: Check author merge token
         id: author_merge_token
-        # Skip the entire merge path when the synchronize re-arm gate
-        # found no existing approval. On the pull_request_review path the
-        # step above is skipped, so `proceed` is empty and the `!= 'false'`
-        # test lets the original approval-triggered flow through unchanged.
+        # Skip the entire merge path when the require_approval gate set
+        # proceed=false — either the synchronize re-arm found no existing
+        # registered-reviewer approval, or (since #544) the direct
+        # pull_request_review approver was not a registered reviewer. The
+        # `!= 'false'` test still lets a genuine registered-reviewer approval
+        # (proceed=true) and any other event shape (empty) through.
         if: steps.require_approval.outputs.proceed != 'false'
         env:
           GH_TOKEN: ${{ secrets.AUTHOR_MERGE_TOKEN }}

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -260,6 +260,16 @@ jobs:
                 # delimiter must be column-0 unless using `<<-` with
                 # tabs; YAML run blocks make that brittle).
                 comment_body='**Automated label removal.** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD (CI green + reviewer-identity APPROVED + Codex cleared). Removed `needs-external-review` so Label Gate passes and the PR can merge. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#195) for the trigger doctrine.'
+                # #530 (ruled DEFER + DOCUMENT): this attribution-comment POST
+                # sits inside with_gh_retry, so a timeout-after-accept could in
+                # principle duplicate the comment. Accepted as a low-probability,
+                # cosmetic residual: the failure path is warn-only (non-fatal),
+                # and the only other retried writes in this workflow are
+                # check-runs keyed on (name, head_sha), which GitHub UPSERTS
+                # (idempotent). A duplicate attribution NOTE on a merged PR is
+                # harmless; gating this POST behind a read-before-write dedup
+                # would add latency to the common single-success path for no
+                # functional gain. Revisit if duplicate comments are ever seen.
                 with_gh_retry gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
                   || echo "::warning::Failed to post attribution comment for PR #$PR"
                 ;;

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -251,6 +251,20 @@ jobs:
               // Hand-creating all four signals at once is possible but is
               // an explicit, traceable action that would surface during
               // self-review.
+              //
+              // #528 (ruled DEFER + DOCUMENT): this audit identifies a
+              // propagation PR by a FINGERPRINT (trusted author + same-repo
+              // head + mergepath-sync/<sha> branch + mergepath@<sha> title
+              // marker), NOT by re-running the merge lane's full byte-for-byte
+              // verify-propagation-pr.sh proof. That is accepted
+              // defense-in-depth, not a gap: pr-audit is a RETROSPECTIVE
+              // detector (it flags an already-merged PR that skipped review),
+              // while the load-bearing teeth — the byte-level faithful-mirror
+              // proof — runs at MERGE time in pr-review-policy.yml +
+              // merge-clearance-gate. A forged fingerprint cannot MERGE without
+              // also passing that proof, so duplicating the heavy verify here
+              // would add audit cost without closing a demonstrated bypass.
+              // Revisit if a fingerprint-only merge bypass is ever shown.
               const isTrustedSyncAuthor =
                 pr.user && pr.user.login === authorIdentity;
               const isSameRepoHead =

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -61,9 +61,15 @@ for f in "$FIXTURES_DIR" "$WORKFLOW"; do
   fi
 done
 
+# #527 (ruled fail-closed): this script mirrors the node-based
+# `codexCleared` computation in pr-audit.yml as a parity self-test. A
+# self-test that silently no-ops when its interpreter is absent can mask
+# drift between this mirror and the workflow, so fail closed when node is
+# missing rather than passing vacuously. The real merge gate runs in the
+# workflow, where node is guaranteed.
 if ! command -v node >/dev/null 2>&1; then
-  echo "check_pr_audit_codex_clearance: SKIP — node not on PATH" >&2
-  exit 0
+  echo "check_pr_audit_codex_clearance: FAIL — node not on PATH; the parity self-test cannot run (fail-closed per #527)" >&2
+  exit 1
 fi
 
 # The mirrored algorithm. Keep this in sync with the

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -583,14 +583,17 @@ else
   echo "  FAIL: on.pull_request.types must include synchronize AND reopened, else the re-arm if: is dead code (#495)" >&2
 fi
 
-# 3. A dedicated approval gate runs only on the pull_request (push) path.
+# 3. A dedicated approval gate runs on the pull_request (re-arm) path and,
+#    since #544, the direct pull_request_review approval path too — so an
+#    unregistered non-author approval arms auto-merge on neither path.
 if grep -Fq 'id: require_approval' <<<"$auto_merge_job_block" \
-  && grep -Eq "if:[[:space:]]*github\.event_name == 'pull_request'$" <<<"$auto_merge_job_block"; then
+  && grep -Eq "github\.event_name == 'pull_request'( \|\||$)" <<<"$auto_merge_job_block" \
+  && grep -Fq "github.event_name == 'pull_request_review'" <<<"$auto_merge_job_block"; then
   pass=$((pass + 1))
-  echo "  PASS: re-arm path has a require_approval gate scoped to pull_request events"
+  echo "  PASS: require_approval gate covers the pull_request re-arm (#495) and the pull_request_review approval (#544)"
 else
   fail=$((fail + 1))
-  echo "  FAIL: re-arm path must add a require_approval step gated on github.event_name == 'pull_request' (#495)" >&2
+  echo "  FAIL: require_approval step must gate on github.event_name == 'pull_request' (#495) AND 'pull_request_review' (#544)" >&2
 fi
 
 # 4. The gate confirms an EXISTING non-author APPROVED review: it must


### PR DESCRIPTION
Authoring-Agent: claude

Closes #527, #528, #529, #530. Touches .github/workflows/ (protected paths) so this is a Phase 4 PR.

## Summary

Resolves the four needs-human-review decisions per your rulings.

- #527 (RULED fail-closed): scripts/ci/check_pr_audit_codex_clearance now exits 1 (FAIL) instead of 0 (SKIP) when node is absent. The script is a parity self-test mirroring pr-audit.yml codexCleared; a silent no-op when its interpreter is missing can mask drift between the mirror and the workflow. The real merge gate runs in the workflow where node is guaranteed. The pagination canary is kept STRICT (no live failure; the workflow already matches its shape).
- #529 (RULED implement): agent-review.yml synchronize re-arm approval gate now restricts the accepted APPROVED review to a REGISTERED reviewer identity (available_reviewers) via an IN(reviewers) jq filter, matching codex-review-check.sh gate (b) and the required merge-clearance-gate. A non-author APPROVED from a non-reviewer account no longer arms auto-merge. Implemented as the available_reviewers SET, not the single Authoring-Agent-mapped reviewer, so a legitimate cross-agent Phase-4b APPROVED (e.g. nathanpayne-codex on a claude-authored PR) still arms; fails closed when load-config yields no reviewers (REVIEWERS_JSON defaults to []). Added load-config to the job needs to source the parsed reviewer set.
- #528 (RULED defer + document): documented in pr-audit.yml why the propagation-PR FINGERPRINT exemption is accepted defense-in-depth — pr-audit is a RETROSPECTIVE detector; the byte-for-byte faithful-mirror proof runs at MERGE time (pr-review-policy.yml + merge-clearance-gate), so a forged fingerprint cannot merge without passing it. No demonstrated bypass.
- #530 (RULED defer + document): documented in auto-clear-blocking-labels.yml why the attribution-comment POST inside with_gh_retry is an accepted low-probability cosmetic residual (failure path warn-only; the only other retried writes are check-runs keyed on name+head_sha, which GitHub upserts).

Deferred: #521 item 5 (agent-review.yml relabel of verified sync pushes) is a transient-conflict robustness nit — pr-review-policy.yml lane is the authority and removes the label, so the early-advisory add is superseded. Noted for a follow-up.

## Testing
- [x] check_pr_audit_codex_clearance PASS (37); check_workflow_parsers PASS; check_auto_clear_workflow PASS (27)
- [x] #529 jq filter verified out-of-band: a registered reviewer APPROVED returns the login; a non-registered approver returns empty (rejected)
- [x] All three workflows yq-parse; bash -n clean on the check

## Self-Review
- [x] Correctness: the available_reviewers filter mirrors gate (b); the SET (not single mapped) choice preserves cross-agent Phase-4b; defaults [] fail-closed
- [x] Regression risk: #527 no-node path is only hit when node is absent (CI always has it); #529 adds a stricter filter on an existing gate; #528/#530 are comments only
- [x] Style and conventions: jq idioms match the existing gate; YAML indentation preserved; ASCII-safe
- [x] Test coverage: existing 37-case + 27-case + workflow-parser suites green; jq behavior validated
- [x] Security and dependency hygiene: tightens identity enforcement (defense-in-depth); no new deps; no token handling changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)