### PR TITLE
fix(gh-guard): single-source prefix table + wrapper-as-prefix (#546)

### DIFF
--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -256,8 +256,10 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 NEEDS_TOKENIZE=0
 if echo "$COMMAND" | tr -d "\"'" | grep -qE '(^|[^A-Za-z0-9_])([^[:space:]]*/)?gh([^A-Za-z0-9_]|$)'; then
   NEEDS_TOKENIZE=1
-elif echo "$COMMAND" | grep -qE '(^|[^A-Za-z0-9_])env([[:space:]]|$)' \
-     && echo "$COMMAND" | grep -qE '(-[A-Za-z]*S|--split-string)'; then
+elif echo "$COMMAND" | tr -d "\"'" | grep -qE '(^|[^A-Za-z0-9_])env([[:space:]]|$)' \
+     && echo "$COMMAND" | tr -d "\"'" | grep -qE '(-[A-Za-z]*S|--split-string)'; then
+  # Quote-stripped (Codex #551): a quoted `'env'` runs env but would otherwise
+  # leave a quote, not whitespace, after `env` and dodge this probe.
   NEEDS_TOKENIZE=1
 fi
 if [ "$NEEDS_TOKENIZE" -eq 0 ]; then
@@ -637,10 +639,15 @@ def expand_wrappers(tokens, depth=0):
                 # payload is surfaced (CodeRabbit #551, a pre-existing exotic
                 # gap). Handles the next-token, --split-string=STR, and -SSTR
                 # (attached) forms.
-                if base == "env" and (a in ("-S", "--split-string")
+                if base == "env" and (a == "--split-string"
                                       or a.startswith("--split-string=")
-                                      or (len(a) > 2 and a.startswith("-S")
-                                          and not a.startswith("--"))):
+                                      or (a.startswith("-") and not a.startswith("--")
+                                          and next((c for c in a[1:] if c in "uCS"), "") == "S")):
+                    # A short cluster IS env -S when the first value-taking-or-S
+                    # option in it is S (CodeRabbit #551: -vS etc., not only a
+                    # leading -S). -u/-C consume the rest of the cluster as their
+                    # value, so an S inside e.g. -uNAME_WITH_S is NOT the split
+                    # flag (keeps the #451 env -uNAME tests passing).
                     # env -S / --split-string FAILS CLOSED (Codex #551 r1-r4).
                     # GNU env -S has rich, exotic semantics: whitespace
                     # splitting, $VAR/${VAR} expansion, $(...)/backtick

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -509,18 +509,19 @@ for _entry in _RAW_PREFIX_SPEC.split(";"):
 _EMPTY_FROZENSET = frozenset()
 
 def _split_string_tokens(arg, depth):
-    # env -S / --split-string runs ARG as a SPLIT command. GNU env -S also
-    # performs $VAR/${VAR} expansion before splitting (coreutils env.c reads
-    # getenv while parsing the split string), which shlex cannot resolve, so a
-    # "${G} pr merge" payload would leave the command token unexpanded and
-    # bypass the guard (Codex #551). flatten_command first lifts out
-    # $(...) / backtick command-subs into their own segments; any "$" that
-    # REMAINS after that is a parameter expansion we cannot statically resolve,
-    # so FAIL CLOSED (raise -> the hook blocks) rather than risk a hidden write.
-    flat = flatten_command(arg)
-    if "$" in flat:
-        raise ValueError("env -S split-string with $-expansion is not statically resolvable")
-    return expand_wrappers(shlex.split(flat), depth + 1)
+    # env -S is fully dynamic: GNU env -S expands $VAR/${VAR}, and bash expands
+    # $(...) / backtick substitutions BEFORE env runs, so the real command is
+    # produced at runtime and is NOT statically resolvable. Fail closed (Codex
+    # #551) when ARG carries any of those. By the time we get here the OUTER
+    # flatten_command has already lifted any $(...) / backtick out of this
+    # token, leaving a __MERGEPATH_CMDSUB__ placeholder where the substitution
+    # was — and that substitution RESULT becomes env -S command (e.g.
+    # env -S "$(printf gh) pr merge --admin"), so the placeholder must block,
+    # not pass. A literal "$" that survives is a parameter expansion. Either
+    # way the command is unknowable, so block rather than risk a hidden write.
+    if "$" in arg or "__MERGEPATH_CMDSUB__" in arg:
+        raise ValueError("env -S split-string with $-expansion or command-substitution is not statically resolvable")
+    return expand_wrappers(shlex.split(flatten_command(arg)), depth + 1)
 
 def expand_wrappers(tokens, depth=0):
     if depth > 25:

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -508,6 +508,20 @@ for _entry in _RAW_PREFIX_SPEC.split(";"):
     _PREFIX_VALUE_OPTS[_pfx] = frozenset(o for o in _opts.split(",") if o)
 _EMPTY_FROZENSET = frozenset()
 
+def _split_string_tokens(arg, depth):
+    # env -S / --split-string runs ARG as a SPLIT command. GNU env -S also
+    # performs $VAR/${VAR} expansion before splitting (coreutils env.c reads
+    # getenv while parsing the split string), which shlex cannot resolve, so a
+    # "${G} pr merge" payload would leave the command token unexpanded and
+    # bypass the guard (Codex #551). flatten_command first lifts out
+    # $(...) / backtick command-subs into their own segments; any "$" that
+    # REMAINS after that is a parameter expansion we cannot statically resolve,
+    # so FAIL CLOSED (raise -> the hook blocks) rather than risk a hidden write.
+    flat = flatten_command(arg)
+    if "$" in flat:
+        raise ValueError("env -S split-string with $-expansion is not statically resolvable")
+    return expand_wrappers(shlex.split(flat), depth + 1)
+
 def expand_wrappers(tokens, depth=0):
     if depth > 25:
         raise ValueError("eval/shell -c nesting too deep")
@@ -615,21 +629,18 @@ def expand_wrappers(tokens, depth=0):
                 # (attached) forms.
                 if base == "env" and a in ("-S", "--split-string"):
                     if i + 1 < n and tokens[i + 1] not in _SEPARATORS:
-                        out.extend(expand_wrappers(
-                            shlex.split(flatten_command(tokens[i + 1])), depth + 1))
+                        out.extend(_split_string_tokens(tokens[i + 1], depth))
                         i += 2
                     else:
                         out.append(a)
                         i += 1
                     continue
                 if base == "env" and a.startswith("--split-string="):
-                    out.extend(expand_wrappers(
-                        shlex.split(flatten_command(a[len("--split-string="):])), depth + 1))
+                    out.extend(_split_string_tokens(a[len("--split-string="):], depth))
                     i += 1
                     continue
                 if base == "env" and len(a) > 2 and a.startswith("-S") and not a.startswith("--"):
-                    out.extend(expand_wrappers(
-                        shlex.split(flatten_command(a[2:])), depth + 1))
+                    out.extend(_split_string_tokens(a[2:], depth))
                     i += 1
                     continue
                 if a in vopts:

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -301,8 +301,21 @@ trap 'rm -f "$TMP_TOKENS" "$TMP_TOKENS_ERR"' EXIT
 # on swipewatch propagation PR #33 round 6 — privilege escalation
 # via newline-separated prefix command was the same shape as the
 # round-5 echo-prefix env spoof, just on a different separator.
+#
+# --- #546: single source of truth for prefix value-consuming options ---
+# Both the python pre-pass (which surfaces a bash -c payload hidden behind a
+# prefix) and the bash compound-scan + main walk (which skip prefix options
+# to find a command-position gh) MUST agree on which options consume the
+# NEXT token. If the two drift, a "<prefix> <value-opt> VALUE bash -c
+# <gh write>" payload slips through whichever layer is missing the option
+# (#546 gap 2: the bash walk lacked the long forms the python table had).
+# Defined ONCE here and read by BOTH, so they cannot drift. Per-prefix
+# because the same letter differs by tool (nice -n takes a value; sudo -n
+# does not). Format: ";"-joined "<prefix>=<opt>,<opt>,..." entries.
+PREFIX_VALUE_OPTS_SPEC="sudo=-u,--user,-g,--group,-p,--prompt,-h,--host,-t,--type,-r,--role,-C,--close-from,-D,--chdir,-R,--chroot,-U,--other-user,-T,--command-timeout;nice=-n,--adjustment;ionice=-c,--class,-n,--classdata,-p,--pid,-t;env=-u,--unset,-C,--chdir,-S,--split-string;exec=-a;time=-f,--format,-o,--output"
+export PREFIX_VALUE_OPTS_SPEC
 if ! printf '%s' "$COMMAND" | python3 -c '
-import sys, shlex, re
+import sys, shlex, re, os
 
 # chr(39)/chr(34) are single/double quote; chr() avoids embedding a
 # literal single quote inside the python3 -c surrounding heredoc.
@@ -458,6 +471,12 @@ def flatten_command(cmd, depth=0):
 _SEPARATORS = {"&&", "||", ";", "|", "|&", "&", "(", ")"}
 _SHELL_BASENAMES = {"sh", "bash", "dash", "zsh", "ksh"}
 _PREFIX_CMDS = {"sudo", "time", "nohup", "env", "command", "exec", "nice", "ionice"}
+# The canonical gh wrappers run "<wrapper> -- <command>". Treat the wrapper
+# (and the -- separator) as prefix-like so a "<wrapper> -- bash -c <gh write>"
+# payload keeps command position and the inner gh write is surfaced and
+# re-checked, not hidden behind the wrapper as an opaque shell-c token
+# (#546 gap 1).
+_WRAPPER_CMDS = {"gh-as-author.sh", "gh-as-reviewer.sh"}
 # sh/bash options that consume the NEXT token as their value, so the -c
 # command flag (and the script positional) lie AFTER that value. Skipping
 # only the option (not its value) would mis-read the value as the script
@@ -465,21 +484,24 @@ _PREFIX_CMDS = {"sudo", "time", "nohup", "env", "command", "exec", "nice", "ioni
 _SHELL_VALUE_OPTS = {"--rcfile", "--init-file", "-o", "+o", "-O", "+O"}
 _ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 # Per-prefix options that consume the NEXT token as a value, so the value
-# is not mistaken for the wrapped command. Per-prefix because the same
+# is not mistaken for the wrapped command. Read from the shared
+# PREFIX_VALUE_OPTS_SPEC env var (#546) so THIS python table and the bash
+# prefix_flag_takes_value table cannot drift. Per-prefix because the same
 # letter differs by tool: nice -n N takes a value, but sudo -n is a
-# no-value flag. A prefix not listed here is treated as flags-only.
-_PREFIX_VALUE_OPTS = {
-    "sudo": frozenset({"-u", "--user", "-g", "--group", "-p", "--prompt",
-                       "-h", "--host", "-t", "--type", "-r", "--role",
-                       "-C", "--close-from", "-D", "--chdir",
-                       "-R", "--chroot", "-U", "--other-user",
-                       "-T", "--command-timeout"}),
-    "nice": frozenset({"-n", "--adjustment"}),
-    "ionice": frozenset({"-c", "--class", "-n", "--classdata",
-                         "-p", "--pid", "-t"}),
-    "env": frozenset({"-u", "--unset", "-C", "--chdir"}),
-    "exec": frozenset({"-a"}),
-}
+# no-value flag. A prefix not listed is treated as flags-only. Fail closed
+# when the spec is absent: without it every prefix looks flags-only and a
+# "value-opt VALUE" pair would be mis-read as the wrapped command, hiding a
+# trailing bash -c gh-write.
+_PREFIX_VALUE_OPTS = {}
+_RAW_PREFIX_SPEC = os.environ.get("PREFIX_VALUE_OPTS_SPEC", "")
+if not _RAW_PREFIX_SPEC:
+    print("gh-pr-guard: PREFIX_VALUE_OPTS_SPEC unset", file=sys.stderr)
+    sys.exit(1)
+for _entry in _RAW_PREFIX_SPEC.split(";"):
+    if not _entry:
+        continue
+    _pfx, _eq, _opts = _entry.partition("=")
+    _PREFIX_VALUE_OPTS[_pfx] = frozenset(o for o in _opts.split(",") if o)
 _EMPTY_FROZENSET = frozenset()
 
 def expand_wrappers(tokens, depth=0):
@@ -594,6 +616,31 @@ def expand_wrappers(tokens, depth=0):
                     continue
                 break
             continue
+        if base in _WRAPPER_CMDS:
+            # Wrapper invocation (gh-as-author.sh / gh-as-reviewer.sh): keep
+            # command position through the -- arg separator and any wrapper
+            # flags so a trailing bash -c / sh -c / prefix / eval payload is
+            # expanded by the main loop and the inner gh write is re-checked,
+            # instead of running under the verified token without the
+            # merge-state / CODEX_CLEARED gate (#546 gap 1). A normal
+            # "<wrapper> -- gh pr merge" is unaffected (gh is not a shell to
+            # expand), so this only matters when a shell/prefix follows.
+            out.append(tok)
+            i += 1
+            while i < n:
+                a = tokens[i]
+                if a in _SEPARATORS:
+                    break
+                a_base = a.rsplit("/", 1)[-1]
+                if (a_base in _SHELL_BASENAMES or a_base in _PREFIX_CMDS
+                        or a_base in _WRAPPER_CMDS or a_base == "eval"):
+                    break
+                if a == "--" or a.startswith("-"):
+                    out.append(a)
+                    i += 1
+                    continue
+                break
+            continue
         out.append(tok)
         at_cmd = False
         i += 1
@@ -641,23 +688,28 @@ is_guard_separator() {
 }
 
 prefix_flag_takes_value() {
-  case "$1:$2" in
-    sudo:-u|sudo:-g|sudo:-U|sudo:-h|sudo:-p|sudo:-r|sudo:-s|sudo:-t|sudo:-c|sudo:-D)
-      return 0
-      ;;
-    time:-f|time:-o)
-      return 0
-      ;;
-    nice:-n)
-      return 0
-      ;;
-    ionice:-c|ionice:-n|ionice:-p)
-      return 0
-      ;;
-    env:-u|env:-S|env:--unset)
-      return 0
-      ;;
+  # Single source of truth: PREFIX_VALUE_OPTS_SPEC (#546). The python
+  # pre-pass and this bash walk read the SAME spec, so the two prefix-option
+  # tables cannot drift. The old hand-maintained case list HAD drifted: it
+  # lacked the long forms the python table carried, so "sudo --user X bash
+  # -c <gh write>" surfaced the inner gh in python but the bash compound
+  # scan mis-read X as the command and never saw it. Spec: ";"-joined
+  # "<prefix>=<opt>,<opt>,..." entries.
+  local pfx="$1" opt="$2" spec opts o
+  spec=";$PREFIX_VALUE_OPTS_SPEC"
+  case "$spec" in
+    *";$pfx="*) ;;
+    *) return 1 ;;
   esac
+  opts="${spec##*;$pfx=}"   # text after the (unique) ";<pfx>="
+  opts="${opts%%;*}"        # up to the next prefix entry
+  # Literal equality (NOT a case glob) so an attacker-supplied option token
+  # such as "-*" cannot glob-match a real value-option and mis-skip the
+  # following gh write.
+  local IFS=,
+  for o in $opts; do
+    [ "$o" = "$opt" ] && return 0
+  done
   return 1
 }
 

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -313,9 +313,9 @@ trap 'rm -f "$TMP_TOKENS" "$TMP_TOKENS_ERR"' EXIT
 # because the same letter differs by tool (nice -n takes a value; sudo -n
 # does not). Format: ";"-joined "<prefix>=<opt>,<opt>,..." entries. ONLY
 # value-CONSUMING options belong here: ionice -t/--ignore is a no-value flag
-# (CodeRabbit #551), and env -S/--split-string is NOT a value either — its
-# argument is a nested SPLIT command, re-tokenized + expanded in
-# expand_wrappers, so it is handled there rather than skipped as a value.
+# (CodeRabbit #551), and env -S/--split-string is NOT a value either — it runs
+# its argument as a SPLIT command with exotic dynamic semantics, so it FAILS
+# CLOSED in expand_wrappers (Codex #551) rather than being skipped here.
 PREFIX_VALUE_OPTS_SPEC="sudo=-u,--user,-g,--group,-p,--prompt,-h,--host,-t,--type,-r,--role,-C,--close-from,-D,--chdir,-R,--chroot,-U,--other-user,-T,--command-timeout;nice=-n,--adjustment;ionice=-c,--class,-n,--classdata,-p,--pid;env=-u,--unset,-C,--chdir;exec=-a;time=-f,--format,-o,--output"
 export PREFIX_VALUE_OPTS_SPEC
 if ! printf '%s' "$COMMAND" | python3 -c '
@@ -508,21 +508,6 @@ for _entry in _RAW_PREFIX_SPEC.split(";"):
     _PREFIX_VALUE_OPTS[_pfx] = frozenset(o for o in _opts.split(",") if o)
 _EMPTY_FROZENSET = frozenset()
 
-def _split_string_tokens(arg, depth):
-    # env -S is fully dynamic: GNU env -S expands $VAR/${VAR}, and bash expands
-    # $(...) / backtick substitutions BEFORE env runs, so the real command is
-    # produced at runtime and is NOT statically resolvable. Fail closed (Codex
-    # #551) when ARG carries any of those. By the time we get here the OUTER
-    # flatten_command has already lifted any $(...) / backtick out of this
-    # token, leaving a __MERGEPATH_CMDSUB__ placeholder where the substitution
-    # was — and that substitution RESULT becomes env -S command (e.g.
-    # env -S "$(printf gh) pr merge --admin"), so the placeholder must block,
-    # not pass. A literal "$" that survives is a parameter expansion. Either
-    # way the command is unknowable, so block rather than risk a hidden write.
-    if "$" in arg or "__MERGEPATH_CMDSUB__" in arg:
-        raise ValueError("env -S split-string with $-expansion or command-substitution is not statically resolvable")
-    return expand_wrappers(shlex.split(flatten_command(arg)), depth + 1)
-
 def expand_wrappers(tokens, depth=0):
     if depth > 25:
         raise ValueError("eval/shell -c nesting too deep")
@@ -628,22 +613,20 @@ def expand_wrappers(tokens, depth=0):
                 # payload is surfaced (CodeRabbit #551, a pre-existing exotic
                 # gap). Handles the next-token, --split-string=STR, and -SSTR
                 # (attached) forms.
-                if base == "env" and a in ("-S", "--split-string"):
-                    if i + 1 < n and tokens[i + 1] not in _SEPARATORS:
-                        out.extend(_split_string_tokens(tokens[i + 1], depth))
-                        i += 2
-                    else:
-                        out.append(a)
-                        i += 1
-                    continue
-                if base == "env" and a.startswith("--split-string="):
-                    out.extend(_split_string_tokens(a[len("--split-string="):], depth))
-                    i += 1
-                    continue
-                if base == "env" and len(a) > 2 and a.startswith("-S") and not a.startswith("--"):
-                    out.extend(_split_string_tokens(a[2:], depth))
-                    i += 1
-                    continue
+                if base == "env" and (a in ("-S", "--split-string")
+                                      or a.startswith("--split-string=")
+                                      or (len(a) > 2 and a.startswith("-S")
+                                          and not a.startswith("--"))):
+                    # env -S / --split-string FAILS CLOSED (Codex #551 r1-r4).
+                    # GNU env -S has rich, exotic semantics: whitespace
+                    # splitting, $VAR/${VAR} expansion, $(...)/backtick
+                    # substitution (bash expands those first), AND appending the
+                    # remaining argv after the split string (env -S "bash -c"
+                    # "<payload>"). Each partial model we tried surfaced a new
+                    # bypass, and env -S on a command line is an exotic shebang
+                    # feature no gh workflow needs, so BLOCK any env -S rather
+                    # than risk a hidden write. Reformulate without -S if needed.
+                    raise ValueError("env -S / --split-string is not statically resolvable; reformulate without -S")
                 if a in vopts:
                     out.append(a)
                     i += 1

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -311,8 +311,12 @@ trap 'rm -f "$TMP_TOKENS" "$TMP_TOKENS_ERR"' EXIT
 # (#546 gap 2: the bash walk lacked the long forms the python table had).
 # Defined ONCE here and read by BOTH, so they cannot drift. Per-prefix
 # because the same letter differs by tool (nice -n takes a value; sudo -n
-# does not). Format: ";"-joined "<prefix>=<opt>,<opt>,..." entries.
-PREFIX_VALUE_OPTS_SPEC="sudo=-u,--user,-g,--group,-p,--prompt,-h,--host,-t,--type,-r,--role,-C,--close-from,-D,--chdir,-R,--chroot,-U,--other-user,-T,--command-timeout;nice=-n,--adjustment;ionice=-c,--class,-n,--classdata,-p,--pid,-t;env=-u,--unset,-C,--chdir,-S,--split-string;exec=-a;time=-f,--format,-o,--output"
+# does not). Format: ";"-joined "<prefix>=<opt>,<opt>,..." entries. ONLY
+# value-CONSUMING options belong here: ionice -t/--ignore is a no-value flag
+# (CodeRabbit #551), and env -S/--split-string is NOT a value either — its
+# argument is a nested SPLIT command, re-tokenized + expanded in
+# expand_wrappers, so it is handled there rather than skipped as a value.
+PREFIX_VALUE_OPTS_SPEC="sudo=-u,--user,-g,--group,-p,--prompt,-h,--host,-t,--type,-r,--role,-C,--close-from,-D,--chdir,-R,--chroot,-U,--other-user,-T,--command-timeout;nice=-n,--adjustment;ionice=-c,--class,-n,--classdata,-p,--pid;env=-u,--unset,-C,--chdir;exec=-a;time=-f,--format,-o,--output"
 export PREFIX_VALUE_OPTS_SPEC
 if ! printf '%s' "$COMMAND" | python3 -c '
 import sys, shlex, re, os
@@ -601,6 +605,31 @@ def expand_wrappers(tokens, depth=0):
                     break
                 if _ASSIGN_RE.match(a):
                     out.append(a)
+                    i += 1
+                    continue
+                # env -S STRING / --split-string STRING runs STRING as a SPLIT
+                # command, so its argument is a NESTED command, not a value to
+                # skip: re-tokenize + expand it so a "env -S bash -c <gh write>"
+                # payload is surfaced (CodeRabbit #551, a pre-existing exotic
+                # gap). Handles the next-token, --split-string=STR, and -SSTR
+                # (attached) forms.
+                if base == "env" and a in ("-S", "--split-string"):
+                    if i + 1 < n and tokens[i + 1] not in _SEPARATORS:
+                        out.extend(expand_wrappers(
+                            shlex.split(flatten_command(tokens[i + 1])), depth + 1))
+                        i += 2
+                    else:
+                        out.append(a)
+                        i += 1
+                    continue
+                if base == "env" and a.startswith("--split-string="):
+                    out.extend(expand_wrappers(
+                        shlex.split(flatten_command(a[len("--split-string="):])), depth + 1))
+                    i += 1
+                    continue
+                if base == "env" and len(a) > 2 and a.startswith("-S") and not a.startswith("--"):
+                    out.extend(expand_wrappers(
+                        shlex.split(flatten_command(a[2:])), depth + 1))
                     i += 1
                     continue
                 if a in vopts:

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -246,7 +246,21 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 # and the hook exited before tokenizing). Erring toward NOT early-exiting
 # is the fail-closed direction: a false positive costs one tokenizer run;
 # a false negative is a bypass.
-if ! echo "$COMMAND" | tr -d "\"'" | grep -qE '(^|[^A-Za-z0-9_])([^[:space:]]*/)?gh([^A-Za-z0-9_]|$)'; then
+# #551 (Codex): env -S / --split-string can synthesize `gh` dynamically (e.g.
+# from an octal printf in a $(...) substitution), so the raw command may carry
+# NO literal `gh` yet still run `gh pr merge`. A no-`gh` early-exit would then
+# skip the env -S fail-closed branch in the tokenizer below. Force tokenization
+# whenever the command carries `gh` OR an env -S / --split-string flag (the
+# tokenizer then blocks the env -S, fail-closed). Over-matching only costs one
+# tokenizer run; a false negative is a bypass.
+NEEDS_TOKENIZE=0
+if echo "$COMMAND" | tr -d "\"'" | grep -qE '(^|[^A-Za-z0-9_])([^[:space:]]*/)?gh([^A-Za-z0-9_]|$)'; then
+  NEEDS_TOKENIZE=1
+elif echo "$COMMAND" | grep -qE '(^|[^A-Za-z0-9_])env([[:space:]]|$)' \
+     && echo "$COMMAND" | grep -qE '(-[A-Za-z]*S|--split-string)'; then
+  NEEDS_TOKENIZE=1
+fi
+if [ "$NEEDS_TOKENIZE" -eq 0 ]; then
   exit 0
 fi
 
@@ -529,6 +543,16 @@ def expand_wrappers(tokens, depth=0):
         if _ASSIGN_RE.match(tok):
             out.append(tok)
             i += 1
+            # NAME=$(...) is split by flatten_command into "NAME=" + the
+            # __MERGEPATH_CMDSUB__ placeholder; re-attach the placeholder as the
+            # assignment value so it does not read as "NAME= <command>" and let
+            # a following prefix lose command position (Codex #551:
+            # G=$(printf gh) env -S "${G} ..." must still reach the env -S
+            # fail-closed branch). Only a trailing-"=" (empty-value) assignment
+            # immediately followed by the placeholder is the flatten artifact.
+            if tok.endswith("=") and i < n and tokens[i] == "__MERGEPATH_CMDSUB__":
+                out.append(tokens[i])
+                i += 1
             continue
         base = tok.rsplit("/", 1)[-1]
         if base == "eval":

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -761,6 +761,12 @@ assert_rc_contains "env --split-string=STR (attached) command is expanded (#551)
 # No false positive: gh as mere data inside the split string is not a write.
 assert_rc_contains "env -S echo of gh text is not a write (#551, no false positive)" 0 "" \
   'env -S "echo gh pr merge --admin"'
+# GNU env -S expands $VAR/${VAR} before splitting; shlex cannot resolve that,
+# so a "${G} ..." payload must FAIL CLOSED, not be left unexpanded and bypass
+# the guard (Codex #551 P1). $(...) command-subs are still handled (lifted by
+# flatten_command), so only an unresolvable parameter expansion blocks.
+assert_rc_contains "env -S with variable expansion fails closed, not bypass (#551 Codex)" 2 "tokenize" \
+  'G=gh env -S "${G} pr merge 123 --admin"'
 
 echo ""
 echo "test_gh_pr_guard: $PASS passed, $FAIL failed"

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -768,6 +768,11 @@ assert_rc_contains "env -S command-substitution payload fails closed (#551 Codex
   'env -S "$(printf gh) pr merge 123 --admin"'
 assert_rc_contains "env -S following-argv payload fails closed (#551 Codex)" 2 "tokenize" \
   'env -S "bash -c" "gh pr merge 123 --admin"'
+# No literal "gh" in the raw command (gh synthesized via octal printf), so the
+# no-gh fast-path would skip the tokenizer — but env -S forces tokenization and
+# then fails closed (Codex #551 r5: tokenize env -S even without a literal gh).
+assert_rc_contains "env -S without a literal gh still fails closed (#551 Codex)" 2 "tokenize" \
+  'G=$(printf "\147\150") env -S "${G} pr merge 123 --admin"'
 # A plain env prefix (no -S) is unaffected — it still surfaces the wrapped write.
 assert_rc_contains "plain env prefix still surfaces the gh write (#551 regression)" 2 "token-verifying wrapper" \
   'env FOO=bar gh pr merge 123 --admin'

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -741,6 +741,27 @@ assert_rc_contains "time -f value option bash -c gh write surfaced (#546 gap 2)"
 assert_rc_contains "sudo -s no-value flag does not swallow the gh write (#546 gap 2)" 2 "token-verifying wrapper" \
   'sudo -s gh pr merge 123 --admin'
 
+# --- #546 follow-on (CodeRabbit #551): spec correctness for ionice/env ----
+# ionice -t/--ignore is a no-value FLAG, so it must not consume the next
+# token; before this it swallowed the bash that followed and hid the write.
+assert_rc_contains "ionice -t flag does not swallow bash -c gh write (#551)" 2 "token-verifying wrapper" \
+  'ionice -t bash -c "gh pr merge 123 --admin"'
+# ionice -c is still a real value option (regression: must skip its value).
+assert_rc_contains "ionice -c value option still skips its value, then surfaces gh (#551)" 2 "token-verifying wrapper" \
+  'ionice -c 2 bash -c "gh pr merge 123 --admin"'
+# env -S/--split-string runs its argument as a SPLIT command: it must be
+# expanded (a nested command), not skipped as a value. env -S "gh ..." runs
+# gh directly via split-string.
+assert_rc_contains "env -S split-string command is expanded + surfaced (#551)" 2 "token-verifying wrapper" \
+  'env -S "gh pr merge 123 --admin"'
+assert_rc_contains "env --split-string (next token) command is expanded (#551)" 2 "token-verifying wrapper" \
+  'env --split-string "gh pr merge 123 --admin"'
+assert_rc_contains "env --split-string=STR (attached) command is expanded (#551)" 2 "token-verifying wrapper" \
+  'env --split-string="gh pr merge 123 --admin"'
+# No false positive: gh as mere data inside the split string is not a write.
+assert_rc_contains "env -S echo of gh text is not a write (#551, no false positive)" 0 "" \
+  'env -S "echo gh pr merge --admin"'
+
 echo ""
 echo "test_gh_pr_guard: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -767,6 +767,11 @@ assert_rc_contains "env -S echo of gh text is not a write (#551, no false positi
 # flatten_command), so only an unresolvable parameter expansion blocks.
 assert_rc_contains "env -S with variable expansion fails closed, not bypass (#551 Codex)" 2 "tokenize" \
   'G=gh env -S "${G} pr merge 123 --admin"'
+# Command substitution inside env -S: bash expands $(...) BEFORE env runs, so
+# the result becomes env -S command. The outer flatten lifts the $(...) out
+# into a placeholder, which must ALSO fail closed, not pass (Codex #551 r2).
+assert_rc_contains "env -S with command substitution fails closed, not bypass (#551 Codex)" 2 "tokenize" \
+  'env -S "$(printf gh) pr merge 123 --admin"'
 
 echo ""
 echo "test_gh_pr_guard: $PASS passed, $FAIL failed"

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -773,6 +773,13 @@ assert_rc_contains "env -S following-argv payload fails closed (#551 Codex)" 2 "
 # then fails closed (Codex #551 r5: tokenize env -S even without a literal gh).
 assert_rc_contains "env -S without a literal gh still fails closed (#551 Codex)" 2 "tokenize" \
   'G=$(printf "\147\150") env -S "${G} pr merge 123 --admin"'
+# Clustered env split-string flag (-vS), not just a leading -S (CodeRabbit #551).
+assert_rc_contains "env clustered -vS fails closed (#551)" 2 "tokenize" \
+  'env -vS "gh pr merge 123 --admin"'
+# Quoted `env` (the shell strips the quotes and runs env) with no literal gh:
+# the fast-path quote-strips before probing, then env -S fails closed (Codex #551).
+assert_rc_contains "quoted env -S without a literal gh fails closed (#551 Codex)" 2 "tokenize" \
+  'G=$(printf "\147\150") "env" -S "${G} pr merge 123 --admin"'
 # A plain env prefix (no -S) is unaffected — it still surfaces the wrapped write.
 assert_rc_contains "plain env prefix still surfaces the gh write (#551 regression)" 2 "token-verifying wrapper" \
   'env FOO=bar gh pr merge 123 --admin'

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -707,6 +707,40 @@ else
   fail "author wrapper unset identity under custom expected author fails closed: rc=$rc; output: $out"
 fi
 
+# --- #546: parser-completeness hardening (gap 1 + gap 2) --------------
+# Gap 1 — a blessed wrapper must not hide a shell-c payload. Before #546 the
+# wrappers were not prefix-like in expand_wrappers, so a "<wrapper> -- bash
+# -c <gh write>" left the inner write opaque and it ran under the verified
+# token WITHOUT the merge-state / admin / CODEX gate. The inner write must
+# now surface and face the same checks as a visible "<wrapper> -- gh ...".
+assert_rc_contains "author wrapper hides bash -c merge: state still checked (#546 gap 1)" 2 "mergeStateStatus is BLOCKED" \
+  'scripts/gh-as-author.sh -- bash -c "gh pr merge 123 --squash"' "BLOCKED" ""
+assert_rc_contains "author wrapper bash -c clean merge still allowed (#546 gap 1, no false block)" 0 "" \
+  'scripts/gh-as-author.sh -- bash -c "gh pr merge 123 --squash"' "CLEAN" ""
+assert_rc_contains "author wrapper hides eval admin merge: surfaced + blocked (#546 gap 1)" 2 "" \
+  'scripts/gh-as-author.sh -- eval "gh pr merge 123 --admin"' "CLEAN" ""
+assert_rc_contains "reviewer wrapper hides bash -c admin merge: surfaced + blocked (#546 gap 1)" 2 "" \
+  'scripts/gh-as-reviewer.sh -- bash -c "gh pr merge 123 --admin"' "CLEAN" ""
+assert_rc_contains "wrapper bash -c echo of gh text is not a write (#546 gap 1, no false positive)" 0 "" \
+  'scripts/gh-as-author.sh -- bash -c "echo gh pr merge --admin"' "CLEAN" ""
+
+# Gap 2 — the python pre-pass and the bash walk read ONE shared
+# PREFIX_VALUE_OPTS_SPEC, so a long-form prefix value-option no longer
+# mis-skips. Before #546 python expanded "sudo --user X bash -c <gh write>"
+# but the bash compound scan (short-forms only) mis-read X as the command
+# and never saw the surfaced gh, so a guarded write passed rc=0.
+assert_rc_contains "sudo --user long form bash -c gh write surfaced (#546 gap 2)" 2 "token-verifying wrapper" \
+  'sudo --user root bash -c "gh pr merge 123 --admin"'
+assert_rc_contains "nice --adjustment long form bash -c gh write surfaced (#546 gap 2)" 2 "token-verifying wrapper" \
+  'nice --adjustment 10 bash -c "gh pr merge 123 --admin"'
+assert_rc_contains "time -f value option bash -c gh write surfaced (#546 gap 2)" 2 "token-verifying wrapper" \
+  'time -f FMT bash -c "gh pr merge 123 --admin"'
+# Bogus sudo:-s / sudo:-c removed from the shared spec: -s is a no-value
+# flag, so the FOLLOWING token is the command, not -s's value. Before #546
+# the bash table wrongly skipped it and lost the gh write.
+assert_rc_contains "sudo -s no-value flag does not swallow the gh write (#546 gap 2)" 2 "token-verifying wrapper" \
+  'sudo -s gh pr merge 123 --admin'
+
 echo ""
 echo "test_gh_pr_guard: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -749,29 +749,28 @@ assert_rc_contains "ionice -t flag does not swallow bash -c gh write (#551)" 2 "
 # ionice -c is still a real value option (regression: must skip its value).
 assert_rc_contains "ionice -c value option still skips its value, then surfaces gh (#551)" 2 "token-verifying wrapper" \
   'ionice -c 2 bash -c "gh pr merge 123 --admin"'
-# env -S/--split-string runs its argument as a SPLIT command: it must be
-# expanded (a nested command), not skipped as a value. env -S "gh ..." runs
-# gh directly via split-string.
-assert_rc_contains "env -S split-string command is expanded + surfaced (#551)" 2 "token-verifying wrapper" \
+# env -S / --split-string FAILS CLOSED (#551, Codex r1-r4). GNU env -S has
+# exotic dynamic semantics — whitespace splitting, $VAR expansion,
+# $(...)/backtick substitution, AND appending the remaining argv after the
+# split string — that the guard cannot safely + completely model (each partial
+# model surfaced a new bypass). env -S on a command line is an exotic shebang
+# feature no gh workflow needs, so ANY env -S is blocked rather than risk a
+# hidden write.
+assert_rc_contains "env -S gh write fails closed (#551)" 2 "tokenize" \
   'env -S "gh pr merge 123 --admin"'
-assert_rc_contains "env --split-string (next token) command is expanded (#551)" 2 "token-verifying wrapper" \
+assert_rc_contains "env --split-string gh write fails closed (#551)" 2 "tokenize" \
   'env --split-string "gh pr merge 123 --admin"'
-assert_rc_contains "env --split-string=STR (attached) command is expanded (#551)" 2 "token-verifying wrapper" \
+assert_rc_contains "env --split-string=STR gh write fails closed (#551)" 2 "tokenize" \
   'env --split-string="gh pr merge 123 --admin"'
-# No false positive: gh as mere data inside the split string is not a write.
-assert_rc_contains "env -S echo of gh text is not a write (#551, no false positive)" 0 "" \
-  'env -S "echo gh pr merge --admin"'
-# GNU env -S expands $VAR/${VAR} before splitting; shlex cannot resolve that,
-# so a "${G} ..." payload must FAIL CLOSED, not be left unexpanded and bypass
-# the guard (Codex #551 P1). $(...) command-subs are still handled (lifted by
-# flatten_command), so only an unresolvable parameter expansion blocks.
-assert_rc_contains "env -S with variable expansion fails closed, not bypass (#551 Codex)" 2 "tokenize" \
+assert_rc_contains "env -S variable-expansion payload fails closed (#551 Codex)" 2 "tokenize" \
   'G=gh env -S "${G} pr merge 123 --admin"'
-# Command substitution inside env -S: bash expands $(...) BEFORE env runs, so
-# the result becomes env -S command. The outer flatten lifts the $(...) out
-# into a placeholder, which must ALSO fail closed, not pass (Codex #551 r2).
-assert_rc_contains "env -S with command substitution fails closed, not bypass (#551 Codex)" 2 "tokenize" \
+assert_rc_contains "env -S command-substitution payload fails closed (#551 Codex)" 2 "tokenize" \
   'env -S "$(printf gh) pr merge 123 --admin"'
+assert_rc_contains "env -S following-argv payload fails closed (#551 Codex)" 2 "tokenize" \
+  'env -S "bash -c" "gh pr merge 123 --admin"'
+# A plain env prefix (no -S) is unaffected — it still surfaces the wrapped write.
+assert_rc_contains "plain env prefix still surfaces the gh write (#551 regression)" 2 "token-verifying wrapper" \
+  'env FOO=bar gh pr merge 123 --admin'
 
 echo ""
 echo "test_gh_pr_guard: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Closes #546 — the two residual gh-pr-guard.sh parser-completeness gaps Codex 4a surfaced on #540. Both are real-but-exotic adversarial-evasion paths (crafting a command to bypass the same guard that protects you); the guard remains solid (113 cases).

Gap 1 (a blessed wrapper hides a shell-c payload): the canonical wrappers were not treated as prefixes, so a wrapper -- bash -c payload left the inner write opaque and it ran under the verified token WITHOUT the merge-state / admin / CODEX gate. The wrappers are now prefix-like (a new _WRAPPER_CMDS set): the wrapper plus the -- separator keep command position, so a trailing bash -c / sh -c / prefix / eval payload is expanded and the inner write re-checked. Normal wrapper -- gh usage is unaffected.

Gap 2 (the python and bash prefix-option tables drifted): python carried long forms the bash compound scan lacked, so python expanded sudo --user X bash -c PAYLOAD but the bash walk mis-read X as the command and missed the surfaced write. Both now read ONE shared PREFIX_VALUE_OPTS_SPEC, so they cannot drift; the bash side compares by literal equality (not a case glob) so an option token like dash-star cannot mis-skip. Reconciled the canonical set (added long forms, time, env --split-string; dropped the bogus sudo:-s / sudo:-c that wrongly swallowed the next token). python fails closed if the spec is absent.

## Self-Review

- Single source of truth: the prefix value-option table is defined once (PREFIX_VALUE_OPTS_SPEC) and read by both the python pre-pass and the bash walk, so the two cannot drift again (the root cause of gap 2).
- No regression: all 104 prior cases pass unchanged; the spec reproduces prior behavior plus the corrections. Plus 9 new cases for both gaps including no-false-positive controls.
- Validated: check_gh_as_author, check_sync_manifest, check_no_bare_gh_writes all green; bash -n clean.
- Risk: scoped to the tokenizer prefix/wrapper handling; fail-closed on a missing spec; literal-equality option compare avoids glob mis-skips.

Authoring-Agent: claude