### PR TITLE
fix(ci): pin dispatchable checkouts + drop non-idempotent comment retry (#548, #530)

### DIFF
--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -260,17 +260,16 @@ jobs:
                 # delimiter must be column-0 unless using `<<-` with
                 # tabs; YAML run blocks make that brittle).
                 comment_body='**Automated label removal.** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD (CI green + reviewer-identity APPROVED + Codex cleared). Removed `needs-external-review` so Label Gate passes and the PR can merge. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#195) for the trigger doctrine.'
-                # #530 (ruled DEFER + DOCUMENT): this attribution-comment POST
-                # sits inside with_gh_retry, so a timeout-after-accept could in
-                # principle duplicate the comment. Accepted as a low-probability,
-                # cosmetic residual: the failure path is warn-only (non-fatal),
-                # and the only other retried writes in this workflow are
-                # check-runs keyed on (name, head_sha), which GitHub UPSERTS
-                # (idempotent). A duplicate attribution NOTE on a merged PR is
-                # harmless; gating this POST behind a read-before-write dedup
-                # would add latency to the common single-success path for no
-                # functional gain. Revisit if duplicate comments are ever seen.
-                with_gh_retry gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
+                # #530 (IMPLEMENTED — was DEFER+DOCUMENT, human-ratified
+                # 2026-06-28): this attribution-comment POST is NON-idempotent,
+                # so it is deliberately NOT wrapped in with_gh_retry. A retry
+                # after a timeout-after-accept would post a DUPLICATE comment;
+                # a single unretried attempt cannot. Failure stays warn-only
+                # (non-fatal) and is purely cosmetic — the label is already
+                # cleared and the workflow log records the action. The other
+                # retried writes here are check-runs keyed on (name, head_sha),
+                # which GitHub UPSERTS (idempotent), so those stay wrapped.
+                gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
                   || echo "::warning::Failed to post attribution comment for PR #$PR"
                 ;;
               1)
@@ -512,7 +511,10 @@ jobs:
                 still_present=$(with_gh_retry gh pr view "$PR" --repo "$REPO" --json labels --jq 'any(.labels[]?; .name == "needs-external-review")' || echo "unknown")
                 if [ "$still_present" = "false" ]; then
                   comment_body='**Automated label removal (scheduled sweep).** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD between event triggers (typical: Codex 👍 after the last push, with no synchronize / review / workflow_run event to fire the event-driven path). Removed `needs-external-review`. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#197) for the sweep doctrine.'
-                  with_gh_retry gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
+                  # #530: non-idempotent comment POST — deliberately unretried
+                  # (a single attempt cannot duplicate); see the event-driven
+                  # job above for the full rationale. Failure is warn-only.
+                  gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
                     || echo "::warning::Failed to post attribution comment for PR #$PR"
                 else
                   # Removal did not take (label still present or verify read

--- a/.github/workflows/onepassword-headless-proof.yml
+++ b/.github/workflows/onepassword-headless-proof.yml
@@ -11,8 +11,14 @@ jobs:
     name: Prove OP_SERVICE_ACCOUNT_TOKEN path
     runs-on: ubuntu-latest
     steps:
+      # Pin to the trusted default branch (#548): this workflow_dispatch-only
+      # proof runs scripts/op-preflight.sh under the privileged
+      # OP_SERVICE_ACCOUNT_TOKEN, so without an explicit ref a manually-selected
+      # branch could run a tampered op-preflight.sh against that 1Password
+      # service-account token. Always run the canonical script from the default branch.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Check proof configuration

--- a/.github/workflows/onepassword-headless-proof.yml
+++ b/.github/workflows/onepassword-headless-proof.yml
@@ -9,6 +9,12 @@ permissions:
 jobs:
   op-service-account-proof:
     name: Prove OP_SERVICE_ACCOUNT_TOKEN path
+    # Reject manual dispatch from a non-default ref (#550 Codex P1): on
+    # workflow_dispatch GitHub runs the workflow DEFINITION from the chosen
+    # ref, which the checkout pin cannot constrain — a feature branch could add
+    # a step reading OP_SERVICE_ACCOUNT_TOKEN before checkout. Restrict this
+    # secret-bearing job to the default branch (this workflow is dispatch-only).
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     steps:
       # Pin to the trusted default branch (#548): this workflow_dispatch-only

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -29,6 +29,12 @@ permissions:
 jobs:
   audit:
     name: Audit Merged PRs
+    # Reject manual dispatch from a non-default ref (#550 Codex P1): on
+    # workflow_dispatch GitHub runs the workflow DEFINITION from the chosen
+    # ref, which the checkout pin cannot constrain — a feature branch could
+    # leak REVIEWER_ASSIGNMENT_TOKEN before checkout. Scheduled runs and
+    # default-branch dispatch pass; a feature-branch dispatch is skipped.
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     steps:
       # Pin to the trusted default branch (#548): this workflow has a

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -31,7 +31,19 @@ jobs:
     name: Audit Merged PRs
     runs-on: ubuntu-latest
     steps:
+      # Pin to the trusted default branch (#548): this workflow has a
+      # workflow_dispatch trigger and runs the inline actions/github-script
+      # audit under the cross-repo REVIEWER_ASSIGNMENT_TOKEN, reading
+      # .github/review-policy.yml from the checkout. Without an explicit ref a
+      # manually-dispatched branch could supply tampered policy/code that runs
+      # under that privileged PAT. Always audit from the canonical default branch.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          # The audit reads via gh / github-script with an explicit token; it
+          # never does git-authenticated writes, so don't leave the checkout
+          # token in .git/config (#548 defense-in-depth).
+          persist-credentials: false
 
       - name: Install js-yaml
         run: npm install --no-save --ignore-scripts --legacy-peer-deps js-yaml

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -59,6 +59,11 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # The external-review check only reads local history (git diff / show
+          # / worktree) and clones PUBLIC mergepath unauthenticated; it never
+          # pushes or uses the workspace remote, so don't leave the checkout
+          # token in .git/config (#548 defense-in-depth).
+          persist-credentials: false
 
       - name: Check for external review triggers from review-policy.yml
         id: check

--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Lint only runs scripts/ci/check_* against the checked-out tree; it
+          # never pushes or uses the workspace remote, so don't leave the
+          # checkout token in .git/config (#548 defense-in-depth).
+          persist-credentials: false
 
       - name: make_ci_scripts_executable
         run: chmod +x scripts/ci/*

--- a/.github/workflows/weekly-drift-audit.yml
+++ b/.github/workflows/weekly-drift-audit.yml
@@ -57,6 +57,12 @@ permissions:
 jobs:
   audit:
     name: Audit downstream consumers for drift
+    # Reject manual dispatch from a non-default ref (#550 Codex P1): on
+    # workflow_dispatch GitHub runs the workflow DEFINITION from the chosen
+    # ref, which the checkout pin cannot constrain — a feature branch could
+    # leak REVIEWER_ASSIGNMENT_TOKEN before checkout. Scheduled runs and
+    # default-branch dispatch pass; a feature-branch dispatch is skipped.
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/weekly-drift-audit.yml
+++ b/.github/workflows/weekly-drift-audit.yml
@@ -64,7 +64,19 @@ jobs:
       ISSUE_TITLE: 'Cross-repo propagation drift detected'
     steps:
       - name: Checkout mergepath
+        # Pin to the trusted default branch (#548): this workflow has a
+        # workflow_dispatch trigger and runs scripts/sync-to-downstream.sh and
+        # scripts/audit-propagation-lane.sh under the cross-repo
+        # REVIEWER_ASSIGNMENT_TOKEN, so without an explicit ref a
+        # manually-dispatched branch could run tampered scripts under that
+        # privileged PAT. Always run the canonical scripts from the default
+        # branch. persist-credentials:false is safe: cross-repo reads use
+        # `gh auth setup-git` (a separate credential helper), not the
+        # workspace checkout token.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Install yq (mikefarah/yq v4)
         # sync-to-downstream.sh requires mikefarah/yq v4+. The

--- a/.github/workflows/weekly-feedback-sweep.yml
+++ b/.github/workflows/weekly-feedback-sweep.yml
@@ -56,7 +56,17 @@ jobs:
 
     steps:
       - name: Checkout
+        # Pin to the trusted default branch (#548): this workflow has a
+        # workflow_dispatch trigger and runs scripts/sweep-unresolved-feedback/*
+        # under the cross-repo REVIEWER_ASSIGNMENT_TOKEN, so without an explicit
+        # ref a manually-dispatched branch could run a tampered version of the
+        # sweep scripts under that privileged PAT. Always run the canonical
+        # scripts from the default branch. persist-credentials:false because the
+        # sweep uses gh with an explicit token, never authenticated git.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Ensure jq + gh present
         run: |

--- a/.github/workflows/weekly-feedback-sweep.yml
+++ b/.github/workflows/weekly-feedback-sweep.yml
@@ -51,6 +51,12 @@ permissions:
 jobs:
   sweep:
     name: Enumerate + render rollup
+    # Reject manual dispatch from a non-default ref (#550 Codex P1): on
+    # workflow_dispatch GitHub runs the workflow DEFINITION from the chosen
+    # ref, which the checkout pin cannot constrain — a feature branch could
+    # leak REVIEWER_ASSIGNMENT_TOKEN before checkout. Scheduled runs and
+    # default-branch dispatch pass; a feature-branch dispatch is skipped.
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/weekly-feedback-sweep.yml
+++ b/.github/workflows/weekly-feedback-sweep.yml
@@ -135,6 +135,12 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          # The failure-notify job only runs gh issue create (explicit
+          # GITHUB_TOKEN); it needs the checkout for repo inference but does no
+          # authenticated git, so drop the persisted token too — keeps the #548
+          # invariant true for the WHOLE workflow (Codex #550 P2).
+          persist-credentials: false
       - name: Open failure-tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/test_465_fail_closed.sh
+++ b/tests/test_465_fail_closed.sh
@@ -92,6 +92,19 @@ assert_grep "D7: weekly-feedback-sweep pins checkout ref (#548 Major)" \
   "$W/weekly-feedback-sweep.yml" 'ref: ${{ github.event.repository.default_branch }}'
 assert_grep "D7: weekly-feedback-sweep drops the persisted checkout token (#548)" \
   "$W/weekly-feedback-sweep.yml" 'persist-credentials: false'
+# Both checkouts (main sweep + the notify-on-failure job) must drop the token,
+# so the #548 invariant holds for the WHOLE file (Codex #550 P2 caught that the
+# failure-notify checkout was initially missed). Propagation-safe: skip if absent.
+if [ -f "$W/weekly-feedback-sweep.yml" ]; then
+  _wfs_pc=$(grep -c 'persist-credentials: false' "$W/weekly-feedback-sweep.yml")
+  if [ "$_wfs_pc" -ge 2 ]; then
+    pass "D7: weekly-feedback-sweep hardens BOTH checkouts (#548 / Codex #550)"
+  else
+    fail "D7: weekly-feedback-sweep both checkouts (#548): $_wfs_pc persist-credentials, expected >= 2"
+  fi
+else
+  echo "SKIP: D7 weekly-feedback-sweep both checkouts (absent)"; SKIP=$((SKIP + 1))
+fi
 assert_grep "D7: weekly-drift-audit pins checkout ref (#548)" \
   "$W/weekly-drift-audit.yml" 'ref: ${{ github.event.repository.default_branch }}'
 assert_grep "D7: weekly-drift-audit drops the persisted checkout token (#548)" \

--- a/tests/test_465_fail_closed.sh
+++ b/tests/test_465_fail_closed.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Structural regression guards for the #465 fail-open / early-clear fixes.
+# Structural regression guards for the #465 fail-open / early-clear fixes,
+# plus the #530 non-idempotent comment-POST and #548 checkout-hardening
+# invariants (cross-workflow, source-level assertions; propagation-safe via
+# the assert_grep/refute_grep SKIP-if-absent contract).
 #
 # The six defects span four YAML workflows and two shell scripts; the
 # workflow ones cannot be unit-executed without a full Actions runner, so
@@ -55,6 +58,13 @@ assert_grep "D3: auto-clear verifies label end-state (still_present)" \
   "$W/auto-clear-blocking-labels.yml" 'still_present'
 refute_grep "D3: auto-clear no longer retries the --remove-label write" \
   "$W/auto-clear-blocking-labels.yml" 'with_gh_retry gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review'
+# #530: the attribution-comment POST is non-idempotent (a retry after a
+# timeout-after-accept duplicates the comment), so it must NOT be retried;
+# the idempotent (name,head_sha) check-run POSTs stay wrapped.
+refute_grep "D3: auto-clear no longer retries the non-idempotent comment POST (#530)" \
+  "$W/auto-clear-blocking-labels.yml" 'with_gh_retry gh pr comment "$PR" --repo "$REPO" --body "$comment_body"'
+assert_grep "D3: auto-clear keeps check-run POSTs retried (idempotent name,head_sha) (#530)" \
+  "$W/auto-clear-blocking-labels.yml" 'with_gh_retry gh api "repos/$REPO/check-runs"'
 
 # Defect 4: codex-review-request re-scans at the deadline before emitting.
 assert_grep "D4: codex-review-request final scan at deadline" \
@@ -73,6 +83,25 @@ assert_grep "D6: codex-review-check tells 404 apart via HTTP status" \
   scripts/codex-review-check.sh 'HTTP 404'
 refute_grep "D6: codex-review-check dropped the unconditional skip-all-checks fail-open" \
   scripts/codex-review-check.sh 'Skipping required-check filter — all checks treated as passing this gate.'
+
+# Defect 7 (#548): every dispatchable-privileged checkout pins the trusted
+# default branch (blocks a manually-dispatched branch from running tampered
+# repo code under a privileged PAT), and checkouts with no authenticated-git
+# path drop the persisted checkout token (defense-in-depth).
+assert_grep "D7: weekly-feedback-sweep pins checkout ref (#548 Major)" \
+  "$W/weekly-feedback-sweep.yml" 'ref: ${{ github.event.repository.default_branch }}'
+assert_grep "D7: weekly-drift-audit pins checkout ref (#548)" \
+  "$W/weekly-drift-audit.yml" 'ref: ${{ github.event.repository.default_branch }}'
+assert_grep "D7: pr-audit pins checkout ref (#548)" \
+  "$W/pr-audit.yml" 'ref: ${{ github.event.repository.default_branch }}'
+assert_grep "D7: onepassword-headless-proof pins checkout ref (#548)" \
+  "$W/onepassword-headless-proof.yml" 'ref: ${{ github.event.repository.default_branch }}'
+assert_grep "D7: pr-review-policy drops the persisted checkout token (#548)" \
+  "$W/pr-review-policy.yml" 'persist-credentials: false'
+assert_grep "D7: repo_lint drops the persisted checkout token (#548)" \
+  "$W/repo_lint.yml" 'persist-credentials: false'
+assert_grep "D7: pr-audit drops the persisted checkout token (#548)" \
+  "$W/pr-audit.yml" 'persist-credentials: false'
 
 echo ""
 echo "test_465_fail_closed: $PASS passed, $FAIL failed, $SKIP skipped"

--- a/tests/test_465_fail_closed.sh
+++ b/tests/test_465_fail_closed.sh
@@ -90,8 +90,12 @@ refute_grep "D6: codex-review-check dropped the unconditional skip-all-checks fa
 # path drop the persisted checkout token (defense-in-depth).
 assert_grep "D7: weekly-feedback-sweep pins checkout ref (#548 Major)" \
   "$W/weekly-feedback-sweep.yml" 'ref: ${{ github.event.repository.default_branch }}'
+assert_grep "D7: weekly-feedback-sweep drops the persisted checkout token (#548)" \
+  "$W/weekly-feedback-sweep.yml" 'persist-credentials: false'
 assert_grep "D7: weekly-drift-audit pins checkout ref (#548)" \
   "$W/weekly-drift-audit.yml" 'ref: ${{ github.event.repository.default_branch }}'
+assert_grep "D7: weekly-drift-audit drops the persisted checkout token (#548)" \
+  "$W/weekly-drift-audit.yml" 'persist-credentials: false'
 assert_grep "D7: pr-audit pins checkout ref (#548)" \
   "$W/pr-audit.yml" 'ref: ${{ github.event.repository.default_branch }}'
 assert_grep "D7: onepassword-headless-proof pins checkout ref (#548)" \

--- a/tests/test_465_fail_closed.sh
+++ b/tests/test_465_fail_closed.sh
@@ -120,6 +120,19 @@ assert_grep "D7: repo_lint drops the persisted checkout token (#548)" \
 assert_grep "D7: pr-audit drops the persisted checkout token (#548)" \
   "$W/pr-audit.yml" 'persist-credentials: false'
 
+# Defect 8 (#550 Codex P1): secret-bearing dispatchable workflows guard the JOB
+# on the default branch, so a non-default workflow_dispatch — which runs the
+# chosen ref's workflow DEFINITION, beyond the checkout pin's reach — cannot
+# leak the secret via a step added ahead of the pinned checkout.
+assert_grep "D8: onepassword-headless-proof guards dispatch to the default branch (#550)" \
+  "$W/onepassword-headless-proof.yml" 'if: github.ref_name == github.event.repository.default_branch'
+assert_grep "D8: weekly-feedback-sweep guards dispatch to the default branch (#550)" \
+  "$W/weekly-feedback-sweep.yml" 'if: github.ref_name == github.event.repository.default_branch'
+assert_grep "D8: weekly-drift-audit guards dispatch to the default branch (#550)" \
+  "$W/weekly-drift-audit.yml" 'if: github.ref_name == github.event.repository.default_branch'
+assert_grep "D8: pr-audit guards dispatch to the default branch (#550)" \
+  "$W/pr-audit.yml" 'if: github.ref_name == github.event.repository.default_branch'
+
 echo ""
 echo "test_465_fail_closed: $PASS passed, $FAIL failed, $SKIP skipped"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Two deferred CI-hardening issues, both on propagated workflow files, batched ahead of the propagation wave.

#548 (checkout hardening, from the #523 actions/checkout v7 review):
- Pin the four dispatchable-privileged workflow checkouts to the trusted default branch so a manually-dispatched branch cannot run tampered repo code under a privileged PAT: weekly-feedback-sweep (the Major, REVIEWER_ASSIGNMENT_TOKEN), weekly-drift-audit, pr-audit, onepassword-headless-proof.
- Add persist-credentials false on checkouts with no authenticated-git path so the token is not left in .git/config: those four plus the flagged pr-review-policy and repo_lint.

#530 (non-idempotent comment write, human-ratified to implement; was DEFER+DOCUMENT):
- Drop the retry wrapper from the two attribution-comment writes in auto-clear-blocking-labels. A retry after a timeout-after-accept would duplicate the comment; a single unretried attempt cannot. Failure stays warn-only (the label is already cleared) and the idempotent (name, head_sha) check-run writes stay wrapped.

## Self-Review

- Safety: no workflow pushes or uses submodules; weekly-drift-audit reads cross-repo via gh auth setup-git (a separate credential helper), so dropping the persisted token is safe. yq confirms ref and persist-credentials nest under each checkout step.
- Scope discipline: the non-dispatchable explicit-token checkouts (agent-review, auto-clear, daily-feedback-rollup) carry no escalation vector and were not flagged by CodeRabbit; left as-is to keep the security surface focused.
- Tests: test_465_fail_closed gains D3 (#530) and D7 (#548), 23 pass. check_codex_scripts, check_auto_clear_workflow, check_workflow_parsers, check_onepassword_headless_proof_workflow, check_workflow_verify_propagation_templated all green.
- Risk: low. Additive checkout hardening plus one retry-wrapper removal on a cosmetic write.

Authoring-Agent: claude